### PR TITLE
Dma v2 desc opt

### DIFF
--- a/axi/rtl/AxiStreamDmaV2Desc.vhd
+++ b/axi/rtl/AxiStreamDmaV2Desc.vhd
@@ -243,11 +243,11 @@ architecture rtl of AxiStreamDmaV2Desc is
    signal invalidCount : sl;
    signal diffCnt      : slv(31 downto 0);
 
-   attribute dont_touch                 : string;
-   attribute dont_touch of r            : signal is "true";
-   attribute dont_touch of intAckEn     : signal is "true";
-   attribute dont_touch of invalidCount : signal is "true";
-   attribute dont_touch of diffCnt      : signal is "true";
+   -- attribute dont_touch                 : string;
+   -- attribute dont_touch of r            : signal is "true";
+   -- attribute dont_touch of intAckEn     : signal is "true";
+   -- attribute dont_touch of invalidCount : signal is "true";
+   -- attribute dont_touch of diffCnt      : signal is "true";
 
 begin
 

--- a/axi/rtl/AxiStreamDmaV2Read.vhd
+++ b/axi/rtl/AxiStreamDmaV2Read.vhd
@@ -117,8 +117,8 @@ architecture rtl of AxiStreamDmaV2Read is
    signal sSlave     : AxiStreamSlaveType;
    signal mSlave     : AxiStreamSlaveType;
 
-   attribute dont_touch      : string;
-   attribute dont_touch of r : signal is "TRUE";
+   -- attribute dont_touch      : string;
+   -- attribute dont_touch of r : signal is "TRUE";
 
 begin
 

--- a/axi/rtl/AxiStreamDmaV2Write.vhd
+++ b/axi/rtl/AxiStreamDmaV2Write.vhd
@@ -116,8 +116,8 @@ architecture rtl of AxiStreamDmaV2Write is
    signal trackDout     : slv(AXI_WRITE_DMA_TRACK_SIZE_C-1 downto 0);
    signal trackData     : AxiWriteDmaTrackType;
 
-   attribute dont_touch      : string;
-   attribute dont_touch of r : signal is "true";
+   -- attribute dont_touch      : string;
+   -- attribute dont_touch of r : signal is "true";
    
 begin
 


### PR DESCRIPTION
committing out "dont_touch" to help speed up the build by default since chipscope is not always inserted 