### PR TITLE
Group buildstamp sub-variables update into a single write transaction

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-** Overview
+## Overview
 A short summary of your changes goes here. If you leave this bank your PR will not be accepted.
 
-** Details
+## Details
 A more detailed explanation of the changes goes here, and could include code examples, etc.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,15 @@
 <!--- Provide a one sentence summary of your changes in the Title above -->
 
-## Description
+### Description
 <!--- Describe your changes in detail. This could include code examples, etc. -->
 <!--- If you leave this blank your PR will not be accepted. -->
 <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
 
-## Details
+### Details
 <!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
 
-## JIRA
+### JIRA
 <!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
 
-## Related
+### Related
 <!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+** Overview
+A short summary of your changes goes here. If you leave this bank your PR will not be accepted.
+
+** Details
+A more detailed explanation of the changes goes here, and could include code examples, etc.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,15 @@
-## Overview
-A short summary of your changes goes here. If you leave this bank your PR will not be accepted.
+<!--- Provide a one sentence summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail. This could include code examples, etc. -->
+<!--- If you leave this blank your PR will not be accepted. -->
+<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
 
 ## Details
-A more detailed explanation of the changes goes here, and could include code examples, etc.
+<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
 
+## JIRA
+<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
+
+## Related
+<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -214,7 +214,8 @@ class AxiVersion(pr.Device):
             p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", value.strip())
             if p is not None:
                 for k,v in p.named.items():
-                    self.node(k).set(v)
+                    self.node(k).set(v,write=False)
+                self.writeAndVerifyBlocks(recurse=False)
         
         self.add(pr.LocalVariable(
             name = 'ImageName',


### PR DESCRIPTION

Group the write of the buildstand sub-variables into a single write/update transaction. This ensures their variable update calls are blocked together. 

This should also serve as an example of ways to group multiple transactions together.