### PR TITLE
Set proper header on Pgp3 opcode transmission.

### DIFF
--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -198,6 +198,7 @@ begin
             v.protTxData(PGP3_BTF_FIELD_C)           := PGP3_USER_C(conv_integer(pgpTxIn.opCodeNumber));
             v.protTxData(PGP3_USER_CHECKSUM_FIELD_C) := pgp3OpCodeChecksum(pgpTxIn.opCodeData);
             v.protTxData(PGP3_USER_OPCODE_FIELD_C)   := pgpTxIn.opCodeData;
+            v.protTxHeader                           := PGP3_K_HEADER_C;
 
             -- If skip was interrupted, hold it for next cycle
             if (r.skpCount = SKP_INTERVAL_G-1) then


### PR DESCRIPTION
The header field wasn't being set to PGP3_K_HEADER_C ("10") when sending OpCodes. This has been fixed.