### PR TITLE
Fix wrong definition of the Git Hash register

### DIFF
--- a/yaml/AxiVersion.yaml
+++ b/yaml/AxiVersion.yaml
@@ -96,9 +96,11 @@ AxiVersion: &AxiVersion
     GitHash:
       at:
         offset: 0x600
+        nelms: 20
       class: IntField
-      sizeBits: 160
+      sizeBits: 8
       mode: RO
+      configBase: 16
       description: GIT SHA-1 Hash       
     #########################################################
     DeviceDna:


### PR DESCRIPTION
IntField object support up to 64-bit values. See section 2.5 in [Describing CPSW Hierarchies with YAML](http://www.slac.stanford.edu/grp/lcls/controls/docs/cpsw/framework/with-at-support/README.yamlDefinition.html).