### PR TITLE
Asynchronous Gearbox

### DIFF
--- a/base/general/rtl/AsyncGearbox.vhd
+++ b/base/general/rtl/AsyncGearbox.vhd
@@ -166,7 +166,7 @@ begin
       gearboxReadyOut <= not(almostFull);
    end generate MASTER_FIFO_GEN;
 
-   NO_MASTER_FIFO_GEN : if (SLAVE_FASTER_C) generate
+   NO_MASTER_FIFO_GEN : if (not SLAVE_FASTER_C) generate
       U_Output : entity work.FifoOutputPipeline
          generic map (
             TPD_G         => TPD_G,

--- a/base/general/rtl/AsyncGearbox.vhd
+++ b/base/general/rtl/AsyncGearbox.vhd
@@ -1,0 +1,155 @@
+-------------------------------------------------------------------------------
+-- Title      : Asynchronous Gearbox
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: A generic gearbox with asynchronous input and output clocks
+-------------------------------------------------------------------------------
+-- This file is part of SURF. It is subject to
+-- the license terms in the LICENSE.txt file found in the top-level directory
+-- of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of SURF, including this file, may be
+-- copied, modified, propagated, or distributed except according to the terms
+-- contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+use work.StdRtlPkg.all;
+
+entity AsyncGearbox is
+
+   generic (
+      TPD_G          : time := 1 ns;
+      INPUT_WIDTH_G  : positive;
+      OUTPUT_WIDTH_G : positive;
+
+      -- Async FIFO generics
+      FIFO_BRAM_EN_G     : boolean               := true;
+      FIFO_PIPE_STAGES_G : natural range 0 to 16 := 0;
+      FIFO_ADDR_WIDTH_G  : integer range 2 to 48 := 4);
+   port (
+      slaveClk : in sl;
+      slaveRst : in sl;
+
+      -- input side data and flow control
+      slaveData  : in  slv(INPUT_WIDTH_G-1 downto 0);
+      slaveValid : in  sl := '1';
+      slaveReady : out sl;
+
+      -- sequencing and slip
+      slip : in sl := '0';
+
+      masterClk : in sl;
+      masterRst : in sl;
+
+      -- output side data and flow control
+      masterData  : out slv(OUTPUT_WIDTH_G-1 downto 0);
+      masterValid : out sl;
+      masterReady : in  sl := '1');
+
+end entity AsyncGearbox;
+
+architecture rtl of AsyncGearbox is
+
+   constant INPUT_FASTER_C : boolean := INPUT_WIDTH_G <= OUTPUT_WIDTH_G;
+
+   signal fastClk : sl;
+   signal fastRst : sl;
+
+   signal gearboxDataIn   : slv(INPUT_WIDTH_G-1 downto 0);
+   signal gearboxValidIn  : sl;
+   signal gearboxReadyIn  : sl;
+   signal gearboxDataOut  : slv(OUTPUT_WIDTH_G-1 downto 0);
+   signal gearboxValidOut : sl;
+   signal gearboxReadyOut : sl;
+   signal gearboxSlip     : sl;
+
+begin
+
+   fastClk <= clkIn when INPUT_FASTER_C else clkOut;
+   fastRst <= rstIn when INPUT_FASTER_C else rstOut;
+
+   U_SynchronizerOneShot_1 : entity work.SynchronizerOneShot
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => fastClk,            -- [in]
+         rst     => fastRst,            -- [in]
+         dataIn  => slip,               -- [in]
+         dataOut => gearboxSlip);       -- [out]
+
+
+   INPUT_FIFO_GEN : if (not INPUT_FASTER_C) generate
+      U_FifoAsync_1 : entity work.FifoAsync
+         generic map (
+            TPD_G         => TPD_G,
+            FWFT_EN_G     => true,
+            DATA_WIDTH_G  => INPUT_WIDTH_G,
+            BRAM_EN_G     => FIFO_BRAM_EN_G,
+            PIPE_STAGES_G => FIFO_PIPE_STAGES_G,
+            ADDR_WIDTH_G  => FIFO_ADDR_WIDTH_G
+            )
+         port map (
+            rst    => rstIn,            -- [in]
+            wr_clk => clkIn,            -- [in]
+            wr_en  => validIn,          -- [in]
+            din    => dataIn,           -- [in]
+            rd_clk => clkOut,           -- [in]
+            rd_en  => gearboxReadyIn,   -- [in]
+            dout   => gearboxDataIn,    -- [out]
+            valid  => gearboxValidIn);  -- [out]
+   end generate INPUT_FIFO_GEN;
+
+   NO_INPUT_FIFO_GEN : if (INPUT_FASTER_C) generate
+      readyIn        <= gearboxReadyIn;
+      gearboxValidIn <= validIn;
+      gearboxDataIn  <= dataIn;
+   end generate NO_INPUT_FIFO_GEN;
+
+   U_Gearbox_1 : entity work.Gearbox
+      generic map (
+         TPD_G          => TPD_G,
+         INPUT_WIDTH_G  => OUTPUT_WIDTH_G,
+         OUTPUT_WIDTH_G => INPUT_WIDTH_G)
+      port map (
+         clk         => fastClk,          -- [in]
+         rst         => fastRst,          -- [in]
+         slaveData   => gearboxDataIn,    -- [in]
+         slaveValid  => gearboxValidIn,   -- [in]
+         slaveReady  => gearboxReadyIn,   -- [out]
+         masterData  => gearboxDataOut,   -- [out]
+         masterValid => gearboxValidOut,  -- [out]
+         masterReady => gearboxReadyOut,  -- [in]
+         slip        => gearboxSlip);
+
+   OUTPUT_FIFO_GEN : if (INPUT_FASTER_C) generate
+      U_FifoAsync_1 : entity work.FifoAsync
+         generic map (
+            TPD_G         => TPD_G,
+            FWFT_EN_G     => true,
+            DATA_WIDTH_G  => OUTPUT_WIDTH_G,
+            BRAM_EN_G     => FIFO_BRAM_EN_G,
+            PIPE_STAGES_G => FIFO_PIPE_STAGES_G,
+            ADDR_WIDTH_G  => FIFO_ADDR_WIDTH_G)
+         port map (
+            rst    => fastRst,          -- [in]
+            wr_clk => fastClk,          -- [in]
+            wr_en  => gearboxValidOut,  -- [in]
+            din    => gearboxDataOut,   -- [in]
+            rd_clk => masterClk,        -- [in]
+            rd_en  => masterReady,      -- [in]
+            dout   => dataOut,          -- [out]
+            valid  => masterValid);     -- [out]
+   end generate INPUT_FIFO_GEN;
+
+   NO_INPUT_FIFO_GEN : if (INPUT_FASTER_C) generate
+      gearboxReadyOut <= masterReady;
+      masterData      <= gearboxDataOut;
+      masterValid     <= gearboxValidOut;
+   end generate NO_INPUT_FIFO_GEN;
+end architecture rtl;

--- a/base/general/rtl/AsyncGearbox.vhd
+++ b/base/general/rtl/AsyncGearbox.vhd
@@ -5,13 +5,13 @@
 -------------------------------------------------------------------------------
 -- Description: A generic gearbox with asynchronous input and output clocks
 -------------------------------------------------------------------------------
--- This file is part of SURF. It is subject to
--- the license terms in the LICENSE.txt file found in the top-level directory
--- of this distribution and at:
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
--- No part of SURF, including this file, may be
--- copied, modified, propagated, or distributed except according to the terms
--- contained in the LICENSE.txt file.
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'SLAC Firmware Standard Library', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
 library ieee;
@@ -70,6 +70,7 @@ architecture mapping of AsyncGearbox is
    signal gearboxReadyOut : sl;
    signal gearboxSlip     : sl;
    signal almostFull      : sl;
+   signal writeEnable     : sl;
 
 begin
 
@@ -98,14 +99,15 @@ begin
          port map (
             rst         => slaveRst,         -- [in]
             wr_clk      => slaveClk,         -- [in]
-            wr_en       => slaveValid,       -- [in]
+            wr_en       => writeEnable,      -- [in]
             din         => slaveData,        -- [in]
             almost_full => almostFull,       -- [out]
             rd_clk      => fastClk,          -- [in]
             rd_en       => gearboxReadyIn,   -- [in]
             dout        => gearboxDataIn,    -- [out]
             valid       => gearboxValidIn);  -- [out]
-      slaveReady <= not(almostFull);
+      slaveReady  <= not(almostFull);
+      writeEnable <= slaveValid and not(almostFull);
    end generate SLAVE_FIFO_GEN;
 
    NO_SLAVE_FIFO_GEN : if (SLAVE_FASTER_C) generate
@@ -156,7 +158,7 @@ begin
          port map (
             rst         => fastRst,          -- [in]
             wr_clk      => fastClk,          -- [in]
-            wr_en       => gearboxValidOut,  -- [in]
+            wr_en       => writeEnable,      -- [in]
             din         => gearboxDataOut,   -- [in]
             almost_full => almostFull,       -- [out]
             rd_clk      => masterClk,        -- [in]
@@ -164,6 +166,7 @@ begin
             dout        => masterData,       -- [out]
             valid       => masterValid);     -- [out]
       gearboxReadyOut <= not(almostFull);
+      writeEnable     <= gearboxValidOut and not(almostFull);
    end generate MASTER_FIFO_GEN;
 
    NO_MASTER_FIFO_GEN : if (not SLAVE_FASTER_C) generate

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -5,13 +5,13 @@
 -------------------------------------------------------------------------------
 -- Description: A generic gearbox
 -------------------------------------------------------------------------------
--- This file is part of SURF. It is subject to
--- the license terms in the LICENSE.txt file found in the top-level directory
--- of this distribution and at:
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
--- No part of SURF, including this file, may be
--- copied, modified, propagated, or distributed except according to the terms
--- contained in the LICENSE.txt file.
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'SLAC Firmware Standard Library', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
 library ieee;

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -24,27 +24,27 @@ use work.StdRtlPkg.all;
 entity Gearbox is
 
    generic (
-      TPD_G          : time    := 1 ns;
-      INPUT_WIDTH_G  : positive := 64;
-      OUTPUT_WIDTH_G : positive := 66);
+      TPD_G          : time := 1 ns;
+      INPUT_WIDTH_G  : positive;
+      OUTPUT_WIDTH_G : positive);
 
    port (
       clk : in sl;
-      rst : in sl; 
+      rst : in sl;
 
       -- input side data and flow control
-      dataIn  : in  slv(INPUT_WIDTH_G-1 downto 0);
-      validIn : in  sl := '1';
-      readyIn : out sl;
+      slaveData  : in  slv(INPUT_WIDTH_G-1 downto 0);
+      slaveValid : in  sl := '1';
+      slaveReady : out sl;
 
       -- sequencing and slip
-      startOfSeq  : in  sl := '0';
-      slip          : in  sl := '0';
+      startOfSeq : in sl := '0';
+      slip       : in sl := '0';
 
       -- output side data and flow control
-      dataOut  : out slv(OUTPUT_WIDTH_G-1 downto 0);
-      validOut : out sl;
-      readyOut : in  sl := '1');
+      masterData  : out slv(OUTPUT_WIDTH_G-1 downto 0);
+      masterValid : out sl;
+      masterReady : in  sl := '1');
 
 end entity Gearbox;
 
@@ -57,35 +57,35 @@ architecture rtl of Gearbox is
    constant SHIFT_WIDTH_C : integer := wordCount(MAX_C, MIN_C) * MIN_C + 1;
 
    type RegType is record
-      validOut   : sl;
-      shiftReg   : slv(SHIFT_WIDTH_C-1 downto 0);
-      writeIndex : integer range 0 to SHIFT_WIDTH_C-1;
-      readyIn    : sl;
-      slip       : sl;
+      masterValid : sl;
+      shiftReg    : slv(SHIFT_WIDTH_C-1 downto 0);
+      writeIndex  : integer range 0 to SHIFT_WIDTH_C-1;
+      slaveReady  : sl;
+      slip        : sl;
    end record;
 
    constant REG_INIT_C : RegType := (
-      validOut   => '0',
-      shiftReg   => (others => '0'),
-      writeIndex => 0,
-      readyIn    => '0',
-      slip       => '0');
+      masterValid => '0',
+      shiftReg    => (others => '0'),
+      writeIndex  => 0,
+      slaveReady  => '0',
+      slip        => '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
 
 begin
 
-   comb : process (dataIn, r, readyOut, rst, slip, startOfSeq, validIn) is
+   comb : process (slaveData, r, masterReady, rst, slip, startOfSeq, slaveValid) is
       variable v : RegType;
    begin
       v := r;
 
       -- Flow control defaults
-      v.readyIn := '0';
+      v.slaveReady := '0';
 
-      if (readyOut = '1') then
-         v.validOut := '0';
+      if (masterReady = '1') then
+         v.masterValid := '0';
       end if;
 
       -- Slip input by incrementing the writeIndex
@@ -96,7 +96,7 @@ begin
 
 
       -- Only do anything if ready for data output
-      if (v.validOut = '0') then
+      if (v.masterValid = '0') then
 
          -- If current write index (assigned last cycle) is greater than output width,
          -- then we have to shift down before assinging an new input
@@ -107,37 +107,37 @@ begin
             -- If write index still greater than output width after shift,
             -- then we have a valid word to output
             if (v.writeIndex >= OUTPUT_WIDTH_G) then
-               v.validOut := '1';
+               v.masterValid := '1';
             end if;
          end if;
       end if;
 
       -- Accept new data if ready to output and shift above did not create an output valid
-      if (validIn = '1' and v.validOut = '0') then
+      if (slaveValid = '1' and v.masterValid = '0') then
 
          -- Reset the sequence if requested
          if (startOfSeq = '1') then
-            v.writeIndex := 0;
-            v.validOut   := '0';
+            v.writeIndex  := 0;
+            v.masterValid := '0';
          end if;
 
          -- Accept the input word
-         v.readyIn := '1';
+         v.slaveReady := '1';
 
          -- Assign incomming data at proper location in shift reg
-         v.shiftReg(v.writeIndex+INPUT_WIDTH_G-1 downto v.writeIndex) := dataIn;
+         v.shiftReg(v.writeIndex+INPUT_WIDTH_G-1 downto v.writeIndex) := slaveData;
 
          -- Increment writeIndex
          v.writeIndex := v.writeIndex + INPUT_WIDTH_G;
 
-         -- Assert validOut
+         -- Assert masterValid
          if (v.writeIndex >= OUTPUT_WIDTH_G) then
-            v.validOut := '1';
+            v.masterValid := '1';
          end if;
 
       end if;
 
-      readyIn <= v.readyIn;
+      slaveReady <= v.slaveReady;
 
       if (rst = '1') then
          v := REG_INIT_C;
@@ -145,8 +145,8 @@ begin
 
       rin <= v;
 
-      validOut <= r.validOut;
-      dataOut  <= r.shiftReg(OUTPUT_WIDTH_G-1 downto 0);
+      masterValid <= r.masterValid;
+      masterData  <= r.shiftReg(OUTPUT_WIDTH_G-1 downto 0);
 
 
    end process comb;

--- a/base/general/tb/GearboxTb.vhd
+++ b/base/general/tb/GearboxTb.vhd
@@ -37,30 +37,53 @@ architecture sim of GearboxTb is
    constant OUTPUT_WIDTH_G : natural := 8;
 
    -- component ports
-   signal clk : sl;                     -- [in]
-   signal rst : sl;                     -- [in]
+   signal clk32 : sl := '0';            -- [in]
+   signal rst32 : sl := '0';            -- [in]
+
+   signal clk66 : sl := '0';
+   signal rst66 : sl := '0';
+
+   signal input : slv(INPUT_WIDTH_G-1 downto 0) := (others => '0');
 
 
-   signal dataIn_0     : slv(INPUT_WIDTH_G-1 downto 0) := "1111100010";  -- [in]
-   signal validIn_0    : sl                            := '0';          -- [in]
-   signal readyIn_0    : sl;                                            -- [out]
-   signal dataOut_0    : slv(OUTPUT_WIDTH_G-1 downto 0);                -- [out]
-   signal validOut_0   : sl;                                            -- [out]
-   signal readyOut_0   : sl                            := '1';          -- [in]
-   signal slip_0       : sl                            := '0';
-   signal startOfSeq_0 : sl                            := '0';
+   signal slaveData_0   : slv(INPUT_WIDTH_G-1 downto 0)  := (others => '0');  -- [in]
+   signal slaveValid_0  : sl                             := '0';              -- [in]
+   signal slaveReady_0  : sl                             := '0';              -- [out]
+   signal masterData_0  : slv(OUTPUT_WIDTH_G-1 downto 0) := (others => '0');  -- [out]
+   signal masterValid_0 : sl                             := '0';              -- [out]
+   signal masterReady_0 : sl                             := '0';              -- [in]
+   signal slip_0        : sl                             := '0';
+   signal startOfSeq_0  : sl                             := '0';
 
---    signal dataIn_1     : slv(OUTPUT_WIDTH_G-1 downto 0) := X"A5";  -- [in]
---    signal validIn_1    : sl                            := '0';    -- [in]
---    signal readyIn_1    : sl;                                      -- [out]
-   signal dataOut_1    : slv(INPUT_WIDTH_G-1 downto 0);  -- [out]
-   signal validOut_1   : sl;                             -- [out]
-   signal readyOut_1   : sl := '1';                      -- [in]
-   signal slip_1       : sl := '0';
-   signal startOfSeq_1 : sl := '0';
-                                                         -- 
+--    signal slaveData_1     : slv(OUTPUT_WIDTH_G-1 downto 0) := X"A5";  -- [in]
+--    signal slaveValid_1    : sl                            := '0';    -- [in]
+--    signal slaveReady_1    : sl;                                      -- [out]
+   signal masterData_1  : slv(INPUT_WIDTH_G-1 downto 0) := (others => '0');  -- [out]
+   signal masterValid_1 : sl                            := '0';              -- [out]
+   signal masterReady_1 : sl                            := '1';              -- [in]
+   signal slip_1        : sl                            := '0';
+   signal startOfSeq_1  : sl                            := '0';
+                                                                             -- 
 
 begin
+
+   U_FifoAsync_1 : entity work.FifoAsync
+      generic map (
+         TPD_G         => TPD_G,
+         FWFT_EN_G     => true,
+         BRAM_EN_G     => true,
+         DATA_WIDTH_G  => INPUT_WIDTH_G,
+         PIPE_STAGES_G => 0)
+      port map (
+         rst    => rst66,               -- [in]
+         wr_clk => clk66,               -- [in]
+         wr_en  => '1',                 -- [in]
+         din    => input,
+         rd_clk => clk32,               -- [in]
+         rd_en  => slaveReady_0,        -- [in]
+         dout   => slaveData_0,         -- [out]
+         valid  => slaveValid_0);       -- [out]
+
 
    U_Gearbox_0 : entity work.Gearbox
       generic map (
@@ -68,14 +91,14 @@ begin
          INPUT_WIDTH_G  => INPUT_WIDTH_G,
          OUTPUT_WIDTH_G => OUTPUT_WIDTH_G)
       port map (
-         clk      => clk,               -- [in]
-         rst      => rst,               -- [in]
-         dataIn   => dataIn_0,          -- [in]
-         validIn  => validIn_0,         -- [in]
-         readyIn  => readyIn_0,         -- [out]
-         dataOut  => dataOut_0,         -- [out]
-         validOut => validOut_0,        -- [out]
-         readyOut => readyOut_0);       -- [in]
+         clk         => clk32,           -- [in]
+         rst         => rst32,           -- [in]
+         slaveData   => slaveData_0,     -- [in]
+         slaveValid  => slaveValid_0,    -- [in]
+         slaveReady  => slaveReady_0,    -- [out]
+         masterData  => masterData_0,    -- [out]
+         masterValid => masterValid_0,   -- [out]
+         masterReady => masterReady_0);  -- [in]
 
    -- component instantiation
    U_Gearbox_1 : entity work.Gearbox
@@ -84,39 +107,50 @@ begin
          INPUT_WIDTH_G  => OUTPUT_WIDTH_G,
          OUTPUT_WIDTH_G => INPUT_WIDTH_G)
       port map (
-         clk        => clk,             -- [in]
-         rst        => rst,             -- [in]
-         dataIn     => dataOut_0,       -- [in]
-         validIn    => validOut_0,      -- [in]
-         readyIn    => readyOut_0,      -- [out]
-         dataOut    => dataOut_1,       -- [out]
-         validOut   => validOut_1,      -- [out]
-         readyOut   => readyOut_1,      -- [in]
-         slip       => slip_1,
-         startOfSeq => startOfSeq_1);
+         clk         => clk32,          -- [in]
+         rst         => rst32,          -- [in]
+         slaveData   => masterData_0,   -- [in]
+         slaveValid  => masterValid_0,  -- [in]
+         slaveReady  => masterReady_0,  -- [out]
+         masterData  => masterData_1,   -- [out]
+         masterValid => masterValid_1,  -- [out]
+         masterReady => masterReady_1,  -- [in]
+         slip        => slip_1,
+         startOfSeq  => startOfSeq_1);
 
 
 
    U_ClkRst_1 : entity work.ClkRst
       generic map (
-         CLK_PERIOD_G      => 10 ns,
+         CLK_PERIOD_G      => 30 ns,
          CLK_DELAY_G       => 1 ns,
          RST_START_DELAY_G => 0 ns,
          RST_HOLD_TIME_G   => 5 us,
          SYNC_RESET_G      => true)
       port map (
-         clkP => clk,
-         rst  => rst);
+         clkP => clk32,
+         rst  => rst32);
+
+   U_ClkRst_2 : entity work.ClkRst
+      generic map (
+         CLK_PERIOD_G      => 80 ns,
+         CLK_DELAY_G       => 1 ns,
+         RST_START_DELAY_G => 0 ns,
+         RST_HOLD_TIME_G   => 5 us,
+         SYNC_RESET_G      => true)
+      port map (
+         clkP => clk66,
+         rst  => rst66);
 
    tb : process is
       variable count : integer := 0;
    begin
-      wait until rst = '1';
-      wait until rst = '0';
+      wait until rst66 = '1';
+      wait until rst66 = '0';
       wait for 1 us;
-      wait until clk = '1';
-      wait until clk = '1';
-      validIn_0 <= '1' after TPD_G;
+      wait until clk66 = '1';
+      wait until clk66 = '1';
+--      slaveValid_0 <= '1' after TPD_G;
 
 --       while (count < 498) loop
 --          wait until clk = '1';
@@ -129,23 +163,23 @@ begin
 
 --       wait until clk = '1';
 --       startOfSeq <= '0';
-      for i in 0 to 10 loop
-         while (count < 100) loop
-            wait until clk = '1';
-            count := count + 1;
-         end loop;
-         count := 0;
+--       for i in 0 to 10 loop
+--          while (count < 100) loop
+--             wait until clk = '1';
+--             count := count + 1;
+--          end loop;
+--          count := 0;
 
-         wait until clk = '1';
-         slip_1 <= '1';
+--          wait until clk = '1';
+--          slip_1 <= '1';
 
-         wait until clk = '1';
-         slip_1 <= '0';
-      end loop;
+--          wait until clk = '1';
+--          slip_1 <= '0';
+--       end loop;
 
 
       while (count < 10000) loop
-         wait until clk = '1';
+         wait until clk66 = '1';
          count := count + 1;
       end loop;
       count := 0;


### PR DESCRIPTION
### Description
- Created `AsyncGearbox` to transition between clock domains along with data widths.

- Also renamed `Gearbox` ports to use master/slave naming.

### Details
The `AsyncGearbox` has in internal `Gearbox` that runs on whichever clock is faster. The side with the smaller data width will have the faster clock. An asynchronous FIFO is placed before the gearbox if the master (output) side is faster, or after the gearbox if the slave (input) side is faster.

It is recommended that the two clocks be perfect ratios of each other relative to the data widths. For applications such as GTs that require input or output acceptance every cycle, both clocks should be created from the same PLL/MMCM.

Example clock speeds:
> `SLAVE_WIDTH_G` = 10
> `MASTER_WIDTH_G` = 8
> Master (output) side is faster.
> `slaveClk` = 10 ns = 100 MHz
> `masterClk` = 8 ns = 125 MHz