### PR TITLE
AxiSpiMaster write-only / read-only mode bug

### DIFF
--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiSpiMaster.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-01-12
--- Last update: 2017-07-10
+-- Last update: 2018-02-01
 -------------------------------------------------------------------------------
 -- Description: Axi lite interface for a single chip "generic SPI master"
 --                For multiple chips on single bus connect multiple cores
@@ -171,7 +171,7 @@ begin
 
             if (rdEn = '1') then
                v.state := WAIT_AXI_TXN_S;
-               if (r.wrData(PACKET_SIZE_C-1) = '0') then
+               if (MODE_G = "WO" or r.wrData(PACKET_SIZE_C-1) = '0') then
                   -- Finish write
                   axiSlaveWriteResponse(v.axiWriteSlave);
                else

--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -171,11 +171,10 @@ begin
 
             if (rdEn = '1') then
                v.state := WAIT_AXI_TXN_S;
-               if (MODE_G = "WO" or r.wrData(PACKET_SIZE_C-1) = '0') then
-                  -- Finish write
+               
+               if (MODE_G = "WO" or (MODE_G = "RW" and r.wrData(PACKET_SIZE_C-1) = '0')) then
                   axiSlaveWriteResponse(v.axiWriteSlave);
                else
-                  -- Finish read
                   v.axiReadSlave.rdata                         := (others => '0');
                   v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := rdData(DATA_SIZE_G-1 downto 0);
                   axiSlaveReadResponse(v.axiReadSlave);


### PR DESCRIPTION
Previously, the state machine would check the r.wrData rd/wr bit to determine if it was completing a read or a write operation and send the proper AXI response.

In the case of MODE_G="WO" and MODE_G="RO", there is no write bit. Checking the write bit then has unpredictable behavior. The module might send an AXI read response even though it is write-only.

Now the module will always send a read response when in "RO" mode and always send a write response when in "WO" mode.