### PR TITLE
Drc reqp 1857

### DIFF
--- a/axi/rtl/AxiDualPortRam.vhd
+++ b/axi/rtl/AxiDualPortRam.vhd
@@ -30,7 +30,7 @@ entity AxiDualPortRam is
       TPD_G            : time                       := 1 ns;
       BRAM_EN_G        : boolean                    := false;
       REG_EN_G         : boolean                    := true;
-      MODE_G           : string                     := "read-first";
+      MODE_G           : string                     := "no-change";
       AXI_WR_EN_G      : boolean                    := true;
       SYS_WR_EN_G      : boolean                    := false;
       SYS_BYTE_WR_EN_G : boolean                    := false;

--- a/axi/rtl/AxiLiteRingBuffer.vhd
+++ b/axi/rtl/AxiLiteRingBuffer.vhd
@@ -117,7 +117,7 @@ begin
          TPD_G        => TPD_G,
          BRAM_EN_G    => BRAM_EN_G,
          REG_EN_G     => REG_EN_G,
-         MODE_G       => "read-first",
+         MODE_G       => "no-change",
          DOB_REG_G    => REG_EN_G,
          DATA_WIDTH_G => DATA_WIDTH_G,
          ADDR_WIDTH_G => RAM_ADDR_WIDTH_G)

--- a/base/ram/rtl/DualPortRam.vhd
+++ b/base/ram/rtl/DualPortRam.vhd
@@ -30,7 +30,7 @@ entity DualPortRam is
       REG_EN_G       : boolean                    := true;
       DOA_REG_G      : boolean                    := false;
       DOB_REG_G      : boolean                    := false;
-      MODE_G         : string                     := "read-first";
+      MODE_G         : string                     := "no-change";
       BYTE_WR_EN_G   : boolean                    := false;
       DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
       BYTE_WIDTH_G   : integer                    := 8;    -- If BRAM, should be multiple of 8 or 9

--- a/base/ram/rtl/QuadPortRam.vhd
+++ b/base/ram/rtl/QuadPortRam.vhd
@@ -27,7 +27,7 @@ entity QuadPortRam is
       TPD_G          : time                       := 1 ns;
       RST_POLARITY_G : sl                         := '1';  -- '1' for active high rst, '0' for active low
       REG_EN_G       : boolean                    := true;
-      MODE_G         : string                     := "read-first";
+      MODE_G         : string                     := "no-change";
       BYTE_WR_EN_G   : boolean                    := false;
       DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
       BYTE_WIDTH_G   : integer                    := 8;

--- a/base/ram/rtl/TrueDualPortRam.vhd
+++ b/base/ram/rtl/TrueDualPortRam.vhd
@@ -31,7 +31,7 @@ entity TrueDualPortRam is
       ALTERA_RAM_G   : string                     := "M9K";
       DOA_REG_G      : boolean                    := false;  -- Extra output register on doutA.
       DOB_REG_G      : boolean                    := false;  -- Extra output register on doutB.
-      MODE_G         : string                     := "read-first";
+      MODE_G         : string                     := "no-change";
       BYTE_WR_EN_G   : boolean                    := false;
       DATA_WIDTH_G   : integer range 1 to (2**24) := 18;
       BYTE_WIDTH_G   : integer                    := 8;  -- Should be multiple of 8 or 9.

--- a/ethernet/RawEthFramer/rtl/RawEthFramerWrapper.vhd
+++ b/ethernet/RawEthFramer/rtl/RawEthFramerWrapper.vhd
@@ -93,7 +93,7 @@ begin
          TPD_G            => TPD_G,
          BRAM_EN_G        => true,
          REG_EN_G         => false,
-         MODE_G           => "read-first",
+         MODE_G           => "no-change",
          AXI_WR_EN_G      => true,
          SYS_WR_EN_G      => false,
          SYS_BYTE_WR_EN_G => false,

--- a/protocols/saci/sim/AxiLiteSaciMasterTb.vhd
+++ b/protocols/saci/sim/AxiLiteSaciMasterTb.vhd
@@ -116,7 +116,7 @@ begin
             REG_EN_G       => false,
             DOA_REG_G      => false,
             DOB_REG_G      => false,
-            MODE_G         => "read-first",
+            MODE_G         => "no-change",
             BYTE_WR_EN_G   => false,
             DATA_WIDTH_G   => 32,
             ADDR_WIDTH_G   => 12)


### PR DESCRIPTION
Changed the default of MODE_G to "no-change" because of this Xilinx recommendation:
```Synchronous clocking is detected for BRAM in SDP mode with WRITE_FIRST write-mode. It is strongly suggested to change this mode to NO_CHANGE for best power characteristics. However, both WRITE_FIRST and NO_CHANGE may exhibit address collisions if the same address appears on both read and write ports resulting in unknown or corrupted read data. It is suggested to confirm via simulation that an address collision never occurs and if so it is suggested to try and avoid this situation. If address collisions cannot be avoided, the write-mode may be set to READ_FIRST which guarantees that the read data is the prior contents of the memory at the cost of additional power in the design. See the FPGA Memory Resources User Guide for additional information.```