### PR TITLE
Fix mismatched function declaration

### DIFF
--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiLitePkg.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-04-02
--- Last update: 2018-01-29
+-- Last update: 2018-08-17
 -------------------------------------------------------------------------------
 -- Description: AXI-Lite Package File
 -------------------------------------------------------------------------------
@@ -388,8 +388,8 @@ package AxiLitePkg is
    -- Generate evenly distributed address map
    function genAxiLiteConfig (num      : positive;
                               base     : slv(31 downto 0);
-                              baseBot  : integer range 0 to 32;
-                              addrBits : integer range 0 to 32)
+                              baseBot  : integer range 1 to 32;
+                              addrBits : integer range 0 to 31)
       return AxiLiteCrossbarMasterConfigArray;
 
 


### PR DESCRIPTION
### Description
This was introduced in commit 83b7079d5fa58c81fe83ca9ac60944305b69bebf, #260. 

Xilinx synthesis doesn't report it as an error, so no one noticed until I tried to simulate it.

### Related
#260 