### PR TITLE
Add xvcSrv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swp
 *._*
 *.db
+xvcSrv


### PR DESCRIPTION
### Description
Compiled xvcSrv binary causes dirty build flag if not ignored by git.

