### PR TITLE
Update to SRV3AxiLite

### DIFF
--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -306,7 +306,7 @@ begin
       end if;
 
       -- Check for overflow
-      if (rxCtrl.overflow = '1') and (r.rxRst = '0') and (GEN_SYNC_FIFO_G = false) then
+      if (rxCtrl.overflow = '1') and (r.rxRst = '0') and (SLAVE_READY_EN_G = false) then
          -- Set the flag
          v.overflowDet := '1';
       end if;


### PR DESCRIPTION
### Description
overflow is only necessary if you are using pause for flow control.  
I wass intended to be SLAVE_READY_EN_G from  PR #227
