### PR TITLE
Bad descriptor return size for read buffers

### DIFF
--- a/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
@@ -763,7 +763,6 @@ begin
 
             -- Write data channel
             v.axiWriteMaster.wlast := '1';
-            v.axiWriteMaster.wstrb := resize(x"FF", 128);
 
             -- Descriptor data, 128-bits
             if DESC_128_EN_C then
@@ -773,6 +772,8 @@ begin
                v.axiWriteMaster.wdata(31  downto  3) := (others => '0');
                v.axiWriteMaster.wdata(2   downto  0) := dmaWrDescRet(descIndex).result;
 
+               v.axiWriteMaster.wstrb := resize(x"FFFF", 128);
+
             -- Descriptor data, 64-bits
             else
                v.axiWriteMaster.wdata(63 downto 32) := x"00000001";
@@ -780,6 +781,9 @@ begin
                v.axiWriteMaster.wdata(15 downto 4)  := dmaRdDescRet(descIndex).buffId(11 downto 0);
                v.axiWriteMaster.wdata(3)            := '0';
                v.axiWriteMaster.wdata(2 downto 0)   := dmaRdDescRet(descIndex).result;
+
+               v.axiWriteMaster.wstrb := resize(x"FF", 128);
+
             end if;
 
             v.axiWriteMaster.awvalid := '1';


### PR DESCRIPTION
Bad descriptor return size for read buffers in AxiStreamDmaV2Desc