### PR TITLE
In the Ads42lb69Core fixed cross clock domain synchronization

### DIFF
--- a/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
+++ b/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiAds42lb69Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-20
--- Last update: 2018-01-08
+-- Last update: 2015-05-19
 -------------------------------------------------------------------------------
 -- Description: AXI-Lite interface to ADS42LB69 ADC IC
 -------------------------------------------------------------------------------
@@ -33,6 +33,7 @@ entity AxiAds42lb69Core is
       DMODE_INIT_G       : slv(1 downto 0)                         := "00";
       DELAY_INIT_G       : Slv9VectorArray(1 downto 0, 7 downto 0) := (others => (others => (others => '0')));
       IODELAY_GROUP_G    : string                                  := "AXI_ADS42LB69_IODELAY_GRP";
+      AXI_ERROR_RESP_G   : slv(1 downto 0)                         := AXI_RESP_SLVERR_C;
       XIL_DEVICE_G       : string                                  := "7SERIES"
    );      
    port (
@@ -60,22 +61,42 @@ architecture mapping of AxiAds42lb69Core is
    signal status : AxiAds42lb69StatusType;
    signal config : AxiAds42lb69ConfigType;
    signal adcDataCnv : Slv16Array(1 downto 0);
+   signal convert    : slv(1 downto 0);
+   signal invert     : slv(1 downto 0);
    
 begin
+   
+   SynchVector0_Inst : entity work.SynchronizerVector
+      generic map(
+         TPD_G   => TPD_G,
+         WIDTH_G => 2)
+      port map(
+         clk     => adcClk,
+         dataIn  => config.convert,
+         dataOut => convert);
+   
+   SynchVector1_Inst : entity work.SynchronizerVector
+      generic map(
+         TPD_G   => TPD_G,
+         WIDTH_G => 2)
+      port map(
+         clk     => adcClk,
+         dataIn  => config.invert,
+         dataOut => invert);
    
    GEN_INVERT : for i in 1 downto 0 generate
       process (adcClk) is
       begin
          if (rising_edge(adcClk)) then
             -- option to convert 2s complement data to binary
-            if config.convert(i) = '1' then
+            if convert(i) = '1' then
                adcDataCnv(i) <= status.adcData(i) - x"8000";
             else
                adcDataCnv(i) <= status.adcData(i);
             end if;
             -- option to invert data
             -- useful when the PCB polarity is swapped
-            if config.invert(i) = '1' then
+            if invert(i) = '1' then
                adcData(i) <= x"FFFF" - adcDataCnv(i);
             else
                adcData(i) <= adcDataCnv(i);
@@ -89,7 +110,8 @@ begin
          TPD_G              => TPD_G,
          SIM_SPEEDUP_G      => SIM_SPEEDUP_G,
          ADC_CLK_FREQ_G     => ADC_CLK_FREQ_G,
-         DMODE_INIT_G       => DMODE_INIT_G)
+         DMODE_INIT_G       => DMODE_INIT_G,
+         AXI_ERROR_RESP_G   => AXI_ERROR_RESP_G)
       port map(
          -- AXI-Lite Register Interface (axiClk domain)
          axiReadMaster  => axiReadMaster,

--- a/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
+++ b/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiAds42lb69Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-20
--- Last update: 2015-05-19
+-- Last update: 2018-04-10
 -------------------------------------------------------------------------------
 -- Description: AXI-Lite interface to ADS42LB69 ADC IC
 -------------------------------------------------------------------------------
@@ -26,15 +26,15 @@ use work.AxiAds42lb69Pkg.all;
 
 entity AxiAds42lb69Core is
    generic (
-      TPD_G              : time                                    := 1 ns;
-      SIM_SPEEDUP_G      : boolean                                 := false;
-      USE_PLL_G          : boolean                                 := false;  -- true = phase compensate the ADC data bus
-      ADC_CLK_FREQ_G     : real                                    := 250.00E+6;  -- units of Hz
-      DMODE_INIT_G       : slv(1 downto 0)                         := "00";
-      DELAY_INIT_G       : Slv9VectorArray(1 downto 0, 7 downto 0) := (others => (others => (others => '0')));
-      IODELAY_GROUP_G    : string                                  := "AXI_ADS42LB69_IODELAY_GRP";
-      XIL_DEVICE_G       : string                                  := "7SERIES"
-   );      
+      TPD_G           : time                                    := 1 ns;
+      SIM_SPEEDUP_G   : boolean                                 := false;
+      USE_PLL_G       : boolean                                 := false;  -- true = phase compensate the ADC data bus
+      ADC_CLK_FREQ_G  : real                                    := 250.00E+6;  -- units of Hz
+      DMODE_INIT_G    : slv(1 downto 0)                         := "00";
+      DELAY_INIT_G    : Slv9VectorArray(1 downto 0, 7 downto 0) := (others => (others => (others => '0')));
+      IODELAY_GROUP_G : string                                  := "AXI_ADS42LB69_IODELAY_GRP";
+      XIL_DEVICE_G    : string                                  := "7SERIES"
+      );
    port (
       -- ADC Ports
       adcIn          : in  AxiAds42lb69InType;
@@ -56,15 +56,15 @@ entity AxiAds42lb69Core is
 end AxiAds42lb69Core;
 
 architecture mapping of AxiAds42lb69Core is
-   
-   signal status : AxiAds42lb69StatusType;
-   signal config : AxiAds42lb69ConfigType;
+
+   signal status     : AxiAds42lb69StatusType;
+   signal config     : AxiAds42lb69ConfigType;
    signal adcDataCnv : Slv16Array(1 downto 0);
    signal convert    : slv(1 downto 0);
    signal invert     : slv(1 downto 0);
-   
+
 begin
-   
+
    SynchVector0_Inst : entity work.SynchronizerVector
       generic map(
          TPD_G   => TPD_G,
@@ -73,7 +73,7 @@ begin
          clk     => adcClk,
          dataIn  => config.convert,
          dataOut => convert);
-   
+
    SynchVector1_Inst : entity work.SynchronizerVector
       generic map(
          TPD_G   => TPD_G,
@@ -82,23 +82,23 @@ begin
          clk     => adcClk,
          dataIn  => config.invert,
          dataOut => invert);
-   
+
    GEN_INVERT : for i in 1 downto 0 generate
       process (adcClk) is
       begin
          if (rising_edge(adcClk)) then
             -- option to convert 2s complement data to binary
             if convert(i) = '1' then
-               adcDataCnv(i) <= status.adcData(i) - x"8000";
+               adcDataCnv(i) <= status.adcData(i) - x"8000" after TPD_G;
             else
-               adcDataCnv(i) <= status.adcData(i);
+               adcDataCnv(i) <= status.adcData(i) after TPD_G;
             end if;
             -- option to invert data
             -- useful when the PCB polarity is swapped
             if invert(i) = '1' then
-               adcData(i) <= x"FFFF" - adcDataCnv(i);
+               adcData(i) <= x"FFFF" - adcDataCnv(i) after TPD_G;
             else
-               adcData(i) <= adcDataCnv(i);
+               adcData(i) <= adcDataCnv(i) after TPD_G;
             end if;
          end if;
       end process;
@@ -106,10 +106,10 @@ begin
 
    AxiAds42lb69Reg_Inst : entity work.AxiAds42lb69Reg
       generic map(
-         TPD_G              => TPD_G,
-         SIM_SPEEDUP_G      => SIM_SPEEDUP_G,
-         ADC_CLK_FREQ_G     => ADC_CLK_FREQ_G,
-         DMODE_INIT_G       => DMODE_INIT_G)
+         TPD_G          => TPD_G,
+         SIM_SPEEDUP_G  => SIM_SPEEDUP_G,
+         ADC_CLK_FREQ_G => ADC_CLK_FREQ_G,
+         DMODE_INIT_G   => DMODE_INIT_G)
       port map(
          -- AXI-Lite Register Interface (axiClk domain)
          axiReadMaster  => axiReadMaster,
@@ -123,7 +123,7 @@ begin
          adcClk         => adcClk,
          adcRst         => adcRst,
          axiClk         => axiClk,
-         axiRst         => axiRst);   
+         axiRst         => axiRst);
 
    AxiAds42lb69Deser_Inst : entity work.AxiAds42lb69Deser
       generic map(

--- a/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
+++ b/devices/Ti/ads42lb69/rtl/AxiAds42lb69Core.vhd
@@ -33,7 +33,6 @@ entity AxiAds42lb69Core is
       DMODE_INIT_G       : slv(1 downto 0)                         := "00";
       DELAY_INIT_G       : Slv9VectorArray(1 downto 0, 7 downto 0) := (others => (others => (others => '0')));
       IODELAY_GROUP_G    : string                                  := "AXI_ADS42LB69_IODELAY_GRP";
-      AXI_ERROR_RESP_G   : slv(1 downto 0)                         := AXI_RESP_SLVERR_C;
       XIL_DEVICE_G       : string                                  := "7SERIES"
    );      
    port (
@@ -110,8 +109,7 @@ begin
          TPD_G              => TPD_G,
          SIM_SPEEDUP_G      => SIM_SPEEDUP_G,
          ADC_CLK_FREQ_G     => ADC_CLK_FREQ_G,
-         DMODE_INIT_G       => DMODE_INIT_G,
-         AXI_ERROR_RESP_G   => AXI_ERROR_RESP_G)
+         DMODE_INIT_G       => DMODE_INIT_G)
       port map(
          -- AXI-Lite Register Interface (axiClk domain)
          axiReadMaster  => axiReadMaster,

--- a/devices/Ti/ads42lb69/rtl/AxiAds42lb69Deser.vhd
+++ b/devices/Ti/ads42lb69/rtl/AxiAds42lb69Deser.vhd
@@ -75,6 +75,10 @@ architecture rtl of AxiAds42lb69Deser is
    
 begin
 
+   assert (XIL_DEVICE_G = "ULTRASCALE" and USE_PLL_G = false) or XIL_DEVICE_G /= "ULTRASCALE"
+      report "ULTRASCALE implementation does not support USE_PLL_G = true"
+      severity failure;
+
    AxiAds42lb69Pll_Inst : entity work.AxiAds42lb69Pll
       generic map(
          TPD_G          => TPD_G,


### PR DESCRIPTION
### Description
The configuration and ADC data of the Ads42lb69Core are asynchronous. The invert and convert bits of the configuration were used in the ADC data clock domain without synchronization. This could potentially lead to random issues due to metastability. this is the best candidate to cause the issue described in ESLZTS-30.
