### PR TITLE
PGPv3 skipInterval bug fix

### DIFF
--- a/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
@@ -115,9 +115,9 @@ architecture rtl of Pgp3AxiL is
    constant REG_INIT_C : RegType := (
       countReset     => '0',
       loopBack       => (others => '0'),
-      flowCntlDis    => '0',
-      txDisable      => '0',
-      skpInterval    => X"0000FFF0",
+      flowCntlDis    => PGP3_TX_IN_INIT_C.flowCntlDis,
+      txDisable      => PGP3_TX_IN_INIT_C.disable,
+      skpInterval    => PGP3_TX_IN_INIT_C.skpInterval,
       autoStatus     => '0',
       axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C,
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Core.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Core.vhd
@@ -31,8 +31,6 @@ entity Pgp3Core is
       RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
       PGP_TX_ENABLE_G             : boolean               := true;
       TX_CELL_WORDS_MAX_G         : integer               := PGP3_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
-      TX_SKP_INTERVAL_G           : integer               := 5000;
-      TX_SKP_BURST_SIZE_G         : integer               := 8;
       TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
       TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0 => "--------");  -- Only used in ROUTED mode
       TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
@@ -44,7 +42,7 @@ entity Pgp3Core is
       -- Tx User interface
       pgpTxClk     : in  sl;
       pgpTxRst     : in  sl;
-      pgpTxIn      : in  Pgp3TxInType;
+      pgpTxIn      : in  Pgp3TxInType := PGP3_TX_IN_INIT_C;
       pgpTxOut     : out Pgp3TxOutType;
       pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
       pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
@@ -60,7 +58,7 @@ entity Pgp3Core is
       -- Rx User interface
       pgpRxClk     : in  sl;
       pgpRxRst     : in  sl;
-      pgpRxIn      : in  Pgp3RxInType;
+      pgpRxIn      : in  Pgp3RxInType := PGP3_RX_IN_INIT_C;
       pgpRxOut     : out Pgp3RxOutType;
       pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
       pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
@@ -109,8 +107,6 @@ begin
          TPD_G                    => TPD_G,
          NUM_VC_G                 => NUM_VC_G,
          CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
-         SKP_INTERVAL_G           => TX_SKP_INTERVAL_G,
-         SKP_BURST_SIZE_G         => TX_SKP_BURST_SIZE_G,
          MUX_MODE_G               => TX_MUX_MODE_G,
          MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
          MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -111,7 +111,7 @@ package Pgp3Pkg is
    constant PGP3_TX_IN_INIT_C : Pgp3TxInType := (
       disable      => '0',
       flowCntlDis  => '0',
-      skpInterval  => x"0000FFF0",
+      skpInterval  => toSlv(5000, 32),
       opCodeEn     => '0',
       opCodeNumber => (others => '0'),
       opCodeData   => (others => '0'));

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -111,7 +111,7 @@ package Pgp3Pkg is
    constant PGP3_TX_IN_INIT_C : Pgp3TxInType := (
       disable      => '0',
       flowCntlDis  => '0',
-      skpInterval  => (others => '0'),
+      skpInterval  => x"0000FFF0",
       opCodeEn     => '0',
       opCodeNumber => (others => '0'),
       opCodeData   => (others => '0'));

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
@@ -39,7 +39,7 @@ entity Pgp3Rx is
       -- User Transmit interface
       pgpRxClk     : in  sl;
       pgpRxRst     : in  sl;
-      pgpRxIn      : in  Pgp3RxInType;
+      pgpRxIn      : in  Pgp3RxInType := PGP3_RX_IN_INIT_C;
       pgpRxOut     : out Pgp3RxOutType;
       pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
       pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0); -- Unused

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxProtocol.vhd
@@ -39,7 +39,7 @@ entity Pgp3RxProtocol is
       -- User Transmit interface
       pgpRxClk    : in  sl;
       pgpRxRst    : in  sl;
-      pgpRxIn     : in  Pgp3RxInType;
+      pgpRxIn     : in  Pgp3RxInType := PGP3_RX_IN_INIT_C;
       pgpRxOut    : out Pgp3RxOutType;
       pgpRxMaster : out AxiStreamMasterType;
       pgpRxSlave  : in  AxiStreamSlaveType;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
@@ -33,8 +33,6 @@ entity Pgp3Tx is
       -- PGP configuration
       NUM_VC_G                 : integer range 1 to 16 := 1;
       CELL_WORDS_MAX_G         : integer               := 256;  -- Number of 64-bit words per cell
-      SKP_INTERVAL_G           : integer               := 5000;
-      SKP_BURST_SIZE_G         : integer               := 8;
       -- Mux configuration
       MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
       MUX_TDEST_ROUTES_G       : Slv8Array             := (0 => "--------");  -- Only used in ROUTED mode
@@ -45,7 +43,7 @@ entity Pgp3Tx is
       -- Transmit interface
       pgpTxClk     : in  sl;
       pgpTxRst     : in  sl;
-      pgpTxIn      : in  Pgp3TxInType;
+      pgpTxIn      : in  Pgp3TxInType := PGP3_TX_IN_INIT_C;
       pgpTxOut     : out Pgp3TxOutType;
       pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
       pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
@@ -204,9 +202,7 @@ begin
    U_Pgp3TxProtocol_1 : entity work.Pgp3TxProtocol
       generic map (
          TPD_G            => TPD_G,
-         NUM_VC_G         => NUM_VC_G,
-         SKP_INTERVAL_G   => SKP_INTERVAL_G,
-         SKP_BURST_SIZE_G => SKP_BURST_SIZE_G)
+         NUM_VC_G         => NUM_VC_G)
       port map (
          pgpTxClk       => pgpTxClk,            -- [in]
          pgpTxRst       => pgpTxRst,            -- [in]

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -34,8 +34,8 @@ entity Pgp3TxProtocol is
       TPD_G            : time                  := 1 ns;
       NUM_VC_G         : integer range 1 to 16 := 4;
       STARTUP_HOLD_G   : integer               := 1000;
-      SKP_INTERVAL_G   : integer               := 5000;
-      SKP_BURST_SIZE_G : integer               := 8);
+      SKP_INTERVAL_G   : integer               := 5000; -- Unused
+      SKP_BURST_SIZE_G : integer               := 8);   -- Unused
 
    port (
       -- User Transmit interface
@@ -71,6 +71,7 @@ architecture rtl of Pgp3TxProtocol is
       overflowDly       : slv(NUM_VC_G-1 downto 0);
       overflowEvent     : slv(NUM_VC_G-1 downto 0);
       overflowEventSent : slv(NUM_VC_G-1 downto 0);
+      skpInterval       : slv(31 downto 0);
       skpCount          : slv(31 downto 0);
       startupCount      : integer;
       pgpTxSlave        : AxiStreamSlaveType;
@@ -91,6 +92,7 @@ architecture rtl of Pgp3TxProtocol is
       overflowDly       => (others => '0'),
       overflowEvent     => (others => '0'),
       overflowEventSent => (others => '0'),
+      skpInterval       => (others => '0'),
       skpCount          => (others => '0'),
       startupCount      => 0,
       pgpTxSlave        => AXI_STREAM_SLAVE_INIT_C,
@@ -147,8 +149,18 @@ begin
       -- Generate the link information message
       linkInfo := pgp3MakeLinkInfo(rxFifoCtrl, locRxLinkReady);
 
-      -- Always increment skpCount
-      v.skpCount := r.skpCount + 1;
+      -- Keep delay copy of skip interval configuration
+      v.skpInterval := pgpTxIn.skpInterval;
+      
+      -- Check for change in configuration
+      if (r.skpInterval /= v.skpInterval) then
+         -- Force a skip
+         v.skpCount := v.skpInterval;
+      -- Check for counter roll over
+      elsif (r.skpCount /= r.skpInterval) then      
+         -- Increment the counter
+         v.skpCount := r.skpCount + 1;
+      end if;
 
       -- Don't accept new frame data by default
       v.pgpTxSlave.tReady := '0';
@@ -244,13 +256,9 @@ begin
             v.protTxData(PGP3_USER_OPCODE_FIELD_C)   := pgpTxIn.opCodeData;
             v.protTxHeader                           := PGP3_K_HEADER_C;
             
-            -- If skip was interrupted, hold it for next cycle
-            if (r.skpCount = SKP_INTERVAL_G-1) then
-               v.skpCount := r.skpCount;
-            end if;
             resetEventMetaData := false;
          -- SKIP codes override data
-         elsif (r.skpCount = pgpTxIn.skpInterval) then
+         elsif (r.skpCount = r.skpInterval) then
             v.skpCount                     := (others => '0');
             v.pgpTxSlave.tReady            := '0';            -- Override any data acceptance.
             v.protTxData                   := (others => '0');

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -33,15 +33,12 @@ entity Pgp3TxProtocol is
    generic (
       TPD_G            : time                  := 1 ns;
       NUM_VC_G         : integer range 1 to 16 := 4;
-      STARTUP_HOLD_G   : integer               := 1000;
-      SKP_INTERVAL_G   : integer               := 5000; -- Unused
-      SKP_BURST_SIZE_G : integer               := 8);   -- Unused
-
+      STARTUP_HOLD_G   : integer               := 1000);
    port (
       -- User Transmit interface
       pgpTxClk    : in  sl;
       pgpTxRst    : in  sl;
-      pgpTxIn     : in  Pgp3TxInType;
+      pgpTxIn     : in  Pgp3TxInType := PGP3_TX_IN_INIT_C;
       pgpTxOut    : out Pgp3TxOutType;
       pgpTxMaster : in  AxiStreamMasterType;
       pgpTxSlave  : out AxiStreamSlaveType;


### PR DESCRIPTION
### Description
- bug fix for dynamic pgpTxIn.skpInterval config
- updaing PGP3_TX_IN_INIT_C.skpInterval non-zero (required to prevent the skpInterval=0 when EN_PGP_MON_G=true)