### PR TITLE
Jgt fixes to Gtx7CfgPkg.vhd

### DIFF
--- a/xilinx/7Series/gtx7/rtl/Gtx7CfgPkg.vhd
+++ b/xilinx/7Series/gtx7/rtl/Gtx7CfgPkg.vhd
@@ -262,7 +262,7 @@ package body Gtx7CfgPkg is
          ret.TXOUT_DIV_G    := qPllCfg.OUT_DIV_G;
          ret.TX_CLK25_DIV_G := qPllCfg.CLK25_DIV_G;
       else
-         assert (true) report "Gtx7CfgPkg: getGtx7Cfg: Illegal TX PLL type: " & txPll severity failure;
+         assert (false) report "Gtx7CfgPkg: getGtx7Cfg: Illegal TX PLL type: " & txPll severity failure;
       end if;
 
       if (rxPll = "CPLL") then
@@ -272,7 +272,7 @@ package body Gtx7CfgPkg is
          ret.RXOUT_DIV_G    := qPllCfg.OUT_DIV_G;
          ret.RX_CLK25_DIV_G := qPllCfg.CLK25_DIV_G;
       else
-         assert (true) report "Gtx7CfgPkg: getGtx7Cfg: Illegal RX PLL type: " & rxPll severity failure;
+         assert (false) report "Gtx7CfgPkg: getGtx7Cfg: Illegal RX PLL type: " & rxPll severity failure;
       end if;
 
       return ret;


### PR DESCRIPTION
I split my fixes into two commits. The first is for the error condition asserts in getGtx7Cfg() and the other is to address the fact that the bit in QPLL_CFG_G that depends on the Vco band wasn't included in the configuration.