### PR TITLE
ESCORE-306 - Adding interleave support to RSSI

### DIFF
--- a/axi/rtl/AxiStreamDepacketizer2.vhd
+++ b/axi/rtl/AxiStreamDepacketizer2.vhd
@@ -249,11 +249,11 @@ begin
                if (ssiGetuserSof(AXIS_CONFIG_C, inputAxisMaster) = '1') then
 
                   -- Assign sideband fields
-                  v.outputAxisMaster(1).tDest(7 downto 0) := inputAxisMaster.tData(PACKET_HDR_TDEST_FIELD_C);
-                  v.outputAxisMaster(1).tId(7 downto 0)   := inputAxisMaster.tData(PACKET_HDR_TID_FIELD_C);
-                  v.outputAxisMaster(1).tUser(7 downto 0) := inputAxisMaster.tData(PACKET_HDR_TUSER_FIELD_C);
-                  sof                                     := inputAxisMaster.tData(PACKET_HDR_SOF_BIT_C);
-                  v.packetNumber                          := inputAxisMaster.tData(PACKET_HDR_SEQ_FIELD_C);
+                  v.outputAxisMaster(1).tDest(7 downto 0) := inputAxisMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C);
+                  v.outputAxisMaster(1).tId(7 downto 0)   := inputAxisMaster.tData(PACKETIZER2_HDR_TID_FIELD_C);
+                  v.outputAxisMaster(1).tUser(7 downto 0) := inputAxisMaster.tData(PACKETIZER2_HDR_TUSER_FIELD_C);
+                  sof                                     := inputAxisMaster.tData(PACKETIZER2_HDR_SOF_BIT_C);
+                  v.packetNumber                          := inputAxisMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C);
 
                   v.activeTDest := v.outputAxisMaster(1).tDest(7 downto 0);
 
@@ -262,7 +262,7 @@ begin
 
 
                   if (sof = not packetActiveRam and v.packetNumber = packetNumberRam and
-                      inputAxisMaster.tData(PACKET_HDR_VERSION_FIELD_C) = PACKET_VERSION_C) then
+                      inputAxisMaster.tData(PACKETIZER2_HDR_VERSION_FIELD_C) = PACKETIZER2_VERSION_C) then
                      -- Header metadata as expected
                      v.state    := MOVE_S;
                      v.sideband := '1';
@@ -322,18 +322,18 @@ begin
                   v.crcDataValid               := '0';
 
                   -- Append EOF metadata to previous txn which has been held
-                  lastBytes                   := conv_integer(inputAxisMaster.tData(PACKET_TAIL_BYTES_FIELD_C));
-                  axiStreamSetUserField(AXIS_CONFIG_C, v.outputAxisMaster(0), inputAxisMaster.tData(PACKET_TAIL_TUSER_FIELD_C), lastBytes);
-                  v.outputAxisMaster(0).tLast := inputAxisMaster.tData(PACKET_TAIL_EOF_BIT_C);
-                  v.outputAxisMaster(0).tKeep := genTkeep(conv_integer(inputAxisMaster.tData(PACKET_TAIL_BYTES_FIELD_C)));
+                  lastBytes                   := conv_integer(inputAxisMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C));
+                  axiStreamSetUserField(AXIS_CONFIG_C, v.outputAxisMaster(0), inputAxisMaster.tData(PACKETIZER2_TAIL_TUSER_FIELD_C), lastBytes);
+                  v.outputAxisMaster(0).tLast := inputAxisMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C);
+                  v.outputAxisMaster(0).tKeep := genTkeep(conv_integer(inputAxisMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C)));
 
                   -- Verify the CRC. Set EOFE if fail.
-                  if (crcOut /= inputAxisMaster.tData(PACKET_TAIL_CRC_FIELD_C) and CRC_EN_G) then
+                  if (crcOut /= inputAxisMaster.tData(PACKETIZER2_TAIL_CRC_FIELD_C) and CRC_EN_G) then
                      axiStreamSetUserBit(AXIS_CONFIG_C, v.outputAxisMaster(0), SSI_EOFE_C, '1', lastBytes);
                   end if;
 
 
-                  if (inputAxisMaster.tData(PACKET_TAIL_EOF_BIT_C) = '1') then
+                  if (inputAxisMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C) = '1') then
                      -- If EOF, reset packetActive and packetNumber                     
                      v.packetActive := '0';
                      v.packetNumber := (others => '0');

--- a/axi/rtl/AxiStreamDepacketizer2.vhd
+++ b/axi/rtl/AxiStreamDepacketizer2.vhd
@@ -261,7 +261,8 @@ begin
                   axiStreamSetUserBit(AXIS_CONFIG_C, v.outputAxisMaster(1), SSI_SOF_C, sof, 0);  -- SOF
 
 
-                  if (sof = not packetActiveRam and v.packetNumber = packetNumberRam) then
+                  if (sof = not packetActiveRam and v.packetNumber = packetNumberRam and
+                      inputAxisMaster.tData(PACKET_HDR_VERSION_FIELD_C) = PACKET_VERSION_C) then
                      -- Header metadata as expected
                      v.state    := MOVE_S;
                      v.sideband := '1';

--- a/axi/rtl/AxiStreamPacketizer2.vhd
+++ b/axi/rtl/AxiStreamPacketizer2.vhd
@@ -224,13 +224,14 @@ begin
             v.wordCount := (others => '0');
             v.crcReset  := '1';
             if (inputAxisMaster.tValid = '1' and v.outputAxisMaster.tValid = '0') then
-               v.outputAxisMaster                                 := axiStreamMasterInit(AXIS_CONFIG_C);
-               v.outputAxisMaster.tValid                          := inputAxisMaster.tValid;
-               v.outputAxisMaster.tData(PACKET_HDR_TUSER_FIELD_C) := inputAxisMaster.tUser(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_TDEST_FIELD_C) := inputAxisMaster.tDest(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_TID_FIELD_C)   := inputAxisMaster.tId(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_SOF_BIT_C)     := not packetActiveOut;
-               v.outputAxisMaster.tData(PACKET_HDR_SEQ_FIELD_C)   := packetNumberOut;
+               v.outputAxisMaster                                   := axiStreamMasterInit(AXIS_CONFIG_C);
+               v.outputAxisMaster.tValid                            := inputAxisMaster.tValid;
+               v.outputAxisMaster.tData(PACKET_HDR_VERSION_FIELD_C) := X"02";
+               v.outputAxisMaster.tData(PACKET_HDR_TUSER_FIELD_C)   := inputAxisMaster.tUser(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_TDEST_FIELD_C)   := inputAxisMaster.tDest(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_TID_FIELD_C)     := inputAxisMaster.tId(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_SOF_BIT_C)       := not packetActiveOut;
+               v.outputAxisMaster.tData(PACKET_HDR_SEQ_FIELD_C)     := packetNumberOut;
 
                -- Frame ID on 63:48?
                axiStreamSetUserBit(AXIS_CONFIG_C, v.outputAxisMaster, SSI_SOF_C, '1', 0);  -- SOF

--- a/axi/rtl/AxiStreamPacketizer2.vhd
+++ b/axi/rtl/AxiStreamPacketizer2.vhd
@@ -224,14 +224,14 @@ begin
             v.wordCount := (others => '0');
             v.crcReset  := '1';
             if (inputAxisMaster.tValid = '1' and v.outputAxisMaster.tValid = '0') then
-               v.outputAxisMaster                                   := axiStreamMasterInit(AXIS_CONFIG_C);
-               v.outputAxisMaster.tValid                            := inputAxisMaster.tValid;
-               v.outputAxisMaster.tData(PACKET_HDR_VERSION_FIELD_C) := X"02";
-               v.outputAxisMaster.tData(PACKET_HDR_TUSER_FIELD_C)   := inputAxisMaster.tUser(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_TDEST_FIELD_C)   := inputAxisMaster.tDest(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_TID_FIELD_C)     := inputAxisMaster.tId(7 downto 0);
-               v.outputAxisMaster.tData(PACKET_HDR_SOF_BIT_C)       := not packetActiveOut;
-               v.outputAxisMaster.tData(PACKET_HDR_SEQ_FIELD_C)     := packetNumberOut;
+               v.outputAxisMaster                                        := axiStreamMasterInit(AXIS_CONFIG_C);
+               v.outputAxisMaster.tValid                                 := inputAxisMaster.tValid;
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_VERSION_FIELD_C) := PACKETIZER2_VERSION_C;
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_TUSER_FIELD_C)   := inputAxisMaster.tUser(7 downto 0);
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C)   := inputAxisMaster.tDest(7 downto 0);
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_TID_FIELD_C)     := inputAxisMaster.tId(7 downto 0);
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_SOF_BIT_C)       := not packetActiveOut;
+               v.outputAxisMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C)     := packetNumberOut;
 
                -- Frame ID on 63:48?
                axiStreamSetUserBit(AXIS_CONFIG_C, v.outputAxisMaster, SSI_SOF_C, '1', 0);  -- SOF
@@ -292,19 +292,19 @@ begin
          when TAIL_S =>
             -- Insert tail when master side is ready for it
             if (v.outputAxisMaster.tValid = '0') then
-               v.outputAxisMaster.tValid                           := '1';
-               v.outputAxisMaster.tKeep                            := X"00FF";
-               v.outputAxisMaster.tData                            := (others => '0');
-               v.outputAxisMaster.tData(PACKET_TAIL_EOF_BIT_C)     := r.eof;
-               v.outputAxisMaster.tData(PACKET_TAIL_TUSER_FIELD_C) := r.tUserLast;
-               v.outputAxisMaster.tData(PACKET_TAIL_BYTES_FIELD_C) := r.lastByteCount;
-               v.outputAxisMaster.tData(PACKET_TAIL_CRC_FIELD_C)   := ite(CRC_EN_G, crcOut, X"00000000");
+               v.outputAxisMaster.tValid                                := '1';
+               v.outputAxisMaster.tKeep                                 := X"00FF";
+               v.outputAxisMaster.tData                                 := (others => '0');
+               v.outputAxisMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C)     := r.eof;
+               v.outputAxisMaster.tData(PACKETIZER2_TAIL_TUSER_FIELD_C) := r.tUserLast;
+               v.outputAxisMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C) := r.lastByteCount;
+               v.outputAxisMaster.tData(PACKETIZER2_TAIL_CRC_FIELD_C)   := ite(CRC_EN_G, crcOut, X"00000000");
                -- Myabe set tuser when SSI enabled?
-               v.outputAxisMaster.tUser                            := (others => '0');
-               v.outputAxisMaster.tLast                            := '1';
-               v.eof                                               := '0';  -- Clear EOF for next frame
-               v.tUserLast                                         := (others => '0');
-               v.state                                             := HEADER_S;  -- Go to idle and wait for new data
+               v.outputAxisMaster.tUser                                 := (others => '0');
+               v.outputAxisMaster.tLast                                 := '1';
+               v.eof                                                    := '0';  -- Clear EOF for next frame
+               v.tUserLast                                              := (others => '0');
+               v.state                                                  := HEADER_S;  -- Go to idle and wait for new data
             end if;
 
       end case;

--- a/axi/rtl/AxiStreamPacketizer2.vhd
+++ b/axi/rtl/AxiStreamPacketizer2.vhd
@@ -26,6 +26,7 @@ use ieee.std_logic_arith.all;
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
 use work.SsiPkg.all;
+use work.AxiStreamPacketizer2Pkg.all;
 
 entity AxiStreamPacketizer2 is
 

--- a/axi/rtl/AxiStreamPacketizer2.vhd
+++ b/axi/rtl/AxiStreamPacketizer2.vhd
@@ -162,7 +162,7 @@ begin
          doutb(15 downto 0) => packetNumberOut,        -- [out]
          doutb(16)          => packetActiveOut);       --[out]
 
-   ETH_CRC : if (CRC_POLY_G = x"04C11DB7") generate         
+   ETH_CRC : if (CRC_POLY_G = x"04C11DB7") generate
       U_Crc32 : entity work.Crc32Parallel
          generic map (
             TPD_G            => TPD_G,
@@ -177,8 +177,8 @@ begin
             crcIn        => inputAxisMaster.tData(63 downto 0),  -- [in]
             crcReset     => rin.crcReset);                       -- [in]
    end generate;
-   
-   GEN_CRC : if (CRC_POLY_G /= x"04C11DB7") generate         
+
+   GEN_CRC : if (CRC_POLY_G /= x"04C11DB7") generate
       U_Crc32 : entity work.Crc32
          generic map (
             TPD_G            => TPD_G,
@@ -224,19 +224,20 @@ begin
             v.wordCount := (others => '0');
             v.crcReset  := '1';
             if (inputAxisMaster.tValid = '1' and v.outputAxisMaster.tValid = '0') then
-               v.outputAxisMaster                     := axiStreamMasterInit(AXIS_CONFIG_C);
-               v.outputAxisMaster.tValid              := inputAxisMaster.tValid;
-               v.outputAxisMaster.tData(7 downto 0)   := inputAxisMaster.tUser(7 downto 0);
-               v.outputAxisMaster.tData(15 downto 8)  := inputAxisMaster.tDest(7 downto 0);
-               v.outputAxisMaster.tData(23 downto 16) := inputAxisMaster.tId(7 downto 0);
-               v.outputAxisMaster.tData(24)           := not packetActiveOut;
-               v.outputAxisMaster.tData(47 downto 32) := packetNumberOut;
+               v.outputAxisMaster                                 := axiStreamMasterInit(AXIS_CONFIG_C);
+               v.outputAxisMaster.tValid                          := inputAxisMaster.tValid;
+               v.outputAxisMaster.tData(PACKET_HDR_TUSER_FIELD_C) := inputAxisMaster.tUser(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_TDEST_FIELD_C) := inputAxisMaster.tDest(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_TID_FIELD_C)   := inputAxisMaster.tId(7 downto 0);
+               v.outputAxisMaster.tData(PACKET_HDR_SOF_BIT_C)     := not packetActiveOut;
+               v.outputAxisMaster.tData(PACKET_HDR_SEQ_FIELD_C)   := packetNumberOut;
+
                -- Frame ID on 63:48?
                axiStreamSetUserBit(AXIS_CONFIG_C, v.outputAxisMaster, SSI_SOF_C, '1', 0);  -- SOF
-               v.packetNumber                         := packetNumberOut + 1;
-               v.packetActive                         := '1';
-               v.activeTDest                          := inputAxisMaster.tDest;
-               v.state                                := MOVE_S;
+               v.packetNumber := packetNumberOut + 1;
+               v.packetActive := '1';
+               v.activeTDest  := inputAxisMaster.tDest;
+               v.state        := MOVE_S;
             end if;
 
          when MOVE_S =>
@@ -290,19 +291,19 @@ begin
          when TAIL_S =>
             -- Insert tail when master side is ready for it
             if (v.outputAxisMaster.tValid = '0') then
-               v.outputAxisMaster.tValid              := '1';
-               v.outputAxisMaster.tKeep               := X"00FF";
-               v.outputAxisMaster.tData               := (others => '0');
-               v.outputAxisMaster.tData(8)            := r.eof;
-               v.outputAxisMaster.tData(7 downto 0)   := r.tUserLast;
-               v.outputAxisMaster.tData(19 downto 16) := r.lastByteCount;
-               v.outputAxisMaster.tData(63 downto 32) := ite(CRC_EN_G, crcOut, X"00000000");
+               v.outputAxisMaster.tValid                           := '1';
+               v.outputAxisMaster.tKeep                            := X"00FF";
+               v.outputAxisMaster.tData                            := (others => '0');
+               v.outputAxisMaster.tData(PACKET_TAIL_EOF_BIT_C)     := r.eof;
+               v.outputAxisMaster.tData(PACKET_TAIL_TUSER_FIELD_C) := r.tUserLast;
+               v.outputAxisMaster.tData(PACKET_TAIL_BYTES_FIELD_C) := r.lastByteCount;
+               v.outputAxisMaster.tData(PACKET_TAIL_CRC_FIELD_C)   := ite(CRC_EN_G, crcOut, X"00000000");
                -- Myabe set tuser when SSI enabled?
-               v.outputAxisMaster.tUser               := (others => '0');
-               v.outputAxisMaster.tLast               := '1';
-               v.eof                                  := '0';       -- Clear EOF for next frame
-               v.tUserLast                            := (others => '0');
-               v.state                                := HEADER_S;  -- Go to idle and wait for new data
+               v.outputAxisMaster.tUser                            := (others => '0');
+               v.outputAxisMaster.tLast                            := '1';
+               v.eof                                               := '0';  -- Clear EOF for next frame
+               v.tUserLast                                         := (others => '0');
+               v.state                                             := HEADER_S;  -- Go to idle and wait for new data
             end if;
 
       end case;

--- a/axi/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/axi/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -28,17 +28,17 @@ package AxiStreamPacketizer2Pkg is
 
    constant PACKETIZER2_VERSION_C : slv(7 downto 0) := X"02";
 
-   type PACKETIZER2_HDR_VERSION_FIELD_C is range 7 downto 0;
-   type PACKETIZER2_HDR_TUSER_FIELD_C is range 15 downto 8;
-   type PACKETIZER2_HDR_TDEST_FIELD_C is range 23 downto 16;
-   type PACKETIZER2_HDR_TID_FIELD_C is range 31 downto 24;
+   subtype PACKETIZER2_HDR_VERSION_FIELD_C is natural range 7 downto 0;
+   subtype PACKETIZER2_HDR_TUSER_FIELD_C is natural range 15 downto 8;
+   subtype PACKETIZER2_HDR_TDEST_FIELD_C is natural range 23 downto 16;
+   subtype PACKETIZER2_HDR_TID_FIELD_C is natural range 31 downto 24;
    constant PACKETIZER2_HDR_SOF_BIT_C : integer := 63;
-   type PACKETIZER2_HDR_SEQ_FIELD_C is range 47 downto 32;
+   subtype PACKETIZER2_HDR_SEQ_FIELD_C is natural range 47 downto 32;
 
    constant PACKETIZER2_TAIL_EOF_BIT_C : integer := 8;
-   type PACKETIZER2_TAIL_TUSER_FIELD_C is range 7 downto 0;
-   type PACKETIZER2_TAIL_BYTES_FIELD_C is range 19 downto 16;
-   type PACKETIZER2_TAIL_CRC_FIELD_C is range 63 downto 32;
+   subtype PACKETIZER2_TAIL_TUSER_FIELD_C is natural range 7 downto 0;
+   subtype PACKETIZER2_TAIL_BYTES_FIELD_C is natural range 19 downto 16;
+   subtype PACKETIZER2_TAIL_CRC_FIELD_C is natural range 63 downto 32;
 
    type Packetizer2DebugType is record
       sof         : sl;

--- a/axi/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/axi/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -3,7 +3,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-07
--- Last update: 2018-02-01
+-- Last update: 2018-02-05
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -26,28 +26,11 @@ use work.SsiPkg.all;
 
 package AxiStreamPacketizer2Pkg is
 
---    constant AXIS_CONFIG_C : AxiStreamConfigType := (
---       TSTRB_EN_C    => false,
---       TDATA_BYTES_C => 8,
---       TDEST_BITS_C  => 0,
---       TID_BITS_C    => 0,
---       TKEEP_MODE_C  => TKEEP_NORMAL_C,
---       TUSER_BITS_C  => 2,
---       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
-
---    constant AXIS_CONFIG_C : AxiStreamConfigType := (
---       TSTRB_EN_C    => false,
---       TDATA_BYTES_C => 8,
---       TDEST_BITS_C  => 8,
---       TID_BITS_C    => 8,
---       TKEEP_MODE_C  => TKEEP_COMP_C,
---       TUSER_BITS_C  => 8,
---       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
-
-   type PACKET_HDR_TUSER_FIELD_C is range 7 downto 0;
-   type PACKET_HDR_TDEST_FIELD_C is range 15 downto 8;
-   type PACKET_HDR_TID_FIELD_C is range 23 downto 16;
-   constant PACKET_HDR_SOF_BIT_C : integer := 24;
+   type PACKET_HDR_VERSION_FIELD_C is range 7 downto 0;
+   type PACKET_HDR_TUSER_FIELD_C is range 15 downto 8;
+   type PACKET_HDR_TDEST_FIELD_C is range 23 downto 16;
+   type PACKET_HDR_TID_FIELD_C is range 31 downto 24;
+   constant PACKET_HDR_SOF_BIT_C : integer := 63;
    type PACKET_HDR_SEQ_FIELD_C is range 47 downto 32;
 
    constant PACKET_TAIL_EOF_BIT_C : integer := 8;
@@ -56,22 +39,78 @@ package AxiStreamPacketizer2Pkg is
    type PACKET_TAIL_CRC_FIELD_C is range 63 downto 32;
 
    type Packetizer2DebugType is record
-      sof  : sl;
-      eof  : sl;
-      eofe : sl;
-      sop  : sl;
-      eop  : sl;
+      sof         : sl;
+      eof         : sl;
+      eofe        : sl;
+      sop         : sl;
+      eop         : sl;
       packetError : sl;
    end record Packetizer2DebugType;
 
    constant PACKETIZER2_DEBUG_INIT_C : Packetizer2DebugType := (
-      sof  => '0',
-      eof  => '0',
-      eofe => '0',
-      sop  => '0',
-      eop  => '0',
+      sof         => '0',
+      eof         => '0',
+      eofe        => '0',
+      sop         => '0',
+      eop         => '0',
       packetError => '0');
 
+
+   function makePacketizer2Header (
+      sof   : sl               := '1';
+      tuser : slv(7 downto 0)  := (others => '0');
+      tdest : slv(7 downto 0)  := (others => '0');
+      tid   : slv(7 downto 0)  := (others => '0');
+      seq   : slv(15 downto 0) := (others => '0'))
+      return slv;
+
+   function makePacketizer2Tail (
+      eof   : sl               := '1';
+      tuser : slv(7 downto 0)  := (others => '0');
+      bytes : slv(3 downto 0)  := "1000";  -- Default 8 bytes
+      crc   : slv(31 downto 0) := (others => '0'))
+      return slv;
+   
 end package AxiStreamPacketizer2Pkg;
+
+package body AxiStreamPacketizer2Pkg is
+
+   function makePacketizer2Header (
+      sof   : sl               := '1';
+      tuser : slv(7 downto 0)  := (others => '0');
+      tdest : slv(7 downto 0)  := (others => '0');
+      tid   : slv(7 downto 0)  := (others => '0');
+      seq   : slv(15 downto 0) := (others => '0'))
+      return slv
+   is
+      variable ret : slv(63 downto 0);
+   begin
+      ret := (others => '0');
+      ret(PACKET_HDR_SOF_BIT_C) := sof;
+      ret(PACKET_HDR_TUSER_FIELD_C) := tuser;
+      ret(PACKET_HDR_TDEST_FIELD_C) := tdest;
+      ret(PACKET_HDR_TID_FIELD_C) := tid;
+      ret(PACKET_HDR_SEQ_FIELD_C) : seq;
+      return ret;
+   end function makePacketizer2Header;
+
+   function makePacketizer2Tail (
+      eof   : sl               := '1';
+      tuser : slv(7 downto 0)  := (others => '0');
+      bytes : slv(3 downto 0)  := "1000";
+      crc   : slv(31 downto 0) := (others => '0'))
+      return slv
+   is
+      variable ret : slv(63 downto 0);
+   begin
+      ret := (others => '0');
+      ret(PACKET_TAIL_EOF_BIT_C) := eof;
+      ret(PACKET_TAIL_TUSER_FIELD_C) := tuser;
+      ret(PACKET_TAIL_BYTES_FIELD_C) := bytes;
+      ret(PACKET_TAIL_CRC_FIELD_C) := crc;
+      return ret;
+   end function makePacketizer2Tail;
+
+end package body AxiStreamPacketizer2Pkg;
 
 

--- a/axi/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/axi/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -26,6 +26,8 @@ use work.SsiPkg.all;
 
 package AxiStreamPacketizer2Pkg is
 
+   constant PACKET_VERSION_C : slv(7 downto 0) := X"02";
+   
    type PACKET_HDR_VERSION_FIELD_C is range 7 downto 0;
    type PACKET_HDR_TUSER_FIELD_C is range 15 downto 8;
    type PACKET_HDR_TDEST_FIELD_C is range 23 downto 16;
@@ -86,6 +88,7 @@ package body AxiStreamPacketizer2Pkg is
       variable ret : slv(63 downto 0);
    begin
       ret := (others => '0');
+      ret(PACKET_HDR_VERSION_FIELD_C) := PACKET_VERSION_C;
       ret(PACKET_HDR_SOF_BIT_C) := sof;
       ret(PACKET_HDR_TUSER_FIELD_C) := tuser;
       ret(PACKET_HDR_TDEST_FIELD_C) := tdest;

--- a/axi/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/axi/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -3,7 +3,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-07
--- Last update: 2018-02-05
+-- Last update: 2018-02-14
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -26,19 +26,19 @@ use work.SsiPkg.all;
 
 package AxiStreamPacketizer2Pkg is
 
-   constant PACKET_VERSION_C : slv(7 downto 0) := X"02";
-   
-   type PACKET_HDR_VERSION_FIELD_C is range 7 downto 0;
-   type PACKET_HDR_TUSER_FIELD_C is range 15 downto 8;
-   type PACKET_HDR_TDEST_FIELD_C is range 23 downto 16;
-   type PACKET_HDR_TID_FIELD_C is range 31 downto 24;
-   constant PACKET_HDR_SOF_BIT_C : integer := 63;
-   type PACKET_HDR_SEQ_FIELD_C is range 47 downto 32;
+   constant PACKETIZER2_VERSION_C : slv(7 downto 0) := X"02";
 
-   constant PACKET_TAIL_EOF_BIT_C : integer := 8;
-   type PACKET_TAIL_TUSER_FIELD_C is range 7 downto 0;
-   type PACKET_TAIL_BYTES_FIELD_C is range 19 downto 16;
-   type PACKET_TAIL_CRC_FIELD_C is range 63 downto 32;
+   type PACKETIZER2_HDR_VERSION_FIELD_C is range 7 downto 0;
+   type PACKETIZER2_HDR_TUSER_FIELD_C is range 15 downto 8;
+   type PACKETIZER2_HDR_TDEST_FIELD_C is range 23 downto 16;
+   type PACKETIZER2_HDR_TID_FIELD_C is range 31 downto 24;
+   constant PACKETIZER2_HDR_SOF_BIT_C : integer := 63;
+   type PACKETIZER2_HDR_SEQ_FIELD_C is range 47 downto 32;
+
+   constant PACKETIZER2_TAIL_EOF_BIT_C : integer := 8;
+   type PACKETIZER2_TAIL_TUSER_FIELD_C is range 7 downto 0;
+   type PACKETIZER2_TAIL_BYTES_FIELD_C is range 19 downto 16;
+   type PACKETIZER2_TAIL_CRC_FIELD_C is range 63 downto 32;
 
    type Packetizer2DebugType is record
       sof         : sl;
@@ -72,7 +72,7 @@ package AxiStreamPacketizer2Pkg is
       bytes : slv(3 downto 0)  := "1000";  -- Default 8 bytes
       crc   : slv(31 downto 0) := (others => '0'))
       return slv;
-   
+
 end package AxiStreamPacketizer2Pkg;
 
 package body AxiStreamPacketizer2Pkg is
@@ -87,13 +87,13 @@ package body AxiStreamPacketizer2Pkg is
    is
       variable ret : slv(63 downto 0);
    begin
-      ret := (others => '0');
-      ret(PACKET_HDR_VERSION_FIELD_C) := PACKET_VERSION_C;
-      ret(PACKET_HDR_SOF_BIT_C) := sof;
-      ret(PACKET_HDR_TUSER_FIELD_C) := tuser;
-      ret(PACKET_HDR_TDEST_FIELD_C) := tdest;
-      ret(PACKET_HDR_TID_FIELD_C) := tid;
-      ret(PACKET_HDR_SEQ_FIELD_C) : seq;
+      ret                             := (others => '0');
+      ret(PACKETIZER2_HDR_VERSION_FIELD_C) := PACKETIZER2_VERSION_C;
+      ret(PACKETIZER2_HDR_SOF_BIT_C)       := sof;
+      ret(PACKETIZER2_HDR_TUSER_FIELD_C)   := tuser;
+      ret(PACKETIZER2_HDR_TDEST_FIELD_C)   := tdest;
+      ret(PACKETIZER2_HDR_TID_FIELD_C)     := tid;
+      ret(PACKETIZER2_HDR_SEQ_FIELD_C)     := seq;
       return ret;
    end function makePacketizer2Header;
 
@@ -106,11 +106,11 @@ package body AxiStreamPacketizer2Pkg is
    is
       variable ret : slv(63 downto 0);
    begin
-      ret := (others => '0');
-      ret(PACKET_TAIL_EOF_BIT_C) := eof;
-      ret(PACKET_TAIL_TUSER_FIELD_C) := tuser;
-      ret(PACKET_TAIL_BYTES_FIELD_C) := bytes;
-      ret(PACKET_TAIL_CRC_FIELD_C) := crc;
+      ret                            := (others => '0');
+      ret(PACKETIZER2_TAIL_EOF_BIT_C)     := eof;
+      ret(PACKETIZER2_TAIL_TUSER_FIELD_C) := tuser;
+      ret(PACKETIZER2_TAIL_BYTES_FIELD_C) := bytes;
+      ret(PACKETIZER2_TAIL_CRC_FIELD_C)   := crc;
       return ret;
    end function makePacketizer2Tail;
 

--- a/axi/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/axi/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -3,7 +3,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-07
--- Last update: 2017-04-14
+-- Last update: 2018-02-01
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -52,7 +52,7 @@ package AxiStreamPacketizer2Pkg is
 
    constant PACKET_TAIL_EOF_BIT_C : integer := 8;
    type PACKET_TAIL_TUSER_FIELD_C is range 7 downto 0;
-   type PACKET_TAIL_BYTES_FIELD_C is range 18 downto 16;
+   type PACKET_TAIL_BYTES_FIELD_C is range 19 downto 16;
    type PACKET_TAIL_CRC_FIELD_C is range 63 downto 32;
 
    type Packetizer2DebugType is record

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -37,66 +37,76 @@ package Pgp3Pkg is
          tUserBits => 2);
 
    -- Define K code BTFs
-   constant IDLE_C : slv(7 downto 0)   := X"99";
-   constant SOF_C  : slv(7 downto 0)   := X"AA";
-   constant EOF_C  : slv(7 downto 0)   := X"55";
-   constant SOC_C  : slv(7 downto 0)   := X"CC";
-   constant EOC_C  : slv(7 downto 0)   := X"33";
-   constant SKP_C  : slv(7 downto 0)   := X"66";
-   constant USER_C : Slv8Array(0 to 7) := (X"78", X"87", X"2D", X"D2", X"1E", X"E1", X"B4", X"4B");
+   constant PGP3_IDLE_C : slv(7 downto 0)   := X"99";
+   constant PGP3_SOF_C  : slv(7 downto 0)   := X"AA";
+   constant PGP3_EOF_C  : slv(7 downto 0)   := X"55";
+   constant PGP3_SOC_C  : slv(7 downto 0)   := X"CC";
+   constant PGP3_EOC_C  : slv(7 downto 0)   := X"33";
+   constant PGP3_SKP_C  : slv(7 downto 0)   := X"66";
+   constant PGP3_USER_C : Slv8Array(0 to 7) := (X"78", X"87", X"2D", X"D2", X"1E", X"E1", X"B4", X"4B");
 
-   constant VALID_BTF_ARRAY_C : Slv8Array := (
-      0  => IDLE_C,
-      1  => SOF_C,
-      2  => EOF_C,
-      3  => SOC_C,
-      4  => EOC_C,
-      5  => SKP_C,
-      6  => USER_C(0),
-      7  => USER_C(1),
-      8  => USER_C(2),
-      9  => USER_C(3),
-      10 => USER_C(4),
-      11 => USER_C(5),
-      12 => USER_C(6),
-      13 => USER_C(7));
+   constant PGP3_VALID_BTF_ARRAY_C : Slv8Array := (
+      0  => PGP3_IDLE_C,
+      1  => PGP3_SOF_C,
+      2  => PGP3_EOF_C,
+      3  => PGP3_SOC_C,
+      4  => PGP3_EOC_C,
+      5  => PGP3_SKP_C,
+      6  => PGP3_USER_C(0),
+      7  => PGP3_USER_C(1),
+      8  => PGP3_USER_C(2),
+      9  => PGP3_USER_C(3),
+      10 => PGP3_USER_C(4),
+      11 => PGP3_USER_C(5),
+      12 => PGP3_USER_C(6),
+      13 => PGP3_USER_C(7));
 
-   constant D_HEADER_C : slv(1 downto 0) := "01";
-   constant K_HEADER_C : slv(1 downto 0) := "10";
+   constant PGP3_D_HEADER_C : slv(1 downto 0) := "01";
+   constant PGP3_K_HEADER_C : slv(1 downto 0) := "10";
 
-   constant SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := (0 => 39, 1 => 58);
+   constant PGP3_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := (0 => 39, 1 => 58);
 
+   type PGP3_BTF_FIELD_C is range 63 downto 56;
+   type PGP3_LINKINFO_FIELD_C is range 39 downto 0;
    type PGP3_SOFC_VC_FIELD_C is range 43 downto 40;
    type PGP3_SOFC_SEQ_FIELD_C is range 55 downto 44;
    type PGP3_EOFC_TUSER_FIELD_C is range 7 downto 0;
    type PGP3_EOFC_BYTES_LAST_FIELD_C is range 19 downto 16;
    type PGP3_EOFC_CRC_FIELD_C is range 55 downto 24;
+   type PGP3_USER_CHECKSUM_FIELD_C is range 55 downto 48;
+   type PGP3_USER_OPCODE_FIELD_C is range 47 downto 0;
 
-   function makeLinkInfo (
+   function pgp3MakeLinkInfo (
       locRxFifoCtrl  : AxiStreamCtrlArray;
       locRxLinkReady : sl)
       return slv;
 
-   procedure extractLinkInfo (
+   procedure pgp3ExtractLinkInfo (
       linkInfo       : in    slv(39 downto 0);
       remRxFifoCtrl  : inout AxiStreamCtrlArray;
       remRxLinkReady : inout sl;
       version        : inout slv(2 downto 0));
 
+   function pgp3OpCodeChecksum (
+      opCodeData : slv(47 downto 0))
+      return slv;
+
 
    type Pgp3TxInType is record
       disable      : sl;
       flowCntlDis  : sl;
-      skpInterval : slv(31 downto 0);
+      skpInterval  : slv(31 downto 0);
       opCodeEn     : sl;
       opCodeNumber : slv(2 downto 0);
       opCodeData   : slv(47 downto 0);
    end record Pgp3TxInType;
+
    type Pgp3TxInArray is array (natural range<>) of Pgp3TxInType;
+
    constant PGP3_TX_IN_INIT_C : Pgp3TxInType := (
       disable      => '0',
       flowCntlDis  => '0',
-      skpInterval => (others => '0'),
+      skpInterval  => (others => '0'),
       opCodeEn     => '0',
       opCodeNumber => (others => '0'),
       opCodeData   => (others => '0'));
@@ -110,7 +120,7 @@ package Pgp3Pkg is
       frameTx     : sl;                 -- A good frame was transmitted
       frameTxErr  : sl;                 -- An errored frame was transmitted
    end record;
-   
+
    type Pgp3TxOutArray is array (natural range<>) of Pgp3TxOutType;
 
    constant PGP3_TX_OUT_INIT_C : Pgp3TxOutType := (
@@ -125,7 +135,7 @@ package Pgp3Pkg is
       loopback : slv(2 downto 0);
       resetRx  : sl;
    end record Pgp3RxInType;
-   
+
    type Pgp3RxInArray is array (natural range<>) of Pgp3RxInType;
 
    constant PGP3_RX_IN_INIT_C : Pgp3RxInType := (
@@ -161,7 +171,9 @@ package Pgp3Pkg is
       ebOverflow : sl;
       ebStatus   : slv(8 downto 0);
    end record Pgp3RxOutType;
+
    type Pgp3RxOutArray is array (natural range<>) of Pgp3RxOutType;
+
    constant PGP3_RX_OUT_INIT_C : Pgp3RxOutType := (
       phyRxActive    => '0',
       linkReady      => '0',
@@ -186,18 +198,18 @@ package Pgp3Pkg is
       ebValid        => '0',
       ebOverflow     => '0',
       ebStatus       => (others => '0'));
-      
+
    type Pgp3RefClkType is (
-      PGP3_REFCLK_125_C,  -- Used in 6.25Gbps only
-      PGP3_REFCLK_156_C,  -- Used in 10.3125Gbps & 6.25Gbps
-      PGP3_REFCLK_250_C,  -- Used in 6.25Gbps only
-      PGP3_REFCLK_312_C); -- Used in 10.3125Gbps & 6.25Gbps
-      
+      PGP3_REFCLK_125_C,                -- Used in 6.25Gbps only
+      PGP3_REFCLK_156_C,                -- Used in 10.3125Gbps & 6.25Gbps
+      PGP3_REFCLK_250_C,                -- Used in 6.25Gbps only
+      PGP3_REFCLK_312_C);               -- Used in 10.3125Gbps & 6.25Gbps
+
 end package Pgp3Pkg;
 
 package body Pgp3Pkg is
 
-   function makeLinkInfo (
+   function pgp3MakeLinkInfo (
       locRxFifoCtrl  : AxiStreamCtrlArray;
       locRxLinkReady : sl)
       return slv
@@ -211,9 +223,9 @@ package body Pgp3Pkg is
       ret(32)           := locRxLinkReady;
       ret(35 downto 33) := PGP3_VERSION_C;
       return ret;
-   end function makeLinkInfo;
+   end function;
 
-   procedure extractLinkInfo (
+   procedure pgp3ExtractLinkInfo (
       linkInfo       : in    slv(39 downto 0);
       remRxFifoCtrl  : inout AxiStreamCtrlArray;
       remRxLinkReady : inout sl;
@@ -225,6 +237,21 @@ package body Pgp3Pkg is
       end loop;
       remRxLinkReady := linkInfo(32);
       version        := linkInfo(35 downto 33);
-   end procedure extractLinkInfo;
+   end procedure;
+
+   function pgp3OpCodeChecksum (
+      opCodeData : slv(47 downto 0))
+      return slv
+   is
+      variable ret : slv(7 downto 0);
+   begin
+      ret := not (opCodeData(7 downto 0) +
+                  opCodeData(15 downto 8) +
+                  opCodeData(23 downto 16) +
+                  opCodeData(31 downto 24) +
+                  opCodeData(39 downto 32) +
+                  opCodeData(47 downto 40));
+      return ret;
+   end function
 
 end package body Pgp3Pkg;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -19,6 +19,8 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
@@ -66,15 +68,15 @@ package Pgp3Pkg is
 
    constant PGP3_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := (0 => 39, 1 => 58);
 
-   type PGP3_BTF_FIELD_C is range 63 downto 56;
-   type PGP3_LINKINFO_FIELD_C is range 39 downto 0;
-   type PGP3_SOFC_VC_FIELD_C is range 43 downto 40;
-   type PGP3_SOFC_SEQ_FIELD_C is range 55 downto 44;
-   type PGP3_EOFC_TUSER_FIELD_C is range 7 downto 0;
-   type PGP3_EOFC_BYTES_LAST_FIELD_C is range 19 downto 16;
-   type PGP3_EOFC_CRC_FIELD_C is range 55 downto 24;
-   type PGP3_USER_CHECKSUM_FIELD_C is range 55 downto 48;
-   type PGP3_USER_OPCODE_FIELD_C is range 47 downto 0;
+   subtype PGP3_BTF_FIELD_C is natural range 63 downto 56;
+   subtype PGP3_LINKINFO_FIELD_C is natural range 39 downto 0;
+   subtype PGP3_SOFC_VC_FIELD_C is natural range 43 downto 40;
+   subtype PGP3_SOFC_SEQ_FIELD_C is natural range 55 downto 44;
+   subtype PGP3_EOFC_TUSER_FIELD_C is natural range 7 downto 0;
+   subtype PGP3_EOFC_BYTES_LAST_FIELD_C is natural range 19 downto 16;
+   subtype PGP3_EOFC_CRC_FIELD_C is natural range 55 downto 24;
+   subtype PGP3_USER_CHECKSUM_FIELD_C is natural range 55 downto 48;
+   subtype PGP3_USER_OPCODE_FIELD_C is natural range 47 downto 0;
 
    function pgp3MakeLinkInfo (
       locRxFifoCtrl  : AxiStreamCtrlArray;
@@ -252,6 +254,6 @@ package body Pgp3Pkg is
                   opCodeData(39 downto 32) +
                   opCodeData(47 downto 40));
       return ret;
-   end function
+   end function;
 
 end package body Pgp3Pkg;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxEb.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxEb.vhd
@@ -71,7 +71,7 @@ begin
       v.fifoWrEn             := phyRxValid;
 
       -- Don't write SKP words into the FIFO
-      if (phyRxHeader = K_HEADER_C and phyRxData(63 downto 56) = SKP_C) then
+      if (phyRxHeader = PGP3_K_HEADER_C and phyRxData(63 downto 56) = PGP3_SKP_C) then
          v.fifoWrEn := '0';
       end if;
 

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
@@ -11,11 +11,11 @@
 -- stream (pre-scrambler). Inserts IDLE and SKP codes as needed. Inserts
 -- user K codes on request.
 -------------------------------------------------------------------------------
--- This file is part of <PROJECT_NAME>. It is subject to
+-- This file is part of SURF. It is subject to
 -- the license terms in the LICENSE.txt file found in the top-level directory
 -- of this distribution and at:
 --    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
--- No part of <PROJECT_NAME>, including this file, may be
+-- No part of SURF, including this file, may be
 -- copied, modified, propagated, or distributed except according to the terms
 -- contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
@@ -27,6 +27,7 @@ use ieee.std_logic_arith.all;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
+use work.AxiStreamPacketizer2Pkg.all;
 use work.SsiPkg.all;
 use work.Pgp3Pkg.all;
 
@@ -110,7 +111,7 @@ begin
    begin
       v := r;
 
-      btf := protRxData(63 downto 56);
+      btf := protRxData(PGP3_BTF_FIELD_C);
 
       v.pgpRxMaster        := REG_INIT_C.pgpRxMaster;
       v.pgpRxOut.opCodeEn  := '0';
@@ -118,13 +119,7 @@ begin
       v.pgpRxOut.linkError := '0';
       v.protRxPhyInit      := '0';
 
-      opCodeChecksum := not (protRxData(7 downto 0) +
-                             protRxData(15 downto 8) +
-                             protRxData(23 downto 16) +
-                             protRxData(31 downto 24) +
-                             protRxData(39 downto 32) +                             
-                             protRxData(47 downto 40));
-
+      opCodeChecksum := pgp3OpCodeChecksum(protRxData(47 downto 0));
 
       -- Just translate straight to AXI-Stream packetizer2 format
       -- and let the depacketizer handle any errors?
@@ -133,9 +128,9 @@ begin
             -- Unlinked
             -- Need N valid headers in a row. Data is ignored.
             v.count := (others => '0');
-            if (protRxHeader = K_HEADER_C) then
-               for i in VALID_BTF_ARRAY_C'range loop
-                  if (btf = VALID_BTF_ARRAY_C(i)) then
+            if (protRxHeader = PGP3_K_HEADER_C) then
+               for i in PGP3_VALID_BTF_ARRAY_C'range loop
+                  if (btf = PGP3_VALID_BTF_ARRAY_C(i)) then
                      -- Valid header, increment count
                      v.count := r.count + 1;
                   end if;
@@ -152,53 +147,54 @@ begin
             -- reset when IDLE or SOF or SOC seen
             v.count := r.count + 1;
 
-            if (protRxHeader = K_HEADER_C) then
-               if (btf = IDLE_C) then
-                  extractLinkInfo(
-                     protRxData(39 downto 0),
+            if (protRxHeader = PGP3_K_HEADER_C) then
+               if (btf = PGP3_IDLE_C) then
+                  pgp3ExtractLinkInfo(
+                     protRxData(PGP3_LINKINFO_FIELD_C),
                      v.remRxFifoCtrl,
                      v.remRxLinkReady,
                      v.version);
                   if (v.version = PGP3_VERSION_C) then
                      v.count := (others => '0');
                   end if;
-               elsif (btf = SOF_C or btf = SOC_C) then
-                  v.pgpRxMaster.tValid              := r.pgpRxOut.linkReady;  -- Hold Everything until
-                  v.pgpRxMaster.tData               := (others => '0');
-                  v.pgpRxMaster.tData(24)           := ite(btf = SOF_C, '1', '0');  -- packetizer SOC bit
-                  v.pgpRxMaster.tData(11 downto 8)  := protRxData(43 downto 40);  -- VC
-                  v.pgpRxMaster.tData(43 downto 32) := protRxData(55 downto 44);  -- packet number
+               elsif (btf = PGP3_SOF_C or btf = PGP3_SOC_C) then
+                  v.pgpRxMaster.tValid := r.pgpRxOut.linkReady;  -- Hold Everything until linkready
+                  v.pgpRxMaster.tData := axiStreamPacketizer2Header(
+                     sof   => ite(btf = SOF_C, '1', '0'),
+                     tdest => resize(protRxData(PGP3_SOFC_VC_FIELD_C), 8),
+                     seq   => resize(protRxData(PGP3_SOFC_SEQ_FIELD_C), PACKET_HDR_SEQ_FIELD_C'length));
                   axiStreamSetUserBit(PGP3_AXIS_CONFIG_C, v.pgpRxMaster, SSI_SOF_C, '1', 0);  -- Set SOF
-                  extractLinkInfo(
-                     protRxData(39 downto 0),
+                  pgp3ExtractLinkInfo(
+                     protRxData(PGP3_LINKINFO_FIELD_C),
                      v.remRxFifoCtrl,
                      v.pgpRxOut.remRxLinkReady,
                      v.version);
                   if (v.version = PGP3_VERSION_C) then
                      v.count := (others => '0');
                   end if;
-               elsif (btf = EOF_C or btf = EOC_C) then
-                  v.pgpRxMaster.tValid              := r.pgpRxOut.linkReady;
-                  v.pgpRxMaster.tLast               := '1';
-                  v.pgpRxMaster.tData               := (others => '0');
-                  v.pgpRxMaster.tData(8)            := toSl(btf = EOF_C);     -- EOF bit
-                  v.pgpRxMaster.tData(7 downto 0)   := protRxData(7 downto 0);    -- TUSER LAST
-                  v.pgpRxMaster.tData(19 downto 16) := protRxData(19 downto 16);  -- Last byte count
-                  v.pgpRxMaster.tData(63 downto 32) := protRxData(55 downto 24);  -- CRC
+               elsif (btf = PGP3_EOF_C or btf = PGP3_EOC_C) then
+                  v.pgpRxMaster.tValid := r.pgpRxOut.linkReady;
+                  v.pgpRxMaster.tLast  := '1';
+                  v.pgpRxMaster.tData := makePacketizer2Tail(
+                     eof   => toSl(btf = PGP3_EOF_C),
+                     tuser => protRxData(PGP3_EOFC_TUSER_FIELD_C),
+                     bytes => protRxData(PGP3_EOFC_BYTES_LAST_FIELD_C),
+                     crc   => protRxData(PGP3_EOFC_CRC_FIELD_C));
+
                else
-                  for i in USER_C'range loop
-                     if (btf = USER_C(i)) then
+                  for i in PGP3_USER_C'range loop
+                     if (btf = PGP3_USER_C(i)) then
                         v.pgpRxOut.opCodeNumber := toSlv(i, 3);
-                        v.pgpRxOut.opCodeData   := protRxData(47 downto 0);
+                        v.pgpRxOut.opCodeData   := protRxData(PGP3_USER_OPCODE_FIELD_C);
                         -- Verify checksun
-                        if (protRxData(55 downto 48) = opCodeChecksum) then
-                           v.pgpRxOut.opCodeEn := '1';                           
+                        if (protRxData(PGP3_USER_CHECKSUM_FIELD_C) = opCodeChecksum) then
+                           v.pgpRxOut.opCodeEn := '1';
                         end if;
                      end if;
                   end loop;
                end if;
             -- Unknown opcodes silently dropped
-            elsif (protRxHeader = D_HEADER_C) then
+            elsif (protRxHeader = PGP3_D_HEADER_C) then
                -- Normal Data
                v.pgpRxMaster.tValid             := r.pgpRxOut.linkReady;
                v.pgpRxMaster.tData(63 downto 0) := protRxData;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
@@ -159,10 +159,10 @@ begin
                   end if;
                elsif (btf = PGP3_SOF_C or btf = PGP3_SOC_C) then
                   v.pgpRxMaster.tValid := r.pgpRxOut.linkReady;  -- Hold Everything until linkready
-                  v.pgpRxMaster.tData := axiStreamPacketizer2Header(
+                  v.pgpRxMaster.tData := makePacketizer2Header(
                      sof   => ite(btf = SOF_C, '1', '0'),
                      tdest => resize(protRxData(PGP3_SOFC_VC_FIELD_C), 8),
-                     seq   => resize(protRxData(PGP3_SOFC_SEQ_FIELD_C), PACKET_HDR_SEQ_FIELD_C'length));
+                     seq   => resize(protRxData(PGP3_SOFC_SEQ_FIELD_C), PACKETIZER2_HDR_SEQ_FIELD_C'length));
                   axiStreamSetUserBit(PGP3_AXIS_CONFIG_C, v.pgpRxMaster, SSI_SOF_C, '1', 0);  -- Set SOF
                   pgp3ExtractLinkInfo(
                      protRxData(PGP3_LINKINFO_FIELD_C),

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
@@ -135,7 +135,7 @@ begin
                      v.count := r.count + 1;
                   end if;
                end loop;
-            elsif (protRxHeader = D_HEADER_C) then
+            elsif (protRxHeader = PGP3_D_HEADER_C) then
                -- Ignore data
                v.count := r.count;
             end if;
@@ -159,10 +159,10 @@ begin
                   end if;
                elsif (btf = PGP3_SOF_C or btf = PGP3_SOC_C) then
                   v.pgpRxMaster.tValid := r.pgpRxOut.linkReady;  -- Hold Everything until linkready
-                  v.pgpRxMaster.tData := makePacketizer2Header(
-                     sof   => ite(btf = SOF_C, '1', '0'),
+                  v.pgpRxMaster.tData(63 downto 0) := makePacketizer2Header(
+                     sof   => ite(btf = PGP3_SOF_C, '1', '0'),
                      tdest => resize(protRxData(PGP3_SOFC_VC_FIELD_C), 8),
-                     seq   => resize(protRxData(PGP3_SOFC_SEQ_FIELD_C), PACKETIZER2_HDR_SEQ_FIELD_C'length));
+                     seq   => resize(protRxData(PGP3_SOFC_SEQ_FIELD_C), 16));
                   axiStreamSetUserBit(PGP3_AXIS_CONFIG_C, v.pgpRxMaster, SSI_SOF_C, '1', 0);  -- Set SOF
                   pgp3ExtractLinkInfo(
                      protRxData(PGP3_LINKINFO_FIELD_C),
@@ -175,7 +175,7 @@ begin
                elsif (btf = PGP3_EOF_C or btf = PGP3_EOC_C) then
                   v.pgpRxMaster.tValid := r.pgpRxOut.linkReady;
                   v.pgpRxMaster.tLast  := '1';
-                  v.pgpRxMaster.tData := makePacketizer2Tail(
+                  v.pgpRxMaster.tData(63 downto 0) := makePacketizer2Tail(
                      eof   => toSl(btf = PGP3_EOF_C),
                      tuser => protRxData(PGP3_EOFC_TUSER_FIELD_C),
                      bytes => protRxData(PGP3_EOFC_BYTES_LAST_FIELD_C),

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
@@ -229,7 +229,7 @@ begin
          DIRECTION_G      => "SCRAMBLER",
          DATA_WIDTH_G     => 64,
          SIDEBAND_WIDTH_G => 9,
-         TAPS_G           => SCRAMBLER_TAPS_C)
+         TAPS_G           => PGP3_SCRAMBLER_TAPS_C)
       port map (
          clk                        => pgpTxClk,        -- [in]
          rst                        => pgpTxRst,        -- [in]

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -160,18 +160,18 @@ begin
                v.protTxData                        := (others => '0');
                v.protTxData(PGP3_BTF_FIELD_C)      := ite(pgpTxMaster.tData(PACKETIZER2_HDR_SOF_BIT_C) = '1', PGP3_SOF_C, PGP3_SOC_C);
                v.protTxData(PGP3_LINKINFO_FIELD_C) := linkInfo;
-               v.protTxData(PGP3_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C), PGP3_SOFC_VC_FIELD_C'length);  -- Virtual Channel
-               v.protTxData(PGP3_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C), PGP3_SOFC_SEQ_FIELD_C'length));  -- Packet number
+               v.protTxData(PGP3_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C), 4);  -- Virtual Channel
+               v.protTxData(PGP3_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C), 12);  -- Packet number
                v.protTxHeader                      := PGP3_K_HEADER_C;
 
             elsif (pgpTxMaster.tLast = '1') then
                -- EOF/EOC
                v.protTxData                               := (others => '0');
-               v.protTxData(PGP3_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C) = '1', EOF_C, EOC_C);
+               v.protTxData(PGP3_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C) = '1', PGP3_EOF_C, PGP3_EOC_C);
                v.protTxData(PGP3_EOFC_TUSER_FIELD_C)      := pgpTxMaster.tData(PACKETIZER2_TAIL_TUSER_FIELD_C);  -- TUSER LAST
                v.protTxData(PGP3_EOFC_BYTES_LAST_FIELD_C) := pgpTxMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C);  -- Last byte count
                v.protTxData(PGP3_EOFC_CRC_FIELD_C)        := pgpTxMaster.tData(PACKETIZER2_TAIL_CRC_FIELD_C);  -- CRC
-               v.protTxHeader                             := K_HEADER_C;
+               v.protTxHeader                             := PGP3_K_HEADER_C;
                -- Debug output
                v.frameTx                                  := pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C);
                v.frameTxErr                               := v.frameTx and ssiGetUserEofe(PGP3_AXIS_CONFIG_C, pgpTxMaster);
@@ -195,7 +195,7 @@ begin
          -- USER codes override data and delay SKP if they happen to coincide
          if (pgpTxIn.opCodeEn = '1' and dataEn = '1') then
             v.pgpTxSlave.tReady                      := '0';  -- Override any data acceptance.
-            v.protTxData(PGP3_BTF_FIELD_C)           := USER_C(conv_integer(pgpTxIn.opCodeNumber));
+            v.protTxData(PGP3_BTF_FIELD_C)           := PGP3_USER_C(conv_integer(pgpTxIn.opCodeNumber));
             v.protTxData(PGP3_USER_CHECKSUM_FIELD_C) := pgp3OpCodeChecksum(pgpTxIn.opCodeData);
             v.protTxData(PGP3_USER_OPCODE_FIELD_C)   := pgpTxIn.opCodeData;
 

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -158,22 +158,22 @@ begin
             if (ssiGetUserSof(PGP3_AXIS_CONFIG_C, pgpTxMaster) = '1') then
                -- SOF/SOC, format SOF/SOC char from data
                v.protTxData                        := (others => '0');
-               v.protTxData(PGP3_BTF_FIELD_C)      := ite(pgpTxMaster.tData(PACKET_HDR_SOF_BIT_C) = '1', PGP3_SOF_C, PGP3_SOC_C);
+               v.protTxData(PGP3_BTF_FIELD_C)      := ite(pgpTxMaster.tData(PACKETIZER2_HDR_SOF_BIT_C) = '1', PGP3_SOF_C, PGP3_SOC_C);
                v.protTxData(PGP3_LINKINFO_FIELD_C) := linkInfo;
-               v.protTxData(PGP3_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKET_HDR_TDEST_FIELD_C), PGP3_SOFC_VC_FIELD_C'length);  -- Virtual Channel
-               v.protTxData(PGP3_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKET_HDR_SEQ_FIELD_C), PGP3_SOFC_SEQ_FIELD_C'length));  -- Packet number
+               v.protTxData(PGP3_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C), PGP3_SOFC_VC_FIELD_C'length);  -- Virtual Channel
+               v.protTxData(PGP3_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C), PGP3_SOFC_SEQ_FIELD_C'length));  -- Packet number
                v.protTxHeader                      := PGP3_K_HEADER_C;
 
             elsif (pgpTxMaster.tLast = '1') then
                -- EOF/EOC
                v.protTxData                               := (others => '0');
-               v.protTxData(PGP3_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKET_TAIL_EOF_BIT_C) = '1', EOF_C, EOC_C);
-               v.protTxData(PGP3_EOFC_TUSER_FIELD_C)      := pgpTxMaster.tData(PACKET_TAIL_TUSER_FIELD_C);  -- TUSER LAST
-               v.protTxData(PGP3_EOFC_BYTES_LAST_FIELD_C) := pgpTxMaster.tData(PACKET_TAIL_BYTES_FIELD_C);  -- Last byte count
-               v.protTxData(PGP3_EOFC_CRC_FIELD_C)        := pgpTxMaster.tData(PACKET_TAIL_CRC_FIELD_C);  -- CRC
+               v.protTxData(PGP3_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C) = '1', EOF_C, EOC_C);
+               v.protTxData(PGP3_EOFC_TUSER_FIELD_C)      := pgpTxMaster.tData(PACKETIZER2_TAIL_TUSER_FIELD_C);  -- TUSER LAST
+               v.protTxData(PGP3_EOFC_BYTES_LAST_FIELD_C) := pgpTxMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C);  -- Last byte count
+               v.protTxData(PGP3_EOFC_CRC_FIELD_C)        := pgpTxMaster.tData(PACKETIZER2_TAIL_CRC_FIELD_C);  -- CRC
                v.protTxHeader                             := K_HEADER_C;
                -- Debug output
-               v.frameTx                                  := pgpTxMaster.tData(PACKET_TAIL_EOF_BIT_C);
+               v.frameTx                                  := pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C);
                v.frameTxErr                               := v.frameTx and ssiGetUserEofe(PGP3_AXIS_CONFIG_C, pgpTxMaster);
             else
                -- Normal data

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -11,11 +11,11 @@
 -- stream (pre-scrambler). Inserts IDLE and SKP codes as needed. Inserts
 -- user K codes on request.
 -------------------------------------------------------------------------------
--- This file is part of <PROJECT_NAME>. It is subject to
+-- This file is part of SURF. It is subject to
 -- the license terms in the LICENSE.txt file found in the top-level directory
 -- of this distribution and at:
 --    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
--- No part of <PROJECT_NAME>, including this file, may be
+-- No part of SURF, including this file, may be
 -- copied, modified, propagated, or distributed except according to the terms
 -- contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
@@ -27,6 +27,7 @@ use ieee.std_logic_arith.all;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
+use work.AxiStreamPacketizer2Pkg.all;
 use work.SsiPkg.all;
 use work.Pgp3Pkg.all;
 
@@ -107,7 +108,7 @@ begin
    begin
       v := r;
 
-      linkInfo := makeLinkInfo(locRxFifoCtrl, locRxLinkReady);
+      linkInfo := pgp3MakeLinkInfo(locRxFifoCtrl, locRxLinkReady);
 
       -- Always increment skpCount
       v.skpCount := r.skpCount + 1;
@@ -145,10 +146,10 @@ begin
          -- Coded in reverse order of priority
 
          -- Send idle chars by default
-         v.protTxData(39 downto 0)  := linkInfo;
-         v.protTxData(55 downto 40) := (others => '0');
-         v.protTxData(63 downto 56) := IDLE_C;
-         v.protTxHeader             := K_HEADER_C;
+         v.protTxData                        := (others => '0');
+         v.protTxData(PGP3_LINKINFO_FIELD_C) := linkInfo;
+         v.protTxData(PGP3_BTF_FIELD_C)      := PGP3_IDLE_C;
+         v.protTxHeader                      := PGP3_K_HEADER_C;
 
          -- Send data if there is data to send
          if (pgpTxMaster.tValid = '1' and dataEn = '1') then
@@ -156,52 +157,47 @@ begin
 
             if (ssiGetUserSof(PGP3_AXIS_CONFIG_C, pgpTxMaster) = '1') then
                -- SOF/SOC, format SOF/SOC char from data
-               v.protTxData               := (others => '0');
-               v.protTxData(63 downto 56) := ite(pgpTxMaster.tData(24) = '1', SOF_C, SOC_C);
-               v.protTxData(39 downto 0)  := linkInfo;
-               v.protTxData(43 downto 40) := pgpTxMaster.tData(11 downto 8);   -- Virtual Channel
-               v.protTxData(55 downto 44) := pgpTxMaster.tData(43 downto 32);  -- Packet number
-               v.protTxHeader             := K_HEADER_C;
+               v.protTxData                        := (others => '0');
+               v.protTxData(PGP3_BTF_FIELD_C)      := ite(pgpTxMaster.tData(PACKET_HDR_SOF_BIT_C) = '1', PGP3_SOF_C, PGP3_SOC_C);
+               v.protTxData(PGP3_LINKINFO_FIELD_C) := linkInfo;
+               v.protTxData(PGP3_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKET_HDR_TDEST_FIELD_C), PGP3_SOFC_VC_FIELD_C'length);  -- Virtual Channel
+               v.protTxData(PGP3_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKET_HDR_SEQ_FIELD_C), PGP3_SOFC_SEQ_FIELD_C'length));  -- Packet number
+               v.protTxHeader                      := PGP3_K_HEADER_C;
 
             elsif (pgpTxMaster.tLast = '1') then
                -- EOF/EOC
-               v.protTxData               := (others => '0');
-               v.protTxData(63 downto 56) := ite(pgpTxMaster.tData(8) = '1', EOF_C, EOC_C);
-               v.protTxData(7 downto 0)   := pgpTxMaster.tData(7 downto 0);    -- TUSER LAST
-               v.protTxData(19 downto 16) := pgpTxMaster.tData(19 downto 16);  -- Last byte count
-               v.protTxData(55 downto 24) := pgpTxMaster.tData(63 downto 32);  -- CRC
-               v.protTxHeader             := K_HEADER_C;
+               v.protTxData                               := (others => '0');
+               v.protTxData(PGP3_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKET_TAIL_EOF_BIT_C) = '1', EOF_C, EOC_C);
+               v.protTxData(PGP3_EOFC_TUSER_FIELD_C)      := pgpTxMaster.tData(PACKET_TAIL_TUSER_FIELD_C);  -- TUSER LAST
+               v.protTxData(PGP3_EOFC_BYTES_LAST_FIELD_C) := pgpTxMaster.tData(PACKET_TAIL_BYTES_FIELD_C);  -- Last byte count
+               v.protTxData(PGP3_EOFC_CRC_FIELD_C)        := pgpTxMaster.tData(PACKET_TAIL_CRC_FIELD_C);  -- CRC
+               v.protTxHeader                             := K_HEADER_C;
                -- Debug output
-               v.frameTx                  := pgpTxMaster.tData(8);
-               v.frameTxErr               := pgpTxMaster.tData(8) and pgpTxMaster.tData(0);
+               v.frameTx                                  := pgpTxMaster.tData(PACKET_TAIL_EOF_BIT_C);
+               v.frameTxErr                               := v.frameTx and ssiGetUserEofe(PGP3_AXIS_CONFIG_C, pgpTxMaster);
             else
                -- Normal data
                v.protTxData(63 downto 0) := pgpTxMaster.tData(63 downto 0);
-               v.protTxHeader            := D_HEADER_C;
+               v.protTxHeader            := PGP3_D_HEADER_C;
             end if;
          end if;
 
          -- 
          if (r.skpCount = pgpTxIn.skpInterval) then
-            v.skpCount                 := (others => '0');
-            v.pgpTxSlave.tReady        := '0';  -- Override any data acceptance.
-            v.protTxData               := (others => '0');
-            v.protTxData(63 downto 56) := SKP_C;
-            v.protTxHeader             := K_HEADER_C;
+            v.skpCount                     := (others => '0');
+            v.pgpTxSlave.tReady            := '0';  -- Override any data acceptance.
+            v.protTxData                   := (others => '0');
+            v.protTxData(PGP3_BTF_FIELD_C) := PGP3_SKP_C;
+            v.protTxHeader                 := PGP3_K_HEADER_C;
          end if;
 
 
          -- USER codes override data and delay SKP if they happen to coincide
          if (pgpTxIn.opCodeEn = '1' and dataEn = '1') then
-            v.pgpTxSlave.tReady        := '0';  -- Override any data acceptance.
-            v.protTxData(63 downto 56) := USER_C(conv_integer(pgpTxIn.opCodeNumber));
-            v.protTxData(55 downto 48) := not (pgpTxIn.opCodeData(7 downto 0) +
-                                               pgpTxIn.opCodeData(15 downto 8) +
-                                               pgpTxIn.opCodeData(23 downto 16) +
-                                               pgpTxIn.opCodeData(31 downto 24) +
-                                               pgpTxIn.opCodeData(39 downto 32) +                                               
-                                               pgpTxIn.opCodeData(47 downto 40));
-            v.protTxData(47 downto 0) := pgpTxIn.opCodeData;
+            v.pgpTxSlave.tReady                      := '0';  -- Override any data acceptance.
+            v.protTxData(PGP3_BTF_FIELD_C)           := USER_C(conv_integer(pgpTxIn.opCodeNumber));
+            v.protTxData(PGP3_USER_CHECKSUM_FIELD_C) := pgp3OpCodeChecksum(pgpTxIn.opCodeData);
+            v.protTxData(PGP3_USER_OPCODE_FIELD_C)   := pgpTxIn.opCodeData;
 
             -- If skip was interrupted, hold it for next cycle
             if (r.skpCount = SKP_INTERVAL_G-1) then

--- a/protocols/rssi/rtl/RssiCoreWrapper.vhd
+++ b/protocols/rssi/rtl/RssiCoreWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : RssiCoreWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-25
--- Last update: 2017-05-09
+-- Last update: 2018-01-31
 -------------------------------------------------------------------------------
 -- Description: Wrapper for RSSI + AXIS packetizer 
 -------------------------------------------------------------------------------
@@ -26,36 +26,37 @@ use work.AxiLitePkg.all;
 
 entity RssiCoreWrapper is
    generic (
-      TPD_G               : time                := 1 ns;
-      CLK_FREQUENCY_G     : real                := 100.0E+6;  -- In units of Hz
-      TIMEOUT_UNIT_G      : real                := 1.0E-6;    -- In units of seconds
-      SERVER_G            : boolean             := true;  -- Module is server or client 
-      RETRANSMIT_ENABLE_G : boolean             := true;  -- Enable/Disable retransmissions in tx module
-      WINDOW_ADDR_SIZE_G  : positive            := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Max number of segments in buffer
-      SEGMENT_ADDR_SIZE_G : positive            := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
-      BYPASS_CHUNKER_G    : boolean             := false;     -- Bypass the AXIS chunker layer
-      PIPE_STAGES_G       : natural             := 0;
-      APP_STREAMS_G       : positive            := 1;
-      APP_STREAM_ROUTES_G : Slv8Array           := (0 => "--------");
-      AXI_ERROR_RESP_G    : slv(1 downto 0) := AXI_RESP_DECERR_C;
+      TPD_G               : time                 := 1 ns;
+      CLK_FREQUENCY_G     : real                 := 100.0E+6;  -- In units of Hz
+      TIMEOUT_UNIT_G      : real                 := 1.0E-6;  -- In units of seconds
+      SERVER_G            : boolean              := true;  -- Module is server or client 
+      RETRANSMIT_ENABLE_G : boolean              := true;  -- Enable/Disable retransmissions in tx module
+      WINDOW_ADDR_SIZE_G  : positive             := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Max number of segments in buffer
+      SEGMENT_ADDR_SIZE_G : positive             := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
+      BYPASS_CHUNKER_G    : boolean              := false;  -- Bypass the AXIS chunker layer
+      PIPE_STAGES_G       : natural              := 0;
+      APP_STREAMS_G       : positive             := 1;
+      APP_STREAM_ROUTES_G : Slv8Array            := (0 => "--------");
+      APP_ILEAVE_EN_G     : boolean              := false;
+      AXI_ERROR_RESP_G    : slv(1 downto 0)      := AXI_RESP_DECERR_C;
       -- AXIS Configurations
       APP_AXIS_CONFIG_G   : AxiStreamConfigArray := (0 => ssiAxiStreamConfig(8, TKEEP_NORMAL_C));
-      TSP_AXIS_CONFIG_G   : AxiStreamConfigType := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      TSP_AXIS_CONFIG_G   : AxiStreamConfigType  := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
       -- Version and connection ID
-      INIT_SEQ_N_G        : natural             := 16#80#;
-      CONN_ID_G           : positive            := 16#12345678#;
-      VERSION_G           : positive            := 1;
-      HEADER_CHKSUM_EN_G  : boolean             := true;
+      INIT_SEQ_N_G        : natural              := 16#80#;
+      CONN_ID_G           : positive             := 16#12345678#;
+      VERSION_G           : positive             := 1;
+      HEADER_CHKSUM_EN_G  : boolean              := true;
       -- Window parameters of receiver module
-      MAX_NUM_OUTS_SEG_G  : positive            := 8;  --   <=(2**WINDOW_ADDR_SIZE_G)
-      MAX_SEG_SIZE_G      : positive            := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
+      MAX_NUM_OUTS_SEG_G  : positive             := 8;  --   <=(2**WINDOW_ADDR_SIZE_G)
+      MAX_SEG_SIZE_G      : positive             := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
       -- RSSI Timeouts
-      ACK_TOUT_G          : positive            := 25;  -- unit depends on TIMEOUT_UNIT_G 
-      RETRANS_TOUT_G      : positive            := 50;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
-      NULL_TOUT_G         : positive            := 200;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= 4*RETRANS_TOUT_G)
+      ACK_TOUT_G          : positive             := 25;  -- unit depends on TIMEOUT_UNIT_G 
+      RETRANS_TOUT_G      : positive             := 50;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
+      NULL_TOUT_G         : positive             := 200;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= 4*RETRANS_TOUT_G)
       -- Counters
-      MAX_RETRANS_CNT_G   : positive            := 2;
-      MAX_CUM_ACK_CNT_G   : positive            := 3);
+      MAX_RETRANS_CNT_G   : positive             := 2;
+      MAX_CUM_ACK_CNT_G   : positive             := 3);
    port (
       -- Clock and Reset
       clk_i             : in  sl;
@@ -87,6 +88,9 @@ end entity RssiCoreWrapper;
 
 architecture mapping of RssiCoreWrapper is
 
+   constant CRC_EN_C   : boolean          := false;  -- Selected false since RSSI already has error checking and to help with SW-to-HW (or HW-to-SW) performance
+   constant CRC_POLY_C : slv(31 downto 0) := x"04C11DB7";
+
    signal rxMasters : AxiStreamMasterArray(APP_STREAMS_G-1 downto 0);
    signal rxSlaves  : AxiStreamSlaveArray(APP_STREAMS_G-1 downto 0);
 
@@ -101,6 +105,7 @@ architecture mapping of RssiCoreWrapper is
 
    signal statusReg        : slv(6 downto 0);
    signal rssiNotConnected : sl;
+   signal rssiConnected    : sl;
 
    -- This should really go in a AxiStreamPacketizerPkg
    constant PACKETIZER_AXIS_CONFIG_C : AxiStreamConfigType := (
@@ -144,11 +149,14 @@ begin
 
    U_AxiStreamMux : entity work.AxiStreamMux
       generic map (
-         TPD_G          => TPD_G,
-         NUM_SLAVES_G   => APP_STREAMS_G,
-         MODE_G         => "ROUTED",
-         TDEST_ROUTES_G => APP_STREAM_ROUTES_G,
-         PIPE_STAGES_G  => 1)
+         TPD_G                => TPD_G,
+         NUM_SLAVES_G         => APP_STREAMS_G,
+         MODE_G               => "ROUTED",
+         TDEST_ROUTES_G       => APP_STREAM_ROUTES_G,
+         ILEAVE_EN_G          => APP_ILEAVE_EN_G,
+         ILEAVE_ON_NOTVALID_G => false,
+         ILEAVE_REARB_G       => (MAX_SEG_SIZE_G/CONV_AXIS_CONFIG_C.TDATA_BYTES_C),
+         PIPE_STAGES_G        => 1)
       port map (
          -- Clock and reset
          axisClk      => clk_i,
@@ -161,19 +169,39 @@ begin
          mAxisSlave   => packetizerSlaves(0));
 
    GEN_PACKER : if (BYPASS_CHUNKER_G = false) generate
-      U_Packetizer : entity work.AxiStreamPacketizer
-         generic map (
-            TPD_G                => TPD_G,
-            MAX_PACKET_BYTES_G   => MAX_SEG_SIZE_G,
-            INPUT_PIPE_STAGES_G  => 0,
-            OUTPUT_PIPE_STAGES_G => 1)
-         port map (
-            axisClk     => clk_i,
-            axisRst     => rst_i,
-            sAxisMaster => packetizerMasters(0),
-            sAxisSlave  => packetizerSlaves(0),
-            mAxisMaster => packetizerMasters(1),
-            mAxisSlave  => packetizerSlaves(1));
+      PACKER_V1 : if (APP_ILEAVE_EN_G = false) generate
+         U_Packetizer : entity work.AxiStreamPacketizer
+            generic map (
+               TPD_G                => TPD_G,
+               MAX_PACKET_BYTES_G   => MAX_SEG_SIZE_G,
+               INPUT_PIPE_STAGES_G  => 0,
+               OUTPUT_PIPE_STAGES_G => 1)
+            port map (
+               axisClk     => clk_i,
+               axisRst     => rst_i,
+               sAxisMaster => packetizerMasters(0),
+               sAxisSlave  => packetizerSlaves(0),
+               mAxisMaster => packetizerMasters(1),
+               mAxisSlave  => packetizerSlaves(1));
+      end generate;
+      PACKER_V2 : if (APP_ILEAVE_EN_G = true) generate
+         U_Packetizer : entity work.AxiStreamPacketizer2
+            generic map (
+               TPD_G                => TPD_G,
+               CRC_EN_G             => CRC_EN_C,
+               CRC_POLY_G           => CRC_POLY_C,
+               MAX_PACKET_BYTES_G   => MAX_SEG_SIZE_G,
+               OUTPUT_SSI_G         => true,
+               INPUT_PIPE_STAGES_G  => 0,
+               OUTPUT_PIPE_STAGES_G => 1)
+            port map (
+               axisClk     => clk_i,
+               axisRst     => rst_i,
+               sAxisMaster => packetizerMasters(0),
+               sAxisSlave  => packetizerSlaves(0),
+               mAxisMaster => packetizerMasters(1),
+               mAxisSlave  => packetizerSlaves(1));
+      end generate;
    end generate;
 
    BYPASS_PACKER : if (BYPASS_CHUNKER_G = true) generate
@@ -238,22 +266,42 @@ begin
          statusReg_o      => statusReg);
 
    statusReg_o      <= statusReg;
-   rssiNotConnected <= not statusReg(0);
+   rssiConnected    <= statusReg(0);
+   rssiNotConnected <= not(rssiConnected);
 
    GEN_DEPACKER : if (BYPASS_CHUNKER_G = false) generate
-      U_Depacketizer : entity work.AxiStreamDepacketizer
-         generic map (
-            TPD_G                => TPD_G,
-            INPUT_PIPE_STAGES_G  => 0,  -- No need for input stage, RSSI output is already pipelined
-            OUTPUT_PIPE_STAGES_G => 1)
-         port map (
-            axisClk     => clk_i,
-            axisRst     => rst_i,
-            restart     => rssiNotConnected,
-            sAxisMaster => depacketizerMasters(1),
-            sAxisSlave  => depacketizerSlaves(1),
-            mAxisMaster => depacketizerMasters(0),
-            mAxisSlave  => depacketizerSlaves(0));
+      DEPACKER_V1 : if (APP_ILEAVE_EN_G = false) generate
+         U_Depacketizer : entity work.AxiStreamDepacketizer
+            generic map (
+               TPD_G                => TPD_G,
+               INPUT_PIPE_STAGES_G  => 0,  -- No need for input stage, RSSI output is already pipelined
+               OUTPUT_PIPE_STAGES_G => 1)
+            port map (
+               axisClk     => clk_i,
+               axisRst     => rst_i,
+               restart     => rssiNotConnected,
+               sAxisMaster => depacketizerMasters(1),
+               sAxisSlave  => depacketizerSlaves(1),
+               mAxisMaster => depacketizerMasters(0),
+               mAxisSlave  => depacketizerSlaves(0));
+      end generate;
+      DEPACKER_V2 : if (APP_ILEAVE_EN_G = true) generate
+         U_Depacketizer : entity work.AxiStreamDepacketizer2
+            generic map (
+               TPD_G                => TPD_G,
+               CRC_EN_G             => CRC_EN_C,
+               CRC_POLY_G           => CRC_POLY_C,
+               INPUT_PIPE_STAGES_G  => 0,  -- No need for input stage, RSSI output is already pipelined
+               OUTPUT_PIPE_STAGES_G => 1)
+            port map (
+               axisClk     => clk_i,
+               axisRst     => rst_i,
+               linkGood    => rssiConnected,
+               sAxisMaster => depacketizerMasters(1),
+               sAxisSlave  => depacketizerSlaves(1),
+               mAxisMaster => depacketizerMasters(0),
+               mAxisSlave  => depacketizerSlaves(0));
+      end generate;
    end generate;
 
    BYPASS_DEPACKER : if (BYPASS_CHUNKER_G = true) generate


### PR DESCRIPTION
Change summary
 - Add VERSION field to Packetizer2 header
 - Add field constants for Packetizer2 header and tail
 - RSSI now uses Packetizer2 when interleaving is enabled
 - Add field constants for PGP3
 - PGP3 internals made compatible with Packetizer2 VERSION field changes.