### PR TITLE
Resolved Vivado syntax warnings and critical warning messages for SURF's I2C lib

### DIFF
--- a/protocols/i2c/rtl/I2cPkg.vhd
+++ b/protocols/i2c/rtl/I2cPkg.vhd
@@ -195,11 +195,11 @@ package I2cPkg is
          clk_cnt : in std_logic_vector(15 downto 0);  -- 4x SCL
 
          -- input signals
-         start,
-         stop,
-         read,
-         write,
-         ack_in :    std_logic;
+         start  : in std_logic;
+         stop   : in std_logic;
+         read   : in std_logic;
+         write  : in std_logic;
+         ack_in : in std_logic;
          din    : in std_logic_vector(7 downto 0);
          filt   : in std_logic_vector((filter-1)*dynfilt downto 0);
 

--- a/protocols/i2c/rtl/i2c_master_byte_ctrl.vhd
+++ b/protocols/i2c/rtl/i2c_master_byte_ctrl.vhd
@@ -91,13 +91,13 @@ entity i2c_master_byte_ctrl is
 		clk_cnt : in std_logic_vector(15 downto 0);	-- 4x SCL
 
 		-- input signals
-		start,
-		stop,
-		read,
-		write,
-		ack_in : std_logic;
+		start  : in std_logic;
+		stop   : in std_logic;
+		read   : in std_logic;
+		write  : in std_logic;
+		ack_in : in std_logic;
 		din    : in std_logic_vector(7 downto 0);
-                filt   : in std_logic_vector((filter-1)*dynfilt downto 0);
+      filt   : in std_logic_vector((filter-1)*dynfilt downto 0);
                 
 		-- output signals
 		cmd_ack  : out std_logic; -- command done


### PR DESCRIPTION
### Description
Resolved Vivado syntax warnings and critical warning messages for SURF's I2C lib

### JIRA
[ESCORE-399](https://jira.slac.stanford.edu/browse/ESCORE-399)