### PR TITLE
salt-tkeep-support

### DIFF
--- a/protocols/salt/core/rtl/SaltPkg.vhd
+++ b/protocols/salt/core/rtl/SaltPkg.vhd
@@ -40,7 +40,8 @@ package SaltPkg is
       TUSER_BITS_C  => 2,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
 
-   constant SALT_MAX_WORDS_C : natural := (1500/4);
+   constant SALT_MAX_BYTES_C : natural := 8192;
+   constant SALT_MAX_WORDS_C : natural := (SALT_MAX_BYTES_C/4);
    constant INTER_GAP_SIZE_C : natural := 12;
 
    constant SOF_C  : slv(31 downto 0) := x"BBBBBBBB";  -- SOF  = start of frame

--- a/protocols/salt/xilinxUltraScale/ruckus.tcl
+++ b/protocols/salt/xilinxUltraScale/ruckus.tcl
@@ -5,7 +5,10 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 if { $::env(VIVADO_VERSION) >= 2016.4 } {
 
    loadSource -dir  "$::DIR_PATH/rtl"
+   
    loadSource -path "$::DIR_PATH/ip/SaltUltraScaleCore.dcp"
+   # loadIpCore -path "$::DIR_PATH/ip/SaltUltraScaleCore.xci"
+   
    loadSource -path "$::DIR_PATH/images/SaltUltraScaleRxOnly.dcp"
    loadSource -path "$::DIR_PATH/images/SaltUltraScaleTxOnly.dcp"
 

--- a/protocols/salt/xilinxUltraScale/tb/SaltUltraScaleTb.vhd
+++ b/protocols/salt/xilinxUltraScale/tb/SaltUltraScaleTb.vhd
@@ -2,7 +2,7 @@
 -- File       : SaltUltraScaleTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-09-03
--- Last update: 2015-09-04
+-- Last update: 2018-01-11
 -------------------------------------------------------------------------------
 -- Description: Simulation Testbed for testing the SaltUltraScale
 -------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ architecture testbed of SaltUltraScaleTb is
    constant TPD_C              : time             := 1 ns;
    constant STATUS_CNT_WIDTH_C : natural          := 32;
    constant AXI_ERROR_RESP_C   : slv(1 downto 0)  := AXI_RESP_SLVERR_C;
-   constant TX_PACKET_LENGTH_C : slv(31 downto 0) := toSlv(1501, 32);
+   constant TX_PACKET_LENGTH_C : slv(31 downto 0) := toSlv(128, 32);
    constant NUMBER_PACKET_C    : slv(31 downto 0) := x"0000001F";
 
    -- PRBS Configuration
@@ -79,6 +79,8 @@ architecture testbed of SaltUltraScaleTb is
    signal errEofe         : sl := '0';
    signal updated         : sl := '0';
    signal linkUpL         : sl := '0';
+   signal txEofeSent      : sl := '0';
+   signal rxErrDet        : sl := '0';
 
    signal errWordCnt : slv(31 downto 0) := (others => '0');
    signal errbitCnt  : slv(31 downto 0) := (others => '0');
@@ -89,7 +91,7 @@ architecture testbed of SaltUltraScaleTb is
    signal ibSaltSlave  : AxiStreamSlaveType;
    signal obSaltMaster : AxiStreamMasterType;
    signal obSaltSlave  : AxiStreamSlaveType;
-   
+
 begin
 
    -----------------------------
@@ -98,35 +100,35 @@ begin
    ClkRst_1x : entity work.ClkRst
       generic map (
          CLK_PERIOD_G      => CLK_PERIOD_C,
-         RST_START_DELAY_G => 0 ns,     -- Wait this long into simulation before asserting reset
+         RST_START_DELAY_G => 0 ns,  -- Wait this long into simulation before asserting reset
          RST_HOLD_TIME_G   => 1000 ns)  -- Hold reset for this long)
       port map (
          clkP => clk,
          clkN => open,
          rst  => rst,
-         rstL => open);          
+         rstL => open);
 
    ClkRst_2p5x : entity work.ClkRst
       generic map (
          CLK_PERIOD_G      => (CLK_PERIOD_C/2.5),
-         RST_START_DELAY_G => 0 ns,     -- Wait this long into simulation before asserting reset
+         RST_START_DELAY_G => 0 ns,  -- Wait this long into simulation before asserting reset
          RST_HOLD_TIME_G   => 1000 ns)  -- Hold reset for this long)
       port map (
          clkP => clk2p5x,
          clkN => open,
          rst  => open,
-         rstL => open); 
+         rstL => open);
 
    ClkRst_5x : entity work.ClkRst
       generic map (
          CLK_PERIOD_G      => (CLK_PERIOD_C/5.0),
-         RST_START_DELAY_G => 0 ns,     -- Wait this long into simulation before asserting reset
+         RST_START_DELAY_G => 0 ns,  -- Wait this long into simulation before asserting reset
          RST_HOLD_TIME_G   => 1000 ns)  -- Hold reset for this long)
       port map (
          clkP => clk5x,
          clkN => open,
          rst  => clk5xRst,
-         rstL => open);   
+         rstL => open);
 
    SaltDelayCtrl_Inst : entity work.SaltDelayCtrl
       generic map (
@@ -135,7 +137,7 @@ begin
       port map (
          iDelayCtrlRdy => iDelayCtrlRdy,
          refClk        => clk5x,
-         refRst        => clk5xRst);         
+         refRst        => clk5xRst);
 
    -----------------
    -- Data Generator
@@ -159,7 +161,7 @@ begin
          PRBS_TAPS_G                => PRBS_TAPS_C,
          -- AXI Stream Configurations
          MASTER_AXI_STREAM_CONFIG_G => ssiAxiStreamConfig(4),
-         MASTER_AXI_PIPE_STAGES_G   => 1)        
+         MASTER_AXI_PIPE_STAGES_G   => 1)
       port map (
          -- Master Port (mAxisClk)
          mAxisClk     => clk,
@@ -174,7 +176,7 @@ begin
          forceEofe    => FORCE_EOFE_C,
          busy         => open,
          tDest        => (others => '0'),
-         tId          => (others => '0'));    
+         tId          => (others => '0'));
 
    linkUpL <= not(linkUp);
 
@@ -186,8 +188,8 @@ begin
          TPD_G               => TPD_C,
          TX_ENABLE_G         => true,
          RX_ENABLE_G         => true,
-         COMMON_TX_CLK_G     => true,   -- Set to true if sAxisClk and clk are the same clock
-         COMMON_RX_CLK_G     => true,   -- Set to true if mAxisClk and clk are the same clock      
+         COMMON_TX_CLK_G     => true,  -- Set to true if sAxisClk and clk are the same clock
+         COMMON_RX_CLK_G     => true,  -- Set to true if mAxisClk and clk are the same clock      
          SLAVE_AXI_CONFIG_G  => ssiAxiStreamConfig(4),
          MASTER_AXI_CONFIG_G => ssiAxiStreamConfig(4))
       port map (
@@ -204,6 +206,8 @@ begin
          clk625MHz     => clk5x,
          iDelayCtrlRdy => iDelayCtrlRdy,
          linkUp        => linkUp,
+         txEofeSent    => txEofeSent,
+         rxErrDet      => rxErrDet,
          -- Slave Port
          sAxisClk      => clk,
          sAxisRst      => rst,
@@ -213,7 +217,7 @@ begin
          mAxisClk      => clk,
          mAxisRst      => rst,
          mAxisMaster   => obSaltMaster,
-         mAxisSlave    => obSaltSlave);    
+         mAxisSlave    => obSaltSlave);
 
    ---------------
    -- Data Checker
@@ -269,7 +273,7 @@ begin
          errWordCnt      => errWordCnt,
          errbitCnt       => errbitCnt,
          packetRate      => open,
-         packetLength    => open);    
+         packetLength    => open);
 
    process(clk)
    begin
@@ -286,37 +290,48 @@ begin
             cnt    <= (others => '0') after TPD_C;
             passed <= '0'             after TPD_C;
             failed <= '0'             after TPD_C;
-         elsif updated = '1' then
-            -- Check for missed packet error
-            if errMissedPacket = '1' then
+         else
+            -- Check for TX Error
+            if txEofeSent = '1' then
                failed <= '1' after TPD_C;
             end if;
-            -- Check for packet length error
-            if errLength = '1' then
+            -- Check for RX Error
+            if rxErrDet = '1' then
                failed <= '1' after TPD_C;
             end if;
-            -- Check for packet data bus error
-            if errDataBus = '1' then
-               failed <= '1' after TPD_C;
-            end if;
-            -- Check for EOFE error
-            if errEofe = '1' then
-               failed <= '1' after TPD_C;
-            end if;
-            -- Check for word error
-            if errWordCnt /= 0 then
-               failed <= '1' after TPD_C;
-            end if;
-            -- Check for bit error
-            if errbitCnt /= 0 then
-               failed <= '1' after TPD_C;
-            end if;
-            -- Check the counter
-            if cnt = NUMBER_PACKET_C then
-               passed <= '1' after TPD_C;
-            else
-               -- Increment the counter
-               cnt <= cnt + 1 after TPD_C;
+            -- Check for SSI PRBS update
+            if updated = '1' then
+               -- Check for missed packet error
+               if errMissedPacket = '1' then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check for packet length error
+               if errLength = '1' then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check for packet data bus error
+               if errDataBus = '1' then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check for EOFE error
+               if errEofe = '1' then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check for word error
+               if errWordCnt /= 0 then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check for bit error
+               if errbitCnt /= 0 then
+                  failed <= '1' after TPD_C;
+               end if;
+               -- Check the counter
+               if cnt = NUMBER_PACKET_C then
+                  passed <= '1' after TPD_C;
+               else
+                  -- Increment the counter
+                  cnt <= cnt + 1 after TPD_C;
+               end if;
             end if;
          end if;
       end if;


### PR DESCRIPTION
adding SALT TKEEP support.  It previously only support 32-bit word transfers.  Now it supports byte level transfers, which is required for LCLS-II MPS