### PR TITLE
SsiPrbsRateGen Update

### DIFF
--- a/protocols/ssi/rtl/SsiPrbsRateGen.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRateGen.vhd
@@ -172,12 +172,9 @@ begin
       axiSlaveRegisterR(axilEp, x"014", 0, frameRate);
       axiSlaveRegisterR(axilEp, x"018", 0, frameRateMax);
       axiSlaveRegisterR(axilEp, x"01C", 0, frameRateMin);
-      axiSlaveRegisterR(axilEp, x"020", 0, bandwidth(31 downto 0));
-      axiSlaveRegisterR(axilEp, x"024", 0, bandwidth(63 downto 32));
-      axiSlaveRegisterR(axilEp, x"028", 0, bandwidthMax(31 downto 0));
-      axiSlaveRegisterR(axilEp, x"02C", 0, bandwidthMax(63 downto 32));
-      axiSlaveRegisterR(axilEp, x"030", 0, bandwidthMin(31 downto 0));
-      axiSlaveRegisterR(axilEp, x"034", 0, bandwidthMin(63 downto 32));
+      axiSlaveRegisterR(axilEp, x"020", 0, bandwidth);
+      axiSlaveRegisterR(axilEp, x"028", 0, bandwidthMax);
+      axiSlaveRegisterR(axilEp, x"030", 0, bandwidthMin);
 
       axiSlaveRegisterR(axilEp, x"040", 0, r.frameCount);
 

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -31,141 +31,142 @@ class SsiPrbsRateGen(pr.Device):
         # Variables
         ##############################
 
-        self.add (pr.RemoteCommand(  
-            name         = "statReset",
+        self.add(pr.RemoteCommand(    
+            name         = "StatReset",
             description  = "",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            mode         = "RW",
-            function     = pr.Command.toggle
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0,
+            base         = pr.UInt,            
+            function     = lambda cmd: cmd.toggle,
+            hidden       = False,
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "packetLength",
+            name         = "PacketLength",
             description  = "",
-            offset       =  0x04,
-            bitSize      =  32,
-            bitOffset    =  0x00,
+            offset       = 0x04,
+            bitSize      = 32,
+            bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "period",
+            name         = "Period",
             description  = "",
-            offset       =  0x08,
-            bitSize      =  32,
-            bitOffset    =  0x00,
+            offset       = 0x08,
+            bitSize      = 32,
+            bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "txEn",
+            name         = "TxEn",
             description  = "",
-            offset       =  0x0C,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = "bool",
+            offset       = 0x0C,
+            bitSize      = 1,
+            bitOffset    = 0,
+            base         = pr.Bool,
             mode         = "RW",
         ))
 
-        self.add(pr.RemoteCommand (   
-            name         = "oneShot",
+        self.add(pr.RemoteCommand(    
+            name         = "OneShot",
             description  = "",
-            offset       =  0x0C,
-            bitSize      =  1,
-            bitOffset    =  0x01,
+            offset       = 0x0C,
+            bitSize      = 1,
+            bitOffset    = 1,
+            base         = pr.UInt,            
+            function     = lambda cmd: cmd.toggle,
+            hidden       = False,
+        ))
+
+        self.add(pr.RemoteVariable(    
+            name         = "Missed",
+            description  = "",
+            offset       = 0x10,
+            bitSize      = 32,
+            bitOffset    = 0,
             base         = pr.UInt,
-            mode         = "WO",
-            function     = pr.Command.toggle
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "missed",
-            description  = "",
-            offset       =  0x10,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = "int",
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "frameRate",
+            name         = "FrameRate",
             description  = "",
-            offset       =  0x14,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x14,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "frameRateMax",
+            name         = "FrameRateMax",
             description  = "",
-            offset       =  0x18,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x18,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "frameRateMin",
+            name         = "FrameRateMin",
             description  = "",
-            offset       =  0x1C,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x1C,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "bandWidth",
+            name         = "BandWidth",
             description  = "",
-            offset       =  0x20,
-            bitSize      =  64,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x20,
+            bitSize      = 64,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "bandWidthMax",
+            name         = "BandWidthMax",
             description  = "",
-            offset       =  0x28,
-            bitSize      =  64,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x28,
+            bitSize      = 64,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "bandWidthMin",
+            name         = "BandWidthMin",
             description  = "",
-            offset       =  0x30,
-            bitSize      =  64,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x30,
+            bitSize      = 64,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "frameCount",
+            name         = "FrameCount",
             description  = "",
-            offset       =  0x40,
-            bitSize      =  64,
-            bitOffset    =  0x00,
-            base         = "int",
+            offset       = 0x40,
+            bitSize      = 64,
+            bitOffset    = 0,
+            base         = pr.UInt,
             pollInterval = 1,
             mode         = "RO",
         ))

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -79,7 +79,7 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 1,
             bitOffset    = 1,
             base         = pr.UInt,            
-            function     = lambda cmd: cmd.toggle,
+            function     = pr.BaseCommand.toggle,
             hidden       = False,
         ))
 


### PR DESCRIPTION
### Description
1) Updating VHDL because breaking apart >32-bit SLV into multiple axiSlaveRegister() no longer required
2) Updating SsiPrbsRateGen.py to rogue v2.8 