### PR TITLE
adding DYNAMIC_QPLL_G support

### DIFF
--- a/base/general/rtl/StdRtlPkg.vhd
+++ b/base/general/rtl/StdRtlPkg.vhd
@@ -22,6 +22,14 @@ use ieee.math_real.all;
 
 package StdRtlPkg is
 
+   -- Useful for pre compiler
+   constant IN_SIMULATION_C : boolean := false
+-- pragma translate_off
+   or true
+-- pragma translate_on
+   ;
+   constant IN_SYNTHESIS_C : boolean := not(IN_SIMULATION_C);
+
    -- Typing std_logic(_vector) is annoying
    subtype sl is std_logic;
    subtype slv is std_logic_vector;

--- a/base/ruckus.tcl
+++ b/base/ruckus.tcl
@@ -6,18 +6,3 @@ loadRuckusTcl "$::DIR_PATH/fifo"
 loadRuckusTcl "$::DIR_PATH/general"
 loadRuckusTcl "$::DIR_PATH/ram"
 loadRuckusTcl "$::DIR_PATH/sync"
-
-# Added VHDL-2008 library for floating point DSP support if not supported in Vivado by default yet
-if { [VersionCheck 2017.2] <= 0 } {
-   # Path to VHDL-2008
-   set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
-
-   # Add the fixed and floating point packages
-   loadSource -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-   loadSource -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
-}

--- a/dsp/core/DspPkg.vhd
+++ b/dsp/core/DspPkg.vhd
@@ -4,7 +4,7 @@
 -- Created    : 2014-04-24
 -- Last update: 2017-09-21
 -------------------------------------------------------------------------------
--- Description: AXI Stream Package File
+-- Description: DSP Package File
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the 
@@ -17,10 +17,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
 
-use work.StdRtlPkg.all;
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 package DspPkg is
 
@@ -46,34 +51,8 @@ package DspPkg is
    constant FP128_NEG_ONE_C : float64 := x"bfff0000000000000000000000000000";
    constant FP128_POS_ONE_C : float64 := x"3fff0000000000000000000000000000";
 
-   -- Useful functions
-   function ite(i : boolean; t : float16; e : float16) return float16;
-   function ite(i : boolean; t : float32; e : float32) return float32;
-   function ite(i : boolean; t : float64; e : float64) return float64;
-   function ite(i : boolean; t : float128; e : float128) return float128;
-
 end package DspPkg;
 
 package body DspPkg is
-
-   function ite (i : boolean; t : float16; e : float16) return float16 is
-   begin
-      if (i) then return t; else return e; end if;
-   end function ite;
-
-   function ite (i : boolean; t : float32; e : float32) return float32 is
-   begin
-      if (i) then return t; else return e; end if;
-   end function ite;
-
-   function ite (i : boolean; t : float64; e : float64) return float64 is
-   begin
-      if (i) then return t; else return e; end if;
-   end function ite;
-
-   function ite (i : boolean; t : float128; e : float128) return float128 is
-   begin
-      if (i) then return t; else return e; end if;
-   end function ite;
 
 end package body DspPkg;

--- a/dsp/float/DspFp32Accum.vhd
+++ b/dsp/float/DspFp32Accum.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/float/DspFp32Max.vhd
+++ b/dsp/float/DspFp32Max.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/float/DspFp32Min.vhd
+++ b/dsp/float/DspFp32Min.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/float/DspFp32Mult.vhd
+++ b/dsp/float/DspFp32Mult.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/float/DspFp32PreMultAccum.vhd
+++ b/dsp/float/DspFp32PreMultAccum.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/float/DspFp32Rectifier.vhd
+++ b/dsp/float/DspFp32Rectifier.vhd
@@ -18,8 +18,15 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+
 use ieee.fixed_float_types.all;
 use ieee.float_pkg.all;
+
+-- synthesis translate_off
+library ieee_proposed;
+use ieee_proposed.fixed_float_types.all;
+use ieee_proposed.float_pkg.all;
+-- synthesis translate_on
 
 use work.StdRtlPkg.all;
 use work.DspPkg.all;

--- a/dsp/logic/DspXor.vhd
+++ b/dsp/logic/DspXor.vhd
@@ -1,0 +1,86 @@
+-------------------------------------------------------------------------------
+-- File       : DspXor.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2017-09-19
+-- Last update: 2017-09-19
+-------------------------------------------------------------------------------
+-- Description: Generalized DSP inferred XOR, which can be used to help with 
+--              performance when implementing FEC and CRC algorithms
+-- Equation: p = XOR(a[i])
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'SLAC Firmware Standard Library', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.StdRtlPkg.all;
+
+entity DspXor is
+   generic (
+      TPD_G     : time                   := 1 ns;
+      USE_DSP_G : string                 := "logic";
+      WIDTH_G   : positive range 2 to 96 := 96);
+   port (
+      clk  : in  sl;
+      -- Inbound Interface
+      ain  : in  slv(WIDTH_G-1 downto 0);
+      -- Outbound Interface
+      pOut : out sl);
+end DspXor;
+
+architecture rtl of DspXor is
+
+   type RegType is record
+      p : sl;
+   end record RegType;
+   constant REG_INIT_C : RegType := (
+      p => '0');
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   attribute use_dsp48      : string;
+   attribute use_dsp48 of r : signal is USE_DSP_G;
+
+   attribute dont_touch        : string;
+   attribute dont_touch of rtl : architecture is "true";  -- prevent optimization from DSP to RTL
+
+begin
+
+   comb : process (ain, r) is
+      variable v : RegType;
+      variable a : signed(WIDTH_G-1 downto 0);
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- typecast from slv to signed
+      a := signed(ain);
+
+      -- Process the data
+      v.p := xor(a);
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+      -- Outputs              
+      pOut <= r.p;
+
+   end process comb;
+
+   seq : process (clk) is
+   begin
+      if rising_edge(clk) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end rtl;

--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -4,7 +4,19 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 # Load Source Code
 loadSource -dir "$::DIR_PATH/core"  -fileType "VHDL 2008"
 loadSource -dir "$::DIR_PATH/float" -fileType "VHDL 2008"
-loadSource -dir "$::DIR_PATH/fixed"
+loadSource -dir "$::DIR_PATH/fixed" -fileType "VHDL 2008"
 
 # Load Simulation
-loadSource -sim_only -dir "$::DIR_PATH/tb/"
+loadSource -sim_only -dir "$::DIR_PATH/tb/" -fileType "VHDL 2008"
+
+# Path to VHDL-2008
+set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
+
+# Add the fixed and floating point packages
+loadSource -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+loadSource -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"

--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -7,12 +7,10 @@ loadSource -dir "$::DIR_PATH/float" -fileType "VHDL 2008"
 loadSource -dir "$::DIR_PATH/fixed" -fileType "VHDL 2008"
 
 # Load Simulation
-loadSource -sim_only -dir "$::DIR_PATH/tb/" -fileType "VHDL 2008"
-
-# Path to VHDL-2008
-set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
+loadSource -sim_only -dir "$::DIR_PATH/tb" -fileType "VHDL 2008"
 
 # Add the fixed and floating point packages
+set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
 loadSource -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
 loadSource -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
 loadSource -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"

--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -5,6 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadSource -dir "$::DIR_PATH/core"  -fileType "VHDL 2008"
 loadSource -dir "$::DIR_PATH/float" -fileType "VHDL 2008"
 loadSource -dir "$::DIR_PATH/fixed" -fileType "VHDL 2008"
+loadSource -dir "$::DIR_PATH/logic" -fileType "VHDL 2008"
 
 # Load Simulation
 loadSource -sim_only -dir "$::DIR_PATH/tb" -fileType "VHDL 2008"

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -388,13 +388,19 @@ begin
          drpDi           => drpDi,
          drpDo           => drpDo);
 
-   U_RstSync : entity work.RstSync
-      generic map (
-         TPD_G => TPD_G)
-      port map (
-         clk      => stableClk,
-         asyncRst => axilRst,
-         syncRst  => stableRst);
+   GEN_RST : if (COMMON_CLK_G = false) generate   
+      U_RstSync : entity work.RstSync
+         generic map (
+            TPD_G => TPD_G)      
+         port map (
+            clk      => stableClk,
+            asyncRst => axilRst,
+            syncRst  => stableRst);     
+   end generate;
+   
+   BYP_RST_SYNC : if (COMMON_CLK_G = true) generate   
+      stableRst <= axilRst; 
+   end generate;   
 
 end rtl;
 

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -55,6 +55,7 @@ entity Pgp2bGtp7FixedLat is
       TX_OUTCLK_SRC_G  : string  := "PLLREFCLK";
       TX_PHASE_ALIGN_G : string  := "MANUAL";
       -- Configure PLL sources
+      DYNAMIC_QPLL_G   : boolean := false; 
       TX_PLL_G         : string  := "PLL0";
       RX_PLL_G         : string  := "PLL1";
 
@@ -121,6 +122,7 @@ entity Pgp2bGtp7FixedLat is
       txPreCursor     : in  slv(4 downto 0)        := (others => '0');
       txPostCursor    : in  slv(4 downto 0)        := (others => '0');
       txDiffCtrl      : in  slv(3 downto 0)        := "1000";
+      drpOverride     : in  sl                     := '0';
       -- AXI-Lite Interface 
       axilClk         : in  sl                     := '0';
       axilRst         : in  sl                     := '0';
@@ -262,6 +264,7 @@ begin
          RXCDR_CFG_G           => RXCDR_CFG_G,
          RXLPM_INCM_CFG_G      => RXLPM_INCM_CFG_G,
          RXLPM_IPCM_CFG_G      => RXLPM_IPCM_CFG_G,
+         DYNAMIC_QPLL_G        => DYNAMIC_QPLL_G,
          TX_PLL_G              => TX_PLL_G,
          RX_PLL_G              => RX_PLL_G,
          TX_EXT_DATA_WIDTH_G   => 16,
@@ -344,6 +347,7 @@ begin
          txPreCursor      => txPreCursor,
          txPostCursor     => txPostCursor,
          txDiffCtrl       => txDiffCtrl,
+         drpOverride      => drpOverride,
          drpGnt           => drpGnt,
          drpRdy           => drpRdy,
          drpEn            => drpEn,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -73,6 +73,8 @@ entity Pgp2bGtp7FixedLat is
    port (
       -- GT Clocking
       stableClk        : in  sl;        -- GT needs a stable clock to "boot up"
+      qPllRxSelect     : in  slv(1 downto 0) := "00";
+      qPllTxSelect     : in  slv(1 downto 0) := "00";      
       gtQPllOutRefClk  : in  slv(1 downto 0) := "00";     -- Signals from QPLLs
       gtQPllOutClk     : in  slv(1 downto 0) := "00";
       gtQPllLock       : in  slv(1 downto 0) := "00";
@@ -305,6 +307,8 @@ begin
          )
       port map (
          stableClkIn      => stableClk,
+         qPllRxSelect     => qPllRxSelect,
+         qPllTxSelect     => qPllTxSelect,
          qPllRefClkIn     => gtQPllOutRefClk,
          qPllClkIn        => gtQPllOutClk,
          qPllLockIn       => gtQPllLock,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -29,7 +29,7 @@ use UNISIM.VCOMPONENTS.all;
 entity Pgp2bGtp7FixedLat is
    generic (
       TPD_G : time := 1 ns;
-
+      COMMON_CLK_G          : boolean              := false;-- set true if (stableClk = axilClk)
       ----------------------------------------------------------------------------------------------
       -- GT Settings
       ----------------------------------------------------------------------------------------------
@@ -356,7 +356,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-         COMMON_CLK_G     => false,
+         COMMON_CLK_G     => COMMON_CLK_G,
          EN_ARBITRATION_G => true,
          TIMEOUT_G        => 4096,
          ADDR_WIDTH_G     => 9,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
@@ -31,6 +31,7 @@ use unisim.vcomponents.all;
 entity Pgp2bGtp7FixedLatWrapper is
    generic (
       TPD_G                   : time                 := 1 ns;
+      COMMON_CLK_G            : boolean              := false;-- set true if (stableClk = axilClk)
       SIM_GTRESET_SPEEDUP_G   : boolean              := false;
       SIM_VERSION_G           : string               := "1.0";
       SIMULATION_G            : boolean              := false;
@@ -370,6 +371,7 @@ begin
    Pgp2bGtp7Fixedlat_Inst : entity work.Pgp2bGtp7FixedLat
       generic map (
          TPD_G                 => TPD_G,
+         COMMON_CLK_G          => COMMON_CLK_G,
          SIM_GTRESET_SPEEDUP_G => SIM_GTRESET_SPEEDUP_C,
          SIM_VERSION_G         => SIM_VERSION_G,
          SIMULATION_G          => SIMULATION_G,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
@@ -71,6 +71,7 @@ entity Pgp2bGtp7FixedLatWrapper is
       RX_REFCLK_SRC_G         : string               := "gtClk0";
       TX_PLL_CFG_G            : Gtp7QPllCfgType      := getGtp7QPllCfg(156.25e6, 3.125e9);
       RX_PLL_CFG_G            : Gtp7QPllCfgType      := getGtp7QPllCfg(156.25e6, 3.125e9);
+      DYNAMIC_QPLL_G          : boolean              := false;
       TX_PLL_G                : string               := "PLL0";
       RX_PLL_G                : string               := "PLL0");
    port (
@@ -113,6 +114,7 @@ entity Pgp2bGtp7FixedLatWrapper is
       txPreCursor      : in  slv(4 downto 0)                  := (others => '0');
       txPostCursor     : in  slv(4 downto 0)                  := (others => '0');
       txDiffCtrl       : in  slv(3 downto 0)                  := "1000";
+      drpOverride      : in  sl                               := '0';
       -- AXI-Lite Interface 
       axilClk          : in  sl                               := '0';
       axilRst          : in  sl                               := '0';
@@ -386,6 +388,7 @@ begin
          TX_BUF_EN_G           => true,
          TX_OUTCLK_SRC_G       => ite(TX_USER_CLK_SRC_G = "txOutClk", "OUTCLKPMA", "PLLREFCLK"),
          TX_PHASE_ALIGN_G      => "MANUAL",
+         DYNAMIC_QPLL_G        => DYNAMIC_QPLL_G,
          TX_PLL_G              => TX_PLL_G,
          RX_PLL_G              => RX_PLL_G,
          VC_INTERLEAVE_G       => VC_INTERLEAVE_G,
@@ -441,6 +444,7 @@ begin
          txPreCursor      => txPreCursor,
          txPostCursor     => txPostCursor,
          txDiffCtrl       => txDiffCtrl,
+         drpOverride      => drpOverride,
          -- AXI-Lite Interface 
          axilClk          => axilClk,
          axilRst          => axilRst,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLatWrapper.vhd
@@ -115,6 +115,8 @@ entity Pgp2bGtp7FixedLatWrapper is
       txPostCursor     : in  slv(4 downto 0)                  := (others => '0');
       txDiffCtrl       : in  slv(3 downto 0)                  := "1000";
       drpOverride      : in  sl                               := '0';
+      qPllRxSelect     : in  slv(1 downto 0)                  := "00";
+      qPllTxSelect     : in  slv(1 downto 0)                  := "00";          
       -- AXI-Lite Interface 
       axilClk          : in  sl                               := '0';
       axilRst          : in  sl                               := '0';
@@ -402,6 +404,8 @@ begin
       port map (
          -- GT Clocking
          stableClk        => stableClk,
+         qPllRxSelect     => qPllRxSelect,
+         qPllTxSelect     => qPllTxSelect,         
          gtQPllOutRefClk  => qPllOutRefClk,
          gtQPllOutClk     => qPllOutClk,
          gtQPllLock       => qPllLock,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
@@ -405,12 +405,18 @@ begin
 
    end generate GTP7_CORE_GEN;
 
-   U_RstSync : entity work.RstSync
-      generic map (
-         TPD_G => TPD_G)      
-      port map (
-         clk      => stableClk,
-         asyncRst => axilRst,
-         syncRst  => stableRst);     
+   GEN_RST : if (COMMON_CLK_G = false) generate   
+      U_RstSync : entity work.RstSync
+         generic map (
+            TPD_G => TPD_G)      
+         port map (
+            clk      => stableClk,
+            asyncRst => axilRst,
+            syncRst  => stableRst);     
+   end generate;
+   
+   BYP_RST_SYNC : if (COMMON_CLK_G = true) generate   
+      stableRst <= axilRst; 
+   end generate;      
 
 end rtl;

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
@@ -47,7 +47,8 @@ entity Pgp2bGtp7MultiLane is
       RX_OS_CFG_G           : bit_vector           := "0001111110000";           -- Set by wizard
       RXCDR_CFG_G           : bit_vector           := x"0000107FE206001041010";  -- Set by wizard
       RXLPM_INCM_CFG_G      : bit                  := '1';    -- Set by wizard
-      RXLPM_IPCM_CFG_G      : bit                  := '0';    -- Set by wizard      
+      RXLPM_IPCM_CFG_G      : bit                  := '0';    -- Set by wizard
+      DYNAMIC_QPLL_G        : boolean              := false;      
       TX_PLL_G              : string               := "PLL0";
       RX_PLL_G              : string               := "PLL1";
       -- Configure Buffer usage
@@ -112,6 +113,7 @@ entity Pgp2bGtp7MultiLane is
       txPreCursor      : in  slv(4 downto 0)                                  := (others => '0');
       txPostCursor     : in  slv(4 downto 0)                                  := (others => '0');
       txDiffCtrl       : in  slv(3 downto 0)                                  := "1000";
+      drpOverride      : in  sl                                               := '0';
       -- AXI-Lite Interface 
       axilClk          : in  sl                                               := '0';
       axilRst          : in  sl                                               := '0';
@@ -240,6 +242,7 @@ begin
             RXCDR_CFG_G              => RXCDR_CFG_G,
             RXLPM_INCM_CFG_G         => RXLPM_INCM_CFG_G,
             RXLPM_IPCM_CFG_G         => RXLPM_IPCM_CFG_G,
+            DYNAMIC_QPLL_G           => DYNAMIC_QPLL_G,
             TX_PLL_G                 => TX_PLL_G,
             RX_PLL_G                 => RX_PLL_G,
             TX_EXT_DATA_WIDTH_G      => 16,
@@ -359,6 +362,7 @@ begin
             txPreCursor      => txPreCursor,
             txPostCursor     => txPostCursor,
             txDiffCtrl       => txDiffCtrl,
+            drpOverride      => drpOverride,
             drpGnt           => drpGnt(i),
             drpRdy           => drpRdy(i),
             drpEn            => drpEn(i),

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
@@ -30,6 +30,7 @@ use UNISIM.VCOMPONENTS.all;
 entity Pgp2bGtp7MultiLane is
    generic (
       TPD_G                 : time                 := 1 ns;
+      COMMON_CLK_G          : boolean              := false;-- set true if (stableClk = axilClk)
       ----------------------------------------------------------------------------------------------
       -- GT Settings
       ----------------------------------------------------------------------------------------------
@@ -370,7 +371,7 @@ begin
          generic map (
             TPD_G            => TPD_G,
             AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-            COMMON_CLK_G     => false,
+            COMMON_CLK_G     => COMMON_CLK_G,
             EN_ARBITRATION_G => true,
             TIMEOUT_G        => 4096,
             ADDR_WIDTH_G     => 9,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7MultiLane.vhd
@@ -73,6 +73,8 @@ entity Pgp2bGtp7MultiLane is
    port (
       -- GT Clocking
       stableClk        : in  sl;        -- GT needs a stable clock to "boot up"
+      qPllRxSelect     : in  slv(1 downto 0) := "00";
+      qPllTxSelect     : in  slv(1 downto 0) := "00";          
       gtQPllOutRefClk  : in  slv(1 downto 0);
       gtQPllOutClk     : in  slv(1 downto 0);
       gtQPllLock       : in  slv(1 downto 0);
@@ -318,6 +320,8 @@ begin
             FTS_LANE_DESKEW_EN_G     => "FALSE")       -- Default
          port map (
             stableClkIn      => stableClk,
+            qPllRxSelect     => qPllRxSelect,
+            qPllTxSelect     => qPllTxSelect,            
             qPllRefClkIn     => gtQPllOutRefClk,
             qPllClkIn        => gtQPllOutClk,
             qPllLockIn       => gtQPllLock,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
@@ -44,6 +44,7 @@ entity Pgp2bGtp7VarLat is
       RXCDR_CFG_G           : bit_vector           := x"0000107FE206001041010";  -- Set by wizard
       RXLPM_INCM_CFG_G      : bit                  := '1';    -- Set by wizard
       RXLPM_IPCM_CFG_G      : bit                  := '0';    -- Set by wizard      
+      DYNAMIC_QPLL_G        : boolean              := false;
       TX_PLL_G              : string               := "PLL0";
       RX_PLL_G              : string               := "PLL1";
       -- Configure Buffer usage
@@ -105,6 +106,7 @@ entity Pgp2bGtp7VarLat is
       txPreCursor      : in  slv(4 downto 0)                  := (others => '0');
       txPostCursor     : in  slv(4 downto 0)                  := (others => '0');
       txDiffCtrl       : in  slv(3 downto 0)                  := "1000";
+      drpOverride      : in  sl                               := '0';
       -- AXI-Lite Interface 
       axilClk          : in  sl                               := '0';
       axilRst          : in  sl                               := '0';
@@ -136,6 +138,7 @@ begin
          RXCDR_CFG_G           => RXCDR_CFG_G,
          RXLPM_INCM_CFG_G      => RXLPM_INCM_CFG_G,
          RXLPM_IPCM_CFG_G      => RXLPM_IPCM_CFG_G,
+         DYNAMIC_QPLL_G        => DYNAMIC_QPLL_G,
          TX_PLL_G              => TX_PLL_G,
          RX_PLL_G              => RX_PLL_G,
          -- Configure Buffer usage
@@ -195,6 +198,7 @@ begin
          txPreCursor         => txPreCursor,
          txPostCursor        => txPostCursor,
          txDiffCtrl          => txDiffCtrl,
+         drpOverride         => drpOverride,
          -- AXI-Lite Interface 
          axilClk             => axilClk,
          axilRst             => axilRst,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
@@ -26,6 +26,7 @@ use work.AxiLitePkg.all;
 entity Pgp2bGtp7VarLat is
    generic (
       TPD_G                 : time                 := 1 ns;
+      COMMON_CLK_G          : boolean              := false;-- set true if (stableClk = axilClk)
       ----------------------------------------------------------------------------------------------
       -- GT Settings
       ----------------------------------------------------------------------------------------------
@@ -120,6 +121,7 @@ begin
    MuliLane_Inst : entity work.Pgp2bGtp7MultiLane
       generic map (
          TPD_G                 => TPD_G,
+         COMMON_CLK_G          => COMMON_CLK_G,
          -- SIM Generics
          SIM_GTRESET_SPEEDUP_G => SIM_GTRESET_SPEEDUP_G,
          SIM_VERSION_G         => SIM_VERSION_G,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLat.vhd
@@ -67,6 +67,8 @@ entity Pgp2bGtp7VarLat is
    port (
       -- GT Clocking
       stableClk        : in  sl;        -- GT needs a stable clock to "boot up"
+      qPllRxSelect     : in  slv(1 downto 0) := "00";
+      qPllTxSelect     : in  slv(1 downto 0) := "00";          
       gtQPllOutRefClk  : in  slv(1 downto 0);
       gtQPllOutClk     : in  slv(1 downto 0);
       gtQPllLock       : in  slv(1 downto 0);
@@ -159,6 +161,8 @@ begin
       port map (
          -- GT Clocking
          stableClk           => stableClk,
+         qPllRxSelect        => qPllRxSelect,
+         qPllTxSelect        => qPllTxSelect,         
          gtQPllOutRefClk     => gtQPllOutRefClk,
          gtQPllOutClk        => gtQPllOutClk,
          gtQPllLock          => gtQPllLock,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
@@ -93,6 +93,8 @@ entity Pgp2bGtp7VarLatWrapper is
       txPostCursor    : in  slv(4 downto 0)        := (others => '0');
       txDiffCtrl      : in  slv(3 downto 0)        := "1000";
       drpOverride     : in  sl                     := '0';
+      qPllRxSelect    : in  slv(1 downto 0)        := "00";
+      qPllTxSelect    : in  slv(1 downto 0)        := "00";          
       -- AXI-Lite Interface 
       axilClk         : in  sl                     := '0';
       axilRst         : in  sl                     := '0';
@@ -237,6 +239,8 @@ begin
       port map (
          -- GT Clocking
          stableClk        => stableClock,
+         qPllRxSelect     => qPllRxSelect,
+         qPllTxSelect     => qPllTxSelect,         
          gtQPllOutRefClk  => gtQPllOutRefClk,
          gtQPllOutClk     => gtQPllOutClk,
          gtQPllLock       => gtQPllLock,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
@@ -31,6 +31,7 @@ use unisim.vcomponents.all;
 entity Pgp2bGtp7VarLatWrapper is
    generic (
       TPD_G                : time                    := 1 ns;
+      COMMON_CLK_G         : boolean                 := false;-- set true if (stableClk = axilClk)
       SIMULATION_G         : boolean                 := false;
       -- MMCM Configurations
       CLKIN_PERIOD_G       : real                    := 6.4;
@@ -207,6 +208,7 @@ begin
    Pgp2bGtp7VarLat_Inst : entity work.Pgp2bGtp7VarLat
       generic map (
          TPD_G                 => TPD_G,
+         COMMON_CLK_G          => COMMON_CLK_G,
          SIM_GTRESET_SPEEDUP_G => ite(SIMULATION_G, "TRUE", "FALSE"),
          -- MGT Configurations
          RXOUT_DIV_G           => RXOUT_DIV_G,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7VarLatWrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp2bGtp7VarLatWrapper is
       TPD_G                : time                    := 1 ns;
       COMMON_CLK_G         : boolean                 := false;-- set true if (stableClk = axilClk)
       SIMULATION_G         : boolean                 := false;
+      DYNAMIC_QPLL_G       : boolean                 := false;
       -- MMCM Configurations
       CLKIN_PERIOD_G       : real                    := 6.4;
       DIVCLK_DIVIDE_G      : natural range 1 to 106  := 1;
@@ -91,6 +92,7 @@ entity Pgp2bGtp7VarLatWrapper is
       txPreCursor     : in  slv(4 downto 0)        := (others => '0');
       txPostCursor    : in  slv(4 downto 0)        := (others => '0');
       txDiffCtrl      : in  slv(3 downto 0)        := "1000";
+      drpOverride     : in  sl                     := '0';
       -- AXI-Lite Interface 
       axilClk         : in  sl                     := '0';
       axilRst         : in  sl                     := '0';
@@ -220,6 +222,7 @@ begin
          RXLPM_INCM_CFG_G      => RXLPM_INCM_CFG_G,
          RXLPM_IPCM_CFG_G      => RXLPM_IPCM_CFG_G,
          -- Configure PLL sources
+         DYNAMIC_QPLL_G        => DYNAMIC_QPLL_G,
          TX_PLL_G              => "PLL0",
          RX_PLL_G              => "PLL1",
          -- Configure PGP
@@ -272,6 +275,7 @@ begin
          txPreCursor      => txPreCursor,
          txPostCursor     => txPostCursor,
          txDiffCtrl       => txDiffCtrl,
+         drpOverride      => drpOverride,
          -- AXI-Lite Interface 
          axilClk          => axilClk,
          axilRst          => axilRst,

--- a/python/surf/xilinx/_Gtpe2Channel.py
+++ b/python/surf/xilinx/_Gtpe2Channel.py
@@ -33,7 +33,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ACJTAG_RESET",
             description  = "",
-            offset       =  (0x0000<<4),
+            offset       =  (0x0000<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -43,7 +43,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ACJTAG_DEBUG_MODE",
             description  = "",
-            offset       =  (0x0000<<4),
+            offset       =  (0x0000<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -53,7 +53,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ACJTAG_MODE",
             description  = "",
-            offset       =  (0x0000<<4),
+            offset       =  (0x0000<<2),
             bitSize      =  1,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -63,7 +63,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "UCODEER_CLR",
             description  = "",
-            offset       =  (0x0000<<4),
+            offset       =  (0x0000<<2),
             bitSize      =  1,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -73,7 +73,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUFRESET_TIME",
             description  = "",
-            offset       =  (0x000C<<4),
+            offset       =  (0x000C<<2),
             bitSize      =  5,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -83,7 +83,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDRPHRESET_TIME",
             description  = "",
-            offset       =  (0x000D<<4),
+            offset       =  (0x000D<<2),
             bitSize      =  5,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -93,7 +93,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDRFREQRESET_TIME",
             description  = "",
-            offset       =  (0x000D<<4),
+            offset       =  (0x000D<<2),
             bitSize      =  5,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -103,7 +103,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPMARESET_TIME",
             description  = "",
-            offset       =  (0x000D<<4),
+            offset       =  (0x000D<<2),
             bitSize      =  5,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -113,7 +113,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPCSRESET_TIME",
             description  = "",
-            offset       =  (0x000E<<4),
+            offset       =  (0x000E<<2),
             bitSize      =  5,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -123,7 +123,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPMRESET_TIME",
             description  = "",
-            offset       =  (0x000E<<4),
+            offset       =  (0x000E<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -133,7 +133,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXISCANRESET_TIME",
             description  = "",
-            offset       =  (0x000F<<4),
+            offset       =  (0x000F<<2),
             bitSize      =  5,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -143,7 +143,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXSYNC_OVRD",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -153,7 +153,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXSYNC_OVRD",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -163,7 +163,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXSYNC_SKIP_DA",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -173,7 +173,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXSYNC_SKIP_DA",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -183,7 +183,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXSYNC_MULTILANE",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -193,7 +193,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXSYNC_MULTILANE",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  1,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -203,7 +203,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPCSRESET_TIME",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  5,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -213,7 +213,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPMARESET_TIME",
             description  = "",
-            offset       =  (0x0010<<4),
+            offset       =  (0x0010<<2),
             bitSize      =  5,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -223,7 +223,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_XCLK_SEL",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -233,7 +233,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_DATA_WIDTH",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  3,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -243,7 +243,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_CLK25_DIV",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  5,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -253,7 +253,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_CM_SEL",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  2,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -263,7 +263,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPRBS_ERR_LOOPBACK",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -273,7 +273,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_BURST_SEQ_LEN",
             description  = "",
-            offset       =  (0x0012<<4),
+            offset       =  (0x0012<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -283,7 +283,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "OUTREFCLK_SEL_INV",
             description  = "",
-            offset       =  (0x0012<<4),
+            offset       =  (0x0012<<2),
             bitSize      =  2,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -293,7 +293,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_BURST_VAL",
             description  = "",
-            offset       =  (0x0012<<4),
+            offset       =  (0x0012<<2),
             bitSize      =  3,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -303,7 +303,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXOOB_CFG",
             description  = "",
-            offset       =  (0x0012<<4),
+            offset       =  (0x0012<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -313,7 +313,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SAS_MIN_COM",
             description  = "",
-            offset       =  (0x0013<<4),
+            offset       =  (0x0013<<2),
             bitSize      =  6,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -323,7 +323,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MIN_BURST",
             description  = "",
-            offset       =  (0x0013<<4),
+            offset       =  (0x0013<<2),
             bitSize      =  6,
             bitOffset    =  3,
             base         = pr.UInt,
@@ -333,7 +333,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_EIDLE_VAL",
             description  = "",
-            offset       =  (0x0013<<4),
+            offset       =  (0x0013<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -343,7 +343,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MIN_WAKE",
             description  = "",
-            offset       =  (0x0014<<4),
+            offset       =  (0x0014<<2),
             bitSize      =  6,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -353,7 +353,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MIN_INIT",
             description  = "",
-            offset       =  (0x0014<<4),
+            offset       =  (0x0014<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -363,7 +363,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SAS_MAX_COM",
             description  = "",
-            offset       =  (0x0015<<4),
+            offset       =  (0x0015<<2),
             bitSize      =  7,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -373,7 +373,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MAX_BURST",
             description  = "",
-            offset       =  (0x0015<<4),
+            offset       =  (0x0015<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -383,7 +383,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MAX_WAKE",
             description  = "",
-            offset       =  (0x0016<<4),
+            offset       =  (0x0016<<2),
             bitSize      =  6,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -393,7 +393,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_MAX_INIT",
             description  = "",
-            offset       =  (0x0016<<4),
+            offset       =  (0x0016<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -403,7 +403,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXOSCALRESET_TIMEOUT",
             description  = "",
-            offset       =  (0x0017<<4),
+            offset       =  (0x0017<<2),
             bitSize      =  5,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -413,7 +413,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXOSCALRESET_TIME",
             description  = "",
-            offset       =  (0x0017<<4),
+            offset       =  (0x0017<<2),
             bitSize      =  5,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -423,7 +423,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TRANS_TIME_RATE",
             description  = "",
-            offset       =  (0x0018<<4),
+            offset       =  (0x0018<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -433,7 +433,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_LOOPBACK_CFG",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -443,7 +443,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_PREDRIVER_MODE",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -453,7 +453,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_EIDLE_DEASSERT_DELAY",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  3,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -463,7 +463,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_EIDLE_ASSERT_DELAY",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  3,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -473,7 +473,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_LOOPBACK_DRIVE_HIZ",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  1,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -483,7 +483,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_DRIVE_MODE",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  5,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -493,7 +493,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PD_TRANS_TIME_TO_P2",
             description  = "",
-            offset       =  (0x001A<<4),
+            offset       =  (0x001A<<2),
             bitSize      =  8,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -503,7 +503,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PD_TRANS_TIME_NONE_P2",
             description  = "",
-            offset       =  (0x001A<<4),
+            offset       =  (0x001A<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -513,7 +513,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PD_TRANS_TIME_FROM_P2",
             description  = "",
-            offset       =  (0x001B<<4),
+            offset       =  (0x001B<<2),
             bitSize      =  12,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -523,7 +523,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PCS_PCIE_EN",
             description  = "",
-            offset       =  (0x001B<<4),
+            offset       =  (0x001B<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -533,7 +533,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(  
             name         = "TXBUF_RESET_ON_RATE_CHANGE",
             description  = "",
-            offset       =  (0x001C<<4),
+            offset       =  (0x001C<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -543,7 +543,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXBUF_EN",
             description  = "",
-            offset       =  (0x001C<<4),
+            offset       =  (0x001C<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -553,7 +553,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXGEARBOX_EN",
             description  = "",
-            offset       =  (0x001C<<4),
+            offset       =  (0x001C<<2),
             bitSize      =  1,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -563,7 +563,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "GEARBOX_MODE",
             description  = "",
-            offset       =  (0x001C<<4),
+            offset       =  (0x001C<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -573,7 +573,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_HOLD_DURING_EIDLE",
             description  = "",
-            offset       =  (0x001E<<4),
+            offset       =  (0x001E<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -583,7 +583,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_OS_CFG",
             description  = "",
-            offset       =  (0x0024<<4),
+            offset       =  (0x0024<<2),
             bitSize      =  13,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -593,7 +593,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_LF_CFG_WRD1",
             description  = "",
-            offset       =  (0x002A<<4),
+            offset       =  (0x002A<<2),
             bitSize      =  2,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -603,7 +603,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_HF_CFG",
             description  = "",
-            offset       =  (0x002A<<4),
+            offset       =  (0x002A<<2),
             bitSize      =  14,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -613,7 +613,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_LF_CFG_WRD0",
             description  = "",
-            offset       =  (0x002B<<4),
+            offset       =  (0x002B<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -623,7 +623,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_QUALIFIER_WRD0",
             description  = "",
-            offset       =  (0x002C<<4),
+            offset       =  (0x002C<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -633,7 +633,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_QUALIFIER_WRD1",
             description  = "",
-            offset       =  (0x002D<<4),
+            offset       =  (0x002D<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -643,7 +643,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_QUALIFIER_WRD2",
             description  = "",
-            offset       =  (0x002E<<4),
+            offset       =  (0x002E<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -653,7 +653,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_QUALIFIER_WRD3",
             description  = "",
-            offset       =  (0x002F<<4),
+            offset       =  (0x002F<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -663,7 +663,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_QUALIFIER_WRD4",
             description  = "",
-            offset       =  (0x0030<<4),
+            offset       =  (0x0030<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -673,7 +673,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_SDATA_MASK_WRD0",
             description  = "",
-            offset       =  (0x0036<<4),
+            offset       =  (0x0036<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -683,7 +683,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_SDATA_MASK_WRD1",
             description  = "",
-            offset       =  (0x0037<<4),
+            offset       =  (0x0037<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -693,7 +693,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_SDATA_MASK_WRD2",
             description  = "",
-            offset       =  (0x0038<<4),
+            offset       =  (0x0038<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -703,7 +703,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_SDATA_MASK_WRD3",
             description  = "",
-            offset       =  (0x0039<<4),
+            offset       =  (0x0039<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -713,7 +713,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_SDATA_MASK_WRD4",
             description  = "",
-            offset       =  (0x003A<<4),
+            offset       =  (0x003A<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -723,7 +723,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_PRESCALE",
             description  = "",
-            offset       =  (0x003B<<4),
+            offset       =  (0x003B<<2),
             bitSize      =  5,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -733,7 +733,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_VERT_OFFSET",
             description  = "",
-            offset       =  (0x003B<<4),
+            offset       =  (0x003B<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -743,7 +743,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_HORZ_OFFSET",
             description  = "",
-            offset       =  (0x003C<<4),
+            offset       =  (0x003C<<2),
             bitSize      =  12,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -753,7 +753,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_DISPERR_SEQ_MATCH",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -763,7 +763,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "DEC_PCOMMA_DETECT",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -773,7 +773,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "DEC_MCOMMA_DETECT",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -783,7 +783,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "DEC_VALID_COMMA_ONLY",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -793,7 +793,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_ERRDET_EN",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -803,7 +803,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_EYE_SCAN_EN",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  1,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -813,7 +813,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_CONTROL",
             description  = "",
-            offset       =  (0x003D<<4),
+            offset       =  (0x003D<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -823,7 +823,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_COMMA_ENABLE",
             description  = "",
-            offset       =  (0x003E<<4),
+            offset       =  (0x003E<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -833,7 +833,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_MCOMMA_VALUE",
             description  = "",
-            offset       =  (0x003F<<4),
+            offset       =  (0x003F<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -843,7 +843,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXSLIDE_MODE",
             description  = "",
-            offset       =  (0x0040<<4),
+            offset       =  (0x0040<<2),
             bitSize      =  2,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -853,7 +853,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_PCOMMA_VALUE",
             description  = "",
-            offset       =  (0x0040<<4),
+            offset       =  (0x0040<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -863,7 +863,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_COMMA_WORD",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  2,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -873,7 +873,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_SIG_VALID_DLY",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  5,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -883,7 +883,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_PCOMMA_DET",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -893,7 +893,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_MCOMMA_DET",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  1,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -903,7 +903,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SHOW_REALIGN_COMMA",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  1,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -913,7 +913,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ALIGN_COMMA_DOUBLE",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  1,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -923,7 +923,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXSLIDE_AUTO_WAIT",
             description  = "",
-            offset       =  (0x0041<<4),
+            offset       =  (0x0041<<2),
             bitSize      =  4,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -933,7 +933,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_CORRECT_USE",
             description  = "",
-            offset       =  (0x0044<<4),
+            offset       =  (0x0044<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -943,7 +943,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_1_ENABLE",
             description  = "",
-            offset       =  (0x0044<<4),
+            offset       =  (0x0044<<2),
             bitSize      =  4,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -953,7 +953,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_1_1",
             description  = "",
-            offset       =  (0x0044<<4),
+            offset       =  (0x0044<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -963,7 +963,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_MAX_LAT",
             description  = "",
-            offset       =  (0x0045<<4),
+            offset       =  (0x0045<<2),
             bitSize      =  6,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -973,7 +973,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_1_2",
             description  = "",
-            offset       =  (0x0045<<4),
+            offset       =  (0x0045<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -983,7 +983,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_MIN_LAT",
             description  = "",
-            offset       =  (0x0046<<4),
+            offset       =  (0x0046<<2),
             bitSize      =  6,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -993,7 +993,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_1_3",
             description  = "",
-            offset       =  (0x0046<<4),
+            offset       =  (0x0046<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1003,7 +1003,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_REPEAT_WAIT",
             description  = "",
-            offset       =  (0x0047<<4),
+            offset       =  (0x0047<<2),
             bitSize      =  5,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -1013,7 +1013,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_1_4",
             description  = "",
-            offset       =  (0x0047<<4),
+            offset       =  (0x0047<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1023,7 +1023,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_USE",
             description  = "",
-            offset       =  (0x0048<<4),
+            offset       =  (0x0048<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -1033,7 +1033,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_ENABLE",
             description  = "",
-            offset       =  (0x0048<<4),
+            offset       =  (0x0048<<2),
             bitSize      =  4,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -1043,7 +1043,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_1",
             description  = "",
-            offset       =  (0x0048<<4),
+            offset       =  (0x0048<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1053,7 +1053,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_KEEP_IDLE",
             description  = "",
-            offset       =  (0x0049<<4),
+            offset       =  (0x0049<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -1063,7 +1063,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_PRECEDENCE",
             description  = "",
-            offset       =  (0x0049<<4),
+            offset       =  (0x0049<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1073,7 +1073,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_LEN",
             description  = "",
-            offset       =  (0x0049<<4),
+            offset       =  (0x0049<<2),
             bitSize      =  2,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -1083,7 +1083,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_2",
             description  = "",
-            offset       =  (0x0049<<4),
+            offset       =  (0x0049<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1093,7 +1093,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_3",
             description  = "",
-            offset       =  (0x004A<<4),
+            offset       =  (0x004A<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1103,7 +1103,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXGEARBOX_EN",
             description  = "",
-            offset       =  (0x004B<<4),
+            offset       =  (0x004B<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1113,7 +1113,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COR_SEQ_2_4",
             description  = "",
-            offset       =  (0x004B<<4),
+            offset       =  (0x004B<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1123,7 +1123,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_1_ENABLE",
             description  = "",
-            offset       =  (0x004C<<4),
+            offset       =  (0x004C<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1133,7 +1133,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_1_1",
             description  = "",
-            offset       =  (0x004C<<4),
+            offset       =  (0x004C<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1143,7 +1143,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_LEN",
             description  = "",
-            offset       =  (0x004D<<4),
+            offset       =  (0x004D<<2),
             bitSize      =  2,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -1153,7 +1153,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_1_2",
             description  = "",
-            offset       =  (0x004D<<4),
+            offset       =  (0x004D<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1163,7 +1163,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_KEEP_ALIGN",
             description  = "",
-            offset       =  (0x004E<<4),
+            offset       =  (0x004E<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1173,7 +1173,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_1_3",
             description  = "",
-            offset       =  (0x004E<<4),
+            offset       =  (0x004E<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1183,7 +1183,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_1_4",
             description  = "",
-            offset       =  (0x004F<<4),
+            offset       =  (0x004F<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1193,7 +1193,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_ENABLE",
             description  = "",
-            offset       =  (0x0050<<4),
+            offset       =  (0x0050<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1203,7 +1203,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_USE",
             description  = "",
-            offset       =  (0x0050<<4),
+            offset       =  (0x0050<<2),
             bitSize      =  1,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -1213,7 +1213,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_1",
             description  = "",
-            offset       =  (0x0050<<4),
+            offset       =  (0x0050<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1223,7 +1223,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "FTS_LANE_DESKEW_CFG",
             description  = "",
-            offset       =  (0x0051<<4),
+            offset       =  (0x0051<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1233,7 +1233,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "FTS_LANE_DESKEW_EN",
             description  = "",
-            offset       =  (0x0051<<4),
+            offset       =  (0x0051<<2),
             bitSize      =  1,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -1243,7 +1243,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_2",
             description  = "",
-            offset       =  (0x0051<<4),
+            offset       =  (0x0051<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1253,7 +1253,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "FTS_DESKEW_SEQ_ENABLE",
             description  = "",
-            offset       =  (0x0052<<4),
+            offset       =  (0x0052<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1263,7 +1263,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CBCC_DATA_SOURCE_SEL",
             description  = "",
-            offset       =  (0x0052<<4),
+            offset       =  (0x0052<<2),
             bitSize      =  1,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -1273,7 +1273,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_3",
             description  = "",
-            offset       =  (0x0052<<4),
+            offset       =  (0x0052<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1283,7 +1283,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_MAX_SKEW",
             description  = "",
-            offset       =  (0x0053<<4),
+            offset       =  (0x0053<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -1293,7 +1293,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CHAN_BOND_SEQ_2_4",
             description  = "",
-            offset       =  (0x0053<<4),
+            offset       =  (0x0053<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1303,7 +1303,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXDLY_TAP_CFG",
             description  = "",
-            offset       =  (0x0054<<4),
+            offset       =  (0x0054<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1313,7 +1313,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXDLY_CFG",
             description  = "",
-            offset       =  (0x0055<<4),
+            offset       =  (0x0055<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1323,7 +1323,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPH_MONITOR_SEL",
             description  = "",
-            offset       =  (0x0057<<4),
+            offset       =  (0x0057<<2),
             bitSize      =  5,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1333,7 +1333,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_DDI_SEL",
             description  = "",
-            offset       =  (0x0057<<4),
+            offset       =  (0x0057<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1343,7 +1343,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_XCLK_SEL",
             description  = "",
-            offset       =  (0x0059<<4),
+            offset       =  (0x0059<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -1353,7 +1353,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_EN",
             description  = "",
-            offset       =  (0x0059<<4),
+            offset       =  (0x0059<<2),
             bitSize      =  1,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -1363,7 +1363,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXOOB_CFG",
             description  = "",
-            offset       =  (0x005A<<4),
+            offset       =  (0x005A<<2),
             bitSize      =  1,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -1373,7 +1373,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "LOOPBACK_CFG",
             description  = "",
-            offset       =  (0x005A<<4),
+            offset       =  (0x005A<<2),
             bitSize      =  1,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1383,7 +1383,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG5",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  3,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1393,7 +1393,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG4",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -1403,7 +1403,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG3",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  1,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -1413,7 +1413,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG2",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  2,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -1423,7 +1423,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG1",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  2,
             bitOffset    =  2,
             base         = pr.UInt,
@@ -1433,7 +1433,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_CFG0",
             description  = "",
-            offset       =  (0x005D<<4),
+            offset       =  (0x005D<<2),
             bitSize      =  2,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1443,7 +1443,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "SATA_PLL_CFG",
             description  = "",
-            offset       =  (0x005E<<4),
+            offset       =  (0x005E<<2),
             bitSize      =  2,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -1453,7 +1453,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPHDLY_CFG_WRD0",
             description  = "",
-            offset       =  (0x0060<<4),
+            offset       =  (0x0060<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1463,7 +1463,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPHDLY_CFG_WRD1",
             description  = "",
-            offset       =  (0x0061<<4),
+            offset       =  (0x0061<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1473,7 +1473,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXDLY_CFG",
             description  = "",
-            offset       =  (0x0062<<4),
+            offset       =  (0x0062<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1483,7 +1483,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXDLY_TAP_CFG",
             description  = "",
-            offset       =  (0x0063<<4),
+            offset       =  (0x0063<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1493,7 +1493,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPH_CFG",
             description  = "",
-            offset       =  (0x0064<<4),
+            offset       =  (0x0064<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1503,7 +1503,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPH_MONITOR_SEL",
             description  = "",
-            offset       =  (0x0065<<4),
+            offset       =  (0x0065<<2),
             bitSize      =  5,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1513,7 +1513,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_BIAS_CFG",
             description  = "",
-            offset       =  (0x0066<<4),
+            offset       =  (0x0066<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1523,7 +1523,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXOOB_CLK_CFG",
             description  = "",
-            offset       =  (0x0068<<4),
+            offset       =  (0x0068<<2),
             bitSize      =  1,
             bitOffset    =  3,
             base         = pr.UInt,
@@ -1533,7 +1533,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_CLKMUX_EN",
             description  = "",
-            offset       =  (0x0068<<4),
+            offset       =  (0x0068<<2),
             bitSize      =  1,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -1543,7 +1543,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_CLKMUX_EN",
             description  = "",
-            offset       =  (0x0068<<4),
+            offset       =  (0x0068<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1553,7 +1553,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TERM_RCAL_CFG",
             description  = "",
-            offset       =  (0x0069<<4),
+            offset       =  (0x0069<<2),
             bitSize      =  15,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1563,7 +1563,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TERM_RCAL_OVRD",
             description  = "",
-            offset       =  (0x006A<<4),
+            offset       =  (0x006A<<2),
             bitSize      =  3,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -1573,7 +1573,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_CLK25_DIV",
             description  = "",
-            offset       =  (0x006A<<4),
+            offset       =  (0x006A<<2),
             bitSize      =  5,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1583,7 +1583,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV5",
             description  = "",
-            offset       =  (0x006B<<4),
+            offset       =  (0x006B<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1593,7 +1593,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV4",
             description  = "",
-            offset       =  (0x006B<<4),
+            offset       =  (0x006B<<2),
             bitSize      =  4,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1603,7 +1603,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_DATA_WIDTH",
             description  = "",
-            offset       =  (0x006B<<4),
+            offset       =  (0x006B<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1613,7 +1613,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PCS_RSVD_ATTR_WRD0",
             description  = "",
-            offset       =  (0x006F<<4),
+            offset       =  (0x006F<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1623,7 +1623,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PCS_RSVD_ATTR_WRD1",
             description  = "",
-            offset       =  (0x0070<<4),
+            offset       =  (0x0070<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1633,7 +1633,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PCS_RSVD_ATTR_WRD2",
             description  = "",
-            offset       =  (0x0071<<4),
+            offset       =  (0x0071<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1643,7 +1643,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_FULL_1",
             description  = "",
-            offset       =  (0x0075<<4),
+            offset       =  (0x0075<<2),
             bitSize      =  7,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1653,7 +1653,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_FULL_0",
             description  = "",
-            offset       =  (0x0075<<4),
+            offset       =  (0x0075<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1663,7 +1663,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_FULL_3",
             description  = "",
-            offset       =  (0x0076<<4),
+            offset       =  (0x0076<<2),
             bitSize      =  7,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1673,7 +1673,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_FULL_2",
             description  = "",
-            offset       =  (0x0076<<4),
+            offset       =  (0x0076<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1683,7 +1683,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_LOW_0",
             description  = "",
-            offset       =  (0x0077<<4),
+            offset       =  (0x0077<<2),
             bitSize      =  7,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1693,7 +1693,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_FULL_4",
             description  = "",
-            offset       =  (0x0077<<4),
+            offset       =  (0x0077<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1703,7 +1703,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_LOW_2",
             description  = "",
-            offset       =  (0x0078<<4),
+            offset       =  (0x0078<<2),
             bitSize      =  7,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1713,7 +1713,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_LOW_1",
             description  = "",
-            offset       =  (0x0078<<4),
+            offset       =  (0x0078<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1723,7 +1723,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_LOW_4",
             description  = "",
-            offset       =  (0x0079<<4),
+            offset       =  (0x0079<<2),
             bitSize      =  7,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1733,7 +1733,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MARGIN_LOW_3",
             description  = "",
-            offset       =  (0x0079<<4),
+            offset       =  (0x0079<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1743,7 +1743,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_DEEMPH1",
             description  = "",
-            offset       =  (0x007A<<4),
+            offset       =  (0x007A<<2),
             bitSize      =  6,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1753,7 +1753,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_DEEMPH0",
             description  = "",
-            offset       =  (0x007A<<4),
+            offset       =  (0x007A<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1763,7 +1763,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_RXDETECT_REF",
             description  = "",
-            offset       =  (0x007C<<4),
+            offset       =  (0x007C<<2),
             bitSize      =  3,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -1773,7 +1773,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_MAINCURSOR_SEL",
             description  = "",
-            offset       =  (0x007C<<4),
+            offset       =  (0x007C<<2),
             bitSize      =  1,
             bitOffset    =  3,
             base         = pr.UInt,
@@ -1783,7 +1783,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV3",
             description  = "",
-            offset       =  (0x007C<<4),
+            offset       =  (0x007C<<2),
             bitSize      =  2,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1793,7 +1793,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV7",
             description  = "",
-            offset       =  (0x007D<<4),
+            offset       =  (0x007D<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1803,7 +1803,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV6",
             description  = "",
-            offset       =  (0x007D<<4),
+            offset       =  (0x007D<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -1813,7 +1813,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TX_RXDETECT_CFG",
             description  = "",
-            offset       =  (0x007D<<4),
+            offset       =  (0x007D<<2),
             bitSize      =  14,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1823,7 +1823,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CLK_COMMON_SWING",
             description  = "",
-            offset       =  (0x007E<<4),
+            offset       =  (0x007E<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1833,7 +1833,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_CM_TRIM",
             description  = "",
-            offset       =  (0x007E<<4),
+            offset       =  (0x007E<<2),
             bitSize      =  4,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1843,7 +1843,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_CFG1",
             description  = "",
-            offset       =  (0x0081<<4),
+            offset       =  (0x0081<<2),
             bitSize      =  1,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -1853,7 +1853,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_CFG",
             description  = "",
-            offset       =  (0x0081<<4),
+            offset       =  (0x0081<<2),
             bitSize      =  4,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1863,7 +1863,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV2_WRD0",
             description  = "",
-            offset       =  (0x0082<<4),
+            offset       =  (0x0082<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1873,7 +1873,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV2_WRD1",
             description  = "",
-            offset       =  (0x0083<<4),
+            offset       =  (0x0083<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1883,7 +1883,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "DMONITOR_CFG_WRD0",
             description  = "",
-            offset       =  (0x0086<<4),
+            offset       =  (0x0086<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1893,7 +1893,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "DMONITOR_CFG_WRD1",
             description  = "",
-            offset       =  (0x0087<<4),
+            offset       =  (0x0087<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1903,7 +1903,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_BIAS_STARTUP_DISABLE",
             description  = "",
-            offset       =  (0x0088<<4),
+            offset       =  (0x0088<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -1913,7 +1913,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_HF_CFG3",
             description  = "",
-            offset       =  (0x0088<<4),
+            offset       =  (0x0088<<2),
             bitSize      =  4,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -1923,7 +1923,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXOUT_DIV",
             description  = "",
-            offset       =  (0x0088<<4),
+            offset       =  (0x0088<<2),
             bitSize      =  3,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -1933,7 +1933,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXOUT_DIV",
             description  = "",
-            offset       =  (0x0088<<4),
+            offset       =  (0x0088<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1943,7 +1943,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG_WRD0",
             description  = "",
-            offset       =  (0x0089<<4),
+            offset       =  (0x0089<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1953,7 +1953,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG_WRD1",
             description  = "",
-            offset       =  (0x008A<<4),
+            offset       =  (0x008A<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1963,7 +1963,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG_WRD2",
             description  = "",
-            offset       =  (0x008B<<4),
+            offset       =  (0x008B<<2),
             bitSize      =  11,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1973,7 +1973,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG3",
             description  = "",
-            offset       =  (0x008C<<4),
+            offset       =  (0x008C<<2),
             bitSize      =  7,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -1983,7 +1983,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPI_CFG0",
             description  = "",
-            offset       =  (0x008D<<4),
+            offset       =  (0x008D<<2),
             bitSize      =  3,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -1993,7 +1993,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_CM_CFG",
             description  = "",
-            offset       =  (0x008D<<4),
+            offset       =  (0x008D<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -2003,7 +2003,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG5",
             description  = "",
-            offset       =  (0x008D<<4),
+            offset       =  (0x008D<<2),
             bitSize      =  2,
             bitOffset    =  10,
             base         = pr.UInt,
@@ -2013,7 +2013,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_LF_CFG2",
             description  = "",
-            offset       =  (0x008D<<4),
+            offset       =  (0x008D<<2),
             bitSize      =  5,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -2023,7 +2023,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_HF_CFG2",
             description  = "",
-            offset       =  (0x008D<<4),
+            offset       =  (0x008D<<2),
             bitSize      =  5,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2033,7 +2033,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_IPCM_CFG",
             description  = "",
-            offset       =  (0x008E<<4),
+            offset       =  (0x008E<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -2043,7 +2043,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_INCM_CFG",
             description  = "",
-            offset       =  (0x008E<<4),
+            offset       =  (0x008E<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -2053,7 +2053,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG4",
             description  = "",
-            offset       =  (0x008E<<4),
+            offset       =  (0x008E<<2),
             bitSize      =  1,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -2063,7 +2063,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG6",
             description  = "",
-            offset       =  (0x008E<<4),
+            offset       =  (0x008E<<2),
             bitSize      =  4,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -2073,7 +2073,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_GC_CFG",
             description  = "",
-            offset       =  (0x008E<<4),
+            offset       =  (0x008E<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2083,7 +2083,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_GC_CFG2",
             description  = "",
-            offset       =  (0x008F<<4),
+            offset       =  (0x008F<<2),
             bitSize      =  3,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -2093,7 +2093,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPI_CFG1",
             description  = "",
-            offset       =  (0x008F<<4),
+            offset       =  (0x008F<<2),
             bitSize      =  1,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -2103,7 +2103,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPI_CFG2",
             description  = "",
-            offset       =  (0x008F<<4),
+            offset       =  (0x008F<<2),
             bitSize      =  1,
             bitOffset    =  3,
             base         = pr.UInt,
@@ -2113,7 +2113,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXLPM_OSINT_CFG",
             description  = "",
-            offset       =  (0x008F<<4),
+            offset       =  (0x008F<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2123,7 +2123,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_CLK_PHASE_SEL",
             description  = "",
-            offset       =  (0x0091<<4),
+            offset       =  (0x0091<<2),
             bitSize      =  1,
             bitOffset    =  15,
             base         = pr.UInt,
@@ -2133,7 +2133,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "USE_PCS_CLK_PHASE_SEL",
             description  = "",
-            offset       =  (0x0091<<4),
+            offset       =  (0x0091<<2),
             bitSize      =  1,
             bitOffset    =  14,
             base         = pr.UInt,
@@ -2143,7 +2143,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "CFOK_CFG2",
             description  = "",
-            offset       =  (0x0091<<4),
+            offset       =  (0x0091<<2),
             bitSize      =  7,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -2153,7 +2153,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ADAPT_CFG0_WRD0",
             description  = "",
-            offset       =  (0x0092<<4),
+            offset       =  (0x0092<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2163,7 +2163,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ADAPT_CFG0_WRD1",
             description  = "",
-            offset       =  (0x0093<<4),
+            offset       =  (0x0093<<2),
             bitSize      =  4,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2173,7 +2173,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_PPM_CFG",
             description  = "",
-            offset       =  (0x0095<<4),
+            offset       =  (0x0095<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2183,7 +2183,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_GREY_SEL",
             description  = "",
-            offset       =  (0x0096<<4),
+            offset       =  (0x0096<<2),
             bitSize      =  1,
             bitOffset    =  5,
             base         = pr.UInt,
@@ -2193,7 +2193,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_INVSTROBE_SEL",
             description  = "",
-            offset       =  (0x0096<<4),
+            offset       =  (0x0096<<2),
             bitSize      =  1,
             bitOffset    =  4,
             base         = pr.UInt,
@@ -2203,7 +2203,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_PPMCLK_SEL",
             description  = "",
-            offset       =  (0x0096<<4),
+            offset       =  (0x0096<<2),
             bitSize      =  1,
             bitOffset    =  3,
             base         = pr.UInt,
@@ -2213,7 +2213,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXPI_SYNFREQ_PPM",
             description  = "",
-            offset       =  (0x0096<<4),
+            offset       =  (0x0096<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2223,7 +2223,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TST_RSV_WRD0",
             description  = "",
-            offset       =  (0x0097<<4),
+            offset       =  (0x0097<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2233,7 +2233,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TST_RSV_WRD1",
             description  = "",
-            offset       =  (0x0098<<4),
+            offset       =  (0x0098<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2243,7 +2243,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV_WRD0",
             description  = "",
-            offset       =  (0x0099<<4),
+            offset       =  (0x0099<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2253,7 +2253,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PMA_RSV_WRD1",
             description  = "",
-            offset       =  (0x009A<<4),
+            offset       =  (0x009A<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2263,7 +2263,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_BUFFER_CFG",
             description  = "",
-            offset       =  (0x009B<<4),
+            offset       =  (0x009B<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2273,7 +2273,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_THRESH_OVRD",
             description  = "",
-            offset       =  (0x009C<<4),
+            offset       =  (0x009C<<2),
             bitSize      =  1,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -2283,7 +2283,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_RESET_ON_EIDLE",
             description  = "",
-            offset       =  (0x009C<<4),
+            offset       =  (0x009C<<2),
             bitSize      =  1,
             bitOffset    =  6,
             base         = pr.UInt,
@@ -2293,7 +2293,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_THRESH_UNDFLW",
             description  = "",
-            offset       =  (0x009C<<4),
+            offset       =  (0x009C<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2303,7 +2303,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_EIDLE_HI_CNT",
             description  = "",
-            offset       =  (0x009D<<4),
+            offset       =  (0x009D<<2),
             bitSize      =  4,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -2313,7 +2313,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_EIDLE_LO_CNT",
             description  = "",
-            offset       =  (0x009D<<4),
+            offset       =  (0x009D<<2),
             bitSize      =  4,
             bitOffset    =  8,
             base         = pr.UInt,
@@ -2323,7 +2323,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_ADDR_MODE",
             description  = "",
-            offset       =  (0x009D<<4),
+            offset       =  (0x009D<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -2333,7 +2333,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_THRESH_OVFLW",
             description  = "",
-            offset       =  (0x009D<<4),
+            offset       =  (0x009D<<2),
             bitSize      =  6,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -2343,7 +2343,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_DEFER_RESET_BUF_EN",
             description  = "",
-            offset       =  (0x009D<<4),
+            offset       =  (0x009D<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2353,7 +2353,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_RESET_ON_COMMAALIGN",
             description  = "",
-            offset       =  (0x009E<<4),
+            offset       =  (0x009E<<2),
             bitSize      =  1,
             bitOffset    =  2,
             base         = pr.UInt,
@@ -2363,7 +2363,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_RESET_ON_RATE_CHANGE",
             description  = "",
-            offset       =  (0x009E<<4),
+            offset       =  (0x009E<<2),
             bitSize      =  1,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -2373,7 +2373,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXBUF_RESET_ON_CB_CHANGE",
             description  = "",
-            offset       =  (0x009E<<4),
+            offset       =  (0x009E<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2383,7 +2383,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "TXDLY_LCFG",
             description  = "",
-            offset       =  (0x009F<<4),
+            offset       =  (0x009F<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2393,7 +2393,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXDLY_LCFG",
             description  = "",
-            offset       =  (0x00A0<<4),
+            offset       =  (0x00A0<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2403,7 +2403,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPH_CFG_WRD0",
             description  = "",
-            offset       =  (0x00A1<<4),
+            offset       =  (0x00A1<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2413,7 +2413,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPH_CFG_WRD1",
             description  = "",
-            offset       =  (0x00A2<<4),
+            offset       =  (0x00A2<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2423,7 +2423,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPHDLY_CFG_WRD0",
             description  = "",
-            offset       =  (0x00A3<<4),
+            offset       =  (0x00A3<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2433,7 +2433,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXPHDLY_CFG_WRD1",
             description  = "",
-            offset       =  (0x00A4<<4),
+            offset       =  (0x00A4<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2443,7 +2443,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RX_DEBUG_CFG",
             description  = "",
-            offset       =  (0x00A5<<4),
+            offset       =  (0x00A5<<2),
             bitSize      =  14,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2453,7 +2453,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "ES_PMA_CFG",
             description  = "",
-            offset       =  (0x00A6<<4),
+            offset       =  (0x00A6<<2),
             bitSize      =  10,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2463,7 +2463,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_PH_RESET_ON_EIDLE",
             description  = "",
-            offset       =  (0x00A7<<4),
+            offset       =  (0x00A7<<2),
             bitSize      =  1,
             bitOffset    =  13,
             base         = pr.UInt,
@@ -2473,7 +2473,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_FR_RESET_ON_EIDLE",
             description  = "",
-            offset       =  (0x00A7<<4),
+            offset       =  (0x00A7<<2),
             bitSize      =  1,
             bitOffset    =  12,
             base         = pr.UInt,
@@ -2483,7 +2483,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_HOLD_DURING_EIDLE",
             description  = "",
-            offset       =  (0x00A7<<4),
+            offset       =  (0x00A7<<2),
             bitSize      =  1,
             bitOffset    =  11,
             base         = pr.UInt,
@@ -2493,7 +2493,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_LOCK_CFG",
             description  = "",
-            offset       =  (0x00A7<<4),
+            offset       =  (0x00A7<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2503,7 +2503,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD0",
             description  = "",
-            offset       =  (0x00A8<<4),
+            offset       =  (0x00A8<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2513,7 +2513,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD1",
             description  = "",
-            offset       =  (0x00A9<<4),
+            offset       =  (0x00A9<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2523,7 +2523,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD2",
             description  = "",
-            offset       =  (0x00AA<<4),
+            offset       =  (0x00AA<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2533,7 +2533,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD3",
             description  = "",
-            offset       =  (0x00AB<<4),
+            offset       =  (0x00AB<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2543,7 +2543,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD4",
             description  = "",
-            offset       =  (0x00AC<<4),
+            offset       =  (0x00AC<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -2553,7 +2553,7 @@ class Gtpe2Channel(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RXCDR_CFG_WRD5",
             description  = "",
-            offset       =  (0x00AD<<4),
+            offset       =  (0x00AD<<2),
             bitSize      =  3,
             bitOffset    =  0,
             base         = pr.UInt,

--- a/python/surf/xilinx/_Gtpe2Channel.py
+++ b/python/surf/xilinx/_Gtpe2Channel.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PyRogue Gtpe2Channel
+#-----------------------------------------------------------------------------
+# File       : Gtpe2Channel.py
+# Created    : 2017-04-12
+#-----------------------------------------------------------------------------
+# Description:
+# PyRogue Gtpe2Channel
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class Gtpe2Channel(pr.Device):
+    def __init__(   self,       
+            name        = "Gtpe2Channel",
+            description = "Gtpe2Channel",
+            **kwargs):
+        super().__init__(name=name, description=description, **kwargs) 
+
+        ##############################
+        # Variables
+        ##############################

--- a/python/surf/xilinx/_Gtpe2Channel.py
+++ b/python/surf/xilinx/_Gtpe2Channel.py
@@ -258,7 +258,7 @@ class Gtpe2Channel(pr.Device):
             bitOffset    =  4,
             base         = pr.UInt,
             mode         = "RW",
-        ))   
+        ))                 
 
         self.add(pr.RemoteVariable(   
             name         = "RXPRBS_ERR_LOOPBACK",
@@ -1560,16 +1560,17 @@ class Gtpe2Channel(pr.Device):
             mode         = "RW",
         ))   
 
-        self.add(pr.RemoteVariable(   
-            name         = "TERM_RCAL_OVRD",
-            description  = "",
-            offset       =  (0x006A<<2),
-            bitSize      =  3,
-            bitOffset    =  13,
-            base         = pr.UInt,
-            mode         = "RW",
-        )) 
-
+        # "This feature is intended for internal use only." (UG482)
+        # self.add(pr.RemoteVariable(   
+            # name         = "TERM_RCAL_OVRD",
+            # description  = "",
+            # offset       =  (0x006A<<2),
+            # bitSize      =  3,
+            # bitOffset    =  13,
+            # base         = pr.UInt,
+            # mode         = "RW",
+        # ))
+                
         self.add(pr.RemoteVariable(   
             name         = "TX_CLK25_DIV",
             description  = "",
@@ -1918,7 +1919,7 @@ class Gtpe2Channel(pr.Device):
             bitOffset    =  11,
             base         = pr.UInt,
             mode         = "RW",
-        )) 
+        ))    
 
         self.add(pr.RemoteVariable(   
             name         = "TXOUT_DIV",
@@ -1928,8 +1929,8 @@ class Gtpe2Channel(pr.Device):
             bitOffset    =  4,
             base         = pr.UInt,
             mode         = "RW",
-        ))      
-
+        ))           
+        
         self.add(pr.RemoteVariable(   
             name         = "RXOUT_DIV",
             description  = "",

--- a/python/surf/xilinx/_Gtpe2Channel.py
+++ b/python/surf/xilinx/_Gtpe2Channel.py
@@ -29,3 +29,2533 @@ class Gtpe2Channel(pr.Device):
         ##############################
         # Variables
         ##############################
+
+        self.add(pr.RemoteVariable(   
+            name         = "ACJTAG_RESET",
+            description  = "",
+            offset       =  (0x0000<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "ACJTAG_DEBUG_MODE",
+            description  = "",
+            offset       =  (0x0000<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "ACJTAG_MODE",
+            description  = "",
+            offset       =  (0x0000<<4),
+            bitSize      =  1,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "UCODEER_CLR",
+            description  = "",
+            offset       =  (0x0000<<4),
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUFRESET_TIME",
+            description  = "",
+            offset       =  (0x000C<<4),
+            bitSize      =  5,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDRPHRESET_TIME",
+            description  = "",
+            offset       =  (0x000D<<4),
+            bitSize      =  5,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDRFREQRESET_TIME",
+            description  = "",
+            offset       =  (0x000D<<4),
+            bitSize      =  5,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPMARESET_TIME",
+            description  = "",
+            offset       =  (0x000D<<4),
+            bitSize      =  5,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPCSRESET_TIME",
+            description  = "",
+            offset       =  (0x000E<<4),
+            bitSize      =  5,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPMRESET_TIME",
+            description  = "",
+            offset       =  (0x000E<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXISCANRESET_TIME",
+            description  = "",
+            offset       =  (0x000F<<4),
+            bitSize      =  5,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXSYNC_OVRD",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXSYNC_OVRD",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXSYNC_SKIP_DA",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXSYNC_SKIP_DA",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXSYNC_MULTILANE",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXSYNC_MULTILANE",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  1,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPCSRESET_TIME",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  5,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPMARESET_TIME",
+            description  = "",
+            offset       =  (0x0010<<4),
+            bitSize      =  5,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_XCLK_SEL",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_DATA_WIDTH",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  3,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_CLK25_DIV",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  5,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_CM_SEL",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  2,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPRBS_ERR_LOOPBACK",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_BURST_SEQ_LEN",
+            description  = "",
+            offset       =  (0x0012<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "OUTREFCLK_SEL_INV",
+            description  = "",
+            offset       =  (0x0012<<4),
+            bitSize      =  2,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_BURST_VAL",
+            description  = "",
+            offset       =  (0x0012<<4),
+            bitSize      =  3,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXOOB_CFG",
+            description  = "",
+            offset       =  (0x0012<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "SAS_MIN_COM",
+            description  = "",
+            offset       =  (0x0013<<4),
+            bitSize      =  6,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MIN_BURST",
+            description  = "",
+            offset       =  (0x0013<<4),
+            bitSize      =  6,
+            bitOffset    =  3,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_EIDLE_VAL",
+            description  = "",
+            offset       =  (0x0013<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MIN_WAKE",
+            description  = "",
+            offset       =  (0x0014<<4),
+            bitSize      =  6,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MIN_INIT",
+            description  = "",
+            offset       =  (0x0014<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "SAS_MAX_COM",
+            description  = "",
+            offset       =  (0x0015<<4),
+            bitSize      =  7,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))           
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MAX_BURST",
+            description  = "",
+            offset       =  (0x0015<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+        
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MAX_WAKE",
+            description  = "",
+            offset       =  (0x0016<<4),
+            bitSize      =  6,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_MAX_INIT",
+            description  = "",
+            offset       =  (0x0016<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXOSCALRESET_TIMEOUT",
+            description  = "",
+            offset       =  (0x0017<<4),
+            bitSize      =  5,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXOSCALRESET_TIME",
+            description  = "",
+            offset       =  (0x0017<<4),
+            bitSize      =  5,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TRANS_TIME_RATE",
+            description  = "",
+            offset       =  (0x0018<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_LOOPBACK_CFG",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_PREDRIVER_MODE",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_EIDLE_DEASSERT_DELAY",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  3,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+        
+        self.add(pr.RemoteVariable(   
+            name         = "TX_EIDLE_ASSERT_DELAY",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  3,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_LOOPBACK_DRIVE_HIZ",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  1,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_DRIVE_MODE",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  5,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "PD_TRANS_TIME_TO_P2",
+            description  = "",
+            offset       =  (0x001A<<4),
+            bitSize      =  8,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "PD_TRANS_TIME_NONE_P2",
+            description  = "",
+            offset       =  (0x001A<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "PD_TRANS_TIME_FROM_P2",
+            description  = "",
+            offset       =  (0x001B<<4),
+            bitSize      =  12,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "PCS_PCIE_EN",
+            description  = "",
+            offset       =  (0x001B<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(  
+            name         = "TXBUF_RESET_ON_RATE_CHANGE",
+            description  = "",
+            offset       =  (0x001C<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXBUF_EN",
+            description  = "",
+            offset       =  (0x001C<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXGEARBOX_EN",
+            description  = "",
+            offset       =  (0x001C<<4),
+            bitSize      =  1,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "GEARBOX_MODE",
+            description  = "",
+            offset       =  (0x001C<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_HOLD_DURING_EIDLE",
+            description  = "",
+            offset       =  (0x001E<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_OS_CFG",
+            description  = "",
+            offset       =  (0x0024<<4),
+            bitSize      =  13,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_LF_CFG_WRD1",
+            description  = "",
+            offset       =  (0x002A<<4),
+            bitSize      =  2,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_HF_CFG",
+            description  = "",
+            offset       =  (0x002A<<4),
+            bitSize      =  14,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_LF_CFG_WRD0",
+            description  = "",
+            offset       =  (0x002B<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_QUALIFIER_WRD0",
+            description  = "",
+            offset       =  (0x002C<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_QUALIFIER_WRD1",
+            description  = "",
+            offset       =  (0x002D<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_QUALIFIER_WRD2",
+            description  = "",
+            offset       =  (0x002E<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_QUALIFIER_WRD3",
+            description  = "",
+            offset       =  (0x002F<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))              
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_QUALIFIER_WRD4",
+            description  = "",
+            offset       =  (0x0030<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))              
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_SDATA_MASK_WRD0",
+            description  = "",
+            offset       =  (0x0036<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_SDATA_MASK_WRD1",
+            description  = "",
+            offset       =  (0x0037<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_SDATA_MASK_WRD2",
+            description  = "",
+            offset       =  (0x0038<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_SDATA_MASK_WRD3",
+            description  = "",
+            offset       =  (0x0039<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))              
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_SDATA_MASK_WRD4",
+            description  = "",
+            offset       =  (0x003A<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+        
+        self.add(pr.RemoteVariable(   
+            name         = "ES_PRESCALE",
+            description  = "",
+            offset       =  (0x003B<<4),
+            bitSize      =  5,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_VERT_OFFSET",
+            description  = "",
+            offset       =  (0x003B<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_HORZ_OFFSET",
+            description  = "",
+            offset       =  (0x003C<<4),
+            bitSize      =  12,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_DISPERR_SEQ_MATCH",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "DEC_PCOMMA_DETECT",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "DEC_MCOMMA_DETECT",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "DEC_VALID_COMMA_ONLY",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_ERRDET_EN",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_EYE_SCAN_EN",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  1,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_CONTROL",
+            description  = "",
+            offset       =  (0x003D<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_COMMA_ENABLE",
+            description  = "",
+            offset       =  (0x003E<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_MCOMMA_VALUE",
+            description  = "",
+            offset       =  (0x003F<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXSLIDE_MODE",
+            description  = "",
+            offset       =  (0x0040<<4),
+            bitSize      =  2,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_PCOMMA_VALUE",
+            description  = "",
+            offset       =  (0x0040<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_COMMA_WORD",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  2,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_SIG_VALID_DLY",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  5,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_PCOMMA_DET",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_MCOMMA_DET",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  1,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "SHOW_REALIGN_COMMA",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  1,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "ALIGN_COMMA_DOUBLE",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  1,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXSLIDE_AUTO_WAIT",
+            description  = "",
+            offset       =  (0x0041<<4),
+            bitSize      =  4,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_CORRECT_USE",
+            description  = "",
+            offset       =  (0x0044<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))               
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_1_ENABLE",
+            description  = "",
+            offset       =  (0x0044<<4),
+            bitSize      =  4,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_1_1",
+            description  = "",
+            offset       =  (0x0044<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_MAX_LAT",
+            description  = "",
+            offset       =  (0x0045<<4),
+            bitSize      =  6,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_1_2",
+            description  = "",
+            offset       =  (0x0045<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_MIN_LAT",
+            description  = "",
+            offset       =  (0x0046<<4),
+            bitSize      =  6,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_1_3",
+            description  = "",
+            offset       =  (0x0046<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_REPEAT_WAIT",
+            description  = "",
+            offset       =  (0x0047<<4),
+            bitSize      =  5,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))             
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_1_4",
+            description  = "",
+            offset       =  (0x0047<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_USE",
+            description  = "",
+            offset       =  (0x0048<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_ENABLE",
+            description  = "",
+            offset       =  (0x0048<<4),
+            bitSize      =  4,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_1",
+            description  = "",
+            offset       =  (0x0048<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_KEEP_IDLE",
+            description  = "",
+            offset       =  (0x0049<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_PRECEDENCE",
+            description  = "",
+            offset       =  (0x0049<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_LEN",
+            description  = "",
+            offset       =  (0x0049<<4),
+            bitSize      =  2,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_2",
+            description  = "",
+            offset       =  (0x0049<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_3",
+            description  = "",
+            offset       =  (0x004A<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXGEARBOX_EN",
+            description  = "",
+            offset       =  (0x004B<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COR_SEQ_2_4",
+            description  = "",
+            offset       =  (0x004B<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_1_ENABLE",
+            description  = "",
+            offset       =  (0x004C<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_1_1",
+            description  = "",
+            offset       =  (0x004C<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_LEN",
+            description  = "",
+            offset       =  (0x004D<<4),
+            bitSize      =  2,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_1_2",
+            description  = "",
+            offset       =  (0x004D<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_KEEP_ALIGN",
+            description  = "",
+            offset       =  (0x004E<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_1_3",
+            description  = "",
+            offset       =  (0x004E<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_1_4",
+            description  = "",
+            offset       =  (0x004F<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_ENABLE",
+            description  = "",
+            offset       =  (0x0050<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_USE",
+            description  = "",
+            offset       =  (0x0050<<4),
+            bitSize      =  1,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_1",
+            description  = "",
+            offset       =  (0x0050<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = "FTS_LANE_DESKEW_CFG",
+            description  = "",
+            offset       =  (0x0051<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "FTS_LANE_DESKEW_EN",
+            description  = "",
+            offset       =  (0x0051<<4),
+            bitSize      =  1,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_2",
+            description  = "",
+            offset       =  (0x0051<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+        
+        self.add(pr.RemoteVariable(   
+            name         = "FTS_DESKEW_SEQ_ENABLE",
+            description  = "",
+            offset       =  (0x0052<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CBCC_DATA_SOURCE_SEL",
+            description  = "",
+            offset       =  (0x0052<<4),
+            bitSize      =  1,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_3",
+            description  = "",
+            offset       =  (0x0052<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))            
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_MAX_SKEW",
+            description  = "",
+            offset       =  (0x0053<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CHAN_BOND_SEQ_2_4",
+            description  = "",
+            offset       =  (0x0053<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXDLY_TAP_CFG",
+            description  = "",
+            offset       =  (0x0054<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXDLY_CFG",
+            description  = "",
+            offset       =  (0x0055<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPH_MONITOR_SEL",
+            description  = "",
+            offset       =  (0x0057<<4),
+            bitSize      =  5,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_DDI_SEL",
+            description  = "",
+            offset       =  (0x0057<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_XCLK_SEL",
+            description  = "",
+            offset       =  (0x0059<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_EN",
+            description  = "",
+            offset       =  (0x0059<<4),
+            bitSize      =  1,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXOOB_CFG",
+            description  = "",
+            offset       =  (0x005A<<4),
+            bitSize      =  1,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "LOOPBACK_CFG",
+            description  = "",
+            offset       =  (0x005A<<4),
+            bitSize      =  1,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG5",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  3,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG4",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG3",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  1,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG2",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  2,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG1",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  2,
+            bitOffset    =  2,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_CFG0",
+            description  = "",
+            offset       =  (0x005D<<4),
+            bitSize      =  2,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "SATA_PLL_CFG",
+            description  = "",
+            offset       =  (0x005E<<4),
+            bitSize      =  2,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPHDLY_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0060<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPHDLY_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0061<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))           
+        
+        self.add(pr.RemoteVariable(   
+            name         = "TXDLY_CFG",
+            description  = "",
+            offset       =  (0x0062<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXDLY_TAP_CFG",
+            description  = "",
+            offset       =  (0x0063<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPH_CFG",
+            description  = "",
+            offset       =  (0x0064<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPH_MONITOR_SEL",
+            description  = "",
+            offset       =  (0x0065<<4),
+            bitSize      =  5,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_BIAS_CFG",
+            description  = "",
+            offset       =  (0x0066<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXOOB_CLK_CFG",
+            description  = "",
+            offset       =  (0x0068<<4),
+            bitSize      =  1,
+            bitOffset    =  3,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_CLKMUX_EN",
+            description  = "",
+            offset       =  (0x0068<<4),
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_CLKMUX_EN",
+            description  = "",
+            offset       =  (0x0068<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TERM_RCAL_CFG",
+            description  = "",
+            offset       =  (0x0069<<4),
+            bitSize      =  15,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "TERM_RCAL_OVRD",
+            description  = "",
+            offset       =  (0x006A<<4),
+            bitSize      =  3,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_CLK25_DIV",
+            description  = "",
+            offset       =  (0x006A<<4),
+            bitSize      =  5,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV5",
+            description  = "",
+            offset       =  (0x006B<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV4",
+            description  = "",
+            offset       =  (0x006B<<4),
+            bitSize      =  4,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_DATA_WIDTH",
+            description  = "",
+            offset       =  (0x006B<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "PCS_RSVD_ATTR_WRD0",
+            description  = "",
+            offset       =  (0x006F<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "PCS_RSVD_ATTR_WRD1",
+            description  = "",
+            offset       =  (0x0070<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "PCS_RSVD_ATTR_WRD2",
+            description  = "",
+            offset       =  (0x0071<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_FULL_1",
+            description  = "",
+            offset       =  (0x0075<<4),
+            bitSize      =  7,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_FULL_0",
+            description  = "",
+            offset       =  (0x0075<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+        
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_FULL_3",
+            description  = "",
+            offset       =  (0x0076<<4),
+            bitSize      =  7,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_FULL_2",
+            description  = "",
+            offset       =  (0x0076<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_LOW_0",
+            description  = "",
+            offset       =  (0x0077<<4),
+            bitSize      =  7,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_FULL_4",
+            description  = "",
+            offset       =  (0x0077<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_LOW_2",
+            description  = "",
+            offset       =  (0x0078<<4),
+            bitSize      =  7,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_LOW_1",
+            description  = "",
+            offset       =  (0x0078<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+                
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_LOW_4",
+            description  = "",
+            offset       =  (0x0079<<4),
+            bitSize      =  7,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MARGIN_LOW_3",
+            description  = "",
+            offset       =  (0x0079<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_DEEMPH1",
+            description  = "",
+            offset       =  (0x007A<<4),
+            bitSize      =  6,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))           
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_DEEMPH0",
+            description  = "",
+            offset       =  (0x007A<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_RXDETECT_REF",
+            description  = "",
+            offset       =  (0x007C<<4),
+            bitSize      =  3,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_MAINCURSOR_SEL",
+            description  = "",
+            offset       =  (0x007C<<4),
+            bitSize      =  1,
+            bitOffset    =  3,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV3",
+            description  = "",
+            offset       =  (0x007C<<4),
+            bitSize      =  2,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))             
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV7",
+            description  = "",
+            offset       =  (0x007D<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV6",
+            description  = "",
+            offset       =  (0x007D<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "TX_RXDETECT_CFG",
+            description  = "",
+            offset       =  (0x007D<<4),
+            bitSize      =  14,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "CLK_COMMON_SWING",
+            description  = "",
+            offset       =  (0x007E<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_CM_TRIM",
+            description  = "",
+            offset       =  (0x007E<<4),
+            bitSize      =  4,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_CFG1",
+            description  = "",
+            offset       =  (0x0081<<4),
+            bitSize      =  1,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_CFG",
+            description  = "",
+            offset       =  (0x0081<<4),
+            bitSize      =  4,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV2_WRD0",
+            description  = "",
+            offset       =  (0x0082<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV2_WRD1",
+            description  = "",
+            offset       =  (0x0083<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "DMONITOR_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0086<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "DMONITOR_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0087<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_BIAS_STARTUP_DISABLE",
+            description  = "",
+            offset       =  (0x0088<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_HF_CFG3",
+            description  = "",
+            offset       =  (0x0088<<4),
+            bitSize      =  4,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXOUT_DIV",
+            description  = "",
+            offset       =  (0x0088<<4),
+            bitSize      =  3,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXOUT_DIV",
+            description  = "",
+            offset       =  (0x0088<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0089<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG_WRD1",
+            description  = "",
+            offset       =  (0x008A<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG_WRD2",
+            description  = "",
+            offset       =  (0x008B<<4),
+            bitSize      =  11,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG3",
+            description  = "",
+            offset       =  (0x008C<<4),
+            bitSize      =  7,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXPI_CFG0",
+            description  = "",
+            offset       =  (0x008D<<4),
+            bitSize      =  3,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_CM_CFG",
+            description  = "",
+            offset       =  (0x008D<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG5",
+            description  = "",
+            offset       =  (0x008D<<4),
+            bitSize      =  2,
+            bitOffset    =  10,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_LF_CFG2",
+            description  = "",
+            offset       =  (0x008D<<4),
+            bitSize      =  5,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_HF_CFG2",
+            description  = "",
+            offset       =  (0x008D<<4),
+            bitSize      =  5,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_IPCM_CFG",
+            description  = "",
+            offset       =  (0x008E<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_INCM_CFG",
+            description  = "",
+            offset       =  (0x008E<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG4",
+            description  = "",
+            offset       =  (0x008E<<4),
+            bitSize      =  1,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG6",
+            description  = "",
+            offset       =  (0x008E<<4),
+            bitSize      =  4,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_GC_CFG",
+            description  = "",
+            offset       =  (0x008E<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_GC_CFG2",
+            description  = "",
+            offset       =  (0x008F<<4),
+            bitSize      =  3,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPI_CFG1",
+            description  = "",
+            offset       =  (0x008F<<4),
+            bitSize      =  1,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPI_CFG2",
+            description  = "",
+            offset       =  (0x008F<<4),
+            bitSize      =  1,
+            bitOffset    =  3,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXLPM_OSINT_CFG",
+            description  = "",
+            offset       =  (0x008F<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_CLK_PHASE_SEL",
+            description  = "",
+            offset       =  (0x0091<<4),
+            bitSize      =  1,
+            bitOffset    =  15,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))        
+
+        self.add(pr.RemoteVariable(   
+            name         = "USE_PCS_CLK_PHASE_SEL",
+            description  = "",
+            offset       =  (0x0091<<4),
+            bitSize      =  1,
+            bitOffset    =  14,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))               
+
+        self.add(pr.RemoteVariable(   
+            name         = "CFOK_CFG2",
+            description  = "",
+            offset       =  (0x0091<<4),
+            bitSize      =  7,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "ADAPT_CFG0_WRD0",
+            description  = "",
+            offset       =  (0x0092<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "ADAPT_CFG0_WRD1",
+            description  = "",
+            offset       =  (0x0093<<4),
+            bitSize      =  4,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_PPM_CFG",
+            description  = "",
+            offset       =  (0x0095<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_GREY_SEL",
+            description  = "",
+            offset       =  (0x0096<<4),
+            bitSize      =  1,
+            bitOffset    =  5,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_INVSTROBE_SEL",
+            description  = "",
+            offset       =  (0x0096<<4),
+            bitSize      =  1,
+            bitOffset    =  4,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_PPMCLK_SEL",
+            description  = "",
+            offset       =  (0x0096<<4),
+            bitSize      =  1,
+            bitOffset    =  3,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXPI_SYNFREQ_PPM",
+            description  = "",
+            offset       =  (0x0096<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "TST_RSV_WRD0",
+            description  = "",
+            offset       =  (0x0097<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))             
+        
+        self.add(pr.RemoteVariable(   
+            name         = "TST_RSV_WRD1",
+            description  = "",
+            offset       =  (0x0098<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV_WRD0",
+            description  = "",
+            offset       =  (0x0099<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))             
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PMA_RSV_WRD1",
+            description  = "",
+            offset       =  (0x009A<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = "RX_BUFFER_CFG",
+            description  = "",
+            offset       =  (0x009B<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_THRESH_OVRD",
+            description  = "",
+            offset       =  (0x009C<<4),
+            bitSize      =  1,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_RESET_ON_EIDLE",
+            description  = "",
+            offset       =  (0x009C<<4),
+            bitSize      =  1,
+            bitOffset    =  6,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_THRESH_UNDFLW",
+            description  = "",
+            offset       =  (0x009C<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_EIDLE_HI_CNT",
+            description  = "",
+            offset       =  (0x009D<<4),
+            bitSize      =  4,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_EIDLE_LO_CNT",
+            description  = "",
+            offset       =  (0x009D<<4),
+            bitSize      =  4,
+            bitOffset    =  8,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_ADDR_MODE",
+            description  = "",
+            offset       =  (0x009D<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_THRESH_OVFLW",
+            description  = "",
+            offset       =  (0x009D<<4),
+            bitSize      =  6,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))           
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RX_DEFER_RESET_BUF_EN",
+            description  = "",
+            offset       =  (0x009D<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_RESET_ON_COMMAALIGN",
+            description  = "",
+            offset       =  (0x009E<<4),
+            bitSize      =  1,
+            bitOffset    =  2,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_RESET_ON_RATE_CHANGE",
+            description  = "",
+            offset       =  (0x009E<<4),
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXBUF_RESET_ON_CB_CHANGE",
+            description  = "",
+            offset       =  (0x009E<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "TXDLY_LCFG",
+            description  = "",
+            offset       =  (0x009F<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))         
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RXDLY_LCFG",
+            description  = "",
+            offset       =  (0x00A0<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPH_CFG_WRD0",
+            description  = "",
+            offset       =  (0x00A1<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPH_CFG_WRD1",
+            description  = "",
+            offset       =  (0x00A2<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPHDLY_CFG_WRD0",
+            description  = "",
+            offset       =  (0x00A3<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXPHDLY_CFG_WRD1",
+            description  = "",
+            offset       =  (0x00A4<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+        
+        self.add(pr.RemoteVariable(   
+            name         = "RX_DEBUG_CFG",
+            description  = "",
+            offset       =  (0x00A5<<4),
+            bitSize      =  14,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "ES_PMA_CFG",
+            description  = "",
+            offset       =  (0x00A6<<4),
+            bitSize      =  10,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_PH_RESET_ON_EIDLE",
+            description  = "",
+            offset       =  (0x00A7<<4),
+            bitSize      =  1,
+            bitOffset    =  13,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_FR_RESET_ON_EIDLE",
+            description  = "",
+            offset       =  (0x00A7<<4),
+            bitSize      =  1,
+            bitOffset    =  12,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_HOLD_DURING_EIDLE",
+            description  = "",
+            offset       =  (0x00A7<<4),
+            bitSize      =  1,
+            bitOffset    =  11,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_LOCK_CFG",
+            description  = "",
+            offset       =  (0x00A7<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD0",
+            description  = "",
+            offset       =  (0x00A8<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD1",
+            description  = "",
+            offset       =  (0x00A9<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD2",
+            description  = "",
+            offset       =  (0x00AA<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD3",
+            description  = "",
+            offset       =  (0x00AB<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD4",
+            description  = "",
+            offset       =  (0x00AC<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "RXCDR_CFG_WRD5",
+            description  = "",
+            offset       =  (0x00AD<<4),
+            bitSize      =  3,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))

--- a/python/surf/xilinx/_Gtpe2Common.py
+++ b/python/surf/xilinx/_Gtpe2Common.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PyRogue Gtpe2Common
+#-----------------------------------------------------------------------------
+# File       : Gtpe2Common.py
+# Created    : 2017-04-12
+#-----------------------------------------------------------------------------
+# Description:
+# PyRogue Gtpe2Common
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class Gtpe2Common(pr.Device):
+    def __init__(   self,       
+            name        = "Gtpe2Common",
+            description = "Gtpe2Common",
+            **kwargs):
+        super().__init__(name=name, description=description, **kwargs)
+
+        ##############################
+        # Variables
+        ##############################
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0002<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0003<<4),
+            bitSize      =  11,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_REFCLK_DIV",
+            description  = "",
+            offset       =  (0x0004<<4),
+            bitSize      =  5,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_FBDIV_45",
+            description  = "",
+            offset       =  (0x0004<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_FBDIV",
+            description  = "",
+            offset       =  (0x0004<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_LOCK_CFG",
+            description  = "",
+            offset       =  (0x0005<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_INIT_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0006<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_INIT_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0007<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 
+
+        self.add(pr.RemoteVariable(   
+            name         = "RSVD_ATTR0",
+            description  = "",
+            offset       =  (0x000A<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_DMON_CFG",
+            description  = "",
+            offset       =  (0x000F<<4),
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL0_DMON_CFG",
+            description  = "",
+            offset       =  (0x000F<<4),
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))          
+
+        self.add(pr.RemoteVariable(   
+            name         = "COMMON_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0011<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "COMMON_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0012<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL_CLKOUT_CFG",
+            description  = "",
+            offset       =  (0x0013<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "BIAS_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0019<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "BIAS_CFG_WRD1",
+            description  = "",
+            offset       =  (0x001A<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))            
+        
+        self.add(pr.RemoteVariable(   
+            name         = "BIAS_CFG_WRD2",
+            description  = "",
+            offset       =  (0x001B<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))    
+
+        self.add(pr.RemoteVariable(   
+            name         = "BIAS_CFG_WRD3",
+            description  = "",
+            offset       =  (0x001C<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))       
+
+        self.add(pr.RemoteVariable(   
+            name         = "RSVD_ATTR1",
+            description  = "",
+            offset       =  (0x0024<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_INIT_CFG_WRD0",
+            description  = "",
+            offset       =  (0x0028<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))      
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_INIT_CFG_WRD1",
+            description  = "",
+            offset       =  (0x0029<<4),
+            bitSize      =  8,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_LOCK_CFG",
+            description  = "",
+            offset       =  (0x002A<<4),
+            bitSize      =  9,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))           
+                
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_REFCLK_DIV",
+            description  = "",
+            offset       =  (0x002B<<4),
+            bitSize      =  5,
+            bitOffset    =  9,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_FBDIV_45",
+            description  = "",
+            offset       =  (0x002B<<4),
+            bitSize      =  1,
+            bitOffset    =  7,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_FBDIV",
+            description  = "",
+            offset       =  (0x002B<<4),
+            bitSize      =  6,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))   
+
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_CFG_WRD0",
+            description  = "",
+            offset       =  (0x002C<<4),
+            bitSize      =  16,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = "PLL1_CFG_WRD1",
+            description  = "",
+            offset       =  (0x002D<<4),
+            bitSize      =  11,
+            bitOffset    =  0,
+            base         = pr.UInt,
+            mode         = "RW",
+        )) 

--- a/python/surf/xilinx/_Gtpe2Common.py
+++ b/python/surf/xilinx/_Gtpe2Common.py
@@ -33,7 +33,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_CFG_WRD0",
             description  = "",
-            offset       =  (0x0002<<4),
+            offset       =  (0x0002<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -43,7 +43,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_CFG_WRD1",
             description  = "",
-            offset       =  (0x0003<<4),
+            offset       =  (0x0003<<2),
             bitSize      =  11,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -53,7 +53,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_REFCLK_DIV",
             description  = "",
-            offset       =  (0x0004<<4),
+            offset       =  (0x0004<<2),
             bitSize      =  5,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -63,7 +63,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_FBDIV_45",
             description  = "",
-            offset       =  (0x0004<<4),
+            offset       =  (0x0004<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -73,7 +73,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_FBDIV",
             description  = "",
-            offset       =  (0x0004<<4),
+            offset       =  (0x0004<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -83,7 +83,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_LOCK_CFG",
             description  = "",
-            offset       =  (0x0005<<4),
+            offset       =  (0x0005<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -93,7 +93,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_INIT_CFG_WRD0",
             description  = "",
-            offset       =  (0x0006<<4),
+            offset       =  (0x0006<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -103,7 +103,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_INIT_CFG_WRD1",
             description  = "",
-            offset       =  (0x0007<<4),
+            offset       =  (0x0007<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -113,7 +113,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RSVD_ATTR0",
             description  = "",
-            offset       =  (0x000A<<4),
+            offset       =  (0x000A<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -123,7 +123,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_DMON_CFG",
             description  = "",
-            offset       =  (0x000F<<4),
+            offset       =  (0x000F<<2),
             bitSize      =  1,
             bitOffset    =  1,
             base         = pr.UInt,
@@ -133,7 +133,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL0_DMON_CFG",
             description  = "",
-            offset       =  (0x000F<<4),
+            offset       =  (0x000F<<2),
             bitSize      =  1,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -143,7 +143,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "COMMON_CFG_WRD0",
             description  = "",
-            offset       =  (0x0011<<4),
+            offset       =  (0x0011<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -153,7 +153,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "COMMON_CFG_WRD1",
             description  = "",
-            offset       =  (0x0012<<4),
+            offset       =  (0x0012<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -163,7 +163,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL_CLKOUT_CFG",
             description  = "",
-            offset       =  (0x0013<<4),
+            offset       =  (0x0013<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -173,7 +173,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "BIAS_CFG_WRD0",
             description  = "",
-            offset       =  (0x0019<<4),
+            offset       =  (0x0019<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -183,7 +183,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "BIAS_CFG_WRD1",
             description  = "",
-            offset       =  (0x001A<<4),
+            offset       =  (0x001A<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -193,7 +193,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "BIAS_CFG_WRD2",
             description  = "",
-            offset       =  (0x001B<<4),
+            offset       =  (0x001B<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -203,7 +203,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "BIAS_CFG_WRD3",
             description  = "",
-            offset       =  (0x001C<<4),
+            offset       =  (0x001C<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -213,7 +213,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "RSVD_ATTR1",
             description  = "",
-            offset       =  (0x0024<<4),
+            offset       =  (0x0024<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -223,7 +223,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_INIT_CFG_WRD0",
             description  = "",
-            offset       =  (0x0028<<4),
+            offset       =  (0x0028<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -233,7 +233,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_INIT_CFG_WRD1",
             description  = "",
-            offset       =  (0x0029<<4),
+            offset       =  (0x0029<<2),
             bitSize      =  8,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -243,7 +243,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_LOCK_CFG",
             description  = "",
-            offset       =  (0x002A<<4),
+            offset       =  (0x002A<<2),
             bitSize      =  9,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -253,7 +253,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_REFCLK_DIV",
             description  = "",
-            offset       =  (0x002B<<4),
+            offset       =  (0x002B<<2),
             bitSize      =  5,
             bitOffset    =  9,
             base         = pr.UInt,
@@ -263,7 +263,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_FBDIV_45",
             description  = "",
-            offset       =  (0x002B<<4),
+            offset       =  (0x002B<<2),
             bitSize      =  1,
             bitOffset    =  7,
             base         = pr.UInt,
@@ -273,7 +273,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_FBDIV",
             description  = "",
-            offset       =  (0x002B<<4),
+            offset       =  (0x002B<<2),
             bitSize      =  6,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -283,7 +283,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_CFG_WRD0",
             description  = "",
-            offset       =  (0x002C<<4),
+            offset       =  (0x002C<<2),
             bitSize      =  16,
             bitOffset    =  0,
             base         = pr.UInt,
@@ -293,7 +293,7 @@ class Gtpe2Common(pr.Device):
         self.add(pr.RemoteVariable(   
             name         = "PLL1_CFG_WRD1",
             description  = "",
-            offset       =  (0x002D<<4),
+            offset       =  (0x002D<<2),
             bitSize      =  11,
             bitOffset    =  0,
             base         = pr.UInt,

--- a/python/surf/xilinx/__init__.py
+++ b/python/surf/xilinx/__init__.py
@@ -11,4 +11,6 @@
 from surf.xilinx._AxiPciePhy import *
 from surf.xilinx._AxiSysMonUltraScale import *
 from surf.xilinx._Gthe3Channel import *
+from surf.xilinx._Gtpe2Channel import *
+from surf.xilinx._Gtpe2Common  import *
 from surf.xilinx._xadc import *

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -2,7 +2,7 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Check for submodule tagging
-if { [SubmoduleCheck {ruckus} {1.4.1} ] < 0 } {exit -1}
+if { [SubmoduleCheck {ruckus} {1.5.0} ] < 0 } {exit -1}
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/axi"        "quiet"

--- a/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
+++ b/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
@@ -220,6 +220,7 @@ entity Gtp7Core is
       -- DRP Interface (stableClkIn Domain)
       drpGnt         : out sl;
       drpRdy         : out sl;
+      drpOverride    : in  sl               := '0';
       drpEn          : in  sl               := '0';
       drpWe          : in  sl               := '0';
       drpAddr        : in  slv(8 downto 0)  := "000000000";
@@ -1283,6 +1284,7 @@ begin
    GEN_RST_SEQ : if (SIMULATION_G = false) generate
       Gtp7RxRstSeq_Inst : entity work.Gtp7RxRstSeq
          port map(
+            DRP_OVERRIDE   => drpOverride,
             RST_IN         => rxUserResetIn,
             GTRXRESET_IN   => gtRxReset,
             RXPMARESETDONE => rxPmaResetDone,

--- a/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
+++ b/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
@@ -51,7 +51,9 @@ entity Gtp7Core is
       -- Configure PLL sources
       TX_PLL_G : string := "PLL0";
       RX_PLL_G : string := "PLL1";
-
+      
+      DYNAMIC_QPLL_G : boolean := false;
+      
       -- Configure Data widths
       TX_EXT_DATA_WIDTH_G : integer := 16;
       TX_INT_DATA_WIDTH_G : integer := 20;
@@ -146,6 +148,8 @@ entity Gtp7Core is
    port (
       stableClkIn : in sl;              -- Freerunning clock needed to drive reset logic
 
+      qPllRxSelect     : in  slv(1 downto 0)  := "00";
+      qPllTxSelect     : in  slv(1 downto 0)  := "00";
       qPllRefClkIn     : in  slv(1 downto 0);
       qPllClkIn        : in  slv(1 downto 0);
       qPllLockIn       : in  slv(1 downto 0);
@@ -273,13 +277,15 @@ architecture rtl of Gtp7Core is
    -- Signals
    --------------------------------------------------------------------------------------------------
 
+   signal rxPllSel  : slv(1 downto 0);
+   signal txPllSel  : slv(1 downto 0);
+   
    ----------------------------
    -- Rx Signals
    signal rxOutClk     : sl;
    signal rxOutClkBufg : sl;
 
    signal rxPllResets     : slv(1 downto 0);
-   signal rxPllLock       : sl;
 
    signal gtRxReset    : sl;            -- GT GTRXRESET
    signal rxResetDone  : sl;            -- GT RXRESETDONE
@@ -370,8 +376,9 @@ begin
    rxOutClkOut     <= rxOutClkBufg;
    qPllResetOut(0) <= rxPllResets(0) or txPllResets(0);
    qPllResetOut(1) <= rxPllResets(1) or txPllResets(1);
-
-   rxPllLock <= qPllLockIn(0) when RX_PLL0_USED_C else qPllLockIn(1);
+   
+   rxPllSel <= qPllRxSelect when DYNAMIC_QPLL_G else RX_SYSCLK_SEL_C;
+   txPllSel <= qPllTxSelect when DYNAMIC_QPLL_G else TX_SYSCLK_SEL_C;
 
    --------------------------------------------------------------------------------------------------
    -- Rx Logic
@@ -424,12 +431,15 @@ begin
    Gtp7RxRst_Inst : entity work.Gtp7RxRst
       generic map (
          TPD_G                  => TPD_G,
+         DYNAMIC_QPLL_G         => DYNAMIC_QPLL_G,
          SIMULATION_G => SIMULATION_G,
          STABLE_CLOCK_PERIOD    => getTimeRatio(STABLE_CLOCK_PERIOD_G, 1.0E-9),
          RETRY_COUNTER_BITWIDTH => 8,
          TX_PLL0_USED           => TX_PLL0_USED_C,
          RX_PLL0_USED           => RX_PLL0_USED_C)
       port map (
+         qPllRxSelect           => qPllRxSelect,
+         qPllTxSelect           => qPllTxSelect,
          STABLE_CLOCK           => stableClkIn,
          RXUSERCLK              => rxUsrClkIn,
          SOFT_RESET             => rxUserResetInt,
@@ -606,10 +616,12 @@ begin
    Gtp7TxRst_Inst : entity work.Gtp7TxRst
       generic map (
          TPD_G                  => TPD_G,
+         DYNAMIC_QPLL_G         => DYNAMIC_QPLL_G,
          STABLE_CLOCK_PERIOD    => getTimeRatio(STABLE_CLOCK_PERIOD_G, 1.0E-9),
          RETRY_COUNTER_BITWIDTH => 8,
          TX_PLL0_USED           => TX_PLL0_USED_C)
       port map (
+         qPllTxSelect      => qPllTxSelect,      
          STABLE_CLOCK      => stableClkIn,
          TXUSERCLK         => txUsrClkIn,
          SOFT_RESET        => txUserResetIn,
@@ -994,8 +1006,8 @@ begin
          PLL0REFCLK           => qPllRefClkIn(0),
          PLL1CLK              => qPllClkIn(1),
          PLL1REFCLK           => qPllRefClkIn(1),
-         RXSYSCLKSEL          => RX_SYSCLK_SEL_C,
-         TXSYSCLKSEL          => TX_SYSCLK_SEL_C,
+         RXSYSCLKSEL          => rxPllSel,
+         TXSYSCLKSEL          => txPllSel,
          ------------------------------- Loopback Ports -----------------------------
          LOOPBACK             => loopbackIn,
          ----------------------------- PCI Express Ports ----------------------------

--- a/xilinx/7Series/gtp7/rtl/Gtp7RxRstSeq.vhd
+++ b/xilinx/7Series/gtp7/rtl/Gtp7RxRstSeq.vhd
@@ -70,6 +70,7 @@ entity Gtp7RxRstSeq is
    generic(
       TPD_G : time := 1 ns);  
    port (
+      DRP_OVERRIDE   : in  std_logic; 
       RST_IN         : in  std_logic; 
       GTRXRESET_IN   : in  std_logic;    
       RXPMARESETDONE : in  std_logic;
@@ -156,7 +157,7 @@ begin
    process (DRPCLK)
    begin
       if rising_edge(DRPCLK) then
-         if (RST = '1') then
+         if (RST = '1') or (DRP_OVERRIDE = '1') then
             state              <= idle    after TPD_G;
             gtrxreset_s        <= '0'     after TPD_G;
             gtrxreset_ss       <= '0'     after TPD_G;


### PR DESCRIPTION
Required for dynamically switching between LCLS-I timing and LCLS-II timing on the pgp-gen3-card

```   --------------
   -- QPLL Module
   --------------
   U_QPLL : entity work.Gtp7QuadPll
      generic map (
         TPD_G                => TPD_G,
         AXI_ERROR_RESP_G     => AXI_ERROR_RESP_G,
         PLL0_REFCLK_SEL_G    => "001",  -- GTREFCLK0 selected
         PLL0_FBDIV_IN_G      => 2,      -- 238 MHz clock reference
         PLL0_FBDIV_45_IN_G   => 5,
         PLL0_REFCLK_DIV_IN_G => 1,
         PLL1_REFCLK_SEL_G    => "010",  -- GTREFCLK1 selected
         PLL1_FBDIV_IN_G      => 1,      -- 371 MHz clock reference
         PLL1_FBDIV_45_IN_G   => 5,
         PLL1_REFCLK_DIV_IN_G => 1)
      port map (
         qPllRefClk      => refClk,
         qPllOutClk      => gtQPllOutClk,
         qPllOutRefClk   => gtQPllOutRefClk,
         qPllLock        => gtQPllLock,
         qPllRefClkLost  => gtQPllRefClkLost,
         qPllLockDetClk  => qPllLockDetClk,
         qPllReset       => gtQPllRst,
         -- AXI Lite interface
         axilClk         => sysClk,
         axilRst         => sysRst,
         axilReadMaster  => axilReadMasters(QPLL_INDEX_C),
         axilReadSlave   => axilReadSlaves(QPLL_INDEX_C),
         axilWriteMaster => axilWriteMasters(QPLL_INDEX_C),
         axilWriteSlave  => axilWriteSlaves(QPLL_INDEX_C));```