### PR TITLE
exposing ETH pause generic configurations

### DIFF
--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGth7.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gth7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGth7 is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -125,9 +127,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -188,7 +192,7 @@ begin
          gt0_qplloutclk_in      => '0',        -- QPLL not used
          gt0_qplloutrefclk_in   => '0',        -- QPLL not used
          -- Configuration and Status
-         an_restart_config      => '0',         
+         an_restart_config      => '0',
          an_adv_config_vector   => GIG_ETH_AN_ADV_CONFIG_INIT_C,
          an_interrupt           => open,
          configuration_vector   => config.coreConfig,
@@ -203,8 +207,8 @@ begin
    --------------------------------     
    U_GigEthReg : entity work.GigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGth7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gth7 Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGth7Wrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -73,7 +75,7 @@ entity GigEthGth7Wrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end GigEthGth7Wrapper;
 
 architecture mapping of GigEthGth7Wrapper is
@@ -102,7 +104,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => open,
-         O     => gtClk);    
+         O     => gtClk);
 
    BUFG_Inst : BUFG
       port map (
@@ -120,7 +122,7 @@ begin
       port map (
          arst   => extRst,
          clk    => refClk,
-         rstOut => refRst);   
+         rstOut => refRst);
 
    ----------------
    -- Clock Manager
@@ -146,21 +148,23 @@ begin
          clkOut(0) => sysClk125,
          clkOut(1) => sysClk62,
          rstOut(0) => sysRst125,
-         rstOut(1) => sysRst62); 
+         rstOut(1) => sysRst62);
 
    --------------
    -- GigE Module 
    --------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       U_GigEthGth7 : entity work.GigEthGth7
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))   
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -189,7 +193,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gth7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGthUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -125,9 +127,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -184,7 +188,7 @@ begin
          rxp                    => gtRxP,
          rxn                    => gtRxN,
          -- Configuration and Status
-         an_restart_config      => '0',         
+         an_restart_config      => '0',
          an_adv_config_vector   => GIG_ETH_AN_ADV_CONFIG_INIT_C,
          an_interrupt           => open,
          configuration_vector   => config.coreConfig,
@@ -199,8 +203,8 @@ begin
    --------------------------------     
    U_GigEthReg : entity work.GigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGthUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gth7 Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGthUltraScaleWrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -73,7 +75,7 @@ entity GigEthGthUltraScaleWrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end GigEthGthUltraScaleWrapper;
 
 architecture mapping of GigEthGthUltraScaleWrapper is
@@ -105,7 +107,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => gtClk,
-         O     => open);  
+         O     => open);
 
    BUFG_GT_Inst : BUFG_GT
       port map (
@@ -128,7 +130,7 @@ begin
       port map (
          arst   => extRst,
          clk    => refClk,
-         rstOut => refRst);   
+         rstOut => refRst);
 
    ----------------
    -- Clock Manager
@@ -154,21 +156,23 @@ begin
          clkOut(0) => sysClk125,
          clkOut(1) => sysClk62,
          rstOut(0) => sysRst125,
-         rstOut(1) => sysRst62); 
+         rstOut(1) => sysRst62);
 
    --------------
    -- GigE Module 
    --------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       U_GigEthGthUltraScale : entity work.GigEthGthUltraScale
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))   
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -197,7 +201,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-07
--- Last update: 2018-07-24
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gth7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGthUltraScale is
    generic (
-      TPD_G         : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G  : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -176,9 +178,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGthUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gth7 Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGthUltraScaleWrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -73,7 +75,7 @@ entity GigEthGthUltraScaleWrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end GigEthGthUltraScaleWrapper;
 
 architecture mapping of GigEthGthUltraScaleWrapper is
@@ -105,7 +107,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => gtClk,
-         O     => open);  
+         O     => open);
 
    BUFG_GT_Inst : BUFG_GT
       port map (
@@ -128,7 +130,7 @@ begin
       port map (
          arst   => extRst,
          clk    => refClk,
-         rstOut => refRst);   
+         rstOut => refRst);
 
    ----------------
    -- Clock Manager
@@ -154,21 +156,23 @@ begin
          clkOut(0) => sysClk125,
          clkOut(1) => sysClk62,
          rstOut(0) => sysRst125,
-         rstOut(1) => sysRst62); 
+         rstOut(1) => sysRst62);
 
    --------------
    -- GigE Module 
    --------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       U_GigEthGthUltraScale : entity work.GigEthGthUltraScale
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))   
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -197,7 +201,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtp7.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gtp7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGtp7 is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -131,9 +133,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -199,7 +203,7 @@ begin
          gt0_pll1outclk_in      => qPllOutClk(1),
          gt0_pll1outrefclk_in   => qPllOutRefClk(1),
          -- Configuration and Status
-         an_restart_config      => '0',         
+         an_restart_config      => '0',
          an_adv_config_vector   => GIG_ETH_AN_ADV_CONFIG_INIT_C,
          an_interrupt           => open,
          configuration_vector   => config.coreConfig,
@@ -215,8 +219,8 @@ begin
    --------------------------------     
    U_GigEthReg : entity work.GigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtp7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-08-20
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gtp7 Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGtp7Wrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -194,11 +196,13 @@ begin
 
       U_GigEthGtp7 : entity work.GigEthGtp7
          generic map (
-            TPD_G         => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G  => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtx7.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-02-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gtx7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGtx7 is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -125,9 +127,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -188,7 +192,7 @@ begin
          gt0_qplloutclk_in      => '0',        -- QPLL not used
          gt0_qplloutrefclk_in   => '0',        -- QPLL not used
          -- Configuration and Status
-         an_restart_config      => '0',         
+         an_restart_config      => '0',
          an_adv_config_vector   => GIG_ETH_AN_ADV_CONFIG_INIT_C,
          an_interrupt           => open,
          configuration_vector   => config.coreConfig,
@@ -203,8 +207,8 @@ begin
    --------------------------------     
    U_GigEthReg : entity work.GigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtx7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gtx7 Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGtx7Wrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -73,7 +75,7 @@ entity GigEthGtx7Wrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end GigEthGtx7Wrapper;
 
 architecture mapping of GigEthGtx7Wrapper is
@@ -102,7 +104,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => open,
-         O     => gtClk);    
+         O     => gtClk);
 
    BUFG_Inst : BUFG
       port map (
@@ -120,7 +122,7 @@ begin
       port map (
          arst   => extRst,
          clk    => refClk,
-         rstOut => refRst);   
+         rstOut => refRst);
 
    ----------------
    -- Clock Manager
@@ -146,21 +148,23 @@ begin
          clkOut(0) => sysClk125,
          clkOut(1) => sysClk62,
          rstOut(0) => sysRst125,
-         rstOut(1) => sysRst62); 
+         rstOut(1) => sysRst62);
 
    --------------
    -- GigE Module 
    --------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       U_GigEthGtx7 : entity work.GigEthGtx7
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))   
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -189,7 +193,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtyUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-04-05
--- Last update: 2018-04-05
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 1000BASE-X Ethernet for Gty
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.GigEthPkg.all;
 
 entity GigEthGtyUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -125,9 +127,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "GMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "GMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -184,7 +188,7 @@ begin
          rxp                    => gtRxP,
          rxn                    => gtRxN,
          -- Configuration and Status
-         an_restart_config      => '0',         
+         an_restart_config      => '0',
          an_adv_config_vector   => GIG_ETH_AN_ADV_CONFIG_INIT_C,
          an_interrupt           => open,
          configuration_vector   => config.coreConfig,
@@ -199,8 +203,8 @@ begin
    --------------------------------     
    U_GigEthReg : entity work.GigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : GigEthGtyUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-04-05
--- Last update: 2018-04-05
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gty Wrapper for 1000BASE-X Ethernet
 -- Note: This module supports up to a MGT QUAD of 1GigE interfaces
@@ -32,6 +32,8 @@ entity GigEthGtyUltraScaleWrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      PAUSE_EN_G         : boolean                          := true;
+      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -164,11 +166,13 @@ begin
 
       U_GigEthGtyUltraScale : entity work.GigEthGtyUltraScale
          generic map (
-            TPD_G         => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G  => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),

--- a/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScaleWrapper.vhd
@@ -27,18 +27,20 @@ use unisim.vcomponents.all;
 
 entity GigEthLvdsUltraScaleWrapper is
    generic (
-      TPD_G              : time                             := 1 ns;
-      NUM_LANE_G         : natural range 1 to 4             := 1;
+      TPD_G             : time                             := 1 ns;
+      NUM_LANE_G        : natural range 1 to 4             := 1;
+      PAUSE_EN_G        : boolean                          := true;
+      PAUSE_512BITS_G   : positive                         := 8;
       -- Clocking Configurations
-      USE_REFCLK_G       : boolean                          := false;  --  FALSE: sgmiiClkP/N,  TRUE: sgmiiRefClk
-      CLKIN_PERIOD_G     : real                             := 1.6;
-      DIVCLK_DIVIDE_G    : positive                         := 2;
-      CLKFBOUT_MULT_F_G  : real                             := 2.0;
+      USE_REFCLK_G      : boolean                          := false;  --  FALSE: sgmiiClkP/N,  TRUE: sgmiiRefClk
+      CLKIN_PERIOD_G    : real                             := 1.6;
+      DIVCLK_DIVIDE_G   : positive                         := 2;
+      CLKFBOUT_MULT_F_G : real                             := 2.0;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G       : boolean                          := false;
+      EN_AXI_REG_G      : boolean                          := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G      : AxiStreamConfigArray(3 downto 0) := (others => AXI_STREAM_CONFIG_INIT_C)
-   );
+      AXIS_CONFIG_G     : AxiStreamConfigArray(3 downto 0) := (others => AXI_STREAM_CONFIG_INIT_C)
+      );
    port (
       -- Local Configurations
       localMac            : in  Slv48Array(NUM_LANE_G-1 downto 0)              := (others => MAC_ADDR_INIT_C);
@@ -74,7 +76,7 @@ entity GigEthLvdsUltraScaleWrapper is
       sgmiiTxN            : out slv(NUM_LANE_G-1 downto 0);
       sgmiiRxP            : in  slv(NUM_LANE_G-1 downto 0);
       sgmiiRxN            : in  slv(NUM_LANE_G-1 downto 0)
-   );
+      );
 end GigEthLvdsUltraScaleWrapper;
 
 architecture mapping of GigEthLvdsUltraScaleWrapper is
@@ -82,26 +84,26 @@ architecture mapping of GigEthLvdsUltraScaleWrapper is
    -- reset is asserted for 2*RST_DURATION_C
    constant RST_DURATION_C : natural range 0 to ((2**30)-1) := 156250000;
 
-   constant NUM_CLOCKS_C   : natural := 3;
+   constant NUM_CLOCKS_C : natural := 3;
 
-   signal sgmiiClk     : sl;
-   signal refClk       : sl;
-   signal refRst       : sl := '1';
-   signal sysClk12NB   : sl;
-   signal sysClk125    : sl;
-   signal sysRst125    : sl;
-   signal sysClk312    : sl;
-   signal sysRst312    : sl;
-   signal sysClk625    : sl;
-   signal sysRst625    : sl;
-   signal sysClkNB     : slv(6 downto 0);
-   signal sysClkB      : slv(6 downto 0);
-   signal sysRst       : slv(6 downto 0);
-   signal locked       : sl;
-   signal clkFb        : sl;
-   signal extRstSync   : sl;
-   signal refCE        : sl := '0';
-   signal refRstCnt    : natural range 0 to RST_DURATION_C := RST_DURATION_C;
+   signal sgmiiClk   : sl;
+   signal refClk     : sl;
+   signal refRst     : sl                                := '1';
+   signal sysClk12NB : sl;
+   signal sysClk125  : sl;
+   signal sysRst125  : sl;
+   signal sysClk312  : sl;
+   signal sysRst312  : sl;
+   signal sysClk625  : sl;
+   signal sysRst625  : sl;
+   signal sysClkNB   : slv(6 downto 0);
+   signal sysClkB    : slv(6 downto 0);
+   signal sysRst     : slv(6 downto 0);
+   signal locked     : sl;
+   signal clkFb      : sl;
+   signal extRstSync : sl;
+   signal refCE      : sl                                := '0';
+   signal refRstCnt  : natural range 0 to RST_DURATION_C := RST_DURATION_C;
 
 begin
 
@@ -113,14 +115,14 @@ begin
    -----------------------------
    IBUFGDS_SGMII : IBUFGDS
       generic map (
-         DIFF_TERM    => FALSE,
-         IBUF_LOW_PWR => FALSE
-      )
+         DIFF_TERM    => false,
+         IBUF_LOW_PWR => false
+         )
       port map (
-         I     => sgmiiClkP,
-         IB    => sgmiiClkN,
-         O     => sgmiiClk
-      );
+         I  => sgmiiClkP,
+         IB => sgmiiClkN,
+         O  => sgmiiClk
+         );
 
    refClk <= sgmiiClk when(USE_REFCLK_G = false) else sgmiiRefClk;
 
@@ -133,15 +135,15 @@ begin
    -----------------
    U_RstSync : entity work.RstSync
       generic map (
-         TPD_G           => TPD_G,
-         IN_POLARITY_G   => '1',
-         OUT_POLARITY_G  => '1'
-      )
+         TPD_G          => TPD_G,
+         IN_POLARITY_G  => '1',
+         OUT_POLARITY_G => '1'
+         )
       port map (
-         clk            => refClk,
-         asyncRst       => extRst,
-         syncRst        => extRstSync
-      );
+         clk      => refClk,
+         asyncRst => extRst,
+         syncRst  => extRstSync
+         );
 
    -- don't reset refCE in order to reduce possible
    -- timing problems. This leads to uncertainty of
@@ -149,21 +151,21 @@ begin
    -- an issue.
    process (refClk)
    begin
-      if ( rising_edge(refClk) ) then
+      if (rising_edge(refClk)) then
          refCE <= not refCE;
       end if;
    end process;
 
    process (refClk)
    begin
-      if ( rising_edge(refClk) ) then
-         if ( extRstSync = '1' ) then
+      if (rising_edge(refClk)) then
+         if (extRstSync = '1') then
             refRst    <= '1' after TPD_G;
-            refRstCnt <=  0  after TPD_G;
+            refRstCnt <= 0   after TPD_G;
          else
-            if ( refCE = '1' ) then
-               if ( refRstCnt = RST_DURATION_C ) then
-                  refRst    <= '0' after TPD_G;
+            if (refCE = '1') then
+               if (refRstCnt = RST_DURATION_C) then
+                  refRst <= '0' after TPD_G;
                else
                   refRstCnt <= refRstCnt + 1 after TPD_G;
                end if;
@@ -195,50 +197,50 @@ begin
    -- the BUFG in the feedback chain.
    U_MMCM : MMCME3_BASE
       generic map(
-         CLKOUT0_DIVIDE_F   => 5.0,
-         CLKOUT1_DIVIDE     => 2,
-         CLKOUT2_DIVIDE     => 1,
-         CLKOUT3_DIVIDE     => 50,
-         CLKOUT4_DIVIDE     => 50,
-         CLKOUT4_CASCADE    => "TRUE",
-         CLKOUT6_DIVIDE     => 10,
-         CLKFBOUT_MULT_F    => CLKFBOUT_MULT_F_G,
-         DIVCLK_DIVIDE      => DIVCLK_DIVIDE_G,
-         CLKIN1_PERIOD      => CLKIN_PERIOD_G
-      )
+         CLKOUT0_DIVIDE_F => 5.0,
+         CLKOUT1_DIVIDE   => 2,
+         CLKOUT2_DIVIDE   => 1,
+         CLKOUT3_DIVIDE   => 50,
+         CLKOUT4_DIVIDE   => 50,
+         CLKOUT4_CASCADE  => "TRUE",
+         CLKOUT6_DIVIDE   => 10,
+         CLKFBOUT_MULT_F  => CLKFBOUT_MULT_F_G,
+         DIVCLK_DIVIDE    => DIVCLK_DIVIDE_G,
+         CLKIN1_PERIOD    => CLKIN_PERIOD_G
+         )
       port map (
-         CLKIN1             => refClk,
-         RST                => refRst,
-         CLKFBIN            => clkFb,
-         CLKFBOUT           => clkFb,
-         CLKOUT0            => sysClkNB(0),
-         CLKOUT1            => sysClkNB(1),
-         CLKOUT2            => sysClkNB(2),
-         CLKOUT3            => sysClkNB(3),
-         CLKOUT4            => sysClkNB(4),
-         CLKOUT5            => sysClkNB(5),
-         CLKOUT6            => sysClkNB(6),
-         LOCKED             => locked,
-         PWRDWN             => '0'
-      );
+         CLKIN1   => refClk,
+         RST      => refRst,
+         CLKFBIN  => clkFb,
+         CLKFBOUT => clkFb,
+         CLKOUT0  => sysClkNB(0),
+         CLKOUT1  => sysClkNB(1),
+         CLKOUT2  => sysClkNB(2),
+         CLKOUT3  => sysClkNB(3),
+         CLKOUT4  => sysClkNB(4),
+         CLKOUT5  => sysClkNB(5),
+         CLKOUT6  => sysClkNB(6),
+         LOCKED   => locked,
+         PWRDWN   => '0'
+         );
 
    GEN_BUFG : for i in 0 to NUM_CLOCKS_C - 1 generate
       U_BUFG_125 : BUFG
          port map (
-            I                  => sysClkNB(i),
-            O                  => sysClkB(i)
-         );
+            I => sysClkNB(i),
+            O => sysClkB(i)
+            );
 
-      U_RESET    : entity work.RstSync
+      U_RESET : entity work.RstSync
          generic map (
-            TPD_G              => TPD_G,
-            IN_POLARITY_G      => '0'
-         )
+            TPD_G         => TPD_G,
+            IN_POLARITY_G => '0'
+            )
          port map (
-            clk                => sysClkB(i),
-            asyncRst           => locked,
-            syncRst            => sysRst(i)
-         );
+            clk      => sysClkB(i),
+            asyncRst => locked,
+            syncRst  => sysRst(i)
+            );
    end generate;
 
    sysClk125 <= sysClkB(0);
@@ -280,28 +282,30 @@ begin
             sel12p50 => speed_is_10_100(i),
             sel1p250 => speed_is_10,
             O        => ethClk
-         );
+            );
 
       -- Generate reset synchronous to the currently selected clock
-      U_RESET    : entity work.RstSync
+      U_RESET : entity work.RstSync
          generic map (
-            TPD_G              => TPD_G,
-            IN_POLARITY_G      => '0'
-         )
+            TPD_G         => TPD_G,
+            IN_POLARITY_G => '0'
+            )
          port map (
-            clk                => ethClk,
-            asyncRst           => locked,
-            syncRst            => ethRst
-         );
+            clk      => ethClk,
+            asyncRst => locked,
+            syncRst  => ethRst
+            );
 
       U_GigEthLvdsUltraScale : entity work.GigEthLvdsUltraScale
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i)
-         )
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i)
+            )
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -337,7 +341,7 @@ begin
             sgmiiTxN           => sgmiiTxN(i),
             sgmiiRxP           => sgmiiRxP(i),
             sgmiiRxN           => sgmiiRxN(i)
-         );
+            );
 
    end generate GEN_LANE;
 

--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGth7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gth7 Wrapper for 10GBASE-R Ethernet
 -- Note: This module supports up to a MGT QUAD of 10GigE interfaces
@@ -29,6 +29,8 @@ entity TenGigEthGth7Wrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      PAUSE_EN_G        : boolean                          := true;
+      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G     : boolean                          := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -71,7 +73,7 @@ entity TenGigEthGth7Wrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end TenGigEthGth7Wrapper;
 
 architecture mapping of TenGigEthGth7Wrapper is
@@ -99,7 +101,7 @@ begin
          TPD_G             => TPD_G,
          USE_GTREFCLK_G    => USE_GTREFCLK_G,
          REFCLK_DIV2_G     => REFCLK_DIV2_G,
-         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)         
+         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)
       port map (
          -- Clocks and Resets
          extRst        => extRst,
@@ -113,7 +115,7 @@ begin
          qplllock      => qplllock,
          qplloutclk    => qplloutclk,
          qplloutrefclk => qplloutrefclk,
-         qpllRst       => qpllReset);        
+         qpllRst       => qpllReset);
 
    qpllReset <= uOr(qpllRst) and not(qPllLock);
 
@@ -122,14 +124,16 @@ begin
    ----------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       TenGigEthGth7_Inst : entity work.TenGigEthGth7
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))       
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -164,7 +168,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-04-06
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10GBASE-R Ethernet for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.EthMacPkg.all;
 
 entity TenGigEthGthUltraScale is
    generic (
-      TPD_G         : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G  : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -234,9 +236,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10GBASE-R Ethernet for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.EthMacPkg.all;
 
 entity TenGigEthGthUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -247,9 +249,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -400,8 +404,8 @@ begin
    --------------------------------     
    U_TenGigEthReg : entity work.TenGigEthReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGthUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: GTH Ultra Scale Wrapper for 10GBASE-R Ethernet
 -- Note: This module supports up to a MGT QUAD of 10GigE interfaces
@@ -27,8 +27,10 @@ use work.TenGigEthPkg.all;
 
 entity TenGigEthGthUltraScaleWrapper is
    generic (
-      TPD_G             : time                             := 1 ns;    
+      TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      PAUSE_EN_G        : boolean                          := true;
+      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
@@ -78,7 +80,7 @@ entity TenGigEthGthUltraScaleWrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end TenGigEthGthUltraScaleWrapper;
 
 architecture mapping of TenGigEthGthUltraScaleWrapper is
@@ -108,7 +110,7 @@ begin
       port map (
          arst   => extRst,
          clk    => coreClock,
-         rstOut => coreReset);   
+         rstOut => coreReset);
 
    ----------------------
    -- Common Clock Module 
@@ -116,7 +118,7 @@ begin
    TenGigEthGthUltraScaleClk_Inst : entity work.TenGigEthGthUltraScaleClk
       generic map (
          TPD_G             => TPD_G,
-         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)         
+         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)
       port map (
          -- MGT Clock Port (156.25 MHz)
          gtRefClk      => gtRefClk,
@@ -129,7 +131,7 @@ begin
          qplllock      => qplllock,
          qplloutclk    => qplloutclk,
          qplloutrefclk => qplloutrefclk,
-         qpllRst       => qpllReset);            
+         qpllRst       => qpllReset);
 
    qpllReset <= uOr(qpllRst) and not(qPllLock);
 
@@ -138,14 +140,16 @@ begin
    ----------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       TenGigEthGthUltraScale_Inst : entity work.TenGigEthGthUltraScale
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))       
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -187,7 +191,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGtx7.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-02-12
--- Last update: 2018-07-30
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10GBASE-R Ethernet for Gtx7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.EthMacPkg.all;
 
 entity TenGigEthGtx7 is
    generic (
-      TPD_G         : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G  : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -233,9 +235,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGtx7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-03-30
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gtx7 Wrapper for 10GBASE-R Ethernet
 -- Note: This module supports up to a MGT QUAD of 10GigE interfaces
@@ -29,6 +29,8 @@ entity TenGigEthGtx7Wrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      PAUSE_EN_G        : boolean                          := true;
+      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G     : boolean                          := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -68,7 +70,7 @@ entity TenGigEthGtx7Wrapper is
       gtTxPostCursor      : in  slv(4 downto 0)                                := "00000";
       gtTxDiffCtrl        : in  slv(3 downto 0)                                := "1110";
       gtRxPolarity        : in  sl                                             := '0';
-      gtTxPolarity        : in  sl                                             := '0';      
+      gtTxPolarity        : in  sl                                             := '0';
       -- MGT Clock Port (156.25 MHz or 312.5 MHz)
       gtRefClk            : in  sl                                             := '0';  -- 156.25 MHz only
       gtClkP              : in  sl                                             := '1';
@@ -78,7 +80,7 @@ entity TenGigEthGtx7Wrapper is
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
       gtRxP               : in  slv(NUM_LANE_G-1 downto 0);
-      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));  
+      gtRxN               : in  slv(NUM_LANE_G-1 downto 0));
 end TenGigEthGtx7Wrapper;
 
 architecture mapping of TenGigEthGtx7Wrapper is
@@ -106,7 +108,7 @@ begin
          TPD_G             => TPD_G,
          USE_GTREFCLK_G    => USE_GTREFCLK_G,
          REFCLK_DIV2_G     => REFCLK_DIV2_G,
-         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)         
+         QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)
       port map (
          -- Clocks and Resets
          extRst        => extRst,
@@ -121,7 +123,7 @@ begin
          qplllock      => qplllock,
          qplloutclk    => qplloutclk,
          qplloutrefclk => qplloutrefclk,
-         qpllRst       => qpllReset);        
+         qpllRst       => qpllReset);
 
    qpllReset <= uOr(qpllRst) and not(qPllLock);
 
@@ -130,14 +132,16 @@ begin
    ----------------
    GEN_LANE :
    for i in 0 to NUM_LANE_G-1 generate
-      
+
       TenGigEthGtx7_Inst : entity work.TenGigEthGtx7
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G     => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G    => AXIS_CONFIG_G(i))       
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),
@@ -169,7 +173,7 @@ begin
             gtTxPostCursor     => gtTxPostCursor,
             gtTxDiffCtrl       => gtTxDiffCtrl,
             gtRxPolarity       => gtRxPolarity,
-            gtTxPolarity       => gtTxPolarity,          
+            gtTxPolarity       => gtTxPolarity,
             -- Quad PLL Ports
             qplllock           => qplllock,
             qplloutclk         => qplloutclk,
@@ -178,7 +182,7 @@ begin
             gtTxP              => gtTxP(i),
             gtTxN              => gtTxN(i),
             gtRxP              => gtRxP(i),
-            gtRxN              => gtRxN(i));  
+            gtRxN              => gtRxN(i));
 
    end generate GEN_LANE;
 

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGtyUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-04-06
--- Last update: 2018-04-09
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10GBASE-R Ethernet for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.EthMacPkg.all;
 
 entity TenGigEthGtyUltraScale is
    generic (
-      TPD_G         : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G  : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -234,9 +236,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : TenGigEthGtyUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-04-06
--- Last update: 2018-04-06
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: GTH Ultra Scale Wrapper for 10GBASE-R Ethernet
 -- Note: This module supports up to a MGT QUAD of 10GigE interfaces
@@ -30,6 +30,8 @@ entity TenGigEthGtyUltraScaleWrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      PAUSE_EN_G        : boolean                          := true;
+      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
@@ -139,11 +141,13 @@ begin
 
       TenGigEthGtyUltraScale_Inst : entity work.TenGigEthGtyUltraScale
          generic map (
-            TPD_G         => TPD_G,
+            TPD_G           => TPD_G,
+            PAUSE_EN_G      => PAUSE_EN_G,
+            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G  => EN_AXI_REG_G,
+            EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGth7.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-02-12
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10 GigE XAUI for Gth7
 -------------------------------------------------------------------------------
@@ -26,11 +26,13 @@ use work.EthMacPkg.all;
 
 entity XauiGth7 is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -58,7 +60,7 @@ entity XauiGth7 is
       gtTxP              : out slv(3 downto 0);
       gtTxN              : out slv(3 downto 0);
       gtRxP              : in  slv(3 downto 0);
-      gtRxN              : in  slv(3 downto 0));  
+      gtRxN              : in  slv(3 downto 0));
 end XauiGth7;
 
 architecture mapping of XauiGth7 is
@@ -79,7 +81,7 @@ architecture mapping of XauiGth7 is
    signal macRxAxisCtrl   : AxiStreamCtrlType;
    signal macTxAxisMaster : AxiStreamMasterType;
    signal macTxAxisSlave  : AxiStreamSlaveType;
-   
+
 begin
 
    phyClk   <= phyClock;
@@ -91,9 +93,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -112,7 +116,7 @@ begin
          xgmiiRxd        => phyRxd,
          xgmiiRxc        => phyRxc,
          xgmiiTxd        => phyTxd,
-         xgmiiTxc        => phyTxc);      
+         xgmiiTxc        => phyTxc);
 
    --------------------
    -- 10 GigE XAUI Core
@@ -151,7 +155,7 @@ begin
          signal_detect        => (others => '1'),
          debug                => status.debugVector,
          configuration_vector => config.configVector,
-         status_vector        => status.statusVector); 
+         status_vector        => status.statusVector);
 
    status.phyReady <= uAnd(status.debugVector);
 
@@ -165,7 +169,7 @@ begin
          TPD_G           => TPD_G,
          IN_POLARITY_G   => '1',
          OUT_POLARITY_G  => '1',
-         RELEASE_DELAY_G => 4) 
+         RELEASE_DELAY_G => 4)
       port map (
          clk      => gtRefClk,
          asyncRst => status.areset,
@@ -176,19 +180,19 @@ begin
          TPD_G           => TPD_G,
          IN_POLARITY_G   => '0',
          OUT_POLARITY_G  => '1',
-         RELEASE_DELAY_G => 4) 
+         RELEASE_DELAY_G => 4)
       port map (
          clk      => gtRefClk,
          asyncRst => status.clkLock,
-         syncRst  => phyReset);         
+         syncRst  => phyReset);
 
    --------------------------------     
    -- Configuration/Status Register   
    --------------------------------     
    U_XauiReg : entity work.XauiReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,
@@ -203,6 +207,6 @@ begin
          phyClk         => phyClock,
          phyRst         => phyReset,
          config         => config,
-         status         => status); 
+         status         => status);
 
 end mapping;

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGth7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gth7 Wrapper for 10 GigE XAUI
 -------------------------------------------------------------------------------
@@ -29,14 +29,16 @@ use unisim.vcomponents.all;
 
 entity XauiGth7Wrapper is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- QUAD PLL Configurations
-      USE_GTREFCLK_G   : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
-      REFCLK_DIV2_G    : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
+      USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
+      REFCLK_DIV2_G   : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -67,7 +69,7 @@ entity XauiGth7Wrapper is
       gtTxP              : out slv(3 downto 0);
       gtTxN              : out slv(3 downto 0);
       gtRxP              : in  slv(3 downto 0);
-      gtRxN              : in  slv(3 downto 0));  
+      gtRxN              : in  slv(3 downto 0));
 end XauiGth7Wrapper;
 
 architecture mapping of XauiGth7Wrapper is
@@ -85,7 +87,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => refClockDiv2,
-         O     => refClock);  
+         O     => refClock);
 
    refClk <= gtRefClk when (USE_GTREFCLK_G) else refClockDiv2 when(REFCLK_DIV2_G) else refClock;
 
@@ -94,11 +96,13 @@ begin
    ----------------------
    XauiGth7_Inst : entity work.XauiGth7
       generic map (
-         TPD_G            => TPD_G,
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
-         EN_AXI_REG_G     => EN_AXI_REG_G,
+         EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations
-         AXIS_CONFIG_G    => AXIS_CONFIG_G)       
+         AXIS_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Local Configurations
          localMac           => localMac,
@@ -126,6 +130,6 @@ begin
          gtTxP              => gtTxP,
          gtTxN              => gtTxN,
          gtRxP              => gtRxP,
-         gtRxN              => gtRxN);  
+         gtRxN              => gtRxN);
 
 end mapping;

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10 GigE XAUI for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -29,13 +29,15 @@ use unisim.vcomponents.all;
 
 entity XauiGthUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                     := 1 ns;
+      PAUSE_EN_G      : boolean                  := true;
+      PAUSE_512BITS_G : positive range 1 to 1024 := 8;
       -- XAUI Configurations
-      REF_CLK_FREQ_G   : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      REF_CLK_FREQ_G  : real                     := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean                  := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -102,9 +104,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -262,8 +266,8 @@ begin
    --------------------------------     
    U_XauiReg : entity work.XauiReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGthUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: GTH UltraScale+ Wrapper for 10 GigE XAUI
 -------------------------------------------------------------------------------
@@ -29,13 +29,15 @@ use unisim.vcomponents.all;
 
 entity XauiGthUltraScaleWrapper is
    generic (
-      TPD_G             : time                := 1 ns;
-      EN_WDT_G          : boolean             := false;
-      STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      TPD_G             : time                     := 1 ns;
+      PAUSE_EN_G        : boolean                  := true;
+      PAUSE_512BITS_G   : positive range 1 to 1024 := 8;
+      EN_WDT_G          : boolean                  := false;
+      STABLE_CLK_FREQ_G : real                     := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G      : boolean             := false;
+      EN_AXI_REG_G      : boolean                  := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G     : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G     : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -133,11 +135,13 @@ begin
    ----------------------
    XauiGthUltraScale_Inst : entity work.XauiGthUltraScale
       generic map (
-         TPD_G            => TPD_G,
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
-         EN_AXI_REG_G     => EN_AXI_REG_G,
+         EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations
-         AXIS_CONFIG_G    => AXIS_CONFIG_G)
+         AXIS_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Local Configurations
          localMac           => localMac,

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGthUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10 GigE XAUI for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -29,11 +29,13 @@ use unisim.vcomponents.all;
 
 entity XauiGthUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -100,9 +102,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -256,8 +260,8 @@ begin
    --------------------------------     
    U_XauiReg : entity work.XauiReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGthUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: GTH Ultra Scale Wrapper for 10 GigE XAUI
 -------------------------------------------------------------------------------
@@ -30,6 +30,8 @@ use unisim.vcomponents.all;
 entity XauiGthUltraScaleWrapper is
    generic (
       TPD_G             : time                := 1 ns;
+      PAUSE_EN_G        : boolean             := true;
+      PAUSE_512BITS_G   : positive            := 8;
       EN_WDT_G          : boolean             := false;
       STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
@@ -133,11 +135,13 @@ begin
    ----------------------
    XauiGthUltraScale_Inst : entity work.XauiGthUltraScale
       generic map (
-         TPD_G            => TPD_G,
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
-         EN_AXI_REG_G     => EN_AXI_REG_G,
+         EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations
-         AXIS_CONFIG_G    => AXIS_CONFIG_G)
+         AXIS_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Local Configurations
          localMac           => localMac,

--- a/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
+++ b/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGtx7Wrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-07
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: Gtx7 Wrapper for 10 GigE XAUI
 -------------------------------------------------------------------------------
@@ -29,14 +29,16 @@ use unisim.vcomponents.all;
 
 entity XauiGtx7Wrapper is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- QUAD PLL Configurations
-      USE_GTREFCLK_G   : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
-      REFCLK_DIV2_G    : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
+      USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
+      REFCLK_DIV2_G   : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -67,7 +69,7 @@ entity XauiGtx7Wrapper is
       gtTxP              : out slv(3 downto 0);
       gtTxN              : out slv(3 downto 0);
       gtRxP              : in  slv(3 downto 0);
-      gtRxN              : in  slv(3 downto 0));  
+      gtRxN              : in  slv(3 downto 0));
 end XauiGtx7Wrapper;
 
 architecture mapping of XauiGtx7Wrapper is
@@ -85,7 +87,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => refClockDiv2,
-         O     => refClock);  
+         O     => refClock);
 
    refClk <= gtRefClk when (USE_GTREFCLK_G) else refClockDiv2 when(REFCLK_DIV2_G) else refClock;
 
@@ -94,11 +96,13 @@ begin
    ----------------------
    XauiGtx7_Inst : entity work.XauiGtx7
       generic map (
-         TPD_G            => TPD_G,
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
-         EN_AXI_REG_G     => EN_AXI_REG_G,
+         EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations
-         AXIS_CONFIG_G    => AXIS_CONFIG_G)       
+         AXIS_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Local Configurations
          localMac           => localMac,
@@ -126,6 +130,6 @@ begin
          gtTxP              => gtTxP,
          gtTxN              => gtTxN,
          gtRxP              => gtRxP,
-         gtRxN              => gtRxN);  
+         gtRxN              => gtRxN);
 
 end mapping;

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGtyUltraScale.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: 10 GigE XAUI for GTH Ultra Scale
 -------------------------------------------------------------------------------
@@ -29,13 +29,15 @@ use unisim.vcomponents.all;
 
 entity XauiGtyUltraScale is
    generic (
-      TPD_G            : time                := 1 ns;
+      TPD_G           : time                := 1 ns;
+      PAUSE_EN_G      : boolean             := true;
+      PAUSE_512BITS_G : positive            := 8;
       -- XAUI Configurations
-      REF_CLK_FREQ_G   : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      REF_CLK_FREQ_G  : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G     : boolean             := false;
+      EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -102,9 +104,11 @@ begin
    --------------------
    U_MAC : entity work.EthMacTop
       generic map (
-         TPD_G         => TPD_G,
-         PHY_TYPE_G    => "XGMII",
-         PRIM_CONFIG_G => AXIS_CONFIG_G)
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PHY_TYPE_G      => "XGMII",
+         PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -262,8 +266,8 @@ begin
    --------------------------------     
    U_XauiReg : entity work.XauiReg
       generic map (
-         TPD_G            => TPD_G,
-         EN_AXI_REG_G     => EN_AXI_REG_G)
+         TPD_G        => TPD_G,
+         EN_AXI_REG_G => EN_AXI_REG_G)
       port map (
          -- Local Configurations
          localMac       => localMac,

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : XauiGtyUltraScaleWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-04-08
--- Last update: 2018-01-08
+-- Last update: 2018-08-23
 -------------------------------------------------------------------------------
 -- Description: GTH UltraScale+ Wrapper for 10 GigE XAUI
 -------------------------------------------------------------------------------
@@ -32,6 +32,8 @@ entity XauiGtyUltraScaleWrapper is
       TPD_G             : time                := 1 ns;
       EN_WDT_G          : boolean             := false;
       STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      PAUSE_EN_G        : boolean             := true;
+      PAUSE_512BITS_G   : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G      : boolean             := false;
       -- AXI Streaming Configurations
@@ -133,11 +135,13 @@ begin
    ----------------------
    XauiGtyUltraScale_Inst : entity work.XauiGtyUltraScale
       generic map (
-         TPD_G            => TPD_G,
+         TPD_G           => TPD_G,
+         PAUSE_EN_G      => PAUSE_EN_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
-         EN_AXI_REG_G     => EN_AXI_REG_G,
+         EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations
-         AXIS_CONFIG_G    => AXIS_CONFIG_G)
+         AXIS_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Local Configurations
          localMac           => localMac,


### PR DESCRIPTION
### Description
- exposing ETH pause generic configurations for 10GBase-KX4 
- exposing ETH pause generic configurations for 10GBase-KR
- exposing ETH pause generic configurations for 1000BASE-KX 

### Note:
Exposing the ETH pause to let us experiment with pauses enabled/disabled with the Advantech switch