### PR TITLE
Adding TX_VALID_THOLD_G to SRP modules

### DIFF
--- a/protocols/srp/rtl/SrpV3Axi.vhd
+++ b/protocols/srp/rtl/SrpV3Axi.vhd
@@ -35,6 +35,7 @@ entity SrpV3Axi is
       TPD_G               : time                    := 1 ns;
       PIPE_STAGES_G       : natural range 0 to 16   := 0;
       FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
+      TX_VALID_THOLD_G    : positive                := 1;
       SLAVE_READY_EN_G    : boolean                 := true;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       ALTERA_SYN_G        : boolean                 := false;
@@ -113,6 +114,7 @@ begin
          TPD_G               => TPD_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
+         TX_VALID_THOLD_G    => TX_VALID_THOLD_G,
          SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          ALTERA_SYN_G        => ALTERA_SYN_G,

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -36,6 +36,7 @@ entity SrpV3AxiLite is
       TPD_G               : time                    := 1 ns;
       PIPE_STAGES_G       : natural range 0 to 16   := 0;
       FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
+      TX_VALID_THOLD_G    : positive                := 1;
       SLAVE_READY_EN_G    : boolean                 := false;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       ALTERA_SYN_G        : boolean                 := false;
@@ -711,7 +712,7 @@ begin
          TPD_G               => TPD_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          SLAVE_READY_EN_G    => true,
-         VALID_THOLD_G       => 1,
+         VALID_THOLD_G       => TX_VALID_THOLD_G,
          -- FIFO configurations
          BRAM_EN_G           => true,
          XIL_DEVICE_G        => "7SERIES",

--- a/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
@@ -37,6 +37,7 @@ entity SrpV3AxiLiteFull is
       TPD_G               : time                    := 1 ns;
       PIPE_STAGES_G       : natural range 0 to 16   := 0;
       FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
+      TX_VALID_THOLD_G    : positive                := 1;
       SLAVE_READY_EN_G    : boolean                 := false;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       ALTERA_SYN_G        : boolean                 := false;
@@ -78,6 +79,7 @@ begin
          TPD_G               => TPD_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
+         TX_VALID_THOLD_G    => TX_VALID_THOLD_G,
          SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          ALTERA_SYN_G        => ALTERA_SYN_G,

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -37,6 +37,7 @@ entity SrpV3Core is
       TPD_G               : time                    := 1 ns;
       PIPE_STAGES_G       : natural range 0 to 16   := 1;
       FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
+      TX_VALID_THOLD_G    : positive                := 1;
       SLAVE_READY_EN_G    : boolean                 := false;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       ALTERA_SYN_G        : boolean                 := false;
@@ -680,7 +681,7 @@ begin
          TPD_G               => TPD_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          SLAVE_READY_EN_G    => true,
-         VALID_THOLD_G       => 1,
+         VALID_THOLD_G       => TX_VALID_THOLD_G,
          -- FIFO configurations
          BRAM_EN_G           => true,
          XIL_DEVICE_G        => "7SERIES",


### PR DESCRIPTION
Which will give the ability to pre-cache the TX path.  This modification is backwards compatible. 