### PR TITLE
Fixed broken SRPv3AxiLiteFull.vhd module

### DIFF
--- a/axi/dma/rtl/AxiStreamDmaWrite.vhd
+++ b/axi/dma/rtl/AxiStreamDmaWrite.vhd
@@ -69,7 +69,7 @@ architecture rtl of AxiStreamDmaWrite is
    constant DATA_BYTES_C      : integer         := LOC_AXIS_CONFIG_C.TDATA_BYTES_C;
    constant ADDR_LSB_C        : integer         := bitSize(DATA_BYTES_C-1);
    constant AWLEN_C           : slv(7 downto 0) := getAxiLen(AXI_CONFIG_G, 4096);
-   constant FIFO_ADDR_WIDTH_C : natural         := (AXI_CONFIG_G.LEN_BITS_C+1);
+   constant FIFO_ADDR_WIDTH_C : natural         := ite((AXI_CONFIG_G.LEN_BITS_C<3),4,(AXI_CONFIG_G.LEN_BITS_C+1));
 
    type StateType is (
       IDLE_S,
@@ -322,7 +322,7 @@ begin
                -- Latch AXI awlen value
                v.awlen     := v.wMaster.awlen(AXI_CONFIG_G.LEN_BITS_C-1 downto 0);
                -- Update the threshold
-               v.threshold := '0' & v.awlen;
+               v.threshold := resize(v.awlen, FIFO_ADDR_WIDTH_C);
                v.threshold := v.threshold + 1;
                -- DMA request has dropped. Abort. This is needed to disable engine while it
                -- is still waiting for an inbound frame.
@@ -353,7 +353,7 @@ begin
                -- Latch AXI awlen value
                v.awlen     := v.wMaster.awlen(AXI_CONFIG_G.LEN_BITS_C-1 downto 0);
                -- Update the threshold
-               v.threshold := '0' & v.awlen;
+               v.threshold := resize(v.awlen, FIFO_ADDR_WIDTH_C);
                v.threshold := v.threshold + 1;
                -- DMA request has dropped. Abort. This is needed to disable engine while it
                -- is still waiting for an inbound frame.

--- a/protocols/srp/rtl/SrpV3Axi.vhd
+++ b/protocols/srp/rtl/SrpV3Axi.vhd
@@ -39,7 +39,7 @@ entity SrpV3Axi is
       ALTERA_SYN_G        : boolean                 := false;
       ALTERA_RAM_G        : string                  := "M9K";
       AXI_CLK_FREQ_G      : real                    := 156.25E+6;  -- units of Hz
-      AXI_CONFIG_G        : AxiConfigType           := (33, 4, 1, 8);
+      AXI_CONFIG_G        : AxiConfigType           := axiConfig(33, 4, 1, 8);
       AXI_BURST_G         : slv(1 downto 0)         := "01";
       AXI_CACHE_G         : slv(3 downto 0)         := "1111";
       ACK_WAIT_BVALID_G   : boolean                 := true;

--- a/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
@@ -83,7 +83,7 @@ begin
          ALTERA_SYN_G        => ALTERA_SYN_G,
          ALTERA_RAM_G        => ALTERA_RAM_G,
          AXI_CLK_FREQ_G      => AXIL_CLK_FREQ_G,
-         AXI_CONFIG_G        => (32, 4, 1, 0),
+         AXI_CONFIG_G        => axiConfig(32, 4, 1, 0),
 --          AXI_BURST_G         => AXI_BURST_G,
 --          AXI_CACHE_G         => AXI_CACHE_G,
 --          ACK_WAIT_BVALID_G   => ACK_WAIT_BVALID_G,


### PR DESCRIPTION
### Description
Fixed the bug where the FIFO address was out-of-range.  In SRPv3AxiLiteFull, the FIFO address was 1.  Now the AxiStreamDmaWrite will prevent FIFO address size < 4

### JIRA
[ESCORE-186](https://jira.slac.stanford.edu/browse/ESCORE-186)
