### PR TITLE
AxiDualPortRam Bug Fix

### DIFF
--- a/axi/axi-lite/rtl/AxiDualPortRam.vhd
+++ b/axi/axi-lite/rtl/AxiDualPortRam.vhd
@@ -64,9 +64,15 @@ end entity AxiDualPortRam;
 architecture rtl of AxiDualPortRam is
 
    -- Number of Axi address bits that need to be manually decoded
-   constant AXI_DEC_BITS_C : integer := ite(DATA_WIDTH_G <= 32, 0, log2((DATA_WIDTH_G-1)/32));
-   subtype AXI_DEC_ADDR_RANGE_C is integer range 1+AXI_DEC_BITS_C downto 2;
-   subtype AXI_RAM_ADDR_RANGE_C is integer range ADDR_WIDTH_G+AXI_DEC_ADDR_RANGE_C'high downto AXI_DEC_ADDR_RANGE_C'high+1;
+   constant AXI_DEC_BITS_C      : integer := ite(DATA_WIDTH_G <= 32, 0, log2((DATA_WIDTH_G-1)/32));
+   
+   constant AXI_DEC_ADDR_HIGH_C : integer := 1+AXI_DEC_BITS_C;
+   constant AXI_DEC_ADDR_LOW_C  : integer := 2;
+   subtype AXI_DEC_ADDR_RANGE_C is integer range AXI_DEC_ADDR_HIGH_C downto AXI_DEC_ADDR_LOW_C;
+   
+   constant AXI_RAM_ADDR_HIGH_C : integer := ADDR_WIDTH_G+AXI_DEC_ADDR_RANGE_C'high;
+   constant AXI_RAM_ADDR_LOW_C  : integer := AXI_DEC_ADDR_RANGE_C'high+1;   
+   subtype AXI_RAM_ADDR_RANGE_C is integer range AXI_RAM_ADDR_HIGH_C downto AXI_RAM_ADDR_LOW_C;
 
    constant ADDR_AXI_WORDS_C : natural := wordCount(DATA_WIDTH_G, 32);
    constant ADDR_AXI_BYTES_C : natural := wordCount(DATA_WIDTH_G, 8);
@@ -258,7 +264,7 @@ begin
       v.axiReadSlave.rdata := axiDout((decAddrInt+1)*32-1 downto decAddrInt*32);
 
       -- Set axiAddr to read address by default
-      v.axiAddr := axiReadMaster.araddr(AXI_RAM_ADDR_RANGE_C);
+      v.axiAddr := axiReadMaster.araddr(AXI_RAM_ADDR_HIGH_C downto AXI_RAM_ADDR_LOW_C);
 
       -- State Machine
       case (r.state) is
@@ -267,20 +273,19 @@ begin
             -- Check for write transaction
             if (axiStatus.writeEnable = '1') then
                if (AXI_WR_EN_G) then
-                  v.axiAddr  := axiWriteMaster.awaddr(AXI_RAM_ADDR_RANGE_C);
+                  v.axiAddr  := axiWriteMaster.awaddr(AXI_RAM_ADDR_HIGH_C downto AXI_RAM_ADDR_LOW_C);
                   if (DATA_WIDTH_G <= 32) then
-                     decAddrInt := conv_integer(axiWriteMaster.awaddr(AXI_RAM_ADDR_RANGE_C));
+                     decAddrInt := conv_integer(axiWriteMaster.awaddr(AXI_RAM_ADDR_LOW_C-1 downto 0));
                   else
                      decAddrInt := conv_integer(axiWriteMaster.awaddr(AXI_DEC_ADDR_RANGE_C));
                   end if;
-                  v.axiWrStrobe((decAddrInt+1)*4-1 downto decAddrInt*4) :=
-                     axiWriteMaster.wstrb;
+                  v.axiWrStrobe((decAddrInt+1)*4-1 downto decAddrInt*4) := axiWriteMaster.wstrb;
                end if;
                axiSlaveWriteResponse(v.axiWriteSlave, ite(AXI_WR_EN_G, AXI_RESP_OK_C, AXI_RESP_SLVERR_C));
             -- Check for read transaction
             elsif (axiStatus.readEnable = '1') then
                -- Set the address bus
-               v.axiAddr := axiReadMaster.araddr(AXI_RAM_ADDR_RANGE_C);
+               v.axiAddr := axiReadMaster.araddr(AXI_RAM_ADDR_HIGH_C downto AXI_RAM_ADDR_LOW_C);
                -- Check for registered BRAM
                if (BRAM_EN_G = true) and (REG_EN_G = true) then
                   v.rdLatecy := 3;      -- read in 3 cycles


### PR DESCRIPTION
### Description
- AxiDualPortRam Bug Fix

### History

Matthias was using this configuration ....
```
   U_LUT : entity work.AxiDualPortRam
      generic map (
         TPD_G            => TPD_G,
         REG_EN_G         => false,
         AXI_WR_EN_G      => true,
         SYS_WR_EN_G      => false,
         SYS_BYTE_WR_EN_G => false,
         COMMON_CLK_G     => true,
         ADDR_WIDTH_G     => 10,
         DATA_WIDTH_G     => 32)
      port map (
         -- Axi Port
         axiClk         => clk160MHz,
         axiRst         => rst160MHz,
         axiReadMaster  => axilReadMasters(LUT_INDEX_C),
         axiReadSlave   => axilReadSlaves(LUT_INDEX_C),
         axiWriteMaster => axilWriteMasters(LUT_INDEX_C),
         axiWriteSlave  => axilWriteSlaves(LUT_INDEX_C),
         -- Standard Port
         clk            => clk160MHz,
         addr           => ramAddr,
         dout           => ramData);
```
... and discovered that only the first word in the BRAM would read/write from software.  The other words would also return.  After doing a VCS simulation, I go this error message:
```
Error-[SIMERR_ASOOB_VALUE_SCOPE] Invalid Array Index
/u/re/ruckman/projects/atlas/atlas-rd53-daq/firmware/submodules/surf/axi/axi-lite/rtl/AxiDualPortRam.vhd, 276
                    v.axiWrStrobe((decAddrInt+1)*4-1 downto decAddrInt*4) :=
  Array subscript 4 out of bounds (3 downto 0)
  in scope: /ATLASRD53FEBTB/U_FEB/U_HITTRIG/U_LUT/COMB at 73665401 PS from 
  process /ATLASRD53FEBTB/U_FEB/U_HITTRIG/U_LUT/COMB.
  Please extend the bounds in the array definition or ensure that the 
  subscript is within the defined bounds.
```
I add more constants to make it easier to see what the integer subtypes were configured as in simulation (subtype configurations don't show up in Vivado XSIM or VCS) and then fixed this firmware module for Matthias case