### PR TITLE
ESCORE-321 - Remove reset on combinatorial outputs

### DIFF
--- a/axi/rtl/AxiReadEmulate.vhd
+++ b/axi/rtl/AxiReadEmulate.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiReadEmulate.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-04-02
--- Last update: 2016-04-26
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: AXI4 Read Emulation Module
 -------------------------------------------------------------------------------
@@ -147,6 +147,9 @@ begin
       ----------------------------------------------------------------------
       end case;
 
+      -- Combinatoral outputs before reset
+      intReadSlave <= v.iSlave;
+      
       -- Reset
       if (axiRst = '1') then
          v := REG_INIT_C;
@@ -154,9 +157,6 @@ begin
 
       -- Register the variable for next clock cycle    
       rin <= v;
-
-      -- Outputs 
-      intReadSlave <= v.iSlave;
 
    end process comb;
 

--- a/axi/rtl/AxiStreamDeMux.vhd
+++ b/axi/rtl/AxiStreamDeMux.vhd
@@ -120,6 +120,9 @@ begin
          v.masters(idx) := sAxisMaster;
       end if;
 
+      -- Combinatorial outputs before the reset
+      sAxisSlave <= v.slave;
+      
       -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
@@ -128,8 +131,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs
-      sAxisSlave      <= v.slave;
+      -- Registered Outputs
       pipeAxisMasters <= r.masters;
 
    end process comb;

--- a/axi/rtl/AxiStreamDepacketizer.vhd
+++ b/axi/rtl/AxiStreamDepacketizer.vhd
@@ -273,16 +273,16 @@ begin
             
       end case;
 
-      ----------------------------------------------------------------------------------------------
-      -- Reset and output assignment
-      ----------------------------------------------------------------------------------------------
+      -- Combinatorial outputs before the reset
+      inputAxisSlave <= v.inputAxisSlave;
+      
+      -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
-
-      inputAxisSlave <= v.inputAxisSlave;
 
       -- Hold each out tvalid until next in tvalid arrives
       outputAxisMaster <= r.outputAxisMaster(0);

--- a/axi/rtl/AxiStreamDepacketizer2.vhd
+++ b/axi/rtl/AxiStreamDepacketizer2.vhd
@@ -395,18 +395,19 @@ begin
             end if;
 
       end case;
-
-      ----------------------------------------------------------------------------------------------
-      -- Reset and output assignment
-      ----------------------------------------------------------------------------------------------
+      
+      -- Combinatorial outputs before the reset
+      inputAxisSlave <= v.inputAxisSlave;
+      
+      -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
-      inputAxisSlave <= v.inputAxisSlave;
-
+      -- Registered Outputs
       outputAxisMaster <= r.outputAxisMaster(0);
       debug            <= r.debug;
 

--- a/axi/rtl/AxiStreamDma.vhd
+++ b/axi/rtl/AxiStreamDma.vhd
@@ -384,7 +384,7 @@ begin
       -- Next register assignment
       rin <= v;
 
-      -- Outputs
+      -- Registered Outputs
       interrupt         <= r.interrupt;
       acknowledge       <= r.acknowledge;
       online            <= r.online;
@@ -476,10 +476,10 @@ begin
          v := IB_INIT_C;
       end if;
 
-      -- Next register assignment
+      -- Register the variable for next clock cycle
       ibin <= v;
 
-      -- Outputs
+      -- Registered Outputs
       ibReq                   <= ib.ibReq;
       popFifoWrite(IB_FIFO_C) <= ib.popFifoWrite;
       popFifoDin(IB_FIFO_C)   <= ib.popFifoDin;
@@ -584,19 +584,21 @@ begin
          v.intPending := '0';
       end if;
 
+      -- Combinatorial outputs before the reset
+      pushFifoRead(OB_FIFO_C) <= v.pushFifoRead;
+      
       -- Reset
       if axiRst = '1' or r.txEnable = '0' then
          v := OB_INIT_C;
       end if;
 
-      -- Next register assignment
+      -- Register the variable for next clock cycle
       obin <= v;
 
-      -- Outputs
+      -- Registered Outputs
       obReq                   <= ob.obReq;
       popFifoWrite(OB_FIFO_C) <= ob.popFifoWrite;
       popFifoDin(OB_FIFO_C)   <= ob.popFifoDin;
-      pushFifoRead(OB_FIFO_C) <= v.pushFifoRead;
 
    end process;
    

--- a/axi/rtl/AxiStreamDmaRead.vhd
+++ b/axi/rtl/AxiStreamDmaRead.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiStreamDmaRead.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-04-25
--- Last update: 2016-10-27
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description:
 -- Block to transfer a single AXI Stream frame from memory using an AXI
@@ -386,6 +386,9 @@ begin
          v.dmaAck.idle := '0';
       end if;
 
+      -- Combinatorial outputs before the reset
+      axiReadMaster.rready <= v.rMaster.rready;      
+
       -- Reset      
       if (axiRst = '1') then
          v := REG_INIT_C;
@@ -397,7 +400,7 @@ begin
       -- Outputs         
       dmaAck               <= r.dmaAck;
       axiReadMaster        <= r.rMaster;
-      axiReadMaster.rready <= v.rMaster.rready;
+
 
    end process comb;
 

--- a/axi/rtl/AxiStreamDmaV2Read.vhd
+++ b/axi/rtl/AxiStreamDmaV2Read.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiStreamDmaV2Read.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-02-02
--- Last update: 2017-09-07
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description:
 -- Block to transfer a single AXI Stream frame from memory using an AXI
@@ -371,6 +371,9 @@ begin
          -- Reset the flag
          v.idle := '0';
       end if;
+      
+      -- Combinatorial outputs before the reset
+      axiReadMaster.rready <= v.rMaster.rready;      
 
       -- Reset      
       if (axiRst = '1') then
@@ -385,7 +388,7 @@ begin
       dmaRdDescAck         <= r.dmaRdDescAck;
       dmaRdDescRet         <= r.dmaRdDescRet;
       axiReadMaster        <= r.rMaster;
-      axiReadMaster.rready <= v.rMaster.rready;
+
 
    end process comb;
 

--- a/axi/rtl/AxiStreamDmaV2Write.vhd
+++ b/axi/rtl/AxiStreamDmaV2Write.vhd
@@ -447,6 +447,9 @@ begin
       else
          v.dmaWrIdle := '0';
       end if;
+      
+      -- Combinatorial outputs before the reset
+      intAxisSlave <= v.slave;
 
       -- Reset      
       if (axiRst = '1') then
@@ -456,8 +459,7 @@ begin
       -- Register the variable for next clock cycle      
       rin <= v;
 
-      -- Outputs   
-      intAxisSlave   <= v.slave;
+      -- Registered Outputs 
       axiWriteMaster <= r.wMaster;
       dmaWrDescReq   <= r.dmaWrDescReq;
       dmaWrDescRet   <= r.dmaWrDescRet;

--- a/axi/rtl/AxiStreamDmaWrite.vhd
+++ b/axi/rtl/AxiStreamDmaWrite.vhd
@@ -505,6 +505,9 @@ begin
          -- Reset the flag
          v.dmaAck.idle := '0';
       end if;
+      
+      -- Combinatorial outputs before the reset
+      intAxisSlave <= v.slave;
 
       -- Reset      
       if (axiRst = '1') then
@@ -514,9 +517,8 @@ begin
       -- Register the variable for next clock cycle      
       rin <= v;
 
-      -- Outputs   
+      -- Registered Outputs 
       dmaAck         <= r.dmaAck;
-      intAxisSlave   <= v.slave;
       axiWriteMaster <= r.wMaster;
       
    end process comb;

--- a/axi/rtl/AxiStreamFlush.vhd
+++ b/axi/rtl/AxiStreamFlush.vhd
@@ -74,9 +74,10 @@ begin
    comb : process (mAxisCtrl, sAxisMaster, axisRst, flushEn, r) is
       variable v : RegType;
    begin
-
+      -- Latch the current value
       v := r;
 
+      -- Reset strobing signals
       v.ibSlave.tReady := '0';
       v.obMaster := AXI_STREAM_MASTER_INIT_C;
 
@@ -132,14 +133,19 @@ begin
             v.state := IDLE_S;
 
       end case;
+      
+      -- Combinatorial outputs before the reset
+      sAxisSlave <= v.ibSlave;
 
+      -- Reset
       if axisRst = '1' then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
-      sAxisSlave  <= v.ibSlave;
+      -- Registered Outputs
       mAxisMaster <= r.obMaster;
 
    end process comb;
@@ -152,4 +158,3 @@ begin
    end process seq;
 
 end rtl;
-

--- a/axi/rtl/AxiStreamMux.vhd
+++ b/axi/rtl/AxiStreamMux.vhd
@@ -214,6 +214,9 @@ begin
          v.arbCnt := (others => '0');
          arbitrate(requests, r.ackNum, v.ackNum, v.valid, v.acks);
       end if;
+      
+      -- Combinatorial outputs before the reset
+      sAxisSlaves <= v.slaves;
 
       -- Reset
       if (axisRst = '1') then
@@ -223,8 +226,7 @@ begin
       -- Assign variable back to signal
       rin <= v;
 
-      -- Outputs  
-      sAxisSlaves    <= v.slaves;
+      -- Registered Outputs
       pipeAxisMaster <= r.master;
 
    end process comb;

--- a/axi/rtl/AxiStreamPacketizer.vhd
+++ b/axi/rtl/AxiStreamPacketizer.vhd
@@ -250,16 +250,18 @@ begin
 
       v.outputAxisMaster.tStrb := v.outputAxisMaster.tKeep;
 
-      ----------------------------------------------------------------------------------------------
-      -- Reset and output assignment
-      ----------------------------------------------------------------------------------------------
+      -- Combinatorial outputs before the reset
+      inputAxisSlave <= v.inputAxisSlave;
+      
+      -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
-      inputAxisSlave   <= v.inputAxisSlave;
+      -- Registered Outputs
       outputAxisMaster <= r.outputAxisMaster;
 
    end process comb;

--- a/axi/rtl/AxiStreamPacketizer2.vhd
+++ b/axi/rtl/AxiStreamPacketizer2.vhd
@@ -308,17 +308,19 @@ begin
       end case;
 
       v.outputAxisMaster.tStrb := v.outputAxisMaster.tKeep;
+      
+      -- Combinatorial outputs before the reset
+      inputAxisSlave <= v.inputAxisSlave;
 
-      ----------------------------------------------------------------------------------------------
-      -- Reset and output assignment
-      ----------------------------------------------------------------------------------------------
+      -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
-      inputAxisSlave   <= v.inputAxisSlave;
+      -- Registered Outputs
       outputAxisMaster <= r.outputAxisMaster;
       rearbitrate      <= r.rearbitrate;
 

--- a/axi/rtl/AxiStreamPacketizerMux.vhd
+++ b/axi/rtl/AxiStreamPacketizerMux.vhd
@@ -316,17 +316,19 @@ begin
             end if;
 
       end case;
+      
+      -- Combinatorial outputs before the reset
+      inputAxisSlaves <= v.inputAxisSlaves;
 
-      ----------------------------------------------------------------------------------------------
-      -- Reset and output assignment
-      ----------------------------------------------------------------------------------------------
+      -- Reset
       if (axisRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
-      inputAxisSlaves   <= v.inputAxisSlaves;
+      -- Registered Outputs
       outputAxisMaster <= r.outputAxisMaster;
 
    end process comb;

--- a/axi/rtl/AxiStreamPrbsFlowCtrl.vhd
+++ b/axi/rtl/AxiStreamPrbsFlowCtrl.vhd
@@ -100,6 +100,9 @@ begin
          -- Move the data
          v.txMaster       := rxMaster;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -110,7 +113,6 @@ begin
       rin <= v;
 
       -- Outputs              
-      rxSlave  <= v.rxSlave;
       txMaster <= r.txMaster;
 
    end process comb;

--- a/axi/rtl/AxiStreamShift.vhd
+++ b/axi/rtl/AxiStreamShift.vhd
@@ -261,6 +261,9 @@ begin
             v.master.tKeep(15 downto AXIS_CONFIG_G.TDATA_BYTES_C) := (others => '0');
             v.master.tStrb(15 downto AXIS_CONFIG_G.TDATA_BYTES_C) := (others => '0');
          end if;
+         
+         -- Combinatorial outputs before the reset
+         sAxisSlave <= v.slave;
 
          -- Reset
          if (axisRst = '1') then
@@ -271,7 +274,6 @@ begin
          rin <= v;
 
          -- Outputs 
-         sAxisSlave     <= v.slave;
          pipeAxisMaster <= r.master;
 
       end process comb;

--- a/axi/rtl/AxiWriteEmulate.vhd
+++ b/axi/rtl/AxiWriteEmulate.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiWriteEmulate.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-04-02
--- Last update: 2016-04-26
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: AXI4 Write Emulation Module
 -------------------------------------------------------------------------------
@@ -141,7 +141,10 @@ begin
                v.state := IDLE_S;
             end if;
       end case;
-
+      
+      -- Combinatorial outputs before the reset
+      intWriteSlave <= v.iSlave;
+      
       -- Reset
       if (axiRst = '1') then
          v := REG_INIT_C;
@@ -150,8 +153,7 @@ begin
       -- Register the variable for next clock cycle    
       rin <= v;
 
-      -- Outputs 
-      intWriteSlave <= v.iSlave;
+     
 
    end process comb;
 

--- a/axi/rtl/AxiWritePathMux.vhd
+++ b/axi/rtl/AxiWritePathMux.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiWritePathMux.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-04-25
--- Last update: 2014-04-29
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description:
 -- Block to connect multiple incoming AXI write path interfaces.
@@ -255,6 +255,15 @@ begin
       else
          v.master.bready := '0';
       end if;
+
+      -- Combinatorial outputs before the reset
+      -- Readies are direct
+      for i in 0 to (NUM_SLAVES_G-1) loop
+         sAxiWriteSlaves(i).awready <= v.slaves(i).awready;
+         sAxiWriteSlaves(i).wready  <= v.slaves(i).wready;
+      end loop;
+      mAxiWriteMaster.bready <= v.master.bready;
+    
    
       if (axiRst = '1') or (NUM_SLAVES_G = 1) then
          v := REG_INIT_C;
@@ -271,14 +280,8 @@ begin
          -- Output data
          sAxiWriteSlaves <= r.slaves;
          mAxiWriteMaster <= r.master;
+      end if;      
 
-         -- Readies are direct
-         for i in 0 to (NUM_SLAVES_G-1) loop
-            sAxiWriteSlaves(i).awready <= v.slaves(i).awready;
-            sAxiWriteSlaves(i).wready  <= v.slaves(i).wready;
-         end loop;
-         mAxiWriteMaster.bready <= v.master.bready;
-      end if;
 
    end process comb;
 

--- a/axi/tb/AxiStreamPipelineTb.vhd
+++ b/axi/tb/AxiStreamPipelineTb.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiStreamPipelineTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-05-02
--- Last update: 2016-09-06
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Simulation Testbed for testing the AxiStreamPipelineTb module
 -------------------------------------------------------------------------------
@@ -202,6 +202,9 @@ begin
             end if;
          end if;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      mAxisSlave  <= v.mAxisSlave;      
 
       -- Reset
       if (rst = '1') then
@@ -212,7 +215,6 @@ begin
       rin <= v;
 
       -- Outputs        
-      mAxisSlave  <= v.mAxisSlave;
       sAxisMaster <= r.sAxisMaster;
       failed      <= r.failed;
       passed      <= r.passed;

--- a/axi/tb/dma_read_tb.vhd
+++ b/axi/tb/dma_read_tb.vhd
@@ -2,7 +2,7 @@
 -- File       : dma_read_tb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-05-02
--- Last update: 2016-09-06
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Simulation Testbed for DMA read
 -------------------------------------------------------------------------------
@@ -265,6 +265,9 @@ begin
       ----------------------------------------------------------------------
       end case;
 
+      -- Combinatoral outputs
+      axisSlave <= v.axisSlave;
+      
       -- Reset      
       if (axiClkRst = '1') then
          v := REG_INIT_C;
@@ -272,9 +275,6 @@ begin
 
       -- Register the variable for next clock cycle      
       rin <= v;
-
-      -- Outputs
-      axisSlave <= v.axisSlave;
 
    end process comb;
 

--- a/base/general/rtl/Encoder10b12b.vhd
+++ b/base/general/rtl/Encoder10b12b.vhd
@@ -2,7 +2,7 @@
 -- File       : Encode12b14b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-10-07
--- Last update: 2017-05-01
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 10B12B Encoder Module
 -------------------------------------------------------------------------------
@@ -83,6 +83,8 @@ begin
             dispOut => v.dispOut);
       end if;
 
+      -- Combinatorial outputs before the reset
+      readyIn <= v.readyIn;      
 
       -- Synchronous reset
       if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
@@ -92,7 +94,6 @@ begin
       rin     <= v;
       dataOut <= r.dataOut;
       dispOut <= r.dispOut;
-      readyIn <= v.readyIn;
       validOut <= r.validOut;
    end process comb;
 

--- a/base/general/rtl/Encoder12b14b.vhd
+++ b/base/general/rtl/Encoder12b14b.vhd
@@ -2,7 +2,7 @@
 -- File       : Encode12b14b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-10-07
--- Last update: 2017-05-01
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 12B14B Encoder Module
 -------------------------------------------------------------------------------
@@ -95,7 +95,10 @@ begin
             dispOut  => v.dispOut,
             invalidK => invalidK);
       end if;
-
+      
+      -- Combinatorial outputs before the reset
+      readyIn  <= v.readyIn;
+      
       -- Synchronous reset
       if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -105,7 +108,6 @@ begin
       dataOut  <= r.dataOut;
       dispOut  <= r.dispOut;
 --      invalidK <= r.invalidK;
-      readyIn  <= v.readyIn;
       validOut <= r.validOut;
    end process comb;
 

--- a/base/general/rtl/Encoder8b10b.vhd
+++ b/base/general/rtl/Encoder8b10b.vhd
@@ -2,7 +2,7 @@
 -- File       : Encoder8b10b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-10-12
--- Last update: 2017-05-01
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 8B10B Encoder Module
 -------------------------------------------------------------------------------
@@ -86,6 +86,9 @@ begin
          end loop;
          v.runDisp := dispChainVar;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      readyIn  <= v.readyIn;      
 
       -- Synchronous reset
       if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
@@ -94,7 +97,6 @@ begin
 
       rin      <= v;
       dataOut  <= r.dataOut;
-      readyIn  <= v.readyIn;
       validOut <= r.validOut;
    end process comb;
 

--- a/base/general/rtl/Scrambler.vhd
+++ b/base/general/rtl/Scrambler.vhd
@@ -101,13 +101,15 @@ begin
          end loop;
       end if;
 
+      -- Combinatorial outputs before the reset
+      inputReady     <= v.inputReady;      
+
       if (rst = '1') then
          v := REG_INIT_C;
       end if;
 
       rin            <= v;
       outputValid    <= r.outputValid;
-      inputReady     <= v.inputReady;
       outputData     <= r.outputData;
       outputSideband <= r.outputSideband;
 

--- a/base/sync/rtl/SynchronizerOneShot.vhd
+++ b/base/sync/rtl/SynchronizerOneShot.vhd
@@ -2,7 +2,7 @@
 -- File       : SynchronizerOneShot.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-02-06
--- Last update: 2016-11-04
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: One-Shot Pulser that has to cross clock domains
 -------------------------------------------------------------------------------
@@ -129,6 +129,9 @@ begin
          ----------------------------------------------------------------------   
          end case;
 
+         -- Combinatorial outputs before the reset
+         dataOut <= v.dataOut;         
+
          -- Reset
          if (rst = RST_POLARITY_G) then
             v := REG_INIT_C;
@@ -136,9 +139,6 @@ begin
 
          -- Register the variable for next clock cycle
          rin <= v;
-
-         -- Outputs 
-         dataOut <= v.dataOut;
 
       end process;
 

--- a/dsp/fixed/DspAddSub.vhd
+++ b/dsp/fixed/DspAddSub.vhd
@@ -2,7 +2,7 @@
 -- File       : DspAddSub.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-12
--- Last update: 2017-09-13
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Generalized DSP inferred DSP inferred add/sub 
 -- Equation: p = a +/- b
@@ -98,6 +98,9 @@ begin
             v.p := a - b;
          end if;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -108,7 +111,6 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
       p       <= std_logic_vector(r.p);
 
    end process comb;

--- a/dsp/fixed/DspComparator.vhd
+++ b/dsp/fixed/DspComparator.vhd
@@ -2,7 +2,7 @@
 -- File       : DspComparator.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-07
--- Last update: 2017-09-07
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Generalized DSP inferred comparator
 -------------------------------------------------------------------------------
@@ -99,7 +99,10 @@ begin
          -- Process the data
          v.diff    := a - b;
       end if;
-
+      
+      -- Outputs              
+      ibReady <= v.ibReady;
+      
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -108,8 +111,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs              
-      ibReady <= v.ibReady;
+    
 
    end process comb;
 

--- a/dsp/fixed/DspPreSubMult.vhd
+++ b/dsp/fixed/DspPreSubMult.vhd
@@ -2,7 +2,7 @@
 -- File       : DspPreSubMult.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-08
--- Last update: 2017-09-08
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Generalized DSP inferred multiplier with pre-adder 
 --              configured as subtractor (based on UG901)
@@ -129,6 +129,9 @@ begin
       end if;
 
       --------------------------------------------------------------------
+      -- Combinatorial outputs before the reset
+      ibReady   <= v.ibReady;
+      tReady(0) <= v.tReady;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -139,9 +142,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady   <= v.ibReady;
-      tReady(0) <= v.tReady;
-      p         <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/fixed/DspSquareDiffMult.vhd
+++ b/dsp/fixed/DspSquareDiffMult.vhd
@@ -2,7 +2,7 @@
 -- File       : DspSquareDiffMult.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-08
--- Last update: 2017-09-08
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Generalized DSP inferred Squarer with pre-adder 
 --              configured as subtractor (based on UG901)
@@ -123,6 +123,9 @@ begin
       end if;
 
       --------------------------------------------------------------------      
+      -- Combinatorial outputs before the reset
+      ibReady   <= v.ibReady;
+      tReady(0) <= v.tReady;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -133,9 +136,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady   <= v.ibReady;
-      tReady(0) <= v.tReady;
-      p         <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32Accum.vhd
+++ b/dsp/float/DspFp32Accum.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32Accum.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-12
--- Last update: 2017-09-18
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred accumulator  
 -- Equation: p = sum(+/-a[i])
@@ -49,7 +49,7 @@ entity DspFp32Accum is
       ibReady : out sl;
       ain     : in  slv(31 downto 0);
       load    : in  sl := '0';
-      add     : in  sl := '1';          -- '1' = add, '0' = subtract
+      add     : in  sl := '1';                       -- '1' = add, '0' = subtract
       -- Outbound Interface
       obValid : out sl;
       obReady : in  sl := '1';
@@ -111,6 +111,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -120,8 +123,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
-      p       <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32AddSub.vhd
+++ b/dsp/float/DspFp32AddSub.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32AddSub.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-30
--- Last update: 2017-09-30
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred add/sub 
 -- Equation: p = a +/- b
@@ -110,7 +110,10 @@ begin
             v.p := a - b;
          end if;
       end if;
-
+      
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+      
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -120,7 +123,6 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
       p       <= std_logic_vector(r.p);
 
    end process comb;

--- a/dsp/float/DspFp32Max.vhd
+++ b/dsp/float/DspFp32Max.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32Max.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-18
--- Last update: 2017-09-18
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred maximum module  
 -- Equation: p = max(a[i])
@@ -108,6 +108,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -117,8 +120,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
-      p       <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32Min.vhd
+++ b/dsp/float/DspFp32Min.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32Min.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-18
--- Last update: 2017-09-18
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred minimum module  
 -- Equation: p = min(a[i])
@@ -107,6 +107,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -116,8 +119,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
-      p       <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32Mult.vhd
+++ b/dsp/float/DspFp32Mult.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32Mult.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-12
--- Last update: 2017-09-18
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred multiplier 
 -- Equation: p = a x b
@@ -106,6 +106,9 @@ begin
          v.p       := a * b;
       end if;
 
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -115,8 +118,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
-      p       <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32PreMultAccum.vhd
+++ b/dsp/float/DspFp32PreMultAccum.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32PreMultAccum.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-12
--- Last update: 2017-09-30
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred accumulator with pre-multiplier 
 -- Equation: p = sum(+/-(a x b)[i])
@@ -50,7 +50,7 @@ entity DspFp32PreMultAccum is
       ain     : in  slv(31 downto 0);
       bin     : in  slv(31 downto 0);
       load    : in  sl := '0';
-      add     : in  sl := '1';          -- '1' = add, '0' = subtract
+      add     : in  sl := '1';                       -- '1' = add, '0' = subtract
       -- Outbound Interface
       obValid : out sl;
       obReady : in  sl := '1';
@@ -148,6 +148,9 @@ begin
       end if;
 
       --------------------------------------------------------------------
+      -- Combinatorial outputs before the reset
+      ibReady   <= v.ibReady;
+      tReady(0) <= v.tReady;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -158,9 +161,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady   <= v.ibReady;
-      tReady(0) <= v.tReady;
-      p         <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/dsp/float/DspFp32Rectifier.vhd
+++ b/dsp/float/DspFp32Rectifier.vhd
@@ -2,7 +2,7 @@
 -- File       : DspFp32Rectifier.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-18
--- Last update: 2017-09-18
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 32-bit Floating Point DSP inferred rectifier module  
 -- Equation: p = a when( a > 0) else 0
@@ -107,6 +107,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      ibReady <= v.ibReady;
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -116,8 +119,7 @@ begin
       rin <= v;
 
       -- Outputs              
-      ibReady <= v.ibReady;
-      p       <= std_logic_vector(r.p);
+      p <= std_logic_vector(r.p);
 
    end process comb;
 

--- a/ethernet/EthMacCore/rtl/EthMacTxBypass.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxBypass.vhd
@@ -150,6 +150,10 @@ begin
                end if;
          ----------------------------------------------------------------------   
          end case;
+         
+         -- Combinatorial outputs before the reset
+         sPrimSlave <= v.sPrimSlave;
+         sBypSlave  <= v.sBypSlave;
 
          -- Reset
          if ethRst = '1' then
@@ -159,9 +163,7 @@ begin
          -- Register the variable for next clock cycle
          rin <= v;
 
-         -- Outputs 
-         sPrimSlave  <= v.sPrimSlave;
-         sBypSlave   <= v.sBypSlave;
+         -- Registered Outputs
          mAxisMaster <= r.mAxisMaster;
 
       end process;

--- a/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
@@ -608,6 +608,10 @@ begin
             end if;
          end if;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
+      mSlave  <= v.mSlave;
 
       -- Reset
       if (ethRst = '1') then
@@ -617,10 +621,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      rxSlave  <= v.rxSlave;
+      -- Registered Outputs       
       sMaster  <= r.sMaster;
-      mSlave   <= v.mSlave;
       txMaster <= r.txMaster;
 
    end process comb;

--- a/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
@@ -273,6 +273,11 @@ begin
             end if;
       ----------------------------------------------------------------------      
       end case;
+      
+      -- Combinatorial outputs before the reset
+      macSlave     <= v.macSlave;
+      crcDataValid <= v.crcDataValid;
+      crcIn        <= v.crcIn;
 
       -- Reset
       if (ethRst = '1') then
@@ -282,16 +287,13 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      macSlave       <= v.macSlave;  -- Flow control with non-registered signal
+      -- Registered Outputs 
       txCountEn      <= r.txCountEn;
       txUnderRun     <= r.txUnderRun;
       txLinkNotReady <= r.txLinkNotReady;
       gmiiTxEn       <= r.gmiiTxEn;
       gmiiTxEr       <= r.gmiiTxEr;
       gmiiTxd        <= r.gmiiTxd;
-      crcDataValid   <= v.crcDataValid;
-      crcIn          <= v.crcIn;
 
    end process comb;
 

--- a/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
@@ -254,6 +254,9 @@ begin
                end if;
          ----------------------------------------------------------------------
          end case;
+         
+         -- Combinatorial outputs before the reset
+         rxSlave <= v.rxSlave;
 
          -- Reset
          if (ethRst = '1') then
@@ -263,8 +266,7 @@ begin
          -- Register the variable for next clock cycle
          rin <= v;
 
-         -- Outputs 
-         rxSlave     <= v.rxSlave;
+         -- Registered Outputs
          mAxisMaster <= r.mAxisMaster;
          pauseTx     <= r.pauseTx;
 

--- a/ethernet/IpV4Engine/rtl/ArpEngine.vhd
+++ b/ethernet/IpV4Engine/rtl/ArpEngine.vhd
@@ -391,6 +391,10 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      arpReqSlaves <= v.arpReqSlaves;
+      ibArpSlave   <= v.ibArpSlave;
 
       -- Reset
       if (rst = '1') then
@@ -400,10 +404,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      arpReqSlaves  <= v.arpReqSlaves;
+      -- Registered Outputs  
       arpAckMasters <= r.arpAckMasters;
-      ibArpSlave    <= v.ibArpSlave;
       obArpMaster   <= r.txArpMaster;
 
    end process comb;

--- a/ethernet/IpV4Engine/rtl/IcmpEngine.vhd
+++ b/ethernet/IpV4Engine/rtl/IcmpEngine.vhd
@@ -203,6 +203,9 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      ibIcmpSlave <= v.ibIcmpSlave;
 
       -- Reset
       if (rst = '1') then
@@ -212,8 +215,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      ibIcmpSlave  <= v.ibIcmpSlave;
+      -- Registered Outputs       
       obIcmpMaster <= r.obIcmpMaster;
 
    end process comb;

--- a/ethernet/IpV4Engine/rtl/IpV4EngineDeMux.vhd
+++ b/ethernet/IpV4Engine/rtl/IpV4EngineDeMux.vhd
@@ -190,6 +190,9 @@ begin
             end case;
          end if;
       end if;
+      
+      -- Combinatorial outputs before the reset
+      obMacSlave <= v.obMacSlave;
 
       -- Reset
       if (rst = '1') then
@@ -199,8 +202,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs
-      obMacSlave   <= v.obMacSlave;
+      -- Registered Outputs
       ibArpMaster  <= r.ibArpMaster;
       ibIpv4Master <= r.ibIpv4Master;
       

--- a/ethernet/IpV4Engine/rtl/IpV4EngineRx.vhd
+++ b/ethernet/IpV4Engine/rtl/IpV4EngineRx.vhd
@@ -349,6 +349,9 @@ begin
       ----------------------------------------------------------------------
       end case;
 
+      -- Combinatorial outputs before the reset    
+      rxSlave <= v.rxSlave;
+
       -- Reset
       if (rst = '1') then
          v := REG_INIT_C;
@@ -356,9 +359,6 @@ begin
 
       -- Register the variable for next clock cycle
       rin <= v;
-
-      -- Outputs        
-      rxSlave <= v.rxSlave;
 
    end process comb;
 

--- a/ethernet/IpV4Engine/rtl/IpV4EngineTx.vhd
+++ b/ethernet/IpV4Engine/rtl/IpV4EngineTx.vhd
@@ -388,6 +388,9 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -397,8 +400,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      rxSlave  <= v.rxSlave;
+      -- Registered Outputs 
       txMaster <= r.txMaster;
 
    end process comb;

--- a/ethernet/IpV4Engine/tb/IpV4EngineCoreTb.vhd
+++ b/ethernet/IpV4Engine/tb/IpV4EngineCoreTb.vhd
@@ -311,6 +311,10 @@ begin
             v.timer  := x"0000";
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      arpAckSlave     <= v.arpAckSlave;
+      ibProtocolSlave <= v.ibProtocolSlave;
 
       -- Reset
       if (rst = '1') then
@@ -320,10 +324,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      arpAckSlave      <= v.arpAckSlave;
+      -- Registered Outputs    
       arpReqMaster     <= r.arpReqMaster;
-      ibProtocolSlave  <= v.ibProtocolSlave;
       obProtocolMaster <= r.obProtocolMaster;
       passed           <= r.passedDly;
       failed           <= r.failedDly;

--- a/ethernet/IpV4Engine/tb/IpV4EngineLoopback.vhd
+++ b/ethernet/IpV4Engine/tb/IpV4EngineLoopback.vhd
@@ -154,6 +154,10 @@ begin
             v.done := '1';
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      ibProtocolSlave <= v.ibProtocolSlave;
+      arpAckSlave     <= v.arpAckSlave;
 
       -- Reset
       if (rst = '1') then
@@ -163,10 +167,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs              
-      ibProtocolSlave  <= v.ibProtocolSlave;
+      -- Registered Outputs         
       obProtocolMaster <= r.obProtocolMaster;
-      arpAckSlave      <= v.arpAckSlave;
       arpReqMaster     <= r.arpReqMaster;
       done             <= r.done;
       remoteMac        <= r.remoteMac;

--- a/ethernet/RawEthFramer/rtl/RawEthFramer.vhd
+++ b/ethernet/RawEthFramer/rtl/RawEthFramer.vhd
@@ -189,6 +189,13 @@ begin
       ----------------------------------------------------------------------
       end case;
 
+      -- Combinatorial outputs before the reset
+      tDest <= v.tDest;
+      rxAck <= v.rxAck;
+      txAck <= v.txAck;
+      rxMac <= v.rxMac;
+      txMac <= v.txMac;
+
       -- Reset
       if (rst = '1') then
          v := REG_INIT_C;
@@ -196,13 +203,6 @@ begin
 
       -- Register the variable for next clock cycle
       rin <= v;
-
-      -- Outputs
-      tDest <= v.tDest;
-      rxAck <= v.rxAck;
-      txAck <= v.txAck;
-      rxMac <= v.rxMac;
-      txMac <= v.txMac;
       
    end process comb;
 

--- a/ethernet/RawEthFramer/rtl/RawEthFramerRx.vhd
+++ b/ethernet/RawEthFramer/rtl/RawEthFramerRx.vhd
@@ -231,6 +231,11 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      obMacSlave <= v.obMacSlave;
+      tDest      <= v.ibAppMaster.tDest;
+      req        <= v.req;
 
       -- Reset
       if (rst = '1') then
@@ -240,11 +245,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      obMacSlave  <= v.obMacSlave;
+      -- Registered Outputs   
       ibAppMaster <= r.ibAppMaster;
-      tDest       <= v.ibAppMaster.tDest;
-      req         <= v.req;
 
    end process comb;
 

--- a/ethernet/RawEthFramer/rtl/RawEthFramerTx.vhd
+++ b/ethernet/RawEthFramer/rtl/RawEthFramerTx.vhd
@@ -327,6 +327,11 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      obAppSlave <= v.obAppSlave;
+      tDest      <= v.tDest;
+      req        <= v.req;
 
       -- Reset
       if (rst = '1') then
@@ -336,11 +341,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      obAppSlave  <= v.obAppSlave;
+      -- Registered Outputs      
       ibMacMaster <= r.ibMacMaster;
-      tDest       <= v.tDest;
-      req         <= v.req;
       
    end process comb;
 

--- a/ethernet/UdpEngine/rtl/UdpEngineArp.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineArp.vhd
@@ -168,6 +168,9 @@ begin
             end case;
          end if;
       end loop;
+      
+      -- Combinatorial outputs before the reset
+      arpAckSlaves <= v.arpAckSlaves;
 
       -- Reset
       if (rst = '1') then
@@ -177,8 +180,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      arpAckSlaves    <= v.arpAckSlaves;
+      -- Registered Outputs
       arpReqMasters   <= r.arpReqMasters;
       clientRemoteMac <= r.clientRemoteMac;
 

--- a/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
@@ -524,8 +524,11 @@ begin
             end if;
             -- Next state
             v.state := IDLE_S;
-----------------------------------------------------------------------
+         ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -535,8 +538,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      rxSlave  <= v.rxSlave;
+      -- Registered Outputs       
       txMaster <= r.txMaster;
       dhcpIp   <= r.dhcpIp;
 

--- a/ethernet/UdpEngine/rtl/UdpEngineRx.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineRx.vhd
@@ -459,6 +459,9 @@ begin
             end case;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -468,12 +471,11 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
+      -- Registered Outputs  
       serverRemotePort <= r.serverRemotePort;
       serverRemoteIp   <= r.serverRemoteIp;
       serverRemoteMac  <= r.serverRemoteMac;
       clientRemoteDet  <= r.clientRemoteDet;
-      rxSlave          <= v.rxSlave;
 
    end process comb;
 

--- a/ethernet/UdpEngine/rtl/UdpEngineTx.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineTx.vhd
@@ -349,6 +349,10 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      ibSlaves    <= v.ibSlaves;
+      obDhcpSlave <= v.obDhcpSlave;
 
       -- Reset
       if (rst = '1') then
@@ -358,10 +362,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      ibSlaves    <= v.ibSlaves;
-      txMaster    <= r.txMaster;
-      obDhcpSlave <= v.obDhcpSlave;
+      -- Registered Outputs   
+      txMaster <= r.txMaster;
       
    end process comb;
 

--- a/ethernet/UdpEngine/tb/UdpEngineCoreTb.vhd
+++ b/ethernet/UdpEngine/tb/UdpEngineCoreTb.vhd
@@ -223,6 +223,9 @@ begin
             v.timer  := x"0000";
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      obClientSlave <= v.obClientSlave;
 
       -- Reset
       if (rst = '1') then
@@ -232,8 +235,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      obClientSlave  <= v.obClientSlave;
+      -- Registered Outputs
       ibClientMaster <= r.ibClientMaster;
       passed         <= r.passedDly;
       failed         <= r.failedDly;

--- a/protocols/clink/hdl/ClinkFraming.vhd
+++ b/protocols/clink/hdl/ClinkFraming.vhd
@@ -383,6 +383,8 @@ begin
          end if;
       end if;
 
+      parReady   <= v.ready;      
+
       ---------------------------------
       -- Reset and outputs
       ---------------------------------
@@ -391,7 +393,6 @@ begin
       end if;
 
       rin        <= v;
-      parReady   <= v.ready;
       chanStatus <= r.status;
 
    end process;

--- a/protocols/jesd204b/rtl/Jesd32bTo16b.vhd
+++ b/protocols/jesd204b/rtl/Jesd32bTo16b.vhd
@@ -2,7 +2,7 @@
 -- File       : Jesd32bTo16b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-24
--- Last update: 2017-08-29
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Converts the 32-bit JESD interface to 16-bit interface
 -------------------------------------------------------------------------------
@@ -126,6 +126,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      rdEn <= v.rdEn;
+
       -- Synchronous Reset
       if (rdRst = '1') then
          v := REG_INIT_C;
@@ -135,7 +138,6 @@ begin
       rin <= v;
 
       -- Outputs
-      rdEn     <= v.rdEn;
       validOut <= r.valid;
       trigOut  <= r.trig;
       dataOut  <= r.data;

--- a/protocols/jesd204b/rtl/Jesd64bTo32b.vhd
+++ b/protocols/jesd204b/rtl/Jesd64bTo32b.vhd
@@ -2,7 +2,7 @@
 -- File       : Jesd64bTo32b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-11-10
--- Last update: 2017-11-10
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Converts the 64-bit JESD interface to 32-bit interface
 -------------------------------------------------------------------------------
@@ -126,6 +126,9 @@ begin
          end if;
       end if;
 
+      -- Combinatorial outputs before the reset
+      rdEn <= v.rdEn;
+
       -- Synchronous Reset
       if (rdRst = '1') then
          v := REG_INIT_C;
@@ -135,7 +138,6 @@ begin
       rin <= v;
 
       -- Outputs
-      rdEn     <= v.rdEn;
       validOut <= r.valid;
       trigOut  <= r.trig;
       dataOut  <= r.data;

--- a/protocols/jesd204b/rtl/JesdAlignFrRepCh.vhd
+++ b/protocols/jesd204b/rtl/JesdAlignFrRepCh.vhd
@@ -2,7 +2,7 @@
 -- File       : JesdAlignFrRepCh.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-15
--- Last update: 2016-02-12
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Align bytes and replace control characters with data
 --
@@ -231,6 +231,10 @@ begin
          v.dataValid    := dataValid_i;
       end if;
       
+      -- Combinatorial outputs before the reset
+      positionErr_o     <= v_positionErr;
+      alignErr_o        <= v_alignErr;
+      
       if (rst = '1') then
          v := REG_INIT_C;
       end if;
@@ -239,8 +243,6 @@ begin
       rin <= v;
 
       -- Output assignment
-      positionErr_o     <= v_positionErr;
-      alignErr_o        <= v_alignErr;
       sampleData_o      <= r.sampleData;
       sampleDataValid_o <= r.dataValid;
    -----------------------------------------------------------

--- a/protocols/mdio/rtl/MdioCore.vhd
+++ b/protocols/mdio/rtl/MdioCore.vhd
@@ -5,7 +5,7 @@
 -- Author     : Till Straumann <strauman@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-11-27
--- Last update: 2017-11-27
+-- Last update: 2018-02-14
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ begin
    begin
       if ( rising_edge( clk ) ) then
          if ( rst /= '0' ) then
-            r <= REG_INIT_C;
+            r <= REG_INIT_C after TPD_G;
          else
             r <= rin after TPD_G;
          end if;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -217,6 +217,9 @@ begin
          end if;
 
       end if;
+      
+      -- Combinatorial outputs before the reset
+      pgpTxSlave <= v.pgpTxSlave;
 
       if (pgpTxRst = '1') then
          v := REG_INIT_C;
@@ -224,7 +227,6 @@ begin
 
       rin <= v;
 
-      pgpTxSlave     <= v.pgpTxSlave;
       protTxData     <= r.protTxData;
       protTxHeader   <= r.protTxHeader;
       protTxValid    <= r.protTxValid;

--- a/protocols/rssi/rtl/RxFSM.vhd
+++ b/protocols/rssi/rtl/RxFSM.vhd
@@ -2,7 +2,7 @@
 -- File       : RxFSM.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-06-11
--- Last update: 2016-06-23
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Receiver FSM
 --              Receiver has the following functionality:
@@ -749,6 +749,11 @@ begin
            
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rdBuffAddr_o   <= v.txBufferAddr & v.txSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);      
+      -- Transport side SSI output
+      tspSsiSlave_o <= v.tspSsiSlave;
 
       -- Synchronous Reset
       if (rst_i = '1') then
@@ -762,7 +767,6 @@ begin
       wrBuffAddr_o   <= r.rxBufferAddr & r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);
       wrBuffWe_o     <= r.segmentWe;
       wrBuffData_o   <= r.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0);
-      rdBuffAddr_o   <= v.txBufferAddr & v.txSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);
       
       -- Assign outputs
       rxFlags_o      <= r.rxF;
@@ -775,9 +779,6 @@ begin
       chksumStrobe_o <= r.chkStb;
       chksumLength_o <= r.chkLen;
       rxParam_o      <= r.rxParam;    
-      
-      -- Transport side SSI output
-      tspSsiSlave_o <= v.tspSsiSlave;
       
       -- Application side SSI output
       appSsiMaster_o <= r.appSsiMaster;      

--- a/protocols/rssi/rtl/TxFSM.vhd
+++ b/protocols/rssi/rtl/TxFSM.vhd
@@ -2,7 +2,7 @@
 -- File       : TxFSM.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-08-09
--- Last update: 2016-01-27
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: Transmitter FSM
 --              Transmitter has the following functionality:
@@ -50,9 +50,9 @@ use work.AxiStreamPkg.all;
 
 entity TxFSM is
    generic (
-      TPD_G              : time     := 1 ns;
-      
-      WINDOW_ADDR_SIZE_G : positive := 3;   -- 2^WINDOW_ADDR_SIZE_G  = Number of segments
+      TPD_G : time := 1 ns;
+
+      WINDOW_ADDR_SIZE_G  : positive := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Number of segments
       SEGMENT_ADDR_SIZE_G : positive := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
 
       SYN_HEADER_SIZE_G  : natural := 24;
@@ -61,102 +61,102 @@ entity TxFSM is
       RST_HEADER_SIZE_G  : natural := 8;
       NULL_HEADER_SIZE_G : natural := 8;
       DATA_HEADER_SIZE_G : natural := 8;
-      
-      HEADER_CHKSUM_EN_G : boolean  := true
-   );
+
+      HEADER_CHKSUM_EN_G : boolean := true
+      );
    port (
-      clk_i      : in  sl;
-      rst_i      : in  sl;
-      
+      clk_i : in sl;
+      rst_i : in sl;
+
       -- Connection FSM indicating active connection
-      connActive_i   : in  sl;
+      connActive_i : in sl;
       -- Closed state in connFSM (initialize seqN)
-      closed_i    : in  sl;
-      
+      closed_i     : in sl;
+
       -- Fault injection corrupts header checksum      
-      injectFault_i : in  sl;
-      
+      injectFault_i : in sl;
+
       -- Various segment requests
-      sndSyn_i        : in  sl;
-      sndAck_i        : in  sl;
-      sndRst_i        : in  sl;
-      sndResend_i     : in  sl;
-      sndNull_i       : in  sl;   
-      
+      sndSyn_i    : in sl;
+      sndAck_i    : in sl;
+      sndRst_i    : in sl;
+      sndResend_i : in sl;
+      sndNull_i   : in sl;
+
       -- Window buff size (Depends on the number of outstanding segments)
-      windowSize_i  : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
-      bufferSize_i  : in integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
-      
+      windowSize_i : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      bufferSize_i : in integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
+
       -- Buffer write
-      wrBuffWe_o     : out  sl;      
-      wrBuffAddr_o   : out  slv( (SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
-      wrBuffData_o   : out  slv(RSSI_WORD_WIDTH_C*8-1 downto 0);      
-      
+      wrBuffWe_o   : out sl;
+      wrBuffAddr_o : out slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+      wrBuffData_o : out slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
+
       -- Buffer read
-      rdBuffAddr_o   : out  slv( (SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
-      rdBuffData_i   : in   slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
-    
+      rdBuffAddr_o : out slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+      rdBuffData_i : in  slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
+
       -- Header read
-      rdHeaderAddr_o  : out  slv(7 downto 0);
-      rdHeaderData_i  : in   slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
+      rdHeaderAddr_o : out slv(7 downto 0);
+      rdHeaderData_i : in  slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
       --
-      headerRdy_i     : in sl;
-      headerLength_i  : in positive;  -- Unconnected for now will be used when EACK    
-      
+      headerRdy_i    : in  sl;
+      headerLength_i : in  positive;    -- Unconnected for now will be used when EACK    
+
       -- Checksum control
-      chksumValid_i : in   sl;
-      chksumEnable_o: out  sl;
-      chksumStrobe_o: out  sl; 
+      chksumValid_i  : in  sl;
+      chksumEnable_o : out sl;
+      chksumStrobe_o : out sl;
       --      
-      chksum_i : in slv(15 downto 0);      
-      
+      chksum_i       : in  slv(15 downto 0);
+
       -- Initial sequence number
-      initSeqN_i   : in slv(7 downto 0);
-    
+      initSeqN_i : in slv(7 downto 0);
+
       -- Tx data (input to header decoder module)
-      txSeqN_o     : out slv(7 downto 0);
-      
+      txSeqN_o : out slv(7 downto 0);
+
       -- FSM outs for header and data flow control
-      synHeadSt_o  : out  sl;
-      ackHeadSt_o  : out  sl;
-      dataHeadSt_o : out  sl;
-      dataSt_o     : out  sl;
-      rstHeadSt_o  : out  sl;
-      nullHeadSt_o : out  sl;
-      
+      synHeadSt_o  : out sl;
+      ackHeadSt_o  : out sl;
+      dataHeadSt_o : out sl;
+      dataSt_o     : out sl;
+      rstHeadSt_o  : out sl;
+      nullHeadSt_o : out sl;
+
       -- Last acked number (Used in Rx FSM to determine if AcnN is valid)
-      lastAckN_o    : out slv(7 downto 0);
-      
+      lastAckN_o : out slv(7 downto 0);
+
       -- Acknowledge mechanism
-      ack_i         : in sl;                   -- From receiver module when a segment with valid ACK is received
-      ackN_i        : in slv(7 downto 0);      -- Number being ACKed
+      ack_i  : in sl;  -- From receiver module when a segment with valid ACK is received
+      ackN_i : in slv(7 downto 0);      -- Number being ACKed
       --eack_i        : in sl;                 -- From receiver module when a segment with valid EACK is received
       --eackSeqnArr_i : in Slv8Array(0 to MAX_RX_NUM_OUTS_SEG_G-1); -- Array of sequence numbers received out of order
 
       -- SSI Application side interface IN
       appSsiMaster_i : in  SsiMasterType;
       appSsiSlave_o  : out SsiSlaveType;
-      
+
       -- SSI Transport side interface OUT
-      tspSsiSlave_i  : in   SsiSlaveType;
-      tspSsiMaster_o : out  SsiMasterType;
-      
+      tspSsiSlave_i  : in  SsiSlaveType;
+      tspSsiMaster_o : out SsiMasterType;
+
       -- Errors (1 cc pulse)
-      lenErr_o         : out sl;
-      ackErr_o         : out sl;
-      
+      lenErr_o : out sl;
+      ackErr_o : out sl;
+
       -- Segment buffer indicator
-      bufferEmpty_o    : out sl   
-   );
+      bufferEmpty_o : out sl
+      );
 end entity TxFSM;
 
 architecture rtl of TxFSM is
 
    -- Init SSI bus
-   constant SSI_MASTER_INIT_C   : SsiMasterType := axis2SsiMaster(RSSI_AXIS_CONFIG_C, AXI_STREAM_MASTER_INIT_C);
-   constant SSI_SLAVE_NOTRDY_C  : SsiSlaveType  := axis2SsiSlave(RSSI_AXIS_CONFIG_C, AXI_STREAM_SLAVE_INIT_C, AXI_STREAM_CTRL_INIT_C);
-   constant SSI_SLAVE_RDY_C     : SsiSlaveType  := axis2SsiSlave(RSSI_AXIS_CONFIG_C, AXI_STREAM_SLAVE_FORCE_C, AXI_STREAM_CTRL_INIT_C);
-   
+   constant SSI_MASTER_INIT_C  : SsiMasterType := axis2SsiMaster(RSSI_AXIS_CONFIG_C, AXI_STREAM_MASTER_INIT_C);
+   constant SSI_SLAVE_NOTRDY_C : SsiSlaveType  := axis2SsiSlave(RSSI_AXIS_CONFIG_C, AXI_STREAM_SLAVE_INIT_C, AXI_STREAM_CTRL_INIT_C);
+   constant SSI_SLAVE_RDY_C    : SsiSlaveType  := axis2SsiSlave(RSSI_AXIS_CONFIG_C, AXI_STREAM_SLAVE_FORCE_C, AXI_STREAM_CTRL_INIT_C);
+
    type TspStateType is (
       --
       INIT_S,
@@ -179,74 +179,74 @@ architecture rtl of TxFSM is
       RESEND_H_S,
       RESEND_DATA_S,
       RESEND_PP_S
-   );
-   
+      );
+
    type AppStateType is (
       IDLE_S,
       WAIT_SOF_S,
       SEG_RCV_S,
       SEG_RDY_S,
       SEG_LEN_ERR
-   );
-   
+      );
+
    type AckStateType is (
       IDLE_S,
       ERR_S,
       ACK_S
-      --EACK_S,
-   );
+    --EACK_S,
+      );
 
    type RegType is record
-   
+
       -- Buffer window handling and acknowledgment control
       -----------------------------------------
-      windowArray    : WindowTypeArray(0 to 2 ** WINDOW_ADDR_SIZE_G-1);      
+      windowArray    : WindowTypeArray(0 to 2 ** WINDOW_ADDR_SIZE_G-1);
       firstUnackAddr : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
       nextSentAddr   : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
       lastSentAddr   : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
-      
-      lastAckSeqN    : slv(7 downto 0);
+
+      lastAckSeqN : slv(7 downto 0);
       --eackAddr       : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
       --eackIndex      : integer;      
-      bufferFull     : sl;
-      bufferEmpty    : sl;
-      ackErr         : sl;     
-      
+      bufferFull  : sl;
+      bufferEmpty : sl;
+      ackErr      : sl;
+
       -- State Machine
-      ackState       : AckStateType;
-      
+      ackState : AckStateType;
+
       -- Application side FSM
       -----------------------------------------     
-      rxSegmentAddr  : slv(SEGMENT_ADDR_SIZE_G downto 0); -- One address bit more to check the overflow
-      rxBufferAddr   : slv(WINDOW_ADDR_SIZE_G-1  downto 0);
-      rxSegmentWe    : sl;
-      sndData        : sl;
-      lenErr         : sl;
-      appBusy        : sl;
-      
-      appSsiMaster      : SsiMasterType;
-      appSsiSlave       : SsiSlaveType;
-      
-      appState       : AppStateType;
-   
+      rxSegmentAddr : slv(SEGMENT_ADDR_SIZE_G downto 0);  -- One address bit more to check the overflow
+      rxBufferAddr  : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
+      rxSegmentWe   : sl;
+      sndData       : sl;
+      lenErr        : sl;
+      appBusy       : sl;
+
+      appSsiMaster : SsiMasterType;
+      appSsiSlave  : SsiSlaveType;
+
+      appState : AppStateType;
+
       -- Transport side FSM
       -----------------------------------------
-      
+
       -- Counters
-      nextSeqN       : slv(7 downto 0);
-      seqN           : slv(7 downto 0);
-      txHeaderAddr   : slv(7 downto 0);
-      txSegmentAddr  : slv(SEGMENT_ADDR_SIZE_G downto 0);
-      txBufferAddr   : slv(WINDOW_ADDR_SIZE_G-1  downto 0);
-      
+      nextSeqN      : slv(7 downto 0);
+      seqN          : slv(7 downto 0);
+      txHeaderAddr  : slv(7 downto 0);
+      txSegmentAddr : slv(SEGMENT_ADDR_SIZE_G downto 0);
+      txBufferAddr  : slv(WINDOW_ADDR_SIZE_G-1 downto 0);
+
       -- Data mux flags
-      synH  : sl;
-      ackH  : sl;      
-      rstH  : sl;
-      nullH : sl;
-      dataH : sl;
-      dataD : sl;
-      resend: sl;
+      synH   : sl;
+      ackH   : sl;
+      rstH   : sl;
+      nullH  : sl;
+      dataH  : sl;
+      dataD  : sl;
+      resend : sl;
 
       -- Varionus controls
       txRdy    : sl;
@@ -254,52 +254,52 @@ architecture rtl of TxFSM is
       buffSent : sl;
       chkEn    : sl;
       chkStb   : sl;
-      
+
       -- Fault injection
       injectFaultD1  : sl;
       injectFaultReg : sl;
-      
+
       -- SSI master
-      tspSsiMaster      : SsiMasterType;
-      tspSsiSlave       : SsiSlaveType;
-      
+      tspSsiMaster : SsiMasterType;
+      tspSsiSlave  : SsiSlaveType;
+
       -- State Machine
-      tspState       : tspStateType;    
+      tspState : tspStateType;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-   
+
       -- Buffer window handling and acknowledgment control
       -----------------------------------------
       -- Window control   
       firstUnackAddr => (others => '0'),
       lastSentAddr   => (others => '0'),
       nextSentAddr   => (others => '0'),
-      
-      lastAckSeqN    => (others => '0'),
+
+      lastAckSeqN => (others => '0'),
       --eackAddr       => (others => '0'),
       --eackIndex      => 0,
-      bufferFull     => '0',
-      bufferEmpty    => '1',
-      windowArray    => (0 to 2 ** WINDOW_ADDR_SIZE_G-1 => WINDOW_INIT_C),
-      ackErr         => '0',
-      
-      ackState        => IDLE_S,
-      
+      bufferFull  => '0',
+      bufferEmpty => '1',
+      windowArray => (0 to 2 ** WINDOW_ADDR_SIZE_G-1 => WINDOW_INIT_C),
+      ackErr      => '0',
+
+      ackState => IDLE_S,
+
       -- Application side FSM
       -----------------------------------------     
-      rxSegmentAddr   => (others => '0'),
-      rxSegmentWe     => '0',
-      rxBufferAddr    => (others => '0'),
-      sndData         => '0',
-      lenErr          => '0',
-      appBusy         => '0',
-      
-      appSsiMaster    => SSI_MASTER_INIT_C,     
-      appSsiSlave     => SSI_SLAVE_NOTRDY_C,
-      
-      appState        => IDLE_S,
-      
+      rxSegmentAddr => (others => '0'),
+      rxSegmentWe   => '0',
+      rxBufferAddr  => (others => '0'),
+      sndData       => '0',
+      lenErr        => '0',
+      appBusy       => '0',
+
+      appSsiMaster => SSI_MASTER_INIT_C,
+      appSsiSlave  => SSI_SLAVE_NOTRDY_C,
+
+      appState => IDLE_S,
+
       -- Transport side FSM
       -----------------------------------------  
       nextSeqN      => (others => '0'),
@@ -307,63 +307,63 @@ architecture rtl of TxFSM is
       txHeaderAddr  => (others => '0'),
       txSegmentAddr => (others => '0'),
       txBufferAddr  => (others => '0'),
-      
+
       --
-      synH     => '0',      
-      ackH     => '0',
-      rstH     => '0',
-      nullH    => '0',
-      dataH    => '0',
-      dataD    => '0',
-      resend   => '0',
-      
+      synH   => '0',
+      ackH   => '0',
+      rstH   => '0',
+      nullH  => '0',
+      dataH  => '0',
+      dataD  => '0',
+      resend => '0',
+
       --
-      txRdy    => '0',      
+      txRdy    => '0',
       buffWe   => '0',
       buffSent => '0',
       chkEn    => '0',
       chkStb   => '0',
-      
+
       -- Fault injection
       injectFaultD1  => '0',
       injectFaultReg => '0',
-      
-      -- SSI master 
-      tspSsiMaster   => SSI_MASTER_INIT_C,
-      tspSsiSlave    => SSI_SLAVE_NOTRDY_C,
-      
-      -- State Machine
-      tspState     => INIT_S
-   );
 
-   signal r   : RegType := REG_INIT_C;
-   signal rin : RegType;
-   signal s_chksum : slv(chksum_i'range);
+      -- SSI master 
+      tspSsiMaster => SSI_MASTER_INIT_C,
+      tspSsiSlave  => SSI_SLAVE_NOTRDY_C,
+
+      -- State Machine
+      tspState => INIT_S
+      );
+
+   signal r                 : RegType := REG_INIT_C;
+   signal rin               : RegType;
+   signal s_chksum          : slv(chksum_i'range);
    signal s_headerAndChksum : slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
 begin
-   
+
    -- Send all 0 if checksum disabled
-   s_chksum <= ite(HEADER_CHKSUM_EN_G, chksum_i, (chksum_i'range=>'0') );
+   s_chksum          <= ite(HEADER_CHKSUM_EN_G, chksum_i, (chksum_i'range => '0'));
    s_headerAndChksum <= rdHeaderData_i(63 downto 16) & s_chksum(15 downto 0);
-   
+
    ----------------------------------------------------------------------------------------------- 
    comb : process (r, rst_i, appSsiMaster_i, sndSyn_i, sndAck_i, connActive_i, closed_i, sndRst_i, initSeqN_i, windowSize_i, headerRdy_i, ack_i, ackN_i, bufferSize_i,
                    sndResend_i, sndNull_i, tspSsiSlave_i, rdHeaderData_i, rdBuffData_i, s_headerAndChksum, chksumValid_i, headerLength_i, injectFault_i) is
-      
+
       variable v : RegType;
 
    begin
       v := r;
-      
+
       -- /////////////////////////////////////////////////////////
       ------------------------------------------------------------
       -- Buffer window handling
       ------------------------------------------------------------   
       -- /////////////////////////////////////////////////////////
-      
+
       ------------------------------------------------------------
       -- Buffer full if next slot is occupied
-      if ( r.windowArray(conv_integer(v.rxBufferAddr)).occupied = '1') then
+      if (r.windowArray(conv_integer(v.rxBufferAddr)).occupied = '1') then
          v.bufferFull := '1';
       else
          v.bufferFull := '0';
@@ -371,39 +371,39 @@ begin
 
       ------------------------------------------------------------
       -- Buffer empty if next unacknowledged slot is unoccupied
-      if ( r.windowArray(conv_integer(r.firstUnackAddr)).occupied = '0') then
+      if (r.windowArray(conv_integer(r.firstUnackAddr)).occupied = '0') then
          v.bufferEmpty := '1';
       else
          v.bufferEmpty := '0';
       end if;
-      
+
       ------------------------------------------------------------
       -- Write seqN and segment type to window array
       ------------------------------------------------------------
       if (r.buffWe = '1') then
-         v.windowArray(conv_integer(r.nextSentAddr)).seqN    := r.nextSeqN;
-         v.windowArray(conv_integer(r.nextSentAddr)).segType := r.rstH & r.nullH & r.dataH;
+         v.windowArray(conv_integer(r.nextSentAddr)).seqN     := r.nextSeqN;
+         v.windowArray(conv_integer(r.nextSentAddr)).segType  := r.rstH & r.nullH & r.dataH;
          v.windowArray(conv_integer(r.nextSentAddr)).occupied := '1';
-         
+
          -- Update last sent address when new segment is being sent
-         v.lastSentAddr := r.nextSentAddr;   
-      else 
-         v.windowArray      := r.windowArray;
+         v.lastSentAddr := r.nextSentAddr;
+      else
+         v.windowArray := r.windowArray;
       end if;
-      
+
       ------------------------------------------------------------
       -- When buffer is sent increase nextSentAddr
       ------------------------------------------------------------
       if (r.buffSent = '1') then
 
-         if r.nextSentAddr < (windowSize_i-1) then 
+         if r.nextSentAddr < (windowSize_i-1) then
             v.nextSentAddr := r.nextSentAddr +1;
          else
             v.nextSentAddr := (others => '0');
          end if;
-            
-      else 
-         v.nextSentAddr     := r.nextSentAddr;
+
+      else
+         v.nextSentAddr := r.nextSentAddr;
       end if;
 
       -- /////////////////////////////////////////////////////////
@@ -413,11 +413,11 @@ begin
       -- Place out of order flags from EACK table (Not in Version 1)
       ------------------------------------------------------------
       -- /////////////////////////////////////////////////////////
-      
+
       case r.ackState is
          ----------------------------------------------------------------------
          when IDLE_S =>
-         
+
             -- Hold ACK address
             v.firstUnackAddr := r.firstUnackAddr;
             v.lastAckSeqN    := r.lastAckSeqN;
@@ -427,73 +427,73 @@ begin
 
             -- Next state condition          
             if (ack_i = '1') then
-               v.ackState    := ACK_S;
+               v.ackState := ACK_S;
             end if;
          ----------------------------------------------------------------------
          when ACK_S =>
-         
+
             -- If the same ackN received do nothing
-            if  (r.lastAckSeqN = ackN_i) then
-                v.firstUnackAddr  := r.firstUnackAddr;             
+            if (r.lastAckSeqN = ackN_i) then
+               v.firstUnackAddr := r.firstUnackAddr;
             -- Increment ACK address until seqN is found next received
             elsif r.firstUnackAddr < (windowSize_i-1) then
-               v.windowArray(conv_integer(r.firstUnackAddr)).occupied := '0';            
-               v.firstUnackAddr  := r.firstUnackAddr+1;
+               v.windowArray(conv_integer(r.firstUnackAddr)).occupied := '0';
+               v.firstUnackAddr                                       := r.firstUnackAddr+1;
             else
                v.windowArray(conv_integer(r.firstUnackAddr)).occupied := '0';
-               v.firstUnackAddr  := (others => '0');
+               v.firstUnackAddr                                       := (others => '0');
             end if;
-                       
+
             --v.eackAddr       := r.firstUnackAddr;
             -- v.eackIndex      := 0;
-            v.ackErr         := '0';
+            v.ackErr := '0';
 
             -- Next state condition            
 
             -- If the same ackN received
-            if  (r.lastAckSeqN = ackN_i) then
-           
-                -- Go back to IDLE
-                v.ackState   := IDLE_S;
-            
-            elsif (r.firstUnackAddr = r.lastSentAddr and r.windowArray(conv_integer(r.firstUnackAddr)).seqN /= ackN_i) then  
+            if (r.lastAckSeqN = ackN_i) then
+
+               -- Go back to IDLE
+               v.ackState := IDLE_S;
+
+            elsif (r.firstUnackAddr = r.lastSentAddr and r.windowArray(conv_integer(r.firstUnackAddr)).seqN /= ackN_i) then
                -- If the acked seqN is not found go to error state
-               v.ackState   := ERR_S;             
-            elsif  (r.windowArray(conv_integer(r.firstUnackAddr)).seqN = ackN_i)  then
-               v.lastAckSeqN := ackN_i; -- Save the last Acked seqN
+               v.ackState := ERR_S;
+            elsif (r.windowArray(conv_integer(r.firstUnackAddr)).seqN = ackN_i) then
+               v.lastAckSeqN := ackN_i;  -- Save the last Acked seqN
                --if eack_i = '1' then
-                  -- Go back to init when the acked seqN is found            
+               -- Go back to init when the acked seqN is found            
                --   v.ackState   := EACK_S;               
                --else
-                  -- Go back to init when the acked seqN is found            
-               v.ackState   := IDLE_S;
-               --end if;
+               -- Go back to init when the acked seqN is found            
+               v.ackState    := IDLE_S;
+            --end if;
             end if;
-         ----------------------------------------------------------------------
-         -- when EACK_S =>
-         
+            ----------------------------------------------------------------------
+            -- when EACK_S =>
+
             -- -- Increment EACK address from firstUnackAddr to nextSentAddr
             -- if r.eackAddr < (windowSize_i-1) then 
-               -- v.eackAddr  := r.eackAddr+1;
+            -- v.eackAddr  := r.eackAddr+1;
             -- else
-               -- v.eackAddr  := (others => '0');
+            -- v.eackAddr  := (others => '0');
             -- end if;
-            
+
             -- -- For every address check if the sequence number equals value from eackSeqnArr_i array.
             -- -- If it matches mark the eack field at the address and compare the next value from the table.          
             -- if  r.windowArray(conv_integer(r.eackAddr)).seqN = eackSeqnArr_i(r.eackIndex)  then
-               -- v.windowArray(conv_integer(r.eackAddr)).eacked := '1';
-               -- v.eackIndex := r.eackIndex + 1;               
+            -- v.windowArray(conv_integer(r.eackAddr)).eacked := '1';
+            -- v.eackIndex := r.eackIndex + 1;               
             -- end if;
-            
+
             -- v.firstUnackAddr  := r.firstUnackAddr;
             -- v.ackErr          := '0';
-            
-            -- -- Next state condition 
-            -- if (r.eackAddr = r.nextSentAddr) then
-               -- -- If the acked seqN is not found go to error state
-               -- v.appState   := IDLE_S;
-            -- end if;
+
+         -- -- Next state condition 
+         -- if (r.eackAddr = r.nextSentAddr) then
+         -- -- If the acked seqN is not found go to error state
+         -- v.appState   := IDLE_S;
+         -- end if;
          ----------------------------------------------------------------------
          when ERR_S =>
             -- Outputs
@@ -501,162 +501,162 @@ begin
             --v.eackAddr       := r.firstUnackAddr;
             --v.eackIndex      := 0;
             v.ackErr         := '1';
-            
+
             -- Next state condition            
-            v.ackState   := IDLE_S;            
+            v.ackState := IDLE_S;
          ----------------------------------------------------------------------
          when others =>
-             -- Outputs
+            -- Outputs
             v.firstUnackAddr := r.firstUnackAddr;
             -- v.eackAddr       := r.firstUnackAddr;
             -- v.eackIndex      := 0;
             v.ackErr         := '1';
 
             -- Next state condition            
-            v.ackState   := IDLE_S;            
+            v.ackState := IDLE_S;
       ----------------------------------------------------------------------
       end case;
-      
+
       -- ///////////////////////////////////////////////////////// 
       ------------------------------------------------------------
       -- Application side FSM
       ------------------------------------------------------------
       -- /////////////////////////////////////////////////////////      
-      
+
       -- Pipeline Master (DFF)
-      v.appSsiMaster    := appSsiMaster_i;
+      v.appSsiMaster := appSsiMaster_i;
       ------------------------------------------------------------
       case r.appState is
          ----------------------------------------------------------------------
          when IDLE_S =>
-         
+
             -- SSI
             v.appSsiSlave := SSI_SLAVE_NOTRDY_C;
-            
+
             -- Buffer write ctl
-            v.rxSegmentAddr := (others =>'0');
+            v.rxSegmentAddr := (others => '0');
             v.rxSegmentWe   := '0';
-            v.rxBufferAddr  := r.rxBufferAddr;         
-            
+            v.rxBufferAddr  := r.rxBufferAddr;
+
             -- txFSM
-            v.sndData     := '0';
-            v.lenErr      := '0';
-            v.appBusy     := '1';
-            
+            v.sndData := '0';
+            v.lenErr  := '0';
+            v.appBusy := '1';
+
             -- Wait if buffer full
             if (v.bufferFull = '0') then
-               v.appState    := WAIT_SOF_S;
+               v.appState := WAIT_SOF_S;
             end if;
          ----------------------------------------------------------------------
          when WAIT_SOF_S =>
-         
+
             -- SSI Ready to receive data from APP
             v.appSsiSlave := SSI_SLAVE_RDY_C;
-            
+
             -- Buffer write ctl
-            v.rxSegmentAddr := (others =>'0');
+            v.rxSegmentAddr := (others => '0');
             v.rxSegmentWe   := '0';
             v.rxBufferAddr  := r.rxBufferAddr;
-            
+
             -- txFSM
-            v.sndData     := '0';
-            v.lenErr      := '0';
-            v.appBusy     := '0';
-            
+            v.sndData := '0';
+            v.lenErr  := '0';
+            v.appBusy := '0';
+
             -- If other segment (NULL, or RST) is requested return to IDLE_S to
             -- check if buffer is still available (not full)
             if (r.buffWe = '1') then
-               v.appState      := IDLE_S;
-               
+               v.appState := IDLE_S;
+
                -- Increment the buffer window address because a NULL segment has filled the current spot
                if r.rxBufferAddr < (windowSize_i-1) then
                   v.rxBufferAddr := r.rxBufferAddr+1;
                else
                   v.rxBufferAddr := (others => '0');
                end if;
-               
+
             -- Wait until receiving the first data            
             -- SOF and EOF received
             -- Packet is only one word long go directly to ready!
-            elsif (appSsiMaster_i.sof = '1' and appSsiMaster_i.valid = '1' and appSsiMaster_i.eof = '1' ) then
-            
+            elsif (appSsiMaster_i.sof = '1' and appSsiMaster_i.valid = '1' and appSsiMaster_i.eof = '1') then
+
                -- First data already received at this point
                v.rxSegmentAddr := r.rxSegmentAddr;
-               v.appBusy     := '1';
+               v.appBusy       := '1';
                v.rxSegmentWe   := '1';
-            
+
                -- Save packet tKeep of last data word
-               v.windowArray(conv_integer(r.rxBufferAddr)).keep    := appSsiMaster_i.keep;            
-               v.windowArray(conv_integer(r.rxBufferAddr)).segSize := conv_integer(r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0)); 
-            
-               v.appState    := SEG_RDY_S;
+               v.windowArray(conv_integer(r.rxBufferAddr)).keep    := appSsiMaster_i.keep;
+               v.windowArray(conv_integer(r.rxBufferAddr)).segSize := conv_integer(r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0));
+
+               v.appState := SEG_RDY_S;
 
             -- SOF received            
             elsif (appSsiMaster_i.sof = '1' and appSsiMaster_i.valid = '1') then
-               
+
                -- First data received
                v.rxSegmentAddr := r.rxSegmentAddr;
-               v.appBusy     := '1';
+               v.appBusy       := '1';
                v.rxSegmentWe   := '1';
-                           
-               v.appState    := SEG_RCV_S;
+
+               v.appState := SEG_RCV_S;
             end if;
          ----------------------------------------------------------------------
          when SEG_RCV_S =>
-         
+
             -- SSI
             v.appSsiSlave  := SSI_SLAVE_RDY_C;
             v.rxBufferAddr := r.rxBufferAddr;
-             
+
             -- Buffer write if data valid 
-            if (appSsiMaster_i.valid = '1') then            
+            if (appSsiMaster_i.valid = '1') then
                v.rxSegmentAddr := r.rxSegmentAddr + 1;
-               v.rxSegmentWe           := '1';
+               v.rxSegmentWe   := '1';
             else
                v.rxSegmentAddr := r.rxSegmentAddr;
-               v.rxSegmentWe           := '0';             
+               v.rxSegmentWe   := '0';
             end if;
-            
+
             -- txFSM
-            v.sndData     := '0';
-            v.lenErr      := '0';
-            v.appBusy     := '1';            
-            
+            v.sndData := '0';
+            v.lenErr  := '0';
+            v.appBusy := '1';
+
             -- Wait until receiving EOF 
             if (appSsiMaster_i.eof = '1' and appSsiMaster_i.valid = '1') then
-            
-               -- Save packet tKeep of last data word
-               v.windowArray(conv_integer(r.rxBufferAddr)).keep   := appSsiMaster_i.keep;
-               
-               -- Save packet length (+1 because it has not incremented for EOF yet)
-               v.windowArray(conv_integer(r.rxBufferAddr)).segSize := conv_integer(r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0))+1;           
 
-               v.appState    := SEG_RDY_S;
-               --
-            elsif (r.rxSegmentAddr > bufferSize_i ) then
+               -- Save packet tKeep of last data word
+               v.windowArray(conv_integer(r.rxBufferAddr)).keep := appSsiMaster_i.keep;
+
+               -- Save packet length (+1 because it has not incremented for EOF yet)
+               v.windowArray(conv_integer(r.rxBufferAddr)).segSize := conv_integer(r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0))+1;
+
+               v.appState := SEG_RDY_S;
+            --
+            elsif (r.rxSegmentAddr > bufferSize_i) then
                v.rxSegmentWe := '0';
-               v.appState    := SEG_LEN_ERR; 
-            elsif (r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G) = '1' ) then
+               v.appState    := SEG_LEN_ERR;
+            elsif (r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G) = '1') then
                v.rxSegmentWe := '0';
-               v.appState    := SEG_LEN_ERR;     
+               v.appState    := SEG_LEN_ERR;
             end if;
          ----------------------------------------------------------------------            
          when SEG_RDY_S =>
-            
+
             -- SSI
             v.appSsiSlave := SSI_SLAVE_NOTRDY_C;
-            
-            v.rxSegmentAddr := (others =>'0');
+
+            v.rxSegmentAddr := (others => '0');
             v.rxSegmentWe   := '0';
-            
+
             -- Request data at txFSM
-            v.sndData     := '1';
-            v.lenErr      := '0';
-            v.appBusy     := '1';
-            
+            v.sndData := '1';
+            v.lenErr  := '0';
+            v.appBusy := '1';
+
             -- Hold request until accepted
             -- And not in resend process
-            if (v.dataH = '1' and v.resend = '0' ) then
+            if (v.dataH = '1' and v.resend = '0') then
                -- Increment the rxBuffer
                if r.rxBufferAddr < (windowSize_i-1) then
                   v.rxBufferAddr := r.rxBufferAddr+1;
@@ -664,37 +664,37 @@ begin
                   v.rxBufferAddr := (others => '0');
                end if;
 
-               v.appState    := IDLE_S;
+               v.appState := IDLE_S;
             end if;
          ----------------------------------------------------------------------
-         when SEG_LEN_ERR => 
-         
+         when SEG_LEN_ERR =>
+
             -- SSI
-            v.appSsiSlave := SSI_SLAVE_NOTRDY_C;
+            v.appSsiSlave          := SSI_SLAVE_NOTRDY_C;
             -- Overflow happened (packet too big)            
-            v.appSsiSlave.overflow   := '1';
-            
-            v.rxSegmentAddr := (others =>'0');
+            v.appSsiSlave.overflow := '1';
+
+            v.rxSegmentAddr := (others => '0');
             v.rxSegmentWe   := '0';
-            
+
             -- Request data at txFSM
-            v.sndData      := '0';
-            v.lenErr      := '1';
-            v.appBusy     := '1';
-            
+            v.sndData := '0';
+            v.lenErr  := '1';
+            v.appBusy := '1';
+
             -- Go back to idle 
-            v.appState    := IDLE_S;
+            v.appState := IDLE_S;
          ----------------------------------------------------------------------
          when others =>
             -- Outs
             v := REG_INIT_C;
 
             -- Next state condition            
-            v.appState   := IDLE_S;            
+            v.appState := IDLE_S;
       ----------------------------------------------------------------------
       end case;
-      
-      
+
+
       -- ///////////////////////////////////////////////////////// 
       ------------------------------------------------------------      
       -- Initialisation of the parameters when the connection is broken
@@ -706,252 +706,252 @@ begin
          v.bufferFull     := REG_INIT_C.bufferFull;
          v.bufferEmpty    := REG_INIT_C.bufferEmpty;
          v.windowArray    := REG_INIT_C.windowArray;
-         
-         v.lastAckSeqN    := initSeqN_i;
-         
-         v.ackState    := REG_INIT_C.ackState;
-         v.appState    := REG_INIT_C.appState;
+
+         v.lastAckSeqN := initSeqN_i;
+
+         v.ackState := REG_INIT_C.ackState;
+         v.appState := REG_INIT_C.appState;
       end if;
       ------------------------------------------------------------
       -- /////////////////////////////////////////////////////////       
-      
+
       -- ///////////////////////////////////////////////////////// 
       ------------------------------------------------------------
       -- Arm fault injection on rising edge of injectFault_i
       ------------------------------------------------------------
       -- /// //////////////////////////////////////////////////////  
       v.injectFaultD1 := injectFault_i;
-      
+
       if (injectFault_i = '1' and r.injectFaultD1 = '0') then
          v.injectFaultReg := '1';
       else
          v.injectFaultReg := r.injectFaultReg;
       end if;
-      
-      
+
+
       -- ///////////////////////////////////////////////////////// 
       ------------------------------------------------------------
       -- Transport side FSM
       ------------------------------------------------------------
       -- /////////////////////////////////////////////////////////  
-      
+
       -- Reset flags 
       -- These flags will hold if not overidden
-      v.tspSsiMaster:= SSI_MASTER_INIT_C;  
-      
+      v.tspSsiMaster := SSI_MASTER_INIT_C;
+
       -- Pipeline incoming slave
-      v.tspSsiSlave       := tspSsiSlave_i;
-       
+      v.tspSsiSlave := tspSsiSlave_i;
+
       case r.tspState is
          ----------------------------------------------------------------------
          when INIT_S =>
             -- Initialize all
             v := REG_INIT_C;
-         
+
             -- Register initial sequence number
-            v.nextSeqN    := initSeqN_i;
-            v.seqN        := r.nextSeqN;
-          
+            v.nextSeqN := initSeqN_i;
+            v.seqN     := r.nextSeqN;
+
             -- Next state condition   
             if (closed_i = '0') then
-               v.tspState      := DISS_CONN_S;
+               v.tspState := DISS_CONN_S;
             end if;
          ----------------------------------------------------------------------
          when DISS_CONN_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
 
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
-             
+
             v.txBufferAddr := r.nextSentAddr;
             --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '0';
-            v.nullH    := '0';
-            v.dataH    := '0';
-            v.dataD    := '0';
+            v.synH         := '0';
+            v.ackH         := '0';
+            v.rstH         := '0';
+            v.nullH        := '0';
+            v.dataH        := '0';
+            v.dataD        := '0';
+            --
+            v.txRdy        := '1';
+            v.buffWe       := '0';
+            v.buffSent     := '0';
+            v.chkEn        := '0';
+            v.chkStb       := '0';
+
+            v.tspSsiMaster := SSI_MASTER_INIT_C;
+
+            -- Next state condition   
+            if (sndSyn_i = '1') then
+               v.tspState := SYN_H_S;
+            elsif (sndAck_i = '1') then
+               v.tspState := ACK_H_S;
+            elsif (sndRst_i = '1') then
+               v.tspState := RST_WE_S;
+            elsif (connActive_i = '1') then
+               v.tspState := CONN_S;
+            elsif (closed_i = '1') then
+               v.tspState := INIT_S;
+            end if;
+         ----------------------------------------------------------------------
+         when CONN_S =>
+            -- Counters 
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
+            v.txHeaderAddr  := (others => '0');
+            v.txSegmentAddr := (others => '0');
+
+            v.txBufferAddr := r.nextSentAddr;
+            --
+            v.synH         := '0';
+            v.ackH         := '0';
+            v.rstH         := '0';
+            v.nullH        := '0';
+            v.dataH        := '0';
+            v.dataD        := '0';
+            v.resend       := '0';
+
             --
             v.txRdy    := '1';
             v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
-            
-           v.tspSsiMaster:= SSI_MASTER_INIT_C;  
-           
+
+            v.tspSsiMaster := SSI_MASTER_INIT_C;
+
             -- Next state condition   
-            if    (sndSyn_i = '1') then
-               v.tspState    := SYN_H_S;
-            elsif (sndAck_i = '1') then
-               v.tspState    := ACK_H_S;
-            elsif (sndRst_i = '1') then
-               v.tspState    := RST_WE_S;
-            elsif (connActive_i = '1') then
-               v.tspState      := CONN_S;
-            elsif (closed_i = '1') then
-               v.tspState      := INIT_S;            
-            end if;
-         ----------------------------------------------------------------------
-         when CONN_S =>
-            -- Counters 
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
-            v.txHeaderAddr  := (others => '0');
-            v.txSegmentAddr := (others => '0');
-             
-            v.txBufferAddr := r.nextSentAddr;
-            --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '0';
-            v.nullH    := '0';       
-            v.dataH    := '0';
-            v.dataD    := '0';
-            v.resend   := '0';
-            
-            --
-            v.txRdy    := '1';
-            v.buffWe   := '0';          
-            v.buffSent := '0';
-            v.chkEn    := '0';
-            v.chkStb   := '0';
-            
-            v.tspSsiMaster:= SSI_MASTER_INIT_C;  
-            
-            -- Next state condition   
-            if    (sndRst_i = '1') then
-               v.tspState    := RST_WE_S;
+            if (sndRst_i = '1') then
+               v.tspState := RST_WE_S;
             elsif (r.sndData = '1' and r.bufferFull = '0') then
-               v.tspState    := DATA_WE_S;
-            elsif (sndResend_i = '1' and r.bufferEmpty = '0') then               
-               v.tspState    := RESEND_INIT_S;
+               v.tspState := DATA_WE_S;
+            elsif (sndResend_i = '1' and r.bufferEmpty = '0') then
+               v.tspState := RESEND_INIT_S;
             elsif (sndAck_i = '1') then
-               v.tspState    := ACK_H_S;  
-            elsif (sndNull_i = '1' and r.bufferFull = '0' and r.appBusy = '0') then   
-               v.tspState    := NULL_WE_S;         
+               v.tspState := ACK_H_S;
+            elsif (sndNull_i = '1' and r.bufferFull = '0' and r.appBusy = '0') then
+               v.tspState := NULL_WE_S;
             elsif (connActive_i = '0') then
-               v.tspState    := INIT_S;
+               v.tspState := INIT_S;
             end if;
-          
+
          ----------------------------------------------------------------------
          -- SYN packet
          ----------------------------------------------------------------------
          when SYN_H_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txSegmentAddr := (others => '0');
-            v.txBufferAddr := r.nextSentAddr;
+            v.txBufferAddr  := r.nextSentAddr;
             --
-            v.synH     := '1';  -- Send SYN header
-            v.ackH     := '0';
-            v.rstH     := '0';
-            v.nullH    := '0';       
-            v.dataH    := '0';
-            v.dataD    := '0';
+            v.synH          := '1';     -- Send SYN header
+            v.ackH          := '0';
+            v.rstH          := '0';
+            v.nullH         := '0';
+            v.dataH         := '0';
+            v.dataD         := '0';
             --
-            v.txRdy    := '0';
-            v.buffWe   := '0';
-            v.buffSent := '0';
-            v.chkEn    := '1';
-            
-            v.tspSsiMaster:= SSI_MASTER_INIT_C;
+            v.txRdy         := '0';
+            v.buffWe        := '0';
+            v.buffSent      := '0';
+            v.chkEn         := '1';
+
+            v.tspSsiMaster                                      := SSI_MASTER_INIT_C;
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
 
             -- Send SOF with header address 0
             if (r.txHeaderAddr = (r.txHeaderAddr'range => '0')) then
-               v.tspSsiMaster.sof   := '1';
+               v.tspSsiMaster.sof := '1';
             else
-               v.tspSsiMaster.sof   := '0';
+               v.tspSsiMaster.sof := '0';
             end if;
-            
+
             -- Increment address and generate strobe   
             if (r.txHeaderAddr = headerLength_i-1 and headerRdy_i = '1') then
-               v.tspSsiMaster.valid  := '0';
-               v.txHeaderAddr        := r.txHeaderAddr;
-               v.chkStb              := '1';
-               
-               if (chksumValid_i = '1') then 
+               v.tspSsiMaster.valid := '0';
+               v.txHeaderAddr       := r.txHeaderAddr;
+               v.chkStb             := '1';
+
+               if (chksumValid_i = '1') then
                   -- Add checksum
                   v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
-                  v.tspSsiMaster.valid  := '1';                
-                  v.tspSsiMaster.eof    := '1';
-                  v.tspSsiMaster.eofe   := '0';
-                  
-                  v.nextSeqN    := r.nextSeqN+1; -- Increment SEQ number at the end of segment transmission
-                  v.seqN        := r.nextSeqN+1;
+                  v.tspSsiMaster.valid                                := '1';
+                  v.tspSsiMaster.eof                                  := '1';
+                  v.tspSsiMaster.eofe                                 := '0';
+
+                  v.nextSeqN := r.nextSeqN+1;  -- Increment SEQ number at the end of segment transmission
+                  v.seqN     := r.nextSeqN+1;
 
                   -- Next state            
-                  v.tspState   := DISS_CONN_S;
+                  v.tspState := DISS_CONN_S;
                end if;
             elsif (tspSsiSlave_i.pause = '0' and headerRdy_i = '1') then
-               v.tspSsiMaster.valid  := '1';
-               v.txHeaderAddr        := r.txHeaderAddr + 1;
-               v.chkStb              := '1';
+               v.tspSsiMaster.valid := '1';
+               v.txHeaderAddr       := r.txHeaderAddr + 1;
+               v.chkStb             := '1';
             else
-               v.tspSsiMaster.valid  := '0';
-               v.txHeaderAddr        := r.txHeaderAddr;
-               v.chkStb              := '0';
-            end if; 
+               v.tspSsiMaster.valid := '0';
+               v.txHeaderAddr       := r.txHeaderAddr;
+               v.chkStb             := '0';
+            end if;
 
          ----------------------------------------------------------------------
          -- ACK packet
          ----------------------------------------------------------------------         
          when ACK_H_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txSegmentAddr := (others => '0');
             v.txBufferAddr  := r.nextSentAddr;
             v.txHeaderAddr  := (others => '0');
-            
+
             --
             v.synH     := '0';
-            v.ackH     := '1';  -- Send ack header
+            v.ackH     := '1';          -- Send ack header
             v.rstH     := '0';
-            v.nullH    := '0';       
+            v.nullH    := '0';
             v.dataH    := '0';
             v.dataD    := '0';
             --
             v.txRdy    := '0';
-            v.buffWe   := '0';          
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '1';
-            
+
             -- Strobe immediately after headerRdy
             if (headerRdy_i = '1') then
-               v.chkStb   := '1';
+               v.chkStb := '1';
             end if;
-            
-            v.tspSsiMaster:= SSI_MASTER_INIT_C;
+
+            v.tspSsiMaster                                      := SSI_MASTER_INIT_C;
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
-            
+
             -- Next state condition (when chksum is ready)
-            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then -- Frame size is one word
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.sof    := '1';
-               v.tspSsiMaster.strb   := (others => '1');
-               v.tspSsiMaster.keep   := (others => '1');
-               v.tspSsiMaster.dest   := (others => '0');
-               v.tspSsiMaster.eof    := '1';
-               v.tspSsiMaster.eofe   := '0';
-               
+            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then  -- Frame size is one word
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.sof   := '1';
+               v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.keep  := (others => '1');
+               v.tspSsiMaster.dest  := (others => '0');
+               v.tspSsiMaster.eof   := '1';
+               v.tspSsiMaster.eofe  := '0';
+
                -- Add checksum to last two bytes 
                v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
-               
+
                --                
-               if  connActive_i = '0' then          
-                  v.tspState   := DISS_CONN_S; 
+               if connActive_i = '0' then
+                  v.tspState := DISS_CONN_S;
                else
-                  v.tspState   := CONN_S; 
+                  v.tspState := CONN_S;
                end if;
-               
+
             end if;
 
          ----------------------------------------------------------------------
@@ -959,78 +959,78 @@ begin
          ----------------------------------------------------------------------         
          when RST_WE_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
-             
+
             v.txBufferAddr := r.nextSentAddr;
             -- State control signals 
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '1';  -- Send reset header 
-            v.nullH    := '0';       
-            v.dataH    := '0';
-            v.dataD    := '0';
+            v.synH         := '0';
+            v.ackH         := '0';
+            v.rstH         := '1';      -- Send reset header 
+            v.nullH        := '0';
+            v.dataH        := '0';
+            v.dataD        := '0';
             -- 
-            v.txRdy    := '0';
-            v.buffWe   := '0';  -- TODO (Check if this is ok) Ignore the buffer because the RST will not get retransmitted
-            v.buffSent := '0';
-            v.chkEn    := '0';
-            v.chkStb   := '0';
-            
+            v.txRdy        := '0';
+            v.buffWe       := '0';  -- TODO (Check if this is ok) Ignore the buffer because the RST will not get retransmitted
+            v.buffSent     := '0';
+            v.chkEn        := '0';
+            v.chkStb       := '0';
+
             -- SSI master 
-            v.tspSsiMaster:= SSI_MASTER_INIT_C;
-            
+            v.tspSsiMaster := SSI_MASTER_INIT_C;
+
             -- Next State condition
-            v.tspState   := RST_H_S;
+            v.tspState := RST_H_S;
          ----------------------------------------------------------------------
          when RST_H_S =>
             -- 
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
 
             v.txSegmentAddr := (others => '0');
-            v.txBufferAddr := r.nextSentAddr;
+            v.txBufferAddr  := r.nextSentAddr;
             v.txHeaderAddr  := (others => '0');
-            
+
             -- Flags
             v.synH     := '0';
             v.ackH     := '0';
-            v.rstH     := '1';  -- Send reset header 
-            v.nullH    := '0';       
+            v.rstH     := '1';          -- Send reset header 
+            v.nullH    := '0';
             v.dataH    := '0';
             v.dataD    := '0';
             --
             v.txRdy    := '0';
-            v.buffWe   := '0';          
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '1';
-            
+
             if (headerRdy_i = '1') then
-               v.chkStb   := '1';
+               v.chkStb := '1';
             end if;
-            
-            v.tspSsiMaster:= SSI_MASTER_INIT_C;
+
+            v.tspSsiMaster                                      := SSI_MASTER_INIT_C;
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
-            
+
             -- Next state condition
-            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0' ) then -- Frame size is one word
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.sof    := '1';
-               v.tspSsiMaster.strb   := (others => '1');
-               v.tspSsiMaster.keep   := (others => '1');
-               v.tspSsiMaster.dest   := (others => '0');
-               v.tspSsiMaster.eof    := '1';
-               v.tspSsiMaster.eofe   := '0';
-               v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum); -- Add header to last two bytes
-                
+            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then  -- Frame size is one word
+               v.tspSsiMaster.valid                                := '1';
+               v.tspSsiMaster.sof                                  := '1';
+               v.tspSsiMaster.strb                                 := (others => '1');
+               v.tspSsiMaster.keep                                 := (others => '1');
+               v.tspSsiMaster.dest                                 := (others => '0');
+               v.tspSsiMaster.eof                                  := '1';
+               v.tspSsiMaster.eofe                                 := '0';
+               v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);  -- Add header to last two bytes
+
                -- Increment seqN
-               v.nextSeqN    := r.nextSeqN+1; -- Increment SEQ number at the end of segment transmission
-               v.seqN        := r.nextSeqN+1;
-               v.buffSent    := '0';          -- Ignore the buffer because the RST will not get retransmitted
-               v.tspState    := CONN_S;
+               v.nextSeqN := r.nextSeqN+1;  -- Increment SEQ number at the end of segment transmission
+               v.seqN     := r.nextSeqN+1;
+               v.buffSent := '0';  -- Ignore the buffer because the RST will not get retransmitted
+               v.tspState := CONN_S;
             --
             end if;
 
@@ -1039,250 +1039,250 @@ begin
          ----------------------------------------------------------------------         
          when NULL_WE_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
-             
+
             v.txBufferAddr := r.nextSentAddr;
-            
+
             -- State control signals 
             v.synH     := '0';
             v.ackH     := '0';
-            v.rstH     := '0';   
-            v.nullH    := '1';  -- Send null header     
+            v.rstH     := '0';
+            v.nullH    := '1';          -- Send null header     
             v.dataH    := '0';
             v.dataD    := '0';
             -- 
             v.txRdy    := '0';
-            v.buffWe   := '1';  -- Update buffer seqN and Type 
+            v.buffWe   := '1';          -- Update buffer seqN and Type 
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
-            
+
             -- SSI master 
-           v.tspSsiMaster:= SSI_MASTER_INIT_C;
-            
+            v.tspSsiMaster := SSI_MASTER_INIT_C;
+
             -- Next State condition
-            v.tspState   := NULL_H_S;
+            v.tspState := NULL_H_S;
          ----------------------------------------------------------------------
          when NULL_H_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            v.txHeaderAddr  := (others => '0');
-            
+            v.nextSeqN     := r.nextSeqN;
+            v.seqN         := r.nextSeqN;
+            v.txHeaderAddr := (others => '0');
+
             v.txSegmentAddr := (others => '0');
-            v.txBufferAddr := r.nextSentAddr;
-            
+            v.txBufferAddr  := r.nextSentAddr;
+
             -- Flags
             v.synH     := '0';
             v.ackH     := '0';
-            v.rstH     := '0';  
-            v.nullH    := '1';  -- Send null header 
+            v.rstH     := '0';
+            v.nullH    := '1';          -- Send null header 
             v.dataH    := '0';
             v.dataD    := '0';
             --
             v.txRdy    := '0';
-            v.buffWe   := '0';          
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '1';
-            
+
             if (headerRdy_i = '1') then
-               v.chkStb   := '1';
+               v.chkStb := '1';
             end if;
-            
+
             -- Leave initialized v.tspSsiMaster
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
-            
+
             -- Next state condition
-            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0' ) then -- Frame size is one word
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.sof    := '1';
-               v.tspSsiMaster.strb   := (others => '1');
-               v.tspSsiMaster.keep   := (others => '1');
-               v.tspSsiMaster.dest   := (others => '0');
-               v.tspSsiMaster.eof    := '1';
-               v.tspSsiMaster.eofe   := '0';
-               
+            if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then  -- Frame size is one word
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.sof   := '1';
+               v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.keep  := (others => '1');
+               v.tspSsiMaster.dest  := (others => '0');
+               v.tspSsiMaster.eof   := '1';
+               v.tspSsiMaster.eofe  := '0';
+
                -- Add checksum to last two bytes
                v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
-               
+
                -- Increment seqN
-               v.nextSeqN    := r.nextSeqN+1; -- Increment SEQ number at the end of segment transmission
-               v.seqN        := r.nextSeqN+1;
-               v.buffSent    := '1';          -- Increment the sent buffer
-               v.tspState   := CONN_S;
+               v.nextSeqN := r.nextSeqN+1;  -- Increment SEQ number at the end of segment transmission
+               v.seqN     := r.nextSeqN+1;
+               v.buffSent := '1';       -- Increment the sent buffer
+               v.tspState := CONN_S;
             end if;
-            
+
          ----------------------------------------------------------------------
          -- DATA packet
          ----------------------------------------------------------------------         
          when DATA_WE_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
-             
+
             v.txBufferAddr := r.nextSentAddr;
-            
+
             -- State control signals 
             v.synH     := '0';
             v.ackH     := '0';
-            v.rstH     := '0';   
-            v.nullH    := '0';      
-            v.dataH    := '1';  -- Send data header 
+            v.rstH     := '0';
+            v.nullH    := '0';
+            v.dataH    := '1';          -- Send data header 
             v.dataD    := '0';
             -- 
             v.txRdy    := '0';
-            v.buffWe   := '1';  -- Update buffer seqN and Type 
+            v.buffWe   := '1';          -- Update buffer seqN and Type 
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
-            
+
             -- SSI master 
             -- Leave initialised v.tspSsiMaster
             v.tspSsiMaster.data := r.tspSsiMaster.data;
-            
+
             -- Next state condition
-            v.tspState   := DATA_H_S;
+            v.tspState := DATA_H_S;
          ----------------------------------------------------------------------
          when DATA_H_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
             v.txSegmentAddr := (others => '0');
             v.txBufferAddr  := r.nextSentAddr;
             --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '0';  
-            v.nullH    := '0';  
-            v.dataH    := '1';  -- Send data header 
-            v.dataD    := '0';
+            v.synH          := '0';
+            v.ackH          := '0';
+            v.rstH          := '0';
+            v.nullH         := '0';
+            v.dataH         := '1';     -- Send data header 
+            v.dataD         := '0';
             --
-            v.txRdy    := '0';
-            v.buffWe   := '0';          
-            v.buffSent := '0';
-            v.chkEn    := '1';
-            
+            v.txRdy         := '0';
+            v.buffWe        := '0';
+            v.buffSent      := '0';
+            v.chkEn         := '1';
+
             -- if header data ready than
             -- strobe the checksum       
             if (headerRdy_i = '1') then
-               v.chkStb   := '1';
+               v.chkStb := '1';
             end if;
-            
+
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
-            
+
             -- Next state condition
             -- Frame size is one word
             -- Wait for the chksum to be ready
             if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then
-               v.tspSsiMaster.valid  := '1';  
-               v.tspSsiMaster.sof    := '1';
-               v.tspSsiMaster.strb   := (others => '1');
-               v.tspSsiMaster.dest   := (others => '0');
-               v.tspSsiMaster.eof    := '0';
-               v.tspSsiMaster.eofe   := '0';
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.sof   := '1';
+               v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.dest  := (others => '0');
+               v.tspSsiMaster.eof   := '0';
+               v.tspSsiMaster.eofe  := '0';
 
                -- Inject fault into checksum
                if (r.injectFaultReg = '1') then
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1'); -- Flip bits in checksum! Point of fault injection!
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1');  -- Flip bits in checksum! Point of fault injection!
                else
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum); -- Add checksum to last two bytes
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);  -- Add checksum to last two bytes
                end if;
-               
+
                -- Set the fault reg to 0
                v.injectFaultReg := '0';
 
                v.tspState := DATA_S;
-               --
-            end if;            
-                 ----------------------------------------------------------------------
+            --
+            end if;
+         ----------------------------------------------------------------------
          when DATA_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN;
-            v.seqN        := r.nextSeqN;
-            
-            v.txHeaderAddr  := (others => '0');            
+            v.nextSeqN := r.nextSeqN;
+            v.seqN     := r.nextSeqN;
+
+            v.txHeaderAddr  := (others => '0');
             v.txBufferAddr  := r.nextSentAddr;
             v.txSegmentAddr := r.txSegmentAddr;
-            
-            --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '0';  
-            v.nullH    := '0';  
-            v.dataH    := '0';   
-            v.dataD    := '1';  -- Send data
-            --
-            v.txRdy    := '0';
-            v.buffWe   := '0';          
-            v.buffSent := '0';
-            v.chkEn    := '0';
-            v.chkStb   := '0';
-            
-            -- Other SSI parameters
-            v.tspSsiMaster.sof    := '0';
-            v.tspSsiMaster.strb   := (others => '1');
-            v.tspSsiMaster.dest   := (others => '0');           
-            v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0)  := rdBuffData_i;
 
-            -- Next state condition
-            if  (r.txSegmentAddr >= r.windowArray(conv_integer(r.txBufferAddr)).segSize) then
-
-               -- Send EOF at the end of the segment
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.eof    := '1';
-               v.tspSsiMaster.eofe   := '0';
-               v.tspSsiMaster.keep   := r.windowArray(conv_integer(r.txBufferAddr)).keep;
-               --
-               v.txSegmentAddr       := r.txSegmentAddr;               
-               --
-               v.tspState   := DATA_SENT_S;
-
-            -- Increment segment address and assert valid only when not paused
-            elsif (tspSsiSlave_i.pause = '0') then
-               v.tspSsiMaster.valid  := '1';            
-               v.txSegmentAddr       := r.txSegmentAddr + 1;
-            else
-               v.tspSsiMaster.valid  := '0';
-               v.txSegmentAddr       := r.txSegmentAddr;
-            end if;
-            
-         -----------------------------------------------------------------------------   
-         when DATA_SENT_S =>
-             -- Outputs
-            v.nextSeqN    := r.nextSeqN+1; -- Increment SEQ number at the end of segment transmission
-            v.seqN        := r.nextSeqN+1;
-            
-            v.txHeaderAddr  := (others => '0');
-            v.txSegmentAddr := (others => '0');
-             
-            v.txBufferAddr := r.nextSentAddr;
             --
             v.synH     := '0';
             v.ackH     := '0';
             v.rstH     := '0';
-            v.nullH    := '0';       
+            v.nullH    := '0';
             v.dataH    := '0';
-            v.dataD    := '0';
-            v.chkEn    := '0';
-            v.chkStb   := '0';
+            v.dataD    := '1';          -- Send data
             --
             v.txRdy    := '0';
-            v.buffWe   := '0';         
-            v.buffSent := '1';     -- Increment buffer last sent address(txBuffer)
-            
+            v.buffWe   := '0';
+            v.buffSent := '0';
+            v.chkEn    := '0';
+            v.chkStb   := '0';
+
+            -- Other SSI parameters
+            v.tspSsiMaster.sof                                  := '0';
+            v.tspSsiMaster.strb                                 := (others => '1');
+            v.tspSsiMaster.dest                                 := (others => '0');
+            v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := rdBuffData_i;
+
+            -- Next state condition
+            if (r.txSegmentAddr >= r.windowArray(conv_integer(r.txBufferAddr)).segSize) then
+
+               -- Send EOF at the end of the segment
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.eof   := '1';
+               v.tspSsiMaster.eofe  := '0';
+               v.tspSsiMaster.keep  := r.windowArray(conv_integer(r.txBufferAddr)).keep;
+               --
+               v.txSegmentAddr      := r.txSegmentAddr;
+               --
+               v.tspState           := DATA_SENT_S;
+
+            -- Increment segment address and assert valid only when not paused
+            elsif (tspSsiSlave_i.pause = '0') then
+               v.tspSsiMaster.valid := '1';
+               v.txSegmentAddr      := r.txSegmentAddr + 1;
+            else
+               v.tspSsiMaster.valid := '0';
+               v.txSegmentAddr      := r.txSegmentAddr;
+            end if;
+
+         -----------------------------------------------------------------------------   
+         when DATA_SENT_S =>
+            -- Outputs
+            v.nextSeqN := r.nextSeqN+1;  -- Increment SEQ number at the end of segment transmission
+            v.seqN     := r.nextSeqN+1;
+
+            v.txHeaderAddr  := (others => '0');
+            v.txSegmentAddr := (others => '0');
+
+            v.txBufferAddr := r.nextSentAddr;
+            --
+            v.synH         := '0';
+            v.ackH         := '0';
+            v.rstH         := '0';
+            v.nullH        := '0';
+            v.dataH        := '0';
+            v.dataD        := '0';
+            v.chkEn        := '0';
+            v.chkStb       := '0';
+            --
+            v.txRdy        := '0';
+            v.buffWe       := '0';
+            v.buffSent     := '1';      -- Increment buffer last sent address(txBuffer)
+
             -- SSI master (Initialise - stop transmission) 
-            v.tspSsiMaster         := SSI_MASTER_INIT_C;
-            
+            v.tspSsiMaster := SSI_MASTER_INIT_C;
+
             -- Next state
-            v.tspState   := CONN_S;
+            v.tspState := CONN_S;
 
          ----------------------------------------------------------------------
          -- Resend all packets from the buffer
@@ -1293,9 +1293,9 @@ begin
             v.txBufferAddr := r.firstUnackAddr;
 
             -- Counters
-            v.nextSeqN    := r.nextSeqN; -- Never increment seqN while resending 
-            v.seqN        := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
-            
+            v.nextSeqN := r.nextSeqN;   -- Never increment seqN while resending 
+            v.seqN     := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
+
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
 
@@ -1309,218 +1309,217 @@ begin
             v.resend   := '1';
             -- 
             v.txRdy    := '0';
-            v.buffWe   := '0'; 
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
 
             -- SSI master 
             v.tspSsiMaster := SSI_MASTER_INIT_C;
-            
+
             -- Next state condition
-            v.tspState   := RESEND_H_S;
+            v.tspState := RESEND_H_S;
          ----------------------------------------------------------------------
          when RESEND_H_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN; -- Never increment seqN while resending
-            v.seqN        := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
-            
+            v.nextSeqN := r.nextSeqN;   -- Never increment seqN while resending
+            v.seqN     := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
+
             v.txSegmentAddr := (others => '0');
             v.txBufferAddr  := r.txBufferAddr;
             --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := r.windowArray(conv_integer(r.txBufferAddr)).segType(2);  
-            v.nullH    := r.windowArray(conv_integer(r.txBufferAddr)).segType(1);  
-            v.dataH    := r.windowArray(conv_integer(r.txBufferAddr)).segType(0); 
-            v.dataD    := '0';
-            v.resend   := '1';
+            v.synH          := '0';
+            v.ackH          := '0';
+            v.rstH          := r.windowArray(conv_integer(r.txBufferAddr)).segType(2);
+            v.nullH         := r.windowArray(conv_integer(r.txBufferAddr)).segType(1);
+            v.dataH         := r.windowArray(conv_integer(r.txBufferAddr)).segType(0);
+            v.dataD         := '0';
+            v.resend        := '1';
             --
-            v.txRdy    := '0';
-            v.buffWe   := '0';          
-            v.buffSent := '0';
-            v.chkEn    := '1';
-            
+            v.txRdy         := '0';
+            v.buffWe        := '0';
+            v.buffSent      := '0';
+            v.chkEn         := '1';
+
             -- if header data ready than
             -- strobe the checksum       
             if (headerRdy_i = '1') then
-               v.chkStb   := '1';
+               v.chkStb := '1';
             end if;
-            
+
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(rdHeaderData_i);
-            
+
             -- Next state condition
             -- Frame size is one word
             -- Wait for chksumb ready
             if (chksumValid_i = '1' and tspSsiSlave_i.pause = '0') then
-               v.tspSsiMaster.sof    := '1';
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.strb   := (others => '1');
-               v.tspSsiMaster.dest   := (others => '0');
-               
+               v.tspSsiMaster.sof   := '1';
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.dest  := (others => '0');
+
                -- Inject fault into checksum
                if (r.injectFaultReg = '1') then
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1'); -- Flip bits in checksum! Point of fault injection!
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1');  -- Flip bits in checksum! Point of fault injection!
                else
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum); -- Add checksum to last two bytes
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);  -- Add checksum to last two bytes
                end if;
-               
+
                -- Set the fault reg to 0
                v.injectFaultReg := '0';
-               
-               -- Null or Rst packet
-               if    (r.windowArray(conv_integer(r.txBufferAddr)).segType(2) = '1' or
-                      r.windowArray(conv_integer(r.txBufferAddr)).segType(1) = '1'
-               ) then 
 
-               -- Send EOF and start sending next packet                            
-                  v.tspSsiMaster.eof    := '1';
-                  v.tspSsiMaster.eofe   := '0';
+               -- Null or Rst packet
+               if (r.windowArray(conv_integer(r.txBufferAddr)).segType(2) = '1' or
+                   r.windowArray(conv_integer(r.txBufferAddr)).segType(1) = '1'
+                   ) then
+
+                  -- Send EOF and start sending next packet                            
+                  v.tspSsiMaster.eof  := '1';
+                  v.tspSsiMaster.eofe := '0';
                   --
-                  v.tspState := RESEND_PP_S;
+                  v.tspState          := RESEND_PP_S;
 
                -- If DATA packet start sending data
                else
                   v.tspState := RESEND_DATA_S;
                end if;
-            end if;               
+            end if;
          ----------------------------------------------------------------------         
          when RESEND_DATA_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN; -- Never increment seqN while resending
-            v.seqN        := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
-            
-            v.txHeaderAddr  := (others => '0');            
+            v.nextSeqN := r.nextSeqN;   -- Never increment seqN while resending
+            v.seqN     := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
+
+            v.txHeaderAddr  := (others => '0');
             v.txBufferAddr  := r.txBufferAddr;
             v.txSegmentAddr := r.txSegmentAddr;
-            
+
             --
-            v.synH     := '0';
-            v.ackH     := '0';
-            v.rstH     := '0';  
-            v.nullH    := '0';  
-            v.dataH    := '0';   
-            v.dataD    := '1';  -- Send data
-            v.resend   := '1';            
+            v.synH   := '0';
+            v.ackH   := '0';
+            v.rstH   := '0';
+            v.nullH  := '0';
+            v.dataH  := '0';
+            v.dataD  := '1';            -- Send data
+            v.resend := '1';
 
             --
             v.txRdy    := '0';
-            v.buffWe   := '0';          
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
-            
+
             -- SSI Control
-             
+
             -- Other SSI parameters
-            v.tspSsiMaster.sof    := '0';
-            v.tspSsiMaster.strb   := (others => '1');
-            v.tspSsiMaster.dest   := (others => '0');
-            v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0)  := rdBuffData_i;
+            v.tspSsiMaster.sof                                  := '0';
+            v.tspSsiMaster.strb                                 := (others => '1');
+            v.tspSsiMaster.dest                                 := (others => '0');
+            v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := rdBuffData_i;
 
             -- Next state condition
-            if  (r.txSegmentAddr >= r.windowArray(conv_integer(r.txBufferAddr)).segSize) then
+            if (r.txSegmentAddr >= r.windowArray(conv_integer(r.txBufferAddr)).segSize) then
 
                -- Send EOF at the end of the segment
-               v.tspSsiMaster.valid  := '1';
-               v.tspSsiMaster.eof    := '1';
-               v.tspSsiMaster.eofe   := '0';
-               v.tspSsiMaster.keep   := r.windowArray(conv_integer(r.txBufferAddr)).keep;
+               v.tspSsiMaster.valid := '1';
+               v.tspSsiMaster.eof   := '1';
+               v.tspSsiMaster.eofe  := '0';
+               v.tspSsiMaster.keep  := r.windowArray(conv_integer(r.txBufferAddr)).keep;
                --
-               v.txSegmentAddr       := r.txSegmentAddr;               
+               v.txSegmentAddr      := r.txSegmentAddr;
                -- 
-               v.tspState   := RESEND_PP_S;
-               
+               v.tspState           := RESEND_PP_S;
+
             -- Increment segment address only when Slave is ready 
-            elsif (tspSsiSlave_i.pause = '0') then                               
-               v.tspSsiMaster.valid  := '1';            
-               v.txSegmentAddr       := r.txSegmentAddr + 1;
+            elsif (tspSsiSlave_i.pause = '0') then
+               v.tspSsiMaster.valid := '1';
+               v.txSegmentAddr      := r.txSegmentAddr + 1;
             else
-               v.tspSsiMaster.valid  := '0';
-               v.txSegmentAddr       := r.txSegmentAddr;
+               v.tspSsiMaster.valid := '0';
+               v.txSegmentAddr      := r.txSegmentAddr;
             end if;
          ----------------------------------------------------------------------            
          when RESEND_PP_S =>
             -- Counters
-            v.nextSeqN    := r.nextSeqN; -- Never increment seqN while resending 
-            v.seqN        := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
-            
+            v.nextSeqN := r.nextSeqN;   -- Never increment seqN while resending 
+            v.seqN     := r.windowArray(conv_integer(r.txBufferAddr)).seqN;
+
             v.txHeaderAddr  := (others => '0');
             v.txSegmentAddr := (others => '0');
-            
+
             -- Increment buffer address (circulary)
             if r.txBufferAddr < (windowSize_i-1) then
                v.txBufferAddr := r.txBufferAddr+1;
             else
                v.txBufferAddr := (others => '0');
             end if;
-            
+
             -- State control signals 
-            v.rstH     := '0'; 
-            v.nullH    := '0';  
-            v.dataH    := '0';  
-            v.nullH    := '0';      
-            v.dataH    := '0'; 
-            v.dataD    := '0';
-            v.resend   := '1';
-            
+            v.rstH   := '0';
+            v.nullH  := '0';
+            v.dataH  := '0';
+            v.nullH  := '0';
+            v.dataH  := '0';
+            v.dataD  := '0';
+            v.resend := '1';
+
             -- 
             v.txRdy    := '0';
-            v.buffWe   := '0'; 
+            v.buffWe   := '0';
             v.buffSent := '0';
             v.chkEn    := '0';
             v.chkStb   := '0';
 
             -- SSI master 
             v.tspSsiMaster := SSI_MASTER_INIT_C;
-            
+
             -- Next state condition
             -- Go back to CONN_S when the last sent address reached 
             if (r.txBufferAddr = r.lastSentAddr) then
-               v.tspState   := CONN_S;        
+               v.tspState := CONN_S;
             else
-               v.tspState   := RESEND_H_S;
+               v.tspState := RESEND_H_S;
             end if;
          ----------------------------------------------------------------------
          when others =>
             --
-            v := REG_INIT_C;         
+            v := REG_INIT_C;
       ----------------------------------------------------------------------
       end case;
-      
+
+      -- Combinatorial outputs before the reset
+      appSsiSlave_o  <= v.appSsiSlave;
+      -- TSP side      
+      -- Combine ram read address
+      rdBuffAddr_o   <= v.txBufferAddr & v.txSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);
+      rdHeaderAddr_o <= v.txHeaderAddr;
+
       -- Synchronous Reset
       if (rst_i = '1') then
          v := REG_INIT_C;
       end if;
-      
+
       rin <= v;
       -----------------------------------------------------------
       ---------------------------------------------------------------------
       -- APP side
-      
+
       -- Combine ram write address      
       wrBuffAddr_o <= r.rxBufferAddr & r.rxSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);
       wrBuffData_o <= r.AppSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0);
       wrBuffWe_o   <= r.rxSegmentWe;
-      
-      -- Slave out immediately
-      appSsiSlave_o <= v.appSsiSlave;
-      
+
       -- Errors
       ackErr_o <= r.ackErr;
       lenErr_o <= r.lenErr;
-      
+
       --
       bufferEmpty_o <= r.bufferEmpty;
-      
+
       -----------------------------------------------------------
       ---------------------------------------------------------------------      
       -- TSP side
-      
-      -- Combine ram read address
-      rdBuffAddr_o     <= v.txBufferAddr & v.txSegmentAddr(SEGMENT_ADDR_SIZE_G-1 downto 0);
-      rdHeaderAddr_o   <= v.txHeaderAddr;      
-
       -- State assignment
       synHeadSt_o  <= r.synH;
       ackHeadSt_o  <= r.ackH;
@@ -1528,14 +1527,14 @@ begin
       dataSt_o     <= r.dataD;
       rstHeadSt_o  <= r.rstH;
       nullHeadSt_o <= r.nullH;
-      
+
       chksumEnable_o <= r.chkEn;
       chksumStrobe_o <= r.chkStb;
-           
+
       -- Sequence number from buffer
       txSeqN_o       <= r.seqN;
       tspSsiMaster_o <= r.tspSsiMaster;
-      
+
       -- 
       lastAckN_o <= r.lastAckSeqN;
    --------------------------------------------------------------------- 
@@ -1548,5 +1547,5 @@ begin
       end if;
    end process seq;
 
-   ---------------------------------------------------------------------
+---------------------------------------------------------------------
 end architecture rtl;

--- a/protocols/salt/core/rtl/SaltTx.vhd
+++ b/protocols/salt/core/rtl/SaltTx.vhd
@@ -352,6 +352,10 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      mSlave  <= v.mSlave;
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -361,10 +365,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      mSlave     <= v.mSlave;
+      -- Registered Outputs 
       sMaster    <= r.sMaster;
-      rxSlave    <= v.rxSlave;
       txMaster   <= r.txMaster;
       txPktSent  <= r.txPktSent;
       txEofeSent <= r.txEofeSent;

--- a/protocols/salt/core/rtl/SaltTxResize.vhd
+++ b/protocols/salt/core/rtl/SaltTxResize.vhd
@@ -115,6 +115,9 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (rst = '1') then
@@ -124,8 +127,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs        
-      rxSlave <= v.rxSlave;
+      -- Registered Outputs    
       txEn    <= r.txEn;
       txData  <= r.txData;
 

--- a/protocols/srp/rtl/AxiLiteSrpV0.vhd
+++ b/protocols/srp/rtl/AxiLiteSrpV0.vhd
@@ -300,19 +300,22 @@ begin
                v.state := WAIT_AXIL_REQ_S;
             end if;
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxFifoAxisSlave <= v.rxFifoAxisSlave;
 
-
+      -- Reset
       if (axilRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
+      -- Registered Outputs
       sAxilWriteSlave  <= r.sAxilWriteSlave;
       sAxilReadSlave   <= r.sAxilReadSlave;
       txFifoAxisMaster <= r.txFifoAxisMaster;
-      rxFifoAxisSlave  <= v.rxFifoAxisSlave;
-
 
    end process comb;
 

--- a/protocols/srp/rtl/SrpV0AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV0AxiLite.vhd
@@ -389,16 +389,21 @@ begin
             v.state := S_IDLE_C;
 
       end case;
+      
+      -- Combinatorial outputs before the reset
+      sFifoAxisSlave <= v.sFifoAxisSlave;
 
+      -- Reset
       if (axiLiteRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
+      -- Registered Outputs
       mAxiLiteWriteMaster <= r.mAxiLiteWriteMaster;
       mAxiLiteReadMaster  <= r.mAxiLiteReadMaster;
-      sFifoAxisSlave      <= v.sFifoAxisSlave;
       mFifoAxisMaster     <= r.mFifoAxisMaster;
 
    end process comb;

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -750,6 +750,9 @@ begin
       if (rxMaster.tLast = '1') and (v.rxSlave.tReady = '1') then
          v.eofe := ssiGetUserEofe(AXIS_CONFIG_C, rxMaster);
       end if;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (axilRst = '1') then
@@ -759,8 +762,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs    
-      rxSlave          <= v.rxSlave;
+      -- Registered Outputs
       mAxilWriteMaster <= r.mAxilWriteMaster;
       mAxilReadMaster  <= r.mAxilReadMaster;
       rxRst            <= r.rxRst or axilRst;

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -651,6 +651,10 @@ begin
       if (rxMaster.tLast = '1') and (v.rxSlave.tReady = '1') then
          v.eofe := ssiGetUserEofe(SRP_AXIS_CONFIG_C, rxMaster);
       end if;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave       <= v.rxSlave;
+      srpRdSlaveInt <= v.srpRdSlave;
 
       -- Reset
       if (srpRst = '1') then
@@ -660,10 +664,8 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs    
-      rxSlave        <= v.rxSlave;
+      -- Registered Outputs
       srpReq         <= r.srpReq;
-      srpRdSlaveInt  <= v.srpRdSlave;
       srpWrMasterInt <= r.srpWrMaster;
 
    end process comb;

--- a/protocols/ssi/rtl/SsiAxiLiteMaster.vhd
+++ b/protocols/ssi/rtl/SsiAxiLiteMaster.vhd
@@ -416,16 +416,21 @@ begin
             v.state := S_IDLE_C;
 
       end case;
+      
+      -- Combinatorial outputs before the reset
+      sFifoAxisSlave <= v.sFifoAxisSlave;
 
+      -- Reset
       if (axiLiteRst = '1') then
          v := REG_INIT_C;
       end if;
 
+      -- Register the variable for next clock cycle
       rin <= v;
 
+      -- Registered Outputs
       mAxiLiteWriteMaster <= r.mAxiLiteWriteMaster;
       mAxiLiteReadMaster  <= r.mAxiLiteReadMaster;
-      sFifoAxisSlave      <= v.sFifoAxisSlave;
       mFifoAxisMaster     <= r.mFifoAxisMaster;
 
    end process comb;

--- a/protocols/ssi/rtl/SsiFrameLimiter.vhd
+++ b/protocols/ssi/rtl/SsiFrameLimiter.vhd
@@ -207,6 +207,9 @@ begin
       if (SLAVE_READY_EN_G = false) then
          v.rxSlave.tReady := '1';
       end if;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (mAxisRst = '1') then
@@ -216,8 +219,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs              
-      rxSlave  <= v.rxSlave;
+      -- Registered Outputs       
       txMaster <= r.txMaster;
 
    end process comb;

--- a/protocols/ssi/rtl/SsiIbFrameFilter.vhd
+++ b/protocols/ssi/rtl/SsiIbFrameFilter.vhd
@@ -193,6 +193,9 @@ begin
                end if;
          ----------------------------------------------------------------------
          end case;
+         
+         -- Combinatorial outputs before the reset
+         sAxisSlave <= v.slave;
 
          -- Synchronous Reset
          if (axisRst = '1') then
@@ -202,8 +205,7 @@ begin
          -- Register the variable for next clock cycle
          rin <= v;
 
-         -- Outputs
-         sAxisSlave     <= v.slave;
+         -- Registered Outputs
          mAxisMaster    <= r.master;
          sAxisDropWrite <= r.wordDropped;
          sAxisTermFrame <= r.frameDropped;

--- a/protocols/ssi/rtl/SsiInsertSof.vhd
+++ b/protocols/ssi/rtl/SsiInsertSof.vhd
@@ -183,6 +183,9 @@ begin
             end if;
       ----------------------------------------------------------------------
       end case;
+      
+      -- Combinatorial outputs before the reset
+      rxSlave <= v.rxSlave;
 
       -- Reset
       if (mAxisRst = '1') then
@@ -192,8 +195,7 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
-      -- Outputs              
-      rxSlave  <= v.rxSlave;
+      -- Registered Outputs        
       txMaster <= r.txMaster;
 
    end process comb;

--- a/protocols/ssi/rtl/SsiObFrameFilter.vhd
+++ b/protocols/ssi/rtl/SsiObFrameFilter.vhd
@@ -233,6 +233,9 @@ begin
                end if;
          ----------------------------------------------------------------------
          end case;
+         
+         -- Combinatorial outputs before the reset
+         sAxisSlave <= v.slave;
 
          -- Synchronous Reset
          if (axisRst = '1') then
@@ -242,8 +245,7 @@ begin
          -- Register the variable for next clock cycle
          rin <= v;
 
-         -- Outputs
-         sAxisSlave     <= v.slave;
+         -- Registered Outputs
          mAxisMaster    <= r.master;
          mAxisDropWrite <= r.wordDropped;
          mAxisTermFrame <= r.frameDropped;

--- a/protocols/ssp/rtl/SspFramer.vhd
+++ b/protocols/ssp/rtl/SspFramer.vhd
@@ -2,7 +2,7 @@
 -- File       : SspFramer.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2014-07-14
--- Last update: 2017-05-01
+-- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: SimpleStreamingProtocol - A simple protocol layer for inserting
 -- idle and framing control characters into a raw data stream. The output of
@@ -31,7 +31,7 @@ entity SspFramer is
       RST_POLARITY_G  : sl      := '0';
       RST_ASYNC_G     : boolean := true;
       AUTO_FRAME_G    : boolean := true;
-      FLOW_CTRL_EN_G : boolean := false;
+      FLOW_CTRL_EN_G  : boolean := false;
       WORD_SIZE_G     : integer := 16;
       K_SIZE_G        : integer := 2;
       SSP_IDLE_CODE_G : slv;
@@ -132,20 +132,20 @@ begin
                   v.dataKOut := SSP_EOF_K_G;
                end if;
             end if;
-
          end if;
+      end if;
 
-         if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
-            v := REG_INIT_C;
-         end if;
+      readyIn <= v.readyIn;
 
+      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
+         v := REG_INIT_C;
       end if;
 
       rin      <= v;
       dataOut  <= r.dataOut;
       dataKOut <= r.dataKOut;
       validOut <= r.validOut;
-      readyIn  <= v.readyIn;
+
 
    end process comb;
 


### PR DESCRIPTION
Disconnect combinatorial outputs from reset path.

Assigning `outputX <= v.regX` after the synchronous reset `if` block causes the reset signal to couple into the output combinatorially. This is unnecessary and can create timing closure issues.

The output needs to instead be assigned from v.regX **before** the synchronous reset `if` block.  