### PR TITLE
RSSI FlowControl Bug Fix

### DIFF
--- a/protocols/rssi/rtl/RssiCore.vhd
+++ b/protocols/rssi/rtl/RssiCore.vhd
@@ -120,7 +120,8 @@ end entity RssiCore;
 architecture rtl of RssiCore is
    --
    constant FIFO_ADDR_WIDTH_C   : positive := ite((SEGMENT_ADDR_SIZE_G < 7), 9, SEGMENT_ADDR_SIZE_G+2);
-   constant FIFO_PAUSE_THRESH_C : positive := ((2**FIFO_ADDR_WIDTH_C)-1) - 16;  -- FIFO_FULL - padding (128 bytes)
+   -- constant FIFO_PAUSE_THRESH_C : positive := ((2**FIFO_ADDR_WIDTH_C)-1) - 16;  -- FIFO_FULL - padding (128 bytes)
+   constant FIFO_PAUSE_THRESH_C : positive := (2**FIFO_ADDR_WIDTH_C) - (2**(SEGMENT_ADDR_SIZE_G+1));  -- pause threshold = FIFO_FULL - (2 x segment buffers)
 
    -- RSSI Parameters
    signal s_appRssiParam : RssiParamType;


### PR DESCRIPTION
### Description
We previously had this:
```
constant FIFO_PAUSE_THRESH_C : positive := ((2**FIFO_ADDR_WIDTH_C)-1) - 16;  -- FIFO_FULL - padding (128 bytes)
```
SEGMENT_ADDR_SIZE_G = 7, which is 2^7 = 128 words
128 words (1024B) > 16 padding
In this pull request, we change the threshold to this:
```
constant FIFO_PAUSE_THRESH_C : positive := (2**FIFO_ADDR_WIDTH_C) - (2**(SEGMENT_ADDR_SIZE_G+1));  -- pause threshold = FIFO_FULL - (2 x segment buffers)
```
This makes sure there's 2 times more buffer room in the FIFO before bursting from the BRAM to the FIFO when SEGMENT_ADDR_SIZE_G > 6, FIFO_PAUSE_THRESH_C becomes effectively  (2**FIFO_ADDR_WIDTH_C)/2.
I have confirmed in dev-board-example that this works. 
https://github.com/slaclab/dev-board-examples/commit/e61df857dc34471bb72ec7e3bcf3947698de3632

### JIRA
[ESROGUE-202](https://jira.slac.stanford.edu/browse/ESROGUE-202) (related)
