### PR TITLE
Fix 8-byte fixed size in endianSwap()

### DIFF
--- a/base/general/rtl/StdRtlPkg.vhd
+++ b/base/general/rtl/StdRtlPkg.vhd
@@ -789,7 +789,7 @@ package body StdRtlPkg is
       inp := resize(vector, BYTES_C*8);
       
       for i in BYTES_C-1 downto 0 loop
-         ret(7+(8*i) downto 8*i) := inp(7+(8*(7-i)) downto (8*(7-i)));
+         ret(7+(8*i) downto 8*i) := inp(7+(8*(BYTES_C-1-i)) downto (8*(BYTES_C-1-i)));
       end loop;
       return ret;
    end function;


### PR DESCRIPTION
### Description
The endian swap function had a bug that effectively required the input size to be 64 bits (8 bytes). This has been fixed. 

Thanks to @ulegat for finding this.