### PR TITLE
fixing genAxiLiteConfig declaration

### DIFF
--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -388,8 +388,8 @@ package AxiLitePkg is
    -- Generate evenly distributed address map
    function genAxiLiteConfig (num      : positive;
                               base     : slv(31 downto 0);
-                              baseBot  : integer range 0 to 32;
-                              addrBits : integer range 0 to 32)
+                              baseBot  : integer range 1 to 32;
+                              addrBits : integer range 0 to 31)
       return AxiLiteCrossbarMasterConfigArray;
 
 


### PR DESCRIPTION
### Description
In the previous change to the AxiLitPkg.vhd parameters of the genAxiLiteConfig were modified in the package body, but not in the function declaration. The mismatch was causing the VCS to fail the compilation. The vivado build didn't mind the mismatch.