### PR TITLE
Add store and forward buffer in SRPv3 TX FIFO path

### DIFF
--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -32,17 +32,18 @@ use ieee.math_real.all;
 
 entity SrpV3AxiLite is
    generic (
-      TPD_G               : time                    := 1 ns;
-      INT_PIPE_STAGES_G   : natural range 0 to 16   := 1;
-      PIPE_STAGES_G       : natural range 0 to 16   := 1;
-      FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
-      TX_VALID_THOLD_G    : positive                := 1;
-      SLAVE_READY_EN_G    : boolean                 := false;
-      GEN_SYNC_FIFO_G     : boolean                 := false;
-      ALTERA_SYN_G        : boolean                 := false;
-      ALTERA_RAM_G        : string                  := "M9K";
-      AXIL_CLK_FREQ_G     : real                    := 156.25E+6;  -- units of Hz    
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType     := ssiAxiStreamConfig(2));
+      TPD_G                 : time                    := 1 ns;
+      INT_PIPE_STAGES_G     : natural range 0 to 16   := 1;
+      PIPE_STAGES_G         : natural range 0 to 16   := 1;
+      FIFO_PAUSE_THRESH_G   : positive range 1 to 511 := 256;
+      TX_VALID_THOLD_G      : positive range 1 to 511 := 256;   -- >1 = only when frame ready or # entries
+      TX_VALID_BURST_MODE_G : boolean                 := true;  -- only used in VALID_THOLD_G>1
+      SLAVE_READY_EN_G      : boolean                 := false;
+      GEN_SYNC_FIFO_G       : boolean                 := false;
+      ALTERA_SYN_G          : boolean                 := false;
+      ALTERA_RAM_G          : string                  := "M9K";
+      AXIL_CLK_FREQ_G       : real                    := 156.25E+6;  -- units of Hz    
+      AXI_STREAM_CONFIG_G   : AxiStreamConfigType     := ssiAxiStreamConfig(2));
    port (
       -- AXIS Slave Interface (sAxisClk domain) 
       sAxisClk         : in  sl;
@@ -791,6 +792,7 @@ begin
          PIPE_STAGES_G       => PIPE_STAGES_G,
          SLAVE_READY_EN_G    => true,
          VALID_THOLD_G       => TX_VALID_THOLD_G,
+         VALID_BURST_MODE_G  => TX_VALID_BURST_MODE_G,
          -- FIFO configurations
          BRAM_EN_G           => true,
          XIL_DEVICE_G        => "7SERIES",


### PR DESCRIPTION
### Description
- Add store and forward buffer in SRPv3 TX FIFO path
- This would avoid sending partial frames upstream while the transaction is still in progress. 

### JIRA
[ESCORE-407](https://jira.slac.stanford.edu/browse/ESCORE-407)