### PR TITLE
Add 'saci' to naming of things to avoid name conflicts

### DIFF
--- a/protocols/saci/sim/FrontEndSaciAnalogTb.vhd
+++ b/protocols/saci/sim/FrontEndSaciAnalogTb.vhd
@@ -2,7 +2,7 @@
 -- File       : FrontEndSaciAnalogTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2012-10-02
--- Last update: 2013-03-01
+-- Last update: 2018-05-16
 -------------------------------------------------------------------------------
 -- Description: Simple Saci testbench with Saci Master connected to the
 -- standard Front End Register interface.
@@ -19,7 +19,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use work.StdRtlPkg.all;
-use work.FrontEndPkg.all;
+use work.FrontEndSaciPkg.all;
 use work.SaciMasterPkg.all;
 
 entity FrontEndSaciAnalogTb is
@@ -39,8 +39,8 @@ architecture testbench of FrontEndSaciAnalogTb is
   signal saciRst   : sl;
 
   -- Front End Register Interface
-  signal frontEndRegCntlIn  : FrontEndRegCntlInType;
-  signal frontEndRegCntlOut : FrontEndRegCntlOutType;
+  signal frontEndRegCntlIn  : FrontEndSaciRegCntlInType;
+  signal frontEndRegCntlOut : FrontEndSaciRegCntlOutType;
 
   -- SACI Master Parallel Interface
   signal saciMasterIn  : SaciMasterInType;
@@ -132,7 +132,7 @@ begin
       pgpTxP       => open);
 
   -- Register Decoder
-  FrontEndRegDecoder_1 : entity work.FrontEndRegDecoder
+  FrontEndSaciRegDecoder_1 : entity work.FrontEndSaciRegDecoder
     generic map (
       DELAY_G => TPD_C)
     port map (

--- a/protocols/saci/sim/FrontEndSaciPkg.vhd
+++ b/protocols/saci/sim/FrontEndSaciPkg.vhd
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------------------
--- File       : FrontEndPkg.vhd
+-- File       : FrontEndSaciPkg.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2012-05-03
 -- Last update: 2012-09-26
@@ -19,41 +19,41 @@ library ieee;
 use ieee.std_logic_1164.all;
 use work.StdRtlPkg.all;
 
-package FrontEndPkg is
+package FrontEndSaciPkg is
 
   -- Register Interface
-  type FrontEndRegCntlInType is record
+  type FrontEndSaciRegCntlInType is record
     regAck    : sl;
     regFail   : sl;
     regDataIn : slv(31 downto 0);
-  end record FrontEndRegCntlInType;
+  end record;
 
-  type FrontEndRegCntlOutType is record
+  type FrontEndSaciRegCntlOutType is record
     regInp     : sl;                    -- Operation in progress
     regReq     : sl;                    -- Request reg transaction
     regOp      : sl;                    -- Read (0) or write (1)
     regAddr    : slv(23 downto 0);      -- Address
     regDataOut : slv(31 downto 0);      -- Write Data
-  end record FrontEndRegCntlOutType;
+  end record;
 
   -- Command Interface
-  type FrontEndCmdCntlOutType is record
+  type FrontEndSaciCmdCntlOutType is record
     cmdEn     : sl;                     -- Command available
     cmdOpCode : slv(7 downto 0);        -- Command Op Code
     cmdCtxOut : slv(23 downto 0);       -- Command Context
-  end record FrontEndCmdCntlOutType;
+  end record;
 
   -- Upstream Data Buffer Interface
-  type FrontEndUsDataOutType is record
+  type FrontEndSaciUsDataOutType is record
     frameTxAfull : sl;
-  end record FrontEndUsDataOutType;
+  end record;
 
-  type FrontEndUsDataInType is record
+  type FrontEndSaciUsDataInType is record
     frameTxEnable : sl;
     frameTxSOF    : sl;
     frameTxEOF    : sl;
     frameTxEOFE   : sl;
     frameTxData   : slv(63 downto 0);
-  end record FrontEndUsDataInType;
+  end record;
 
-end package FrontEndPkg;
+end package FrontEndSaciPkg;

--- a/protocols/saci/sim/FrontEndSaciRegDecoder.vhd
+++ b/protocols/saci/sim/FrontEndSaciRegDecoder.vhd
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------------------
--- File       : FrontEndRegDecoder.vhd
+-- File       : FrontEndSaciRegDecoder.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2012-05-07
--- Last update: 2013-03-05
+-- Last update: 2018-05-16
 -------------------------------------------------------------------------------
 -- Description: Decodes register addresses from the Front End interface.
 -------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ use work.Version.all;
 use work.FrontEndPkg.all;
 use work.SaciMasterPkg.all;
 
-entity FrontEndRegDecoder is
+entity FrontEndSaciRegDecoder is
   
   generic (
     DELAY_G : time := 1 ns);
@@ -41,9 +41,9 @@ entity FrontEndRegDecoder is
     saciMasterIn  : out SaciMasterInType;
     saciMasterOut : in  SaciMasterOutType);
 
-end entity FrontEndRegDecoder;
+end entity FrontEndSaciRegDecoder;
 
-architecture rtl of FrontEndRegDecoder is
+architecture rtl of FrontEndSaciRegDecoder is
 
   constant FRONT_END_REG_WRITE_C : sl := '1';
   constant FRONT_END_REG_READ_C  : sl := '0';

--- a/protocols/saci/sim/FrontEndSaciTb.vhd
+++ b/protocols/saci/sim/FrontEndSaciTb.vhd
@@ -2,7 +2,7 @@
 -- File       : FrontEndSaciTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2012-10-02
--- Last update: 2013-03-01
+-- Last update: 2018-05-16
 -------------------------------------------------------------------------------
 -- Description: Simple Saci testbench with Saci Master connected to the
 -- standard Front End Register interface.
@@ -19,7 +19,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use work.StdRtlPkg.all;
-use work.FrontEndPkg.all;
+use work.FrontEndSaciPkg.all;
 use work.SaciMasterPkg.all;
 
 entity FrontEndSaciTb is
@@ -39,8 +39,8 @@ architecture testbench of FrontEndSaciTb is
   signal saciRst   : sl;
 
   -- Front End Register Interface
-  signal frontEndRegCntlIn : FrontEndRegCntlInType;
-  signal frontEndRegCntlOut : FrontEndRegCntlOutType;
+  signal frontEndRegCntlIn : FrontEndSaciRegCntlInType;
+  signal frontEndRegCntlOut : FrontEndSaciRegCntlOutType;
 
   -- SACI Master Parallel Interface
   signal saciMasterIn  : SaciMasterInType;
@@ -132,7 +132,7 @@ begin
       pgpTxP       => open);
 
   -- Register Decoder
-  FrontEndRegDecoder_1: entity work.FrontEndRegDecoder
+  FrontEndSaciRegDecoder_1: entity work.FrontEndSaciRegDecoder
     generic map (
       DELAY_G => TPD_C)
     port map (


### PR DESCRIPTION
### Description
Generic 'FrontEnd*' module namers were conflicting with module names in another project

This code is probably way out of date and not working anyway, but for now we'll just change the module names to avoid conflicts.