### PR TITLE
Fixed width mismatch when OUTPUT_BUFG_G=false

### DIFF
--- a/xilinx/7Series/general/rtl/ClockManager7.vhd
+++ b/xilinx/7Series/general/rtl/ClockManager7.vhd
@@ -33,11 +33,11 @@ entity ClockManager7 is
       INPUT_BUFG_G           : boolean                          := true;
       FB_BUFG_G              : boolean                          := true;
       OUTPUT_BUFG_G          : boolean                          := true;
-      RST_IN_POLARITY_G      : sl                               := '1';  -- '0' for active low
+      RST_IN_POLARITY_G      : sl                               := '1';     -- '0' for active low
       NUM_CLOCKS_G           : integer range 1 to 7;
       -- MMCM attributes
       BANDWIDTH_G            : string                           := "OPTIMIZED";
-      CLKIN_PERIOD_G         : real                             := 10.0;  -- Input period in ns );
+      CLKIN_PERIOD_G         : real                             := 10.0;    -- Input period in ns );
       DIVCLK_DIVIDE_G        : integer range 1 to 106           := 1;
       CLKFBOUT_MULT_F_G      : real range 1.0 to 64.0           := 1.0;
       CLKFBOUT_MULT_G        : integer range 2 to 64            := 5;
@@ -379,8 +379,10 @@ begin
    end generate OutBufgGen;
 
    NoOutBufgGen : if (not OUTPUT_BUFG_G) generate
-      clkOutLoc <= clkOutMmcm;
-      clkOut    <= clkOutLoc;
+      ClkOutGen : for i in NUM_CLOCKS_G-1 downto 0 generate
+         clkOutLoc(i) <= clkOutMmcm(i);
+         clkOut(i)    <= clkOutLoc(i);
+      end generate ClkOutGen;
    end generate NoOutBufgGen;
 
    locked <= lockedLoc;


### PR DESCRIPTION
### Description
I found and fixed a width mismatch bug when disabling output BUFG insertion. 
