### PR TITLE
CPSW requires all WO variables to be 32-bit size and 32-bit aligned 

### DIFF
--- a/yaml/Ad5780.yaml
+++ b/yaml/Ad5780.yaml
@@ -100,7 +100,9 @@ children:
   hardReset:
     at:
       offset: 0x3F8
-    sizeBits: 1
+    # sizeBits: 1 
+    # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+    sizeBits: 32 
     lsBit: 0
     mode: WO
     description: HardReset

--- a/yaml/AxiSysMonUltraScale.yaml
+++ b/yaml/AxiSysMonUltraScale.yaml
@@ -41,6 +41,8 @@ AxiSysMonUltraScale: &AxiSysMonUltraScale
       class: IntField
       name: CONVSTR
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32     
       description: CONVST Register
     #########################################################
     SYSMONRR:
@@ -49,6 +51,8 @@ AxiSysMonUltraScale: &AxiSysMonUltraScale
       class: IntField
       name: SYSMONRR
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32    
       description: SYSMON Hard Macro Reset Register
     #########################################################
     GIER:

--- a/yaml/AxiVersion.yaml
+++ b/yaml/AxiVersion.yaml
@@ -66,7 +66,9 @@ AxiVersion: &AxiVersion
         offset: 0x10C
       class: IntField
       mode: WO
-      sizeBits: 1
+      #sizeBits: 1
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: Optional User Reset 
     #########################################################
     FdSerial:

--- a/yaml/AxiXadc.yaml
+++ b/yaml/AxiXadc.yaml
@@ -24,6 +24,8 @@ AxiXadc: &AxiXadc
       class: IntField
       name: SRR
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: Software Reset Register
     #########################################################
     SR:
@@ -48,6 +50,8 @@ AxiXadc: &AxiXadc
       class: IntField
       name: CONVSTR
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: CONVST Register
     #########################################################
     SYSMONRR:
@@ -56,6 +60,8 @@ AxiXadc: &AxiXadc
       class: IntField
       name: SYSMONRR
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: XADC Hard Macro Reset Register
     #########################################################
     GIER:

--- a/yaml/EthMacPhy.yaml
+++ b/yaml/EthMacPhy.yaml
@@ -85,23 +85,29 @@ EthMacPhy: &EthMacPhy
       at:
         offset: 0xFF4
       class: IntField
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: CounterReset
     #########################################################
     SoftReset:
       at:
         offset: 0xFF8
       class: IntField
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: SoftReset
     #########################################################
     HardReset:
       at:
         offset: 0xFFC
       class: IntField
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32         
       description: HardReset
     #########################################################

--- a/yaml/GigEthReg.yaml
+++ b/yaml/GigEthReg.yaml
@@ -86,23 +86,29 @@ GigEthReg: &GigEthReg
       class: IntField
       at:
         offset: 0xFF4
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32         
       description: CounterReset  
     #########################################################:
     SoftReset:
       class: IntField
       at:
         offset: 0xFF8
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32         
       description: SoftReset    
     #########################################################:
     HardReset:
       class: IntField
       at:
         offset: 0xFFC
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32         
       description: HardReset          
     #########################################################

--- a/yaml/SsiPrbsRx.yaml
+++ b/yaml/SsiPrbsRx.yaml
@@ -158,7 +158,9 @@ SsiPrbsRx: &SsiPrbsRx
         offset: 0x3FC
       class: IntField
       name: CntRst
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32         
       description: Status counter reset      
     #########################################################

--- a/yaml/SsiPrbsTx.yaml
+++ b/yaml/SsiPrbsTx.yaml
@@ -57,15 +57,18 @@ SsiPrbsTx: &SsiPrbsTx
       sizeBits: 1
       description: ''
     #########################################################
-    OneShot:
-      at:
-        offset: 0x00
-      class: IntField
-      name: OneShot
-      mode: WO
-      lsBit: 4
-      sizeBits: 1
-      description: ''
+    # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+    # which makes this variable not supported unless we rewrite the firmware
+    #########################################################
+    # OneShot:
+      # at:
+        # offset: 0x00
+      # class: IntField
+      # name: OneShot
+      # mode: WO
+      # lsBit: 4
+      # sizeBits: 1
+      # description: ''
     #########################################################
     FwCnt:
       at:
@@ -129,13 +132,16 @@ SsiPrbsTx: &SsiPrbsTx
       mode: RO
       description: ''
     #########################################################
-    C_OneShot:
-      name: C_OneShot
-      at:
-        offset: 0x0      
-      class: SequenceCommand
-      description: ''
-      sequence:
-      - entry: OneShot
-        value: 0x1
+    # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+    # which makes this command not supported unless we rewrite the firmware
+    #########################################################
+    # C_OneShot:
+      # name: C_OneShot
+      # at:
+        # offset: 0x0      
+      # class: SequenceCommand
+      # description: ''
+      # sequence:
+      # - entry: OneShot
+        # value: 0x1
     #########################################################

--- a/yaml/TenGigEthReg.yaml
+++ b/yaml/TenGigEthReg.yaml
@@ -126,23 +126,29 @@ TenGigEthReg: &TenGigEthReg
       class: IntField
       at:
         offset: 0xFF4
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: CounterReset  
     #########################################################
     SoftReset:
       class: IntField
       at:
         offset: 0xFF8
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: SoftReset    
     #########################################################
     HardReset:
       class: IntField
       at:
         offset: 0xFFC
-      sizeBits: 1    
+      # sizeBits: 1    
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: HardReset          
     #########################################################

--- a/yaml/XauiReg.yaml
+++ b/yaml/XauiReg.yaml
@@ -94,8 +94,10 @@ XauiReg: &XauiReg
         offset: 0xFF4
       class: IntField
       name: CounterReset
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: CounterReset
     #########################################################
     SoftReset:
@@ -103,8 +105,10 @@ XauiReg: &XauiReg
         offset: 0xFF8
       class: IntField
       name: SoftReset
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: SoftReset
     #########################################################
     HardReset:
@@ -112,7 +116,9 @@ XauiReg: &XauiReg
         offset: 0xFFC
       class: IntField
       name: HardReset
-      sizeBits: 1
+      # sizeBits: 1
       mode: WO
+      # CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
+      sizeBits: 32          
       description: HardReset
     #########################################################


### PR DESCRIPTION
### Description
CPSW requires all WO variables to be 32-bit size and 32-bit aligned 
