### PR TITLE
Python bug fix for AxiMicronP30.py

### DIFF
--- a/python/surf/devices/micron/_AxiMicronP30.py
+++ b/python/surf/devices/micron/_AxiMicronP30.py
@@ -30,7 +30,7 @@ class AxiMicronP30(pr.Device):
         super().__init__(
             name        = name, 
             description = description, 
-            size        = (0x1 << 11), 
+            size        = (0x1 << 12), 
             **kwargs)
         
         self._mcs = McsReader()        


### PR DESCRIPTION
### Description
Not enough "size" allocated for _rawWrite/_rawRead.  Fixed it in d61db37 commit. 
