### PR TITLE
Data reduction pipeline needs one packet, with one tlast.  Sub frames…

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -208,6 +208,8 @@ begin
                   else
                      -- Increment the counter
                      v.index := r.index + 1;
+                     -- Don't send the packet (or Frame?) yet.  Wait until the last packet (Frame?) comes in.
+                     v.txMaster.tLast := '0' ;
                   end if;
                end if;
             end if;


### PR DESCRIPTION
Data reduction pipeline needs one packet, with one tlast.  Sub frames implemented by axistreambatcherventbuilderisn't compatible with drop. added lines 211 to axistreambatchereventbilder.vhd so batcher puts all input packets onto one output packet.