### PR TITLE
New UART Features

### DIFF
--- a/protocols/uart/rtl/UartAxiLiteMaster.vhd
+++ b/protocols/uart/rtl/UartAxiLiteMaster.vhd
@@ -2,7 +2,7 @@
 -- File       : UartAxiLiteMaster.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-06-09
--- Last update: 2016-06-29
+-- Last update: 2018-06-09
 -------------------------------------------------------------------------------
 -- Description: Ties together everything needed for a full duplex UART.
 -- This includes Baud Rate Generator, Transmitter, Receiver and FIFOs.
@@ -32,6 +32,9 @@ entity UartAxiLiteMaster is
       TPD_G             : time                  := 1 ns;
       AXIL_CLK_FREQ_G   : real                  := 125.0e6;
       BAUD_RATE_G       : integer               := 115200;
+      STOP_BITS_G       : integer range 1 to 2  := 1;
+      PARITY_G          : string                := "NONE";  -- "NONE" "ODD" "EVEN"
+      DATA_WIDTH_G      : integer range 5 to 8  := 8;
       FIFO_BRAM_EN_G    : boolean               := false;
       FIFO_ADDR_WIDTH_G : integer range 4 to 48 := 5);
    port (
@@ -119,6 +122,9 @@ begin
          TPD_G             => TPD_G,
          CLK_FREQ_G        => AXIL_CLK_FREQ_G,
          BAUD_RATE_G       => BAUD_RATE_G,
+         STOP_BITS_G       => STOP_BITS_G,
+         PARITY_G          => PARITY_G,
+         DATA_WIDTH_G      => DATA_WIDTH_G,
          FIFO_BRAM_EN_G    => FIFO_BRAM_EN_G,
          FIFO_ADDR_WIDTH_G => FIFO_ADDR_WIDTH_G)
       port map (

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartRx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2018-05-03
+-- Last update: 2018-05-27
 -------------------------------------------------------------------------------
 -- Description: UART Receiver
 -------------------------------------------------------------------------------
@@ -22,180 +22,185 @@ use ieee.std_logic_unsigned.all;
 use work.StdRtlPkg.all;
 
 entity UartRx is
-  generic (
-    TPD_G        : time                 := 1 ns;
-    PARITY_EN_G  : integer range 0 to 1 := 0;  -- 0 is 0 parity bit, 1 stop bit | 1 is 0/1 parity bit, 2/1 stop bit
-    PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
-    DATA_WIDTH_G : integer range 5 to 8 := 8);
-  port (
-    clk         : in  sl;
-    rst         : in  sl;
-    baud16x     : in  sl;
-    rdData      : out slv(7 downto 0);
-    rdValid     : out sl;
-    parityError : out sl;
-    rdReady     : in  sl;
-    rx          : in  sl);
+   generic (
+      TPD_G        : time                 := 1 ns;
+      STOP_BITS_G  : integer range 1 to 2 := 0;
+      PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
+      DATA_WIDTH_G : integer range 5 to 8 := 8);
+   port (
+      clk         : in  sl;
+      rst         : in  sl;
+      baud16x     : in  sl;
+      rdData      : out slv(7 downto 0);
+      rdValid     : out sl;
+      parityError : out sl;
+      rdReady     : in  sl;
+      rx          : in  sl);
 end entity UartRx;
 
 architecture rtl of UartRx is
 
-  type StateType is (WAIT_START_BIT_S, WAIT_8_S, WAIT_16_S, SAMPLE_RX_S, PARITY_S, WAIT_STOP_S, WRITE_OUT_S);
+   type StateType is (WAIT_START_BIT_S, WAIT_8_S, WAIT_16_S, SAMPLE_RX_S, CALC_PARITY_S, PARITY_S, WAIT_STOP_S, WRITE_OUT_S);
 
-  type RegType is
-  record
-    rdValid      : sl;
-    rdData       : slv(DATA_WIDTH_G-1 downto 0);
-    rxState      : stateType;
-    rxShiftReg   : slv(DATA_WIDTH_G-1 downto 0);
-    rxShiftCount : slv(3 downto 0);
-    baud16xCount : slv(3 downto 0);
-    parity       : sl;
-    parityError  : sl;
-  end record regType;
+   type RegType is
+   record
+      rdValid      : sl;
+      rdData       : slv(DATA_WIDTH_G-1 downto 0);
+      rxState      : stateType;
+      rxShiftReg   : slv(DATA_WIDTH_G-1 downto 0);
+      rxShiftCount : slv(3 downto 0);
+      baud16xCount : slv(3 downto 0);
+      parity       : sl;
+      parityError  : sl;
+   end record regType;
 
-  constant REG_INIT_C : RegType := (
-    rdValid      => '0',
-    rdData       => (others => '0'),
-    rxState      => WAIT_START_BIT_S,
-    rxShiftReg   => (others => '0'),
-    rxShiftCount => (others => '0'),
-    baud16xCount => (others => '0'),
-    parity       => '0',
-    parityError  => '0');
+   constant REG_INIT_C : RegType := (
+      rdValid      => '0',
+      rdData       => (others => '0'),
+      rxState      => WAIT_START_BIT_S,
+      rxShiftReg   => (others => '0'),
+      rxShiftCount => (others => '0'),
+      baud16xCount => (others => '0'),
+      parity       => '0',
+      parityError  => '0');
 
-  signal r   : RegType := REG_INIT_C;
-  signal rin : RegType;
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
-  signal rxSync : sl;
-  signal rxFall : sl;
+   signal rxSync : sl;
+   signal rxFall : sl;
 
 
 begin
 
-  U_SynchronizerEdge_1 : entity work.SynchronizerEdge
-    generic map (
-      TPD_G    => TPD_G,
-      STAGES_G => 3,
-      INIT_G   => "111")
-    port map (
-      clk         => clk,               -- [in]
-      rst         => rst,               -- [in]
-      dataIn      => rx,                -- [in]
-      dataOut     => rxSync,            -- [out]
-      risingEdge  => open,              -- [out]
-      fallingEdge => rxFall);           -- [out]
+   U_SynchronizerEdge_1 : entity work.SynchronizerEdge
+      generic map (
+         TPD_G    => TPD_G,
+         STAGES_G => 3,
+         INIT_G   => "111")
+      port map (
+         clk         => clk,            -- [in]
+         rst         => rst,            -- [in]
+         dataIn      => rx,             -- [in]
+         dataOut     => rxSync,         -- [out]
+         risingEdge  => open,           -- [out]
+         fallingEdge => rxFall);        -- [out]
 
-  comb : process (baud16x, r, rdReady, rst, rxFall, rxSync) is
-    variable v : RegType;
-  begin
-    v := r;
+   assert (not(STOP_BITS_G = 2 and PARITY_G /= "NONE"))
+      report "Invalid stopbit:parity combination" severity failure;
 
-    if (rdReady = '1') then
-      v.rdValid := '0';
-    end if;
+   comb : process (baud16x, r, rdReady, rst, rxFall, rxSync) is
+      variable v : RegType;
+   begin
+      v := r;
 
-    case r.rxState is
+      if (rdReady = '1') then
+         v.rdValid := '0';
+      end if;
 
-      -- Wait for RX to drop to indicate start bit
-      when WAIT_START_BIT_S =>
-        if (rxFall = '1') then
-          v.rxState      := WAIT_8_S;
-          v.baud16xCount := "0000";
-          v.rxShiftCount := "0000";
-        end if;
+      case r.rxState is
 
-        -- Wait 8 baud16x counts to find center of start bit
-        -- Every rx bit is 16 baud16x pulses apart
-        -- reset parity error flag
-      when WAIT_8_S =>
-        v.parityError := '0';
-        if (baud16x = '1') then
-          v.baud16xCount := r.baud16xCount + 1;
-          if (r.baud16xCount = "0111") then
-            v.baud16xCount := "0000";
+         -- Wait for RX to drop to indicate start bit
+         when WAIT_START_BIT_S =>
+            if (rxFall = '1') then
+               v.rxState      := WAIT_8_S;
+               v.baud16xCount := "0000";
+               v.rxShiftCount := "0000";
+            end if;
+
+            -- Wait 8 baud16x counts to find center of start bit
+            -- Every rx bit is 16 baud16x pulses apart
+            -- reset parity error flag
+         when WAIT_8_S =>
+            v.parityError := '0';
+            if (baud16x = '1') then
+               v.baud16xCount := r.baud16xCount + 1;
+               if (r.baud16xCount = "0111") then
+                  v.baud16xCount := "0000";
+                  v.rxState      := WAIT_16_S;
+               end if;
+            end if;
+
+            -- Wait 16 baud16x counts (center of next bit)
+         when WAIT_16_S =>
+            if (baud16x = '1') then
+               v.baud16xCount := r.baud16xCount + 1;
+               if (r.baud16xCount = "1111") then
+                  v.rxState := SAMPLE_RX_S;
+               end if;
+            end if;
+
+            -- Sample the rx line and shift it in.
+            -- Go back and wait 16 for the next bit unless last bit
+         when SAMPLE_RX_S =>
+            v.rxShiftReg   := rxSync & r.rxShiftReg(DATA_WIDTH_G-1 downto 1);
+            v.rxShiftCount := r.rxShiftCount + 1;
             v.rxState      := WAIT_16_S;
-          end if;
-        end if;
-
-        -- Wait 16 baud16x counts (center of next bit)
-      when WAIT_16_S =>
-        if (baud16x = '1') then
-          v.baud16xCount := r.baud16xCount + 1;
-          if (r.baud16xCount = "1111") then
-            if (r.rxShiftCount = DATA_WIDTH_G and PARITY_EN_G = 1) then
-              v.rxState := PARITY_S;
-              v.parity  := oddParity(v.rxShiftReg);
-            else
-              v.rxState := SAMPLE_RX_S;
+            if (r.rxShiftCount = DATA_WIDTH_G-1) then
+               if(PARITY_G /= "NONE") then
+                  v.rxState := CALC_PARITY_S;
+               else
+                  v.rxState := WAIT_STOP_S;
+               end if;
             end if;
-          end if;
-        end if;
 
-        -- Sample the rx line and shift it in.
-        -- Go back and wait 16 for the next bit unless last bit
-      when SAMPLE_RX_S =>
-        v.rxShiftReg   := rxSync & r.rxShiftReg(DATA_WIDTH_G-1 downto 1);
-        v.rxShiftCount := r.rxShiftCount + 1;
-        v.rxState      := WAIT_16_S;
-        if (r.rxShiftCount = DATA_WIDTH_G-1) then
-          if(PARITY_EN_G = 1) then
-            v.rxState := WAIT_16_S;
-          else
-            v.rxState := WAIT_STOP_S;
-          end if;
-        end if;
-
-        -- Samples parity bit on rx line and compare it to the calculated parity
-        -- raises a parityError flag if it does not match
-      when PARITY_S =>
-        case PARITY_G is
-          when "NONE" => v.rxState := WAIT_STOP_S;
-          when "EVEN" =>
-            if(v.parity = rxSync) then
-              v.rxState := WAIT_STOP_S;
-            else
-              v.parityError := '1';
+            -- Wait 16 baud16x counts (center of next bit) and calculate parity
+         when CALC_PARITY_S =>
+            if (baud16x = '1') then
+               v.baud16xCount := r.baud16xCount + 1;
+               if (r.baud16xCount = "1111") then
+                  v.rxState := PARITY_S;
+                  v.parity  := oddParity(v.rxShiftReg);
+               end if;
             end if;
-          when "ODD" =>
-            if(not(v.parity) = rxSync) then
-              v.rxState := WAIT_STOP_S;
-            else
-              v.parityError := '1';
+
+            -- Samples parity bit on rx line and compare it to the calculated parity
+            -- raises a parityError flag if it does not match          
+         when PARITY_S =>
+            if(PARITY_G = "NONE") then v.rxState := WAIT_STOP_S; end if;
+            if(PARITY_G = "EVEN") then
+               v.rxState := WAIT_STOP_S;
+               if(v.parity /= rxSync) then
+                  v.parityError := '1';
+               end if;
             end if;
-          when others => null;
-        end case;
+            if(PARITY_G = "ODD") then
+               v.rxState := WAIT_STOP_S;
+               if(not(v.parity) /= rxSync) then
+                  v.parityError := '1';
+               end if;
+            end if;
 
-        -- Wait for the stop bit
-      when WAIT_STOP_S =>
-        if (rxSync = '1') then
-          v.rxState := WRITE_OUT_S;
-        end if;
+            -- Wait for the stop bit
+         when WAIT_STOP_S =>
+            if (rxSync = '1') then
+               v.rxState := WRITE_OUT_S;
+            end if;
 
-        -- Put the parallel rx data on the output port.
-      when WRITE_OUT_S =>
-        v.rdData  := r.rxShiftReg;
-        v.rdValid := '1';
-        v.rxState := WAIT_START_BIT_S;
+            -- Put the parallel rx data on the output port.
+         when WRITE_OUT_S =>
+            v.rdData  := r.rxShiftReg;
+            v.rdValid := '1';
+            v.rxState := WAIT_START_BIT_S;
 
-    end case;
+      end case;
 
-    if (rst = '1') then
-      v := REG_INIT_C;
-    end if;
+      if (rst = '1') then
+         v := REG_INIT_C;
+      end if;
 
-    rin         <= v;
-    rdData      <= r.rdData;
-    rdValid     <= r.rdValid;
-    parityError <= r.parityError;
-    
-  end process comb;
+      rin         <= v;
+      rdData      <= r.rdData;
+      rdValid     <= r.rdValid;
+      parityError <= r.parityError;
+      
+   end process comb;
 
-  sync : process (clk) is
-  begin
-    if (rising_edge(clk)) then
-      r <= rin after TPD_G;
-    end if;
-  end process;
+   sync : process (clk) is
+   begin
+      if (rising_edge(clk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process;
 
 end architecture RTL;

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -98,9 +98,9 @@ begin
       end if;
 
       if (PARITY_G = "ODD") then
-         v.parity := evenParity(r.rxShfitReg);
+         v.parity := evenParity(r.rxShiftReg);
       elsif (PARITY_G = "EVEN") then
-         v.parity := oddParity(r.rxShfitReg);
+         v.parity := oddParity(r.rxShiftReg);
       else
          v.parity := '0';
       end if;

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartRx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2018-05-01
+-- Last update: 2018-05-03
 -------------------------------------------------------------------------------
 -- Description: UART Receiver
 -------------------------------------------------------------------------------
@@ -145,7 +145,9 @@ begin
             v.rxState := WAIT_STOP_S;
           end if;
         end if;
-        
+
+        -- Samples parity bit on rx line and compare it to the calculated parity
+        -- raises a parityError flag if it does not match
       when PARITY_S =>
         case PARITY_G is
           when "NONE" => v.rxState := WAIT_STOP_S;
@@ -161,7 +163,7 @@ begin
             else
               v.parityError := '1';
             end if;
-		  when others => null;
+          when others => null;
         end case;
 
         -- Wait for the stop bit

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartRx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2016-06-09
+-- Last update: 2018-05-01
 -------------------------------------------------------------------------------
 -- Description: UART Receiver
 -------------------------------------------------------------------------------
@@ -22,138 +22,178 @@ use ieee.std_logic_unsigned.all;
 use work.StdRtlPkg.all;
 
 entity UartRx is
-   generic (
-      TPD_G : time := 1 ns);
-   port (
-      clk     : in  sl;
-      rst     : in  sl;
-      baud16x : in  sl;
-      rdData  : out slv(7 downto 0);
-      rdValid : out sl;
-      rdReady   : in  sl;
-      rx      : in  sl);
+  generic (
+    TPD_G        : time                 := 1 ns;
+    PARITY_EN_G  : integer range 0 to 1 := 0;  -- 0 is 0 parity bit, 1 stop bit | 1 is 0/1 parity bit, 2/1 stop bit
+    PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
+    DATA_WIDTH_G : integer range 5 to 8 := 8);
+  port (
+    clk         : in  sl;
+    rst         : in  sl;
+    baud16x     : in  sl;
+    rdData      : out slv(7 downto 0);
+    rdValid     : out sl;
+    parityError : out sl;
+    rdReady     : in  sl;
+    rx          : in  sl);
 end entity UartRx;
 
 architecture rtl of UartRx is
 
-   type StateType is (WAIT_START_BIT_S, WAIT_8_S, WAIT_16_S, SAMPLE_RX_S, WAIT_STOP_S, WRITE_OUT_S);
+  type StateType is (WAIT_START_BIT_S, WAIT_8_S, WAIT_16_S, SAMPLE_RX_S, PARITY_S, WAIT_STOP_S, WRITE_OUT_S);
 
-   type RegType is
-   record
-      rdValid      : sl;
-      rdData       : slv(7 downto 0);
-      rxState      : stateType;
-      rxShiftReg   : slv(7 downto 0);
-      rxShiftCount : slv(2 downto 0);
-      baud16xCount : slv(3 downto 0);
-   end record regType;
+  type RegType is
+  record
+    rdValid      : sl;
+    rdData       : slv(DATA_WIDTH_G-1 downto 0);
+    rxState      : stateType;
+    rxShiftReg   : slv(DATA_WIDTH_G-1 downto 0);
+    rxShiftCount : slv(2 downto 0);
+    baud16xCount : slv(3 downto 0);
+    parity       : sl;
+    parityError  : sl;
+  end record regType;
 
-   constant REG_INIT_C : RegType := (
-      rdValid      => '0',
-      rdData       => (others => '0'),
-      rxState      => WAIT_START_BIT_S,
-      rxShiftReg   => (others => '0'),
-      rxShiftCount => (others => '0'),
-      baud16xCount => (others => '0'));
+  constant REG_INIT_C : RegType := (
+    rdValid      => '0',
+    rdData       => (others => '0'),
+    rxState      => WAIT_START_BIT_S,
+    rxShiftReg   => (others => '0'),
+    rxShiftCount => (others => '0'),
+    baud16xCount => (others => '0'),
+    parity       => '0',
+    parityError  => '0');
 
-   signal r   : RegType := REG_INIT_C;
-   signal rin : RegType;
+  signal r   : RegType := REG_INIT_C;
+  signal rin : RegType;
 
-   signal rxSync : sl;
-   signal rxFall : sl;
+  signal rxSync : sl;
+  signal rxFall : sl;
+
 
 begin
 
-   U_SynchronizerEdge_1 : entity work.SynchronizerEdge
-      generic map (
-         TPD_G    => TPD_G,
-         STAGES_G => 3,
-         INIT_G   => "111")
-      port map (
-         clk         => clk,            -- [in]
-         rst         => rst,            -- [in]
-         dataIn      => rx,             -- [in]
-         dataOut     => rxSync,         -- [out]
-         risingEdge  => open,           -- [out]
-         fallingEdge => rxFall);        -- [out]
+  U_SynchronizerEdge_1 : entity work.SynchronizerEdge
+    generic map (
+      TPD_G    => TPD_G,
+      STAGES_G => 3,
+      INIT_G   => "111")
+    port map (
+      clk         => clk,               -- [in]
+      rst         => rst,               -- [in]
+      dataIn      => rx,                -- [in]
+      dataOut     => rxSync,            -- [out]
+      risingEdge  => open,              -- [out]
+      fallingEdge => rxFall);           -- [out]
 
-   comb : process (baud16x, r, rdReady, rst, rxFall, rxSync) is
-      variable v : RegType;
-   begin
-      v := r;
+  comb : process (baud16x, r, rdReady, rst, rxFall, rxSync) is
+    variable v : RegType;
+  begin
+    v := r;
 
-      if (rdReady = '1') then
-         v.rdValid := '0';
-      end if;
+    if (rdReady = '1') then
+      v.rdValid := '0';
+    end if;
 
-      case r.rxState is
+    case r.rxState is
 
-         -- Wait for RX to drop to indicate start bit
-         when WAIT_START_BIT_S =>
-            if (rxFall = '1') then
-               v.rxState      := WAIT_8_S;
-               v.baud16xCount := "0000";
-            end if;
+      -- Wait for RX to drop to indicate start bit
+      when WAIT_START_BIT_S =>
+        if (rxFall = '1') then
+          v.rxState      := WAIT_8_S;
+          v.baud16xCount := "0000";
+          v.rxShiftCount := "000";
+        end if;
 
-         -- Wait 8 baud16x counts to find center of start bit
-         -- Every rx bit is 16 baud16x pulses apart
-         when WAIT_8_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = "0111") then
-                  v.baud16xCount := "0000";
-                  v.rxState      := WAIT_16_S;
-               end if;
-            end if;
-
-         -- Wait 16 baud16x counts (center of next bit)
-         when WAIT_16_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = "1111") then
-                  v.rxState := SAMPLE_RX_S;
-               end if;
-            end if;
-
-         -- Sample the rx line and shift it in.
-         -- Go back and wait 16 for the next bit unless last bit
-         when SAMPLE_RX_S =>
-            v.rxShiftReg   := rxSync & r.rxShiftReg(7 downto 1);
-            v.rxShiftCount := r.rxShiftCount + 1;
+        -- Wait 8 baud16x counts to find center of start bit
+        -- Every rx bit is 16 baud16x pulses apart
+        -- reset parity error flag
+      when WAIT_8_S =>
+        v.parityError := '0';
+        if (baud16x = '1') then
+          v.baud16xCount := r.baud16xCount + 1;
+          if (r.baud16xCount = "0111") then
+            v.baud16xCount := "0000";
             v.rxState      := WAIT_16_S;
-            if (r.rxShiftCount = "111") then
-               v.rxState := WAIT_STOP_S;
+          end if;
+        end if;
+
+        -- Wait 16 baud16x counts (center of next bit)
+      when WAIT_16_S =>
+        if (baud16x = '1') then
+          v.baud16xCount := r.baud16xCount + 1;
+          if (r.baud16xCount = "1111") then
+            if (r.rxShiftCount = DATA_WIDTH_G-1 and PARITY_EN_G = 1) then
+              v.rxState := PARITY_S;
+              v.parity  := oddParity(v.rxShiftReg);
+            else
+              v.rxState := SAMPLE_RX_S;
             end if;
+          end if;
+        end if;
 
-         -- Wait for the stop bit
-         when WAIT_STOP_S =>
-            if (rxSync = '1') then
-               v.rxState := WRITE_OUT_S;
+        -- Sample the rx line and shift it in.
+        -- Go back and wait 16 for the next bit unless last bit
+      when SAMPLE_RX_S =>
+        v.rxShiftReg   := rxSync & r.rxShiftReg(DATA_WIDTH_G-1 downto 1);
+        v.rxShiftCount := r.rxShiftCount + 1;
+        v.rxState      := WAIT_16_S;
+        if (r.rxShiftCount = DATA_WIDTH_G-1) then
+          if(PARITY_EN_G = 1) then
+            v.rxState := WAIT_16_S;
+          else
+            v.rxState := WAIT_STOP_S;
+          end if;
+        end if;
+        
+      when PARITY_S =>
+        case PARITY_G is
+          when "NONE" => v.rxState := WAIT_STOP_S;
+          when "EVEN" =>
+            if(v.parity = rxSync) then
+              v.rxState := WAIT_STOP_S;
+            else
+              v.parityError := '1';
             end if;
+          when "ODD" =>
+            if(not(v.parity) = rxSync) then
+              v.rxState := WAIT_STOP_S;
+            else
+              v.parityError := '1';
+            end if;
+		  when others => null;
+        end case;
 
-         -- Put the parallel rx data on the output port.
-         when WRITE_OUT_S =>
-            v.rdData  := r.rxShiftReg;
-            v.rdValid := '1';
-            v.rxState := WAIT_START_BIT_S;
+        -- Wait for the stop bit
+      when WAIT_STOP_S =>
+        if (rxSync = '1') then
+          v.rxState := WRITE_OUT_S;
+        end if;
 
-      end case;
+        -- Put the parallel rx data on the output port.
+      when WRITE_OUT_S =>
+        v.rdData  := r.rxShiftReg;
+        v.rdValid := '1';
+        v.rxState := WAIT_START_BIT_S;
 
-      if (rst = '1') then
-         v := REG_INIT_C;
-      end if;
+    end case;
 
-      rin     <= v;
-      rdData  <= r.rdData;
-      rdValid <= r.rdValid;
+    if (rst = '1') then
+      v := REG_INIT_C;
+    end if;
 
-   end process comb;
+    rin         <= v;
+    rdData      <= r.rdData;
+    rdValid     <= r.rdValid;
+    parityError <= r.parityError;
+    
+  end process comb;
 
-   sync : process (clk) is
-   begin
-      if (rising_edge(clk)) then
-         r <= rin after TPD_G;
-      end if;
-   end process;
+  sync : process (clk) is
+  begin
+    if (rising_edge(clk)) then
+      r <= rin after TPD_G;
+    end if;
+  end process;
 
 end architecture RTL;

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -24,7 +24,7 @@ use work.StdRtlPkg.all;
 entity UartRx is
    generic (
       TPD_G        : time                 := 1 ns;
-      STOP_BITS_G  : integer range 1 to 2 := 0;
+      STOP_BITS_G  : integer range 1 to 2 := 1;
       PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
       DATA_WIDTH_G : integer range 5 to 8 := 8);
    port (

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -48,7 +48,7 @@ architecture rtl of UartRx is
     rdData       : slv(DATA_WIDTH_G-1 downto 0);
     rxState      : stateType;
     rxShiftReg   : slv(DATA_WIDTH_G-1 downto 0);
-    rxShiftCount : slv(2 downto 0);
+    rxShiftCount : slv(3 downto 0);
     baud16xCount : slv(3 downto 0);
     parity       : sl;
     parityError  : sl;
@@ -102,7 +102,7 @@ begin
         if (rxFall = '1') then
           v.rxState      := WAIT_8_S;
           v.baud16xCount := "0000";
-          v.rxShiftCount := "000";
+          v.rxShiftCount := "0000";
         end if;
 
         -- Wait 8 baud16x counts to find center of start bit
@@ -123,7 +123,7 @@ begin
         if (baud16x = '1') then
           v.baud16xCount := r.baud16xCount + 1;
           if (r.baud16xCount = "1111") then
-            if (r.rxShiftCount = DATA_WIDTH_G-1 and PARITY_EN_G = 1) then
+            if (r.rxShiftCount = DATA_WIDTH_G and PARITY_EN_G = 1) then
               v.rxState := PARITY_S;
               v.parity  := oddParity(v.rxShiftReg);
             else

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -87,7 +87,7 @@ begin  -- architecture RTL
 
             -- Wait for next baud16x to synchronize
             -- Then load the shift reg
-            -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop bit if PARITY_EN_G=1
+            -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop
          when SYNC_EN_16_S =>
             if (baud16x = '1') then
                if(STOP_BITS_G = 1 and PARITY_G = "NONE") then

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartTx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2018-05-27
+-- Last update: 2018-06-05
 -------------------------------------------------------------------------------
 -- Description: Uart Transmitter
 -------------------------------------------------------------------------------
@@ -93,9 +93,9 @@ begin  -- architecture RTL
                if(STOP_BITS_G = 1 and PARITY_G = "NONE") then
                   v.shiftReg := '1' & r.holdReg & '0';
                elsif(STOP_BITS_G = 1 and PARITY_G = "EVEN") then
-                  v.shiftReg := '1' & v.parity & r.holdReg & '0';
+                  v.shiftReg := '1' & r.parity & r.holdReg & '0';
                elsif(STOP_BITS_G = 1 and PARITY_G = "ODD") then
-                  v.shiftReg := '1' & not(v.parity) & r.holdReg & '0';
+                  v.shiftReg := '1' & not(r.parity) & r.holdReg & '0';
                elsif(STOP_BITS_G = 2 and PARITY_G = "NONE") then
                   v.shiftReg := '1' & '1' & r.holdReg & '0';
                else

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartTx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2018-05-01
+-- Last update: 2018-05-03
 -------------------------------------------------------------------------------
 -- Description: Uart Transmitter
 -------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ begin  -- architecture RTL
               when "NONE" => v.shiftReg := '1' & '1' & r.holdReg & '0';
               when "EVEN" => v.shiftReg := '1' & v.parity & r.holdReg & '0';
               when "ODD"  => v.shiftReg := '1' & not(v.parity) & r.holdReg & '0';
-			  when others => null;
+              when others => null;
             end case;
           else
             v.shiftReg := '1' & r.holdReg & '0';

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartTx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2018-05-03
+-- Last update: 2018-05-27
 -------------------------------------------------------------------------------
 -- Description: Uart Transmitter
 -------------------------------------------------------------------------------
@@ -22,124 +22,129 @@ use ieee.std_logic_unsigned.all;
 use work.StdRtlPkg.all;
 
 entity UartTx is
-  generic (
-    TPD_G        : time                 := 1 ns;
-    PARITY_EN_G  : integer range 0 to 1 := 0;  -- 0 is 0 parity bit, 1 stop bit | 1 is 0/1 parity bit, 2/1 stop bit
-    PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
-    DATA_WIDTH_G : integer range 5 to 8 := 8);
-  port (
-    clk     : in  sl;
-    rst     : in  sl;
-    baud16x : in  sl;
-    wrData  : in  slv(DATA_WIDTH_G-1 downto 0);
-    wrValid : in  sl;
-    wrReady : out sl;
-    tx      : out sl);
+   generic (
+      TPD_G        : time                 := 1 ns;
+      STOP_BITS_G  : integer range 1 to 2 := 1;
+      PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
+      DATA_WIDTH_G : integer range 5 to 8 := 8);
+   port (
+      clk     : in  sl;
+      rst     : in  sl;
+      baud16x : in  sl;
+      wrData  : in  slv(DATA_WIDTH_G-1 downto 0);
+      wrValid : in  sl;
+      wrReady : out sl;
+      tx      : out sl);
 end entity UartTx;
 
 architecture RTL of UartTx is
+   constant PARITY_BITS_C     : integer := ite(PARITY_G = "NONE", 0, 1);
+   constant START_BIT_C       : integer := 1;
+   constant SHIFT_REG_WIDTH_C : integer := START_BIT_C + DATA_WIDTH_G + PARITY_BITS_C + STOP_BITS_G;
 
-  type StateType is (WAIT_DATA_S, SYNC_EN_16_S, WAIT_16_S, TX_BIT_S);
+   type StateType is (WAIT_DATA_S, SYNC_EN_16_S, WAIT_16_S, TX_BIT_S);
 
-  type RegType is record
-    wrReady      : sl;
-    holdReg      : slv(DATA_WIDTH_G-1 downto 0);
-    parity       : sl;
-    txState      : StateType;
-    baud16xCount : slv(3 downto 0);
-    shiftReg     : slv(DATA_WIDTH_G + PARITY_EN_G + 1 downto 0);
-    shiftCount   : slv(3 downto 0);
-  end record RegType;
+   type RegType is record
+      wrReady      : sl;
+      holdReg      : slv(DATA_WIDTH_G-1 downto 0);
+      parity       : sl;
+      txState      : StateType;
+      baud16xCount : slv(3 downto 0);
+      shiftReg     : slv(SHIFT_REG_WIDTH_C-1 downto 0);
+      shiftCount   : slv(3 downto 0);
+   end record RegType;
 
-  constant REG_INIT_C : RegType := (
-    wrReady      => '0',
-    holdReg      => (others => '0'),
-    parity       => '0',
-    txState      => WAIT_DATA_S,
-    baud16xCount => (others => '0'),
-    shiftReg     => (others => '1'),
-    shiftCount   => (others => '0'));
+   constant REG_INIT_C : RegType := (
+      wrReady      => '0',
+      holdReg      => (others => '0'),
+      parity       => '0',
+      txState      => WAIT_DATA_S,
+      baud16xCount => (others => '0'),
+      shiftReg     => (others => '1'),
+      shiftCount   => (others => '0'));
 
-  signal r   : RegType := REG_INIT_C;
-  signal rin : RegType;
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
 begin  -- architecture RTL
+   
 
+   comb : process (baud16x, r, rst, wrData, wrValid) is
+      variable v : RegType;
+   begin
+      v := r;
 
-  comb : process (baud16x, r, rst, wrData, wrValid) is
-    variable v : RegType;
-  begin
-    v := r;
-
-    case r.txState is
-      -- Wait for new data to send
-      when WAIT_DATA_S =>
-        v.wrReady := '1';
-        if (wrValid = '1' and r.wrReady = '1') then
-          v.wrReady := '0';
-          v.holdReg := wrData;
-          v.txState := SYNC_EN_16_S;
-          v.parity  := oddParity(wrData);  -- returns 1 if wrData is odd, 0 if even
-        end if;
-
-        -- Wait for next baud16x to synchronize
-        -- Then load the shift reg
-        -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop bit if PARITY_EN_G=1
-      when SYNC_EN_16_S =>
-        if (baud16x = '1') then
-          if(PARITY_EN_G = 1) then
-            case PARITY_G is
-              when "NONE" => v.shiftReg := '1' & '1' & r.holdReg & '0';
-              when "EVEN" => v.shiftReg := '1' & v.parity & r.holdReg & '0';
-              when "ODD"  => v.shiftReg := '1' & not(v.parity) & r.holdReg & '0';
-              when others => null;
-            end case;
-          else
-            v.shiftReg := '1' & r.holdReg & '0';
-          end if;
-
-          v.baud16xCount := (others => '0');
-          v.shiftCount   := (others => '0');
-          v.txState      := WAIT_16_S;
-        end if;
-
-        -- Wait 16 baud_16x counts (the baud rate)
-        -- When shifted all bits, wait for next tx data
-      when WAIT_16_S =>
-        if (baud16x = '1') then
-          v.baud16xCount := r.baud16xCount + 1;
-          if (r.baud16xCount = 15) then
-            v.txState := TX_BIT_S;
-            if (r.shiftCount = DATA_WIDTH_G + PARITY_EN_G + 1) then
-              v.txState := WAIT_DATA_S;
+      case r.txState is
+         -- Wait for new data to send
+         when WAIT_DATA_S =>
+            v.wrReady := '1';
+            if (wrValid = '1' and r.wrReady = '1') then
+               v.wrReady := '0';
+               v.holdReg := wrData;
+               v.txState := SYNC_EN_16_S;
+               v.parity  := oddParity(wrData);  -- returns 1 if wrData is odd, 0 if even
             end if;
-          end if;
-        end if;
 
-        -- Shift to TX next bit, increment shift count
-      when TX_BIT_S =>
-        v.shiftReg   := '0' & r.shiftReg(DATA_WIDTH_G + PARITY_EN_G + 1 downto 1);
-        v.shiftCount := r.shiftCount + 1;
-        v.txState    := WAIT_16_S;
+            -- Wait for next baud16x to synchronize
+            -- Then load the shift reg
+            -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop bit if PARITY_EN_G=1
+         when SYNC_EN_16_S =>
+            if (baud16x = '1') then
+               if(STOP_BITS_G = 1 and PARITY_G = "NONE") then
+                  v.shiftReg := '1' & r.holdReg & '0';
+               elsif(STOP_BITS_G = 1 and PARITY_G = "EVEN") then
+                  v.shiftReg := '1' & v.parity & r.holdReg & '0';
+               elsif(STOP_BITS_G = 1 and PARITY_G = "ODD") then
+                  v.shiftReg := '1' & not(v.parity) & r.holdReg & '0';
+               elsif(STOP_BITS_G = 2 and PARITY_G = "NONE") then
+                  v.shiftReg := '1' & '1' & r.holdReg & '0';
+               else
+                  assert (not(STOP_BITS_G = 2 and PARITY_G /= "NONE"))
+                     report "Invalid stopbit:parity combination" severity failure;
+               end if;
 
-    end case;
+               v.baud16xCount := (others => '0');
+               v.shiftCount   := (others => '0');
+               v.txState      := WAIT_16_S;
+            end if;
 
-    if (rst = '1') then
-      v := REG_INIT_C;
-    end if;
+            -- Wait 16 baud_16x counts (the baud rate)
+            -- When shifted all bits, wait for next tx data
+         when WAIT_16_S =>
+            if (baud16x = '1') then
+               v.baud16xCount := r.baud16xCount + 1;
+               if (r.baud16xCount = 15) then
+                  v.txState := TX_BIT_S;
+                  if (r.shiftCount = SHIFT_REG_WIDTH_C-1) then
+                     v.txState := WAIT_DATA_S;
+                  end if;
+               end if;
+            end if;
 
-    rin     <= v;
-    wrReady <= r.wrReady;
-    tx      <= r.shiftReg(0);
+            -- Shift to TX next bit, increment shift count
+         when TX_BIT_S =>
+            v.shiftReg   := '0' & r.shiftReg(SHIFT_REG_WIDTH_C-1 downto 1);
+            v.shiftCount := r.shiftCount + 1;
+            v.txState    := WAIT_16_S;
 
-  end process;
+      end case;
 
-  seq : process (clk) is
-  begin
-    if (rising_edge(clk)) then
-      r <= rin after TPD_G;
-    end if;
-  end process seq;
+      if (rst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      rin     <= v;
+      wrReady <= r.wrReady;
+      tx      <= r.shiftReg(0);
+
+   end process;
+
+   seq : process (clk) is
+   begin
+      if (rising_edge(clk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
 
 
 end architecture RTL;

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -2,7 +2,7 @@
 -- File       : UartTx.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-05-13
--- Last update: 2016-06-28
+-- Last update: 2018-05-01
 -------------------------------------------------------------------------------
 -- Description: Uart Transmitter
 -------------------------------------------------------------------------------
@@ -22,108 +22,124 @@ use ieee.std_logic_unsigned.all;
 use work.StdRtlPkg.all;
 
 entity UartTx is
-   generic (
-      TPD_G : time := 1 ns);
-   port (
-      clk     : in  sl;
-      rst     : in  sl;
-      baud16x : in  sl;
-      wrData  : in  slv(7 downto 0);
-      wrValid : in  sl;
-      wrReady : out sl;
-      tx      : out sl);
+  generic (
+    TPD_G        : time                 := 1 ns;
+    PARITY_EN_G  : integer range 0 to 1 := 0;  -- 0 is 0 parity bit, 1 stop bit | 1 is 0/1 parity bit, 2/1 stop bit
+    PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
+    DATA_WIDTH_G : integer range 5 to 8 := 8);
+  port (
+    clk     : in  sl;
+    rst     : in  sl;
+    baud16x : in  sl;
+    wrData  : in  slv(DATA_WIDTH_G-1 downto 0);
+    wrValid : in  sl;
+    wrReady : out sl;
+    tx      : out sl);
 end entity UartTx;
 
 architecture RTL of UartTx is
 
-   type StateType is (WAIT_DATA_S, SYNC_EN_16_S, WAIT_16_S, TX_BIT_S);
+  type StateType is (WAIT_DATA_S, SYNC_EN_16_S, WAIT_16_S, TX_BIT_S);
 
-   type RegType is record
-      wrReady      : sl;
-      holdReg      : slv(7 downto 0);
-      txState      : StateType;
-      baud16xCount : slv(3 downto 0);
-      shiftReg     : slv(9 downto 0);
-      shiftCount   : slv(3 downto 0);
-   end record RegType;
+  type RegType is record
+    wrReady      : sl;
+    holdReg      : slv(DATA_WIDTH_G-1 downto 0);
+    parity       : sl;
+    txState      : StateType;
+    baud16xCount : slv(3 downto 0);
+    shiftReg     : slv(DATA_WIDTH_G + PARITY_EN_G + 1 downto 0);
+    shiftCount   : slv(3 downto 0);
+  end record RegType;
 
-   constant REG_INIT_C : RegType := (
-      wrReady      => '0',
-      holdReg      => (others => '0'),
-      txState      => WAIT_DATA_S,
-      baud16xCount => (others => '0'),
-      shiftReg     => (others => '1'),
-      shiftCount   => (others => '0'));
+  constant REG_INIT_C : RegType := (
+    wrReady      => '0',
+    holdReg      => (others => '0'),
+    parity       => '0',
+    txState      => WAIT_DATA_S,
+    baud16xCount => (others => '0'),
+    shiftReg     => (others => '1'),
+    shiftCount   => (others => '0'));
 
-   signal r   : RegType := REG_INIT_C;
-   signal rin : RegType;
+  signal r   : RegType := REG_INIT_C;
+  signal rin : RegType;
 
 begin  -- architecture RTL
 
 
-   comb : process (baud16x, r, rst, wrData, wrValid) is
-      variable v : RegType;
-   begin
-      v := r;
+  comb : process (baud16x, r, rst, wrData, wrValid) is
+    variable v : RegType;
+  begin
+    v := r;
 
-      case r.txState is
-         -- Wait for new data to send
-         when WAIT_DATA_S =>
-            v.wrReady := '1';
-            if (wrValid = '1' and r.wrReady = '1') then
-               v.wrReady := '0';                     
-               v.holdReg := wrData;
-               v.txState := SYNC_EN_16_S;
+    case r.txState is
+      -- Wait for new data to send
+      when WAIT_DATA_S =>
+        v.wrReady := '1';
+        if (wrValid = '1' and r.wrReady = '1') then
+          v.wrReady := '0';
+          v.holdReg := wrData;
+          v.txState := SYNC_EN_16_S;
+          v.parity  := oddParity(wrData);  -- returns 1 if wrData is odd, 0 if even
+        end if;
+
+        -- Wait for next baud16x to synchronize
+        -- Then load the shift reg
+        -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop bit if PARITY_EN_G=1
+      when SYNC_EN_16_S =>
+        if (baud16x = '1') then
+          if(PARITY_EN_G = 1) then
+            case PARITY_G is
+              when "NONE" => v.shiftReg := '1' & '1' & r.holdReg & '0';
+              when "EVEN" => v.shiftReg := '1' & v.parity & r.holdReg & '0';
+              when "ODD"  => v.shiftReg := '1' & not(v.parity) & r.holdReg & '0';
+			  when others => null;
+            end case;
+          else
+            v.shiftReg := '1' & r.holdReg & '0';
+          end if;
+
+          v.baud16xCount := (others => '0');
+          v.shiftCount   := (others => '0');
+          v.txState      := WAIT_16_S;
+        end if;
+
+        -- Wait 16 baud_16x counts (the baud rate)
+        -- When shifted all bits, wait for next tx data
+      when WAIT_16_S =>
+        if (baud16x = '1') then
+          v.baud16xCount := r.baud16xCount + 1;
+          if (r.baud16xCount = 15) then
+            v.txState := TX_BIT_S;
+            if (r.shiftCount = DATA_WIDTH_G + PARITY_EN_G + 1) then
+              v.txState := WAIT_DATA_S;
             end if;
+          end if;
+        end if;
 
-         -- Wait for next baud16x to synchronize
-         -- Then load the shift reg
-         -- Bit 0 is the start bit, bit 9 is the stop bit
-         when SYNC_EN_16_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := (others => '0');
-               v.shiftReg     := '1' & r.holdReg & '0';
-               v.shiftCount   := (others => '0');
-               v.txState      := WAIT_16_S;
-            end if;
+        -- Shift to TX next bit, increment shift count
+      when TX_BIT_S =>
+        v.shiftReg   := '0' & r.shiftReg(DATA_WIDTH_G + PARITY_EN_G + 1 downto 1);
+        v.shiftCount := r.shiftCount + 1;
+        v.txState    := WAIT_16_S;
 
-         -- Wait 16 baud_16x counts (the baud rate)
-         -- When shifted all bits, wait for next tx data
-         when WAIT_16_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = 15) then
-                  v.txState := TX_BIT_S;
-                  if (r.shiftCount = 9) then
-                     v.txState := WAIT_DATA_S;
-                  end if;
-               end if;
-            end if;
+    end case;
 
-         -- Shift to TX next bit, increment shift count
-         when TX_BIT_S =>
-            v.shiftReg   := '0' & r.shiftReg(9 downto 1);
-            v.shiftCount := r.shiftCount + 1;
-            v.txState    := WAIT_16_S;
+    if (rst = '1') then
+      v := REG_INIT_C;
+    end if;
 
-      end case;
+    rin     <= v;
+    wrReady <= r.wrReady;
+    tx      <= r.shiftReg(0);
 
-      if (rst = '1') then
-         v := REG_INIT_C;
-      end if;
+  end process;
 
-      rin     <= v;
-      wrReady <= r.wrReady;
-      tx      <= r.shiftReg(0);
-
-   end process;
-
-   seq : process (clk) is
-   begin
-      if (rising_edge(clk)) then
-         r <= rin after TPD_G;
-      end if;
-   end process seq;
+  seq : process (clk) is
+  begin
+    if (rising_edge(clk)) then
+      r <= rin after TPD_G;
+    end if;
+  end process seq;
 
 
 end architecture RTL;

--- a/protocols/uart/rtl/UartWrapper.vhd
+++ b/protocols/uart/rtl/UartWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : UartAxiLiteMaster.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-06-09
--- Last update: 2016-06-09
+-- Last update: 2018-06-09
 -------------------------------------------------------------------------------
 -- Description: Ties together everything needed for a full duplex UART.
 -- This includes Baud Rate Generator, Transmitter, Receiver and FIFOs.
@@ -29,6 +29,9 @@ entity UartWrapper is
       TPD_G             : time                  := 1 ns;
       CLK_FREQ_G        : real                  := 125.0e6;
       BAUD_RATE_G       : integer               := 115200;
+      STOP_BITS_G       : integer range 1 to 2  := 1;
+      PARITY_G          : string                := "NONE";  -- "NONE" "ODD" "EVEN"
+      DATA_WIDTH_G      : integer range 5 to 8  := 8;
       FIFO_BRAM_EN_G    : boolean               := false;
       FIFO_ADDR_WIDTH_G : integer range 4 to 48 := 4);
    port (
@@ -96,7 +99,10 @@ begin
    -------------------------------------------------------------------------------------------------
    U_UartTx_1 : entity work.UartTx
       generic map (
-         TPD_G => TPD_G)
+         TPD_G        => TPD_G,
+         STOP_BITS_G  => STOP_BITS_G,
+         PARITY_G     => PARITY_G,
+         DATA_WIDTH_G => DATA_WIDTH_G)
       port map (
          clk     => clk,                -- [in]
          rst     => rst,                -- [in]
@@ -120,7 +126,7 @@ begin
          BRAM_EN_G       => FIFO_BRAM_EN_G,
          FWFT_EN_G       => true,
          PIPE_STAGES_G   => 0,
-         DATA_WIDTH_G    => 8,
+         DATA_WIDTH_G    => DATA_WIDTH_G,
          ADDR_WIDTH_G    => FIFO_ADDR_WIDTH_G)
       port map (
          rst      => rst,               -- [in]
@@ -138,7 +144,9 @@ begin
    -------------------------------------------------------------------------------------------------
    U_UartRx_1 : entity work.UartRx
       generic map (
-         TPD_G => TPD_G)
+         TPD_G        => TPD_G,
+         PARITY_G     => PARITY_G,
+         DATA_WIDTH_G => DATA_WIDTH_G)
       port map (
          clk     => clk,                -- [in]
          rst     => rst,                -- [in]
@@ -165,7 +173,7 @@ begin
          BRAM_EN_G       => FIFO_BRAM_EN_G,
          FWFT_EN_G       => true,
          PIPE_STAGES_G   => 0,
-         DATA_WIDTH_G    => 8,
+         DATA_WIDTH_G    => DATA_WIDTH_G,
          ADDR_WIDTH_G    => FIFO_ADDR_WIDTH_G)
       port map (
          rst      => rst,               -- [in]

--- a/protocols/uart/sim/UartAxiLiteMasterTb.vhd
+++ b/protocols/uart/sim/UartAxiLiteMasterTb.vhd
@@ -2,7 +2,7 @@
 -- File       : UartAxiLiteMasterTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-06-27
--- Last update: 2018-06-09
+-- Last update: 2016-06-28
 -------------------------------------------------------------------------------
 -- Description: Testbench for design "UartAxiLiteMaster"
 -------------------------------------------------------------------------------
@@ -38,9 +38,6 @@ architecture sim of UartAxiLiteMasterTb is
    constant TPD_G             : time                  := 1 ns;
    constant CLK_FREQ_G        : real                  := 125.0e6;
    constant BAUD_RATE_G       : integer               := 115200;
-   constant STOP_BITS_G       : integer range 1 to 2  := 1;
-   constant PARITY_G          : string                := "NONE";  -- "NONE" "ODD" "EVEN"
-   constant DATA_WIDTH_G      : integer range 5 to 8  := 8;
    constant FIFO_BRAM_EN_G    : boolean               := false;
    constant FIFO_ADDR_WIDTH_G : integer range 4 to 48 := 5;
 
@@ -80,9 +77,6 @@ begin
          TPD_G             => TPD_G,
          CLK_FREQ_G        => CLK_FREQ_G,
          BAUD_RATE_G       => BAUD_RATE_G,
-         STOP_BITS_G       => STOP_BITS_G,
-         PARITY_G          => PARITY_G,
-         DATA_WIDTH_G      => DATA_WIDTH_G,
          FIFO_BRAM_EN_G    => FIFO_BRAM_EN_G,
          FIFO_ADDR_WIDTH_G => FIFO_ADDR_WIDTH_G)
       port map (
@@ -103,9 +97,6 @@ begin
          TPD_G             => TPD_G,
          AXIL_CLK_FREQ_G   => CLK_FREQ_G,
          BAUD_RATE_G       => BAUD_RATE_G,
-         STOP_BITS_G       => STOP_BITS_G,
-         PARITY_G          => PARITY_G,
-         DATA_WIDTH_G      => DATA_WIDTH_G,
          FIFO_BRAM_EN_G    => FIFO_BRAM_EN_G,
          FIFO_ADDR_WIDTH_G => FIFO_ADDR_WIDTH_G)
       port map (
@@ -139,121 +130,121 @@ begin
 
    test : process is
       function hexStrToSlv (s : string) return slv is
-      variable tmp            : string(1 to s'length) := resize(s, s'length);
-      variable char           : character;
-      variable ret            : slv(s'length*4-1 downto 0);
-   begin
-      for i in tmp'range loop
-         ret(ret'high downto 4) := ret(ret'high-4 downto 0);
-         case tmp(i) is
-            when '0'    => ret(3 downto 0) := toSlv(0, 4);
-            when '1'    => ret(3 downto 0) := toSlv(1, 4);
-            when '2'    => ret(3 downto 0) := toSlv(2, 4);
-            when '3'    => ret(3 downto 0) := toSlv(3, 4);
-            when '4'    => ret(3 downto 0) := toSlv(4, 4);
-            when '5'    => ret(3 downto 0) := toSlv(5, 4);
-            when '6'    => ret(3 downto 0) := toSlv(6, 4);
-            when '7'    => ret(3 downto 0) := toSlv(7, 4);
-            when '8'    => ret(3 downto 0) := toSlv(8, 4);
-            when '9'    => ret(3 downto 0) := toSlv(9, 4);
-            when 'A'    => ret(3 downto 0) := toSlv(10, 4);
-            when 'a'    => ret(3 downto 0) := toSlv(10, 4);
-            when 'B'    => ret(3 downto 0) := toSlv(11, 4);
-            when 'b'    => ret(3 downto 0) := toSlv(11, 4);
-            when 'C'    => ret(3 downto 0) := toSlv(12, 4);
-            when 'c'    => ret(3 downto 0) := toSlv(12, 4);
-            when 'D'    => ret(3 downto 0) := toSlv(13, 4);
-            when 'd'    => ret(3 downto 0) := toSlv(13, 4);
-            when 'E'    => ret(3 downto 0) := toSlv(14, 4);
-            when 'e'    => ret(3 downto 0) := toSlv(14, 4);
-            when 'F'    => ret(3 downto 0) := toSlv(15, 4);
-            when 'f'    => ret(3 downto 0) := toSlv(15, 4);
-            when others => ret(3 downto 0) := toSlv(0, 4);
-         end case;
+         variable tmp  : string(1 to s'length) := resize(s, s'length);
+         variable char : character;
+         variable ret  : slv(s'length*4-1 downto 0);
+      begin
+         for i in tmp'range loop
+            ret(ret'high downto 4) := ret(ret'high-4 downto 0);
+            case tmp(i) is
+               when '0'    => ret(3 downto 0) := toSlv(0, 4);
+               when '1'    => ret(3 downto 0) := toSlv(1, 4);
+               when '2'    => ret(3 downto 0) := toSlv(2, 4);
+               when '3'    => ret(3 downto 0) := toSlv(3, 4);
+               when '4'    => ret(3 downto 0) := toSlv(4, 4);
+               when '5'    => ret(3 downto 0) := toSlv(5, 4);
+               when '6'    => ret(3 downto 0) := toSlv(6, 4);
+               when '7'    => ret(3 downto 0) := toSlv(7, 4);
+               when '8'    => ret(3 downto 0) := toSlv(8, 4);
+               when '9'    => ret(3 downto 0) := toSlv(9, 4);
+               when 'A'    => ret(3 downto 0) := toSlv(10, 4);
+               when 'a'    => ret(3 downto 0) := toSlv(10, 4);
+               when 'B'    => ret(3 downto 0) := toSlv(11, 4);
+               when 'b'    => ret(3 downto 0) := toSlv(11, 4);
+               when 'C'    => ret(3 downto 0) := toSlv(12, 4);
+               when 'c'    => ret(3 downto 0) := toSlv(12, 4);
+               when 'D'    => ret(3 downto 0) := toSlv(13, 4);
+               when 'd'    => ret(3 downto 0) := toSlv(13, 4);
+               when 'E'    => ret(3 downto 0) := toSlv(14, 4);
+               when 'e'    => ret(3 downto 0) := toSlv(14, 4);
+               when 'F'    => ret(3 downto 0) := toSlv(15, 4);
+               when 'f'    => ret(3 downto 0) := toSlv(15, 4);
+               when others => ret(3 downto 0) := toSlv(0, 4);
+            end case;
 
-      end loop;
-      return ret;
+         end loop;
+         return ret;
 
-   end function;
+      end function;
 
-   procedure sendString (
-      s : in string) is
-   begin
-      print("Sending: " & s);
-      wait until clk = '1';
-      wait until clk = '1';
-
-      for i in s'range loop
-         wrData  <= toSlv(character'pos(s(i)), 8);
-         wrValid <= '1';
+      procedure sendString (
+         s : in string) is
+      begin
+         print("Sending: " & s);
          wait until clk = '1';
-
-         if (wrReady = '1') then
-            wrValid <= '0';
+         wait until clk = '1';         
+         
+         for i in s'range loop
+            wrData  <= toSlv(character'pos(s(i)), 8);
+            wrValid <= '1';
             wait until clk = '1';
-         else
-            wait until clk = '1';
-            while (wrReady = '0') loop
+            
+            if (wrReady = '1') then
+               wrValid <= '0';
                wait until clk = '1';
-            end loop;
+            else
+               wait until clk = '1';                              
+               while (wrReady = '0') loop
+                  wait until clk = '1';
+               end loop;
 
-            wrValid <= '0';
-            wait until clk = '1';
-         end if;
-      end loop;
-   end procedure sendString;
-
-   procedure receiveString (
-      s : inout string)
-   is
-      variable i : integer := 1;
-   begin
-      while (true) loop
-         wait until clk = '1';
-         if (rdValid = '1') then
-            s(i) := character'val(conv_integer(rdData));
-            if (s(i) = CR or s(i) = LF) then
-               exit;
+               wrValid <= '0';
+               wait until clk = '1';
             end if;
-            i := i+1;
-         end if;
-      end loop;
-      print("Received: " & s);
+         end loop;
+      end procedure sendString;
 
-   end procedure receiveString;
+      procedure receiveString (
+         s : inout string)
+      is
+         variable i : integer := 1;
+      begin
+         while (true) loop
+            wait until clk = '1';
+            if (rdValid = '1') then
+               s(i) := character'val(conv_integer(rdData));
+               if (s(i) = CR or s(i) = LF) then
+                  exit;
+               end if;
+               i:=i+1;
+            end if;
+         end loop;
+         print("Received: " & s);
 
-   procedure uartRegWrite (
-      wrAddr : in slv(31 downto 0);
-      wrData : in slv(31 downto 0))
-   is
-      variable s     : string(1 to 20);
-      variable reply : string(1 to 24);
-   begin
-      s := "W " & hstr(wrAddr) & " " & hstr(wrData) & CR;
-      sendString(s);
-      receiveString(reply);
-   end procedure uartRegWrite;
+      end procedure receiveString;
 
-   procedure uartRegRead (
-      rdAddr : in    slv(31 downto 0);
-      rdData : inout slv(31 downto 0))
-   is
-      variable s     : string(1 to 11);
-      variable reply : string(1 to 30);
-      variable tmp   : integer;
-   begin
-      s      := "R " & hstr(rdAddr) & CR;
-      sendString(s);
-      receiveString(reply);
-      tmp    := int(reply(12 to 19), 16);
-      print(reply(12 to 19));
-      print(str(tmp));
-      rdData := toSlv(tmp, 32);
-      print("Read Data: " & hstr(rdData));
-   end procedure;
+      procedure uartRegWrite (
+         wrAddr : in slv(31 downto 0);
+         wrData : in slv(31 downto 0))
+      is
+         variable s     : string(1 to 20);
+         variable reply : string(1 to 24);
+      begin
+         s := "W " & hstr(wrAddr) & " " & hstr(wrData) & CR;
+         sendString(s);
+         receiveString(reply);
+      end procedure uartRegWrite;
 
-   variable addr : slv(31 downto 0);
-   variable data : slv(31 downto 0);
+      procedure uartRegRead (
+         rdAddr : in    slv(31 downto 0);
+         rdData : inout slv(31 downto 0))
+      is
+         variable s     : string(1 to 11);
+         variable reply : string(1 to 30);
+         variable tmp : integer;
+      begin
+         s      := "R " & hstr(rdAddr) & CR;
+         sendString(s);
+         receiveString(reply);
+         tmp := int(reply(12 to 19), 16);
+         print(reply(12 to 19));
+         print(str(tmp));
+         rdData := toSlv(tmp, 32);
+         print("Read Data: " & hstr(rdData));
+      end procedure;
+
+      variable addr : slv(31 downto 0);
+      variable data : slv(31 downto 0);
    begin
       wait until rst = '1';
       wait until rst = '0';
@@ -261,9 +252,9 @@ begin
       wait until clk = '1';
 
       uartRegWrite(X"12345670", X"08765432");
-      uartRegWrite(X"03030300", X"12345678");
+      uartRegWrite(X"03030300", X"12345678");      
       uartRegRead(X"12345670", data);
-      uartRegRead(X"03030300", data);
+      uartRegRead(X"03030300", data);      
 
 
    end process test;

--- a/protocols/uart/sim/UartAxiLiteMasterTb.vhd
+++ b/protocols/uart/sim/UartAxiLiteMasterTb.vhd
@@ -2,7 +2,7 @@
 -- File       : UartAxiLiteMasterTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-06-27
--- Last update: 2016-06-28
+-- Last update: 2018-06-09
 -------------------------------------------------------------------------------
 -- Description: Testbench for design "UartAxiLiteMaster"
 -------------------------------------------------------------------------------
@@ -38,6 +38,9 @@ architecture sim of UartAxiLiteMasterTb is
    constant TPD_G             : time                  := 1 ns;
    constant CLK_FREQ_G        : real                  := 125.0e6;
    constant BAUD_RATE_G       : integer               := 115200;
+   constant STOP_BITS_G       : integer range 1 to 2  := 1;
+   constant PARITY_G          : string                := "NONE";  -- "NONE" "ODD" "EVEN"
+   constant DATA_WIDTH_G      : integer range 5 to 8  := 8;
    constant FIFO_BRAM_EN_G    : boolean               := false;
    constant FIFO_ADDR_WIDTH_G : integer range 4 to 48 := 5;
 
@@ -77,6 +80,9 @@ begin
          TPD_G             => TPD_G,
          CLK_FREQ_G        => CLK_FREQ_G,
          BAUD_RATE_G       => BAUD_RATE_G,
+         STOP_BITS_G       => STOP_BITS_G,
+         PARITY_G          => PARITY_G,
+         DATA_WIDTH_G      => DATA_WIDTH_G,
          FIFO_BRAM_EN_G    => FIFO_BRAM_EN_G,
          FIFO_ADDR_WIDTH_G => FIFO_ADDR_WIDTH_G)
       port map (
@@ -97,6 +103,9 @@ begin
          TPD_G             => TPD_G,
          AXIL_CLK_FREQ_G   => CLK_FREQ_G,
          BAUD_RATE_G       => BAUD_RATE_G,
+         STOP_BITS_G       => STOP_BITS_G,
+         PARITY_G          => PARITY_G,
+         DATA_WIDTH_G      => DATA_WIDTH_G,
          FIFO_BRAM_EN_G    => FIFO_BRAM_EN_G,
          FIFO_ADDR_WIDTH_G => FIFO_ADDR_WIDTH_G)
       port map (
@@ -130,121 +139,121 @@ begin
 
    test : process is
       function hexStrToSlv (s : string) return slv is
-         variable tmp  : string(1 to s'length) := resize(s, s'length);
-         variable char : character;
-         variable ret  : slv(s'length*4-1 downto 0);
-      begin
-         for i in tmp'range loop
-            ret(ret'high downto 4) := ret(ret'high-4 downto 0);
-            case tmp(i) is
-               when '0'    => ret(3 downto 0) := toSlv(0, 4);
-               when '1'    => ret(3 downto 0) := toSlv(1, 4);
-               when '2'    => ret(3 downto 0) := toSlv(2, 4);
-               when '3'    => ret(3 downto 0) := toSlv(3, 4);
-               when '4'    => ret(3 downto 0) := toSlv(4, 4);
-               when '5'    => ret(3 downto 0) := toSlv(5, 4);
-               when '6'    => ret(3 downto 0) := toSlv(6, 4);
-               when '7'    => ret(3 downto 0) := toSlv(7, 4);
-               when '8'    => ret(3 downto 0) := toSlv(8, 4);
-               when '9'    => ret(3 downto 0) := toSlv(9, 4);
-               when 'A'    => ret(3 downto 0) := toSlv(10, 4);
-               when 'a'    => ret(3 downto 0) := toSlv(10, 4);
-               when 'B'    => ret(3 downto 0) := toSlv(11, 4);
-               when 'b'    => ret(3 downto 0) := toSlv(11, 4);
-               when 'C'    => ret(3 downto 0) := toSlv(12, 4);
-               when 'c'    => ret(3 downto 0) := toSlv(12, 4);
-               when 'D'    => ret(3 downto 0) := toSlv(13, 4);
-               when 'd'    => ret(3 downto 0) := toSlv(13, 4);
-               when 'E'    => ret(3 downto 0) := toSlv(14, 4);
-               when 'e'    => ret(3 downto 0) := toSlv(14, 4);
-               when 'F'    => ret(3 downto 0) := toSlv(15, 4);
-               when 'f'    => ret(3 downto 0) := toSlv(15, 4);
-               when others => ret(3 downto 0) := toSlv(0, 4);
-            end case;
+      variable tmp            : string(1 to s'length) := resize(s, s'length);
+      variable char           : character;
+      variable ret            : slv(s'length*4-1 downto 0);
+   begin
+      for i in tmp'range loop
+         ret(ret'high downto 4) := ret(ret'high-4 downto 0);
+         case tmp(i) is
+            when '0'    => ret(3 downto 0) := toSlv(0, 4);
+            when '1'    => ret(3 downto 0) := toSlv(1, 4);
+            when '2'    => ret(3 downto 0) := toSlv(2, 4);
+            when '3'    => ret(3 downto 0) := toSlv(3, 4);
+            when '4'    => ret(3 downto 0) := toSlv(4, 4);
+            when '5'    => ret(3 downto 0) := toSlv(5, 4);
+            when '6'    => ret(3 downto 0) := toSlv(6, 4);
+            when '7'    => ret(3 downto 0) := toSlv(7, 4);
+            when '8'    => ret(3 downto 0) := toSlv(8, 4);
+            when '9'    => ret(3 downto 0) := toSlv(9, 4);
+            when 'A'    => ret(3 downto 0) := toSlv(10, 4);
+            when 'a'    => ret(3 downto 0) := toSlv(10, 4);
+            when 'B'    => ret(3 downto 0) := toSlv(11, 4);
+            when 'b'    => ret(3 downto 0) := toSlv(11, 4);
+            when 'C'    => ret(3 downto 0) := toSlv(12, 4);
+            when 'c'    => ret(3 downto 0) := toSlv(12, 4);
+            when 'D'    => ret(3 downto 0) := toSlv(13, 4);
+            when 'd'    => ret(3 downto 0) := toSlv(13, 4);
+            when 'E'    => ret(3 downto 0) := toSlv(14, 4);
+            when 'e'    => ret(3 downto 0) := toSlv(14, 4);
+            when 'F'    => ret(3 downto 0) := toSlv(15, 4);
+            when 'f'    => ret(3 downto 0) := toSlv(15, 4);
+            when others => ret(3 downto 0) := toSlv(0, 4);
+         end case;
 
-         end loop;
-         return ret;
+      end loop;
+      return ret;
 
-      end function;
+   end function;
 
-      procedure sendString (
-         s : in string) is
-      begin
-         print("Sending: " & s);
+   procedure sendString (
+      s : in string) is
+   begin
+      print("Sending: " & s);
+      wait until clk = '1';
+      wait until clk = '1';
+
+      for i in s'range loop
+         wrData  <= toSlv(character'pos(s(i)), 8);
+         wrValid <= '1';
          wait until clk = '1';
-         wait until clk = '1';         
-         
-         for i in s'range loop
-            wrData  <= toSlv(character'pos(s(i)), 8);
-            wrValid <= '1';
+
+         if (wrReady = '1') then
+            wrValid <= '0';
             wait until clk = '1';
-            
-            if (wrReady = '1') then
-               wrValid <= '0';
-               wait until clk = '1';
-            else
-               wait until clk = '1';                              
-               while (wrReady = '0') loop
-                  wait until clk = '1';
-               end loop;
-
-               wrValid <= '0';
-               wait until clk = '1';
-            end if;
-         end loop;
-      end procedure sendString;
-
-      procedure receiveString (
-         s : inout string)
-      is
-         variable i : integer := 1;
-      begin
-         while (true) loop
+         else
             wait until clk = '1';
-            if (rdValid = '1') then
-               s(i) := character'val(conv_integer(rdData));
-               if (s(i) = CR or s(i) = LF) then
-                  exit;
-               end if;
-               i:=i+1;
+            while (wrReady = '0') loop
+               wait until clk = '1';
+            end loop;
+
+            wrValid <= '0';
+            wait until clk = '1';
+         end if;
+      end loop;
+   end procedure sendString;
+
+   procedure receiveString (
+      s : inout string)
+   is
+      variable i : integer := 1;
+   begin
+      while (true) loop
+         wait until clk = '1';
+         if (rdValid = '1') then
+            s(i) := character'val(conv_integer(rdData));
+            if (s(i) = CR or s(i) = LF) then
+               exit;
             end if;
-         end loop;
-         print("Received: " & s);
+            i := i+1;
+         end if;
+      end loop;
+      print("Received: " & s);
 
-      end procedure receiveString;
+   end procedure receiveString;
 
-      procedure uartRegWrite (
-         wrAddr : in slv(31 downto 0);
-         wrData : in slv(31 downto 0))
-      is
-         variable s     : string(1 to 20);
-         variable reply : string(1 to 24);
-      begin
-         s := "W " & hstr(wrAddr) & " " & hstr(wrData) & CR;
-         sendString(s);
-         receiveString(reply);
-      end procedure uartRegWrite;
+   procedure uartRegWrite (
+      wrAddr : in slv(31 downto 0);
+      wrData : in slv(31 downto 0))
+   is
+      variable s     : string(1 to 20);
+      variable reply : string(1 to 24);
+   begin
+      s := "W " & hstr(wrAddr) & " " & hstr(wrData) & CR;
+      sendString(s);
+      receiveString(reply);
+   end procedure uartRegWrite;
 
-      procedure uartRegRead (
-         rdAddr : in    slv(31 downto 0);
-         rdData : inout slv(31 downto 0))
-      is
-         variable s     : string(1 to 11);
-         variable reply : string(1 to 30);
-         variable tmp : integer;
-      begin
-         s      := "R " & hstr(rdAddr) & CR;
-         sendString(s);
-         receiveString(reply);
-         tmp := int(reply(12 to 19), 16);
-         print(reply(12 to 19));
-         print(str(tmp));
-         rdData := toSlv(tmp, 32);
-         print("Read Data: " & hstr(rdData));
-      end procedure;
+   procedure uartRegRead (
+      rdAddr : in    slv(31 downto 0);
+      rdData : inout slv(31 downto 0))
+   is
+      variable s     : string(1 to 11);
+      variable reply : string(1 to 30);
+      variable tmp   : integer;
+   begin
+      s      := "R " & hstr(rdAddr) & CR;
+      sendString(s);
+      receiveString(reply);
+      tmp    := int(reply(12 to 19), 16);
+      print(reply(12 to 19));
+      print(str(tmp));
+      rdData := toSlv(tmp, 32);
+      print("Read Data: " & hstr(rdData));
+   end procedure;
 
-      variable addr : slv(31 downto 0);
-      variable data : slv(31 downto 0);
+   variable addr : slv(31 downto 0);
+   variable data : slv(31 downto 0);
    begin
       wait until rst = '1';
       wait until rst = '0';
@@ -252,9 +261,9 @@ begin
       wait until clk = '1';
 
       uartRegWrite(X"12345670", X"08765432");
-      uartRegWrite(X"03030300", X"12345678");      
+      uartRegWrite(X"03030300", X"12345678");
       uartRegRead(X"12345670", data);
-      uartRegRead(X"03030300", data);      
+      uartRegRead(X"03030300", data);
 
 
    end process test;


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

 Added generic for enabling the parity bit. 
   - PARITY_EN_G : integer range 0 to 1 := 0;

 Added generic for selecting parity.
   - PARITY_G     : string               := "NONE";
   - Options are: "NONE", "EVEN", "ODD"

 Added generic for selecting data-width of 5, 6, 7, or 8.
   - DATA_WIDTH_G : integer range 5 to 8 := 8;

 Added extra state (PARITY_S) in UartRX.vhd for parity checking. 


