### PR TITLE
Updates to Clink python to support latest rogue

### DIFF
--- a/python/surf/protocols/clink/_ClinkChannel.py
+++ b/python/surf/protocols/clink/_ClinkChannel.py
@@ -164,18 +164,18 @@ class ClinkChannel(pr.Device):
             self._tx = surf.protocols.clink.ClinkSerialTx()
             pr.streamConnect(self._tx,serial)
 
-    @pr.command(order=1, value='', name='SendString', description='Send a command string')
-    def sendString(self, arg):
-        if self._tx is not None:
-            self._tx.sendString(arg)
+        @self.command(value='', name='SendString', description='Send a command string')
+        def sendString(arg):
+            if self._tx is not None:
+                self._tx.sendString(arg)
 
-    @pr.command(order=2, name='SendEscape', description='Send an escape charactor')
-    def sendEscape(self):
-        if self._tx is not None:
-            self._tx.sendEscape()
+        @self.command(name='SendEscape', description='Send an escape charactor')
+        def sendEscape():
+            if self._tx is not None:
+                self._tx.sendEscape()
 
-    @pr.command(order=3, name='SendGcp', description='Send gcp command')
-    def sendGcp(self):
-        if self._tx is not None:
-            self._tx.sendString("gcp")
+        @self.command(name='SendGcp', description='Send gcp command')
+        def sendGcp():
+            if self._tx is not None:
+                self._tx.sendString("gcp")
 

--- a/python/surf/protocols/clink/_ClinkSerialTx.py
+++ b/python/surf/protocols/clink/_ClinkSerialTx.py
@@ -29,7 +29,7 @@ class ClinkSerialTx(rogue.interfaces.stream.Master):
         ba = bytearray(4)
         ba[0] = 27
 
-        frame = self._reqFrame(len(ba),True,0)
+        frame = self._reqFrame(len(ba),True)
         frame.write(ba,0)
         self._sendFrame(frame)
 
@@ -41,7 +41,7 @@ class ClinkSerialTx(rogue.interfaces.stream.Master):
             i += 4
         ba[i] = 0x0D
 
-        frame = self._reqFrame(len(ba),True,0)
+        frame = self._reqFrame(len(ba),True)
         frame.write(ba,0)
         self._sendFrame(frame)
 


### PR DESCRIPTION

Remove deprecated class method decorators for serial send commands.

Fix reqFrame call for new API in serial send commands.

