### PR TITLE
Depreciating AxiStreamBatcherEventBuilder's Event Interface

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -167,8 +167,10 @@ begin
                   -- Reset the flag
                   v.ready := '0';
                else
-                  -- Check for NULL frame (defined as a single word transaction)
-                  if (rxMasters(i).tLast = '1') then
+                  -- Check for NULL frame (defined as a single word transaction with EOFE asserted and byte count = 1)
+                  if (rxMasters(i).tLast = '1') and  -- TLAST asserted
+                  (ssiGetUserEofe(AXIS_CONFIG_G, rxMasters(i)) = '1') and  -- EOFE flag set
+                  (getTKeep(rxMasters(i).tKeep(AXIS_CONFIG_G.TDATA_BYTES_C-1 downto 0), AXIS_CONFIG_G) = 1) then  -- byte count = 1
                      -- NULL frame detected
                      v.accept(i) := '0';
                   else

--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -167,8 +167,8 @@ begin
                   -- Reset the flag
                   v.ready := '0';
                else
-                  -- Check for NULL frame
-                  if (rxMasters(i).tLast = '1') and (rxMasters(i).tKeep(0) = '0') then
+                  -- Check for NULL frame (defined as a single word transaction)
+                  if (rxMasters(i).tLast = '1') then
                      -- NULL frame detected
                      v.accept(i) := '0';
                   else


### PR DESCRIPTION
### Description
- Depreciating AxiStreamBatcherEventBuilder's Event Interface
- Using NULL frames to drop AXIS stream frames at the AxiStreamBatcherEventBuilder instead