### PR TITLE
Rogue device tweaks

### DIFF
--- a/python/surf/axi/_AxiStreamDmaV2.py
+++ b/python/surf/axi/_AxiStreamDmaV2.py
@@ -5,21 +5,21 @@ class AxiStreamDmaV2Desc(pr.Device):
         super().__init__(description='', **kwargs)
 
         
-#         self.add(pr.RemoteVariable(
-#             name='HwEnable',
-#             mode = 'RO',
-#             offset=0x0,
-#             bitOffset=0,
-#             bitSize=1,
-#         ))
+        self.add(pr.RemoteVariable(
+            name='HwEnable',
+            mode = 'RO',
+            offset=0x0,
+            bitOffset=0,
+            bitSize=1,
+        ))
         
-#         self.add(pr.RemoteVariable(
-#             name='Version',
-#             mode = 'RO',            
-#             offset=0x0,
-#             bitOffset=24,
-#             bitSize=8,
-#         ))
+        self.add(pr.RemoteVariable(
+            name='Version',
+            mode = 'RO',            
+            offset=0x0,
+            bitOffset=24,
+            bitSize=8,
+        ))
 
         self.add(pr.RemoteVariable(
             name='IntEnable',

--- a/python/surf/axi/_AxiStreamDmaV2.py
+++ b/python/surf/axi/_AxiStreamDmaV2.py
@@ -1,0 +1,188 @@
+import pyrogue as pr
+
+class AxiStreamDmaV2Desc(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(description='', **kwargs)
+
+        
+#         self.add(pr.RemoteVariable(
+#             name='HwEnable',
+#             mode = 'RO',
+#             offset=0x0,
+#             bitOffset=0,
+#             bitSize=1,
+#         ))
+        
+#         self.add(pr.RemoteVariable(
+#             name='Version',
+#             mode = 'RO',            
+#             offset=0x0,
+#             bitOffset=24,
+#             bitSize=8,
+#         ))
+
+        self.add(pr.RemoteVariable(
+            name='IntEnable',
+            mode = 'RO',            
+            offset=0x4,
+            bitOffset=0,
+            bitSize=1,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='ContEn',
+            mode = 'RO',
+            offset=0x8,
+            bitOffset=0,
+            bitSize=1,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='DropEn',
+            mode = 'RO',
+            offset=0xC,
+            bitOffset=0,
+            bitSize=1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name='WrBaseAddr',
+            mode = 'RO',
+            offset=0x10,
+            bitOffset=0,
+            bitSize=64,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='RdBaseAddr',
+            mode = 'RO',
+            offset=0x14,
+            bitOffset=0,
+            bitSize=64,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='FifoReset',
+            mode = 'RO',
+            offset=0x20,
+            bitOffset=0,
+            bitSize=1,
+        ))
+        self.add(pr.RemoteVariable(
+            name='BufBaseAddr',
+            mode = 'RO',
+            offset=0x24,
+            bitOffset=0,
+            bitSize=32,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='MaxSize',
+            mode = 'RO',
+            offset=0x28,
+            bitOffset=0,
+            bitSize=24,
+            disp='{:d}',
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='Online',
+            mode = 'RO',
+            offset=0x2C,
+            bitOffset=0,
+            bitSize=1,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='Acknowledge',
+            mode = 'RO',
+            offset=0x30,
+            bitOffset=0,
+            bitSize=1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name='ChanCount',
+            mode = 'RO',
+            offset=0x34,
+            bitOffset=0,
+            bitSize=8,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name='DescAwidth',
+            mode = 'RO',
+            offset=0x38,
+            bitOffset=0,
+            bitSize=8,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='DescCache',
+            mode = 'RO',
+            offset=0x3C,
+            bitOffset=0,
+            bitSize=4,
+        ))
+        self.add(pr.RemoteVariable(
+            name='BuffCache',
+            mode = 'RO',
+            offset=0x3C,
+            bitOffset=8,
+            bitSize=4,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='FifoDin',
+            mode = 'RO',
+            offset=0x40,
+            bitOffset=0,
+            bitSize=32,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='IntAckCount',
+            mode = 'RO',
+            offset=0x4C,
+            bitOffset=0,
+            bitSize=16,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='IntEnableDup',
+            mode = 'RO',
+            offset=0x4C,
+            bitOffset=17,
+            bitSize=1,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='IntReqCount',
+            mode = 'RO',
+            offset=0x50,
+            bitOffset=0,
+            bitSize=32,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='WrIndex',
+            mode = 'RO',
+            offset=0x54,
+            bitOffset=0,
+            bitSize=32,
+        ))
+        self.add(pr.RemoteVariable(
+            name='RdIndex',
+            mode = 'RO',
+            offset=0x58,
+            bitOffset=0,
+            bitSize=32,
+        ))
+        
+        self.add(pr.RemoteVariable(
+            name='WrReqMissed',
+            mode = 'RO',
+            offset=0x5C,
+            bitOffset=0,
+            bitSize=32,
+        ))

--- a/python/surf/axi/__init__.py
+++ b/python/surf/axi/__init__.py
@@ -14,3 +14,4 @@ from surf.axi._AxiStreamDmaRingWrite  import *
 from surf.axi._AxiStreamMonitoring    import *
 from surf.axi._AxiVersion             import *
 from surf.axi._AxiVersionLegacy       import *
+from surf.axi._AxiStreamDmaV2         import *

--- a/python/surf/protocols/pgp/_pgp2baxi.py
+++ b/python/surf/protocols/pgp/_pgp2baxi.py
@@ -215,7 +215,8 @@ class Pgp2bAxi(pr.Device):
         for offset, name in enumerate(countVars):
             self.add(pr.RemoteVariable(
                 name        = name, 
-                offset      = ((offset*4)+0x28), 
+                offset      = ((offset*4)+0x28),
+                disp        = '{:d}',
                 bitSize     = 32, 
                 bitOffset   = 0, 
                 mode        = "RO", 
@@ -251,7 +252,8 @@ class Pgp2bAxi(pr.Device):
             bitSize     = 8, 
             bitOffset   = 0, 
             mode        = "RO", 
-            base        = pr.UInt, 
+            base        = pr.UInt,
+            disp        = "{:d}",
             description = "",
             pollInterval = 1,
         ))
@@ -262,7 +264,8 @@ class Pgp2bAxi(pr.Device):
             bitSize     = 8, 
             bitOffset   = 0, 
             mode        = "RO", 
-            base        = pr.UInt, 
+            base        = pr.UInt,
+            disp        = "{:d}",            
             description = "",
             pollInterval = 1,
         ))

--- a/python/surf/protocols/pgp/_pgp2baxi.py
+++ b/python/surf/protocols/pgp/_pgp2baxi.py
@@ -22,55 +22,57 @@ import pyrogue as pr
 
 class Pgp2bAxi(pr.Device):
     def __init__(self, 
-            name        = "Pgp2bAxi",
-            description = "Configuration and status of a downstream PGP link",
-            **kwargs):
+                 name        = "Pgp2bAxi",
+                 description = "Configuration and status of a downstream PGP link",
+                 writeEn = True,
+                 **kwargs):
         super().__init__(name=name, description=description, **kwargs) 
-        
-        self.add(pr.RemoteVariable(
-            name        = "Loopback", 
-            description = "GT Loopback Mode",
-            offset      = 0xC, 
-            bitSize     = 3, 
-            bitOffset   = 0, 
-            mode        = "RW", 
-            base        = pr.UInt,
-            enum = {0: 'No',
-                    1: 'Near-end PCS',
-                    2: 'Near-end PMA',
-                    4: 'Far-end PMA',
-                    6: 'Far-end PCS'},
-        ))
-        
-        self.add(pr.RemoteVariable(
-            name        = "LocData", 
-            description = "Sideband data to transmit",
-            offset      = 0x10, 
-            bitSize     = 8, 
-            bitOffset   = 0, 
-            mode        = "RW", 
-            base        = pr.UInt,
-        ))
-        
-        self.add(pr.RemoteVariable(
-            name        = "LocDataEn", 
-            description = "Enable sideband data to transmit",
-            offset      = 0x10, 
-            bitSize     = 1, 
-            bitOffset   = 8, 
-            mode        = "RW", 
-            base        = pr.Bool,
-        ))
-        
-        self.add(pr.RemoteVariable(
-            name        = "AutoStatus", 
-            description = "Auto Status Send Enable (PPI)",
-            offset      = 0x14, 
-            bitSize     = 1, 
-            bitOffset   = 0, 
-            mode        = "RW", 
-            base        = pr.Bool,
-        ))
+
+        if writeEn:
+            self.add(pr.RemoteVariable(
+                name        = "Loopback", 
+                description = "GT Loopback Mode",
+                offset      = 0xC, 
+                bitSize     = 3, 
+                bitOffset   = 0, 
+                mode        = "RW", 
+                base        = pr.UInt,
+                enum = {0: 'No',
+                        1: 'Near-end PCS',
+                        2: 'Near-end PMA',
+                        4: 'Far-end PMA',
+                        6: 'Far-end PCS'},
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = "LocData", 
+                description = "Sideband data to transmit",
+                offset      = 0x10, 
+                bitSize     = 8, 
+                bitOffset   = 0, 
+                mode        = "RW", 
+                base        = pr.UInt,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = "LocDataEn", 
+                description = "Enable sideband data to transmit",
+                offset      = 0x10, 
+                bitSize     = 1, 
+                bitOffset   = 8, 
+                mode        = "RW", 
+                base        = pr.Bool,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = "AutoStatus", 
+                description = "Auto Status Send Enable (PPI)",
+                offset      = 0x14, 
+                bitSize     = 1, 
+                bitOffset   = 0, 
+                mode        = "RW", 
+                base        = pr.Bool,
+            ))
 
         self.add(pr.RemoteVariable(
             name        = "RxPhyReady",       
@@ -311,17 +313,20 @@ class Pgp2bAxi(pr.Device):
 #             self.ResetRx.set(0, False)
 #             self.ResetTx.set(0, False)
 #             self.ResetTx._block.startTransaction(rim.Write, check=True)
-            
-        self.add(pr.RemoteCommand(
-            name        = "Flush", 
-            offset      = 0x08, 
-            bitSize     = 1, 
-            bitOffset   = 0, 
-            function    = pr.BaseCommand.toggle,
-        ))
+
+
+        if writeEn:
+            self.add(pr.RemoteCommand(
+                name        = "Flush", 
+                offset      = 0x08, 
+                bitSize     = 1, 
+                bitOffset   = 0, 
+                function    = pr.BaseCommand.toggle,
+                ))
 
         def softReset(self):
-            self.Flush()
+            if writeEn:
+                self.Flush()
 
         def hardReset(self):
             self.ResetTxRx()

--- a/python/surf/xilinx/_Gthe3Channel.py
+++ b/python/surf/xilinx/_Gthe3Channel.py
@@ -85,7 +85,6 @@ class Gthe3Channel(pr.Device):
             bitOffset    =  0x05,
             base         = pr.UInt,
             mode         = "RW",
-            value        = 2,
             enum         = {
                 0 : '-',
                 2 : '16',
@@ -2757,6 +2756,16 @@ class Gthe3Channel(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            enum         = {
+                0 : '-',
+                2 : '16',
+                3 : '20',
+                4 : '32',
+                5 : '40',
+                6 : '64',
+                7 : '80',
+                8 : '128',
+                9 : '160'},
         ))
 
         self.add(pr.RemoteVariable(   

--- a/python/surf/xilinx/_xadc.py
+++ b/python/surf/xilinx/_xadc.py
@@ -614,6 +614,6 @@ class Xadc(pr.Device):
         # Hide all the variable
         self.hideVariables(hidden=True)
         # Then unhide the most interesting ones
-        vars = ["Temperature", "VccInt", "VccAux", "VccBram"]
+        vars = ["enable", "Temperature", "VccInt", "VccAux", "VccBram"]
         self.hideVariables(hidden=False, variables=vars)
        

--- a/python/surf/xilinx/_xadc.py
+++ b/python/surf/xilinx/_xadc.py
@@ -331,7 +331,9 @@ class Xadc(pr.Device):
             self.add(pr.LinkVariable(
                 name=f'Aux[{i}]',
                 units='V',
-                dependencies=[self.AuxRaw[i]],
+                disp='{:1.3f}',
+                mode='RO',
+                variable=self.AuxRaw[i],
                 linkedGet=self.convAuxVoltage))
         
         if (zynq):


### PR DESCRIPTION
### Description
Several Rogue devices have been added or tweaked in small ways.
### Details
Mostly making registers 'RO' when they should be or adjusting `disp=` displays.
This is an accumulation of tweaks applied during development in other projects, namely HPS.
