### PR TITLE
pyrogue bug fix

### DIFF
--- a/python/surf/devices/micron/_AxiMicronN25Q.py
+++ b/python/surf/devices/micron/_AxiMicronN25Q.py
@@ -227,12 +227,13 @@ class AxiMicronN25Q(pr.Device):
                     bar.update(0xFFF)      
                 # Get the start bursting address
                 if ( (byteCnt==0) and (wordCnt==0) ):
-                    # Start a burst transfer
+                    # Start address of a burst transfer
                     self.readCmd(int(self._mcs.entry[i][0])) 
                     # Get the data
                     dataArray = self.getDataReg()
-                # Get the data for MCS file
+                # Get the data/addr for MCS file
                 data = int(self._mcs.entry[i][1])
+                addr = int(self._mcs.entry[i][0])
                 # Get the prom data from data array                    
                 prom = ((dataArray[wordCnt] >> 8*(3-byteCnt)) & 0xFF)
                 # Compare PROM to file


### PR DESCRIPTION
```ppa-pc90513 ~/projects/aes-stream-drivers/data_dev/driver$ cd ~/projects/kcu1500-dev/software/ ; source setup_template.csh ; python3 scripts/updateStaticImageProm.py --dev /dev/datadev_0 --mcs_primary ../firmware/targets/PcieGen1Mig0/images/TopWithoutPR-0x00000001-20171109124633-ruckman-dirty_primary.mcs --mcs_secondary ../firmware/targets/PcieGen1Mig0/images/TopWithoutPR-0x00000001-20171109124633-ruckman-dirty_secondary.mcs
Rogue/pyrogue version 2.2.1. https://github.com/slaclab/rogue
LoadMcsFile: ../firmware/targets/PcieGen1Mig0/images/TopWithoutPR-0x00000001-20171109124633-ruckman-dirty_primary.mcs
Reading .MCS:    [####################################]  100%             
Erasing PROM:    [####################################]  100%             
Writing PROM:    [####################################]  100%             
Verifying PROM:  [------------------------------------]    0%
Addr = 0x0: MCS = 0xff != PROM = 0x0

ERROR:pyrogue.BaseCommand.LoadMcsFile:verifyProm() Failed

Traceback (most recent call last):
  File "/afs/slac.stanford.edu/g/reseng/vol12/rogue/master/python/pyrogue/_Command.py", line 81, in call
    pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/afs/slac.stanford.edu/g/reseng/vol12/rogue/master/python/pyrogue/_Variable.py", line 705, in varFuncHelper
    return func(**args)
  File "/u/re/ruckman/projects/kcu1500-dev/firmware/submodules/surf/python/surf/devices/micron/_AxiMicronN25Q.py", line 117, in LoadMcsFile
    self.verifyProm()
  File "/u/re/ruckman/projects/kcu1500-dev/firmware/submodules/surf/python/surf/devices/micron/_AxiMicronN25Q.py", line 242, in verifyProm
    raise McsException('verifyProm() Failed\n\n')
surf.misc._mcsreader.McsException: verifyProm() Failed```