### PR TITLE
adding EXT_CTRL_ONLY_G to AxiLiteRingBuffer.vhd

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteRingBuffer.vhd
+++ b/axi/axi-lite/rtl/AxiLiteRingBuffer.vhd
@@ -25,6 +25,7 @@ entity AxiLiteRingBuffer is
    generic (
       -- General Configurations
       TPD_G            : time                   := 1 ns;
+      EXT_CTRL_ONLY_G  : boolean                := false;
       BRAM_EN_G        : boolean                := true;
       REG_EN_G         : boolean                := true;
       DATA_WIDTH_G     : positive range 1 to 32 := 32;
@@ -275,7 +276,7 @@ begin
          -- Check for an out of 32 bit aligned address
          axiWriteResp := ite(axilWriteMaster.awaddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
          -- Check for first mapped address access (which is the control register)
-         if (axilWriteMaster.awaddr(RAM_ADDR_WIDTH_G+2-1 downto 2) = 0) then
+         if (axilWriteMaster.awaddr(RAM_ADDR_WIDTH_G+2-1 downto 2) = 0)  and (EXT_CTRL_ONLY_G = false) then
             v.bufferEnable := axilWriteMaster.wdata(31);
             v.bufferClear  := axilWriteMaster.wdata(30);
          else
@@ -293,7 +294,7 @@ begin
          -- Check for an out of 32 bit aligned address
          axiReadResp           := ite(axilReadMaster.araddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
          -- Control register mapped at address 0
-         if (axilReadMaster.araddr(RAM_ADDR_WIDTH_G+2-1 downto 2) = 0) then
+         if (axilReadMaster.araddr(RAM_ADDR_WIDTH_G+2-1 downto 2) = 0) and (EXT_CTRL_ONLY_G = false) then
             v.axilReadSlave.rdata(31)                          := axilR.bufferEnable;
             v.axilReadSlave.rdata(30)                          := axilR.bufferClear;
             v.axilReadSlave.rdata(29)                          := extBufferEnable;


### PR DESCRIPTION
### Description
- adding EXT_CTRL_ONLY_G to AxiLiteRingBuffer.vhd
- Allows the users to get access to the full RAM data (instead of all but the first sample) when doing external control
