### PR TITLE
GTX7's QPLL Bug Fix

### DIFF
--- a/xilinx/7Series/gtx7/rtl/Gtx7QuadPll.vhd
+++ b/xilinx/7Series/gtx7/rtl/Gtx7QuadPll.vhd
@@ -147,7 +147,7 @@ begin
          BGBYPASSB        => '1',
          BGMONITORENB     => '1',
          BGPDB            => '1',
-         BGRCALOVRD       => "00000",
+         BGRCALOVRD       => "11111",
          PMARSVD          => "00000000",
          RCALENB          => '1');
 


### PR DESCRIPTION
### Description
Based on UG476 (v1.12), setting BGRCALOVRD to 5'b11111
"Reserved. This port must be set to 5'b11111. This value should not be modified."
