### PR TITLE
v1.9.3 release candidate

### DIFF
--- a/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
@@ -139,7 +139,6 @@ architecture rtl of AxiStreamDmaV2Desc is
       axiWriteMaster : AxiWriteMasterType;
 
       -- Configuration
-      buffBaseAddr : slv(31 downto 0);   -- For buffer entries
       wrBaseAddr   : slv(63 downto 0);   -- For wr ring buffer
       rdBaseAddr   : slv(63 downto 0);   -- For rd ring buffer
       maxSize      : slv(31 downto 0);
@@ -202,7 +201,6 @@ architecture rtl of AxiStreamDmaV2Desc is
       axilReadSlave   => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave  => AXI_LITE_WRITE_SLAVE_INIT_C,
       axiWriteMaster  => axiWriteMasterInit(AXI_CONFIG_G, '1', "01", "0000"),
-      buffBaseAddr    => (others => '0'),
       wrBaseAddr      => (others => '0'),
       rdBaseAddr      => (others => '0'),
       maxSize         => (others => '0'),
@@ -472,7 +470,6 @@ begin
       axiSlaveRegister(regCon, x"018", 0, v.rdBaseAddr(31 downto 0));
       axiSlaveRegister(regCon, x"01C", 0, v.rdBaseAddr(63 downto 32));
       axiSlaveRegister(regCon, x"020", 0, v.fifoReset);
-      axiSlaveRegister(regCon, x"024", 0, v.buffBaseAddr);
       axiSlaveRegister(regCon, x"028", 0, v.maxSize);
       axiSlaveRegister(regCon, x"02C", 0, v.online);
       axiSlaveRegister(regCon, x"030", 0, v.acknowledge);
@@ -604,11 +601,11 @@ begin
          for i in 0 to CHAN_COUNT_G-1 loop
 
             if DESC_128_EN_C then
-               v.dmaWrDescAck(i).address(63 downto 40) := r.buffBaseAddr(31 downto 8);
+               v.dmaWrDescAck(i).address(63 downto 40) := (others=>'0');
                v.dmaWrDescAck(i).address(39 downto  4) := wrFifoDout(63 downto 28);
                v.dmaWrDescAck(i).address(3  downto  0) := (others=>'0');
             else
-               v.dmaWrDescAck(i).address(63 downto 32) := r.buffBaseAddr;
+               v.dmaWrDescAck(i).address(63 downto 32) := (others=>'0');
                v.dmaWrDescAck(i).address(31 downto  0) := r.wrAddr;
             end if;
 
@@ -876,7 +873,7 @@ begin
 
       -- Format request, 128-bits
       if DESC_128_EN_C then
-         dmaRdReq.address(63 downto 40) := r.buffBaseAddr(31 downto 8);
+         dmaRdReq.address(63 downto 40) := (others=>'0');
          dmaRdReq.address(39 downto  4) := rdFifoDout(127 downto 92);
          dmaRdReq.address(3  downto  0) := (others=>'0');
          dmaRdReq.buffId(27 downto 0)   := rdFifoDout(91 downto 64);
@@ -890,7 +887,7 @@ begin
 
       -- Format request, 64-bits
       else 
-         dmaRdReq.address(63 downto 32) := r.buffBaseAddr;
+         dmaRdReq.address(63 downto 32) := (others=>'0');
          dmaRdReq.address(31 downto  0) := r.rdAddr;
          dmaRdReq.dest                  := rdFifoDout(63 downto 56);
          dmaRdReq.size(23 downto 0)     := rdFifoDout(55 downto 32);

--- a/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
@@ -503,7 +503,7 @@ begin
 
       if DESC_128_EN_C then
          axiSlaveRegister(regCon, x"060", 0, v.fifoDin);
-         axiWrDetect(regCon, x"064", v.rdFifoWr(2));
+         axiWrDetect(regCon, x"060", v.rdFifoWr(2));
 
          axiSlaveRegister(regCon, x"064", 0, v.fifoDin);
          axiWrDetect(regCon, x"064", v.rdFifoWr(3));

--- a/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/AxiStreamDmaV2Desc.vhd
@@ -771,9 +771,9 @@ begin
             if DESC_128_EN_C then
                v.axiWriteMaster.wdata(127)           := '1';
                v.axiWriteMaster.wdata(126 downto 64) := (others => '0');
-               v.axiWriteMaster.wdata(63  downto 32) := dmaWrDescRet(descIndex).buffId;
+               v.axiWriteMaster.wdata(63  downto 32) := dmaRdDescRet(descIndex).buffId;
                v.axiWriteMaster.wdata(31  downto  3) := (others => '0');
-               v.axiWriteMaster.wdata(2   downto  0) := dmaWrDescRet(descIndex).result;
+               v.axiWriteMaster.wdata(2   downto  0) := dmaRdDescRet(descIndex).result;
 
                v.axiWriteMaster.wstrb := resize(x"FFFF", 128);
 

--- a/xilinx/7Series/general/rtl/ClockManager7.vhd
+++ b/xilinx/7Series/general/rtl/ClockManager7.vhd
@@ -33,11 +33,11 @@ entity ClockManager7 is
       INPUT_BUFG_G           : boolean                          := true;
       FB_BUFG_G              : boolean                          := true;
       OUTPUT_BUFG_G          : boolean                          := true;
-      RST_IN_POLARITY_G      : sl                               := '1';  -- '0' for active low
+      RST_IN_POLARITY_G      : sl                               := '1';     -- '0' for active low
       NUM_CLOCKS_G           : integer range 1 to 7;
       -- MMCM attributes
       BANDWIDTH_G            : string                           := "OPTIMIZED";
-      CLKIN_PERIOD_G         : real                             := 10.0;  -- Input period in ns );
+      CLKIN_PERIOD_G         : real                             := 10.0;    -- Input period in ns );
       DIVCLK_DIVIDE_G        : integer range 1 to 106           := 1;
       CLKFBOUT_MULT_F_G      : real range 1.0 to 64.0           := 1.0;
       CLKFBOUT_MULT_G        : integer range 2 to 64            := 5;
@@ -379,8 +379,10 @@ begin
    end generate OutBufgGen;
 
    NoOutBufgGen : if (not OUTPUT_BUFG_G) generate
-      clkOutLoc <= clkOutMmcm;
-      clkOut    <= clkOutLoc;
+      ClkOutGen : for i in NUM_CLOCKS_G-1 downto 0 generate
+         clkOutLoc(i) <= clkOutMmcm(i);
+         clkOut(i)    <= clkOutLoc(i);
+      end generate ClkOutGen;
    end generate NoOutBufgGen;
 
    locked <= lockedLoc;


### PR DESCRIPTION
### Description
AxiStreamDmaV2: Remove buffer base address (https://github.com/slaclab/surf/pull/343)
ClockManager7: Fixed width mismatch when OUTPUT_BUFG_G=false (https://github.com/slaclab/surf/pull/344)
AxiStreamDmaV2: Fix bad descriptor return (https://github.com/slaclab/surf/pull/346)
AxiStreamDmaV2: Fix bad address decode for write index (https://github.com/slaclab/surf/pull/347)