### PR TITLE
Update AxiVersion with better use of LinkVariables

### DIFF
--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -218,38 +218,42 @@ class AxiVersion(pr.Device):
         ))
 
         
-        def parseBuildStamp(var, value, disp):
-            p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", value.strip())
-            if p is not None:
-                for k,v in p.named.items():
-                    self.node(k).set(v)
+        def parseBuildStamp(var,read):
+            p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", var.dependencies[0].get(read))
+            if p is None:
+                return ''
+            else:
+                return p[var.name]
         
-        self.add(pr.LocalVariable(
+        self.add(pr.LinkVariable(
             name = 'ImageName',
             mode = 'RO',
-            value = ''))
+            linkedGet = parseBuildStamp,
+            variable = self.BuildStamp))
  
-        self.add(pr.LocalVariable(
+        self.add(pr.LinkVariable(
             name = 'BuildEnv',
             mode = 'RO',
-            value = ''))
+            linkedGet = parseBuildStamp,
+            variable = self.BuildStamp))
 
-        self.add(pr.LocalVariable(
+        self.add(pr.LinkVariable(
             name = 'BuildServer',
             mode = 'RO',
-            value = ''))
+            linkedGet = parseBuildStamp,
+            variable = self.BuildStamp))
        
-        self.add(pr.LocalVariable(
+        self.add(pr.LinkVariable(
             name = 'BuildDate',
             mode = 'RO',
-            value = ''))
+            linkedGet = parseBuildStamp,
+            variable = self.BuildStamp))
        
-        self.add(pr.LocalVariable(
+        self.add(pr.LinkVariable(
             name = 'Builder',
             mode = 'RO',
-            value = ''))
-
-        self.BuildStamp.addListener(parseBuildStamp)        
+            linkedGet = parseBuildStamp,
+            variable = self.BuildStamp))
        
 
     def hardReset(self):

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -84,7 +84,7 @@ class AxiVersion(pr.Device):
             name         = 'UpTime',
             description  = 'Time since power up or last firmware reload',
             mode         = 'RO',
-            dependencies = [self.UpTimeCnt],
+            variable     = self.UpTimeCnt,
             linkedGet    = lambda read: str(datetime.timedelta(seconds=self.UpTimeCnt.get(read))),
             units        = 'HH:MM:SS',
         ))
@@ -191,7 +191,7 @@ class AxiVersion(pr.Device):
         self.add(pr.LinkVariable(
             name         = 'GitHashShort',
             mode         = 'RO',
-            dependencies = [self.GitHash],
+            variable     = self.GitHash,
             disp         = '{:07x}',
             linkedGet    = lambda read: self.GitHash.get(read) >> 132,
         ))

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -85,7 +85,7 @@ class AxiVersion(pr.Device):
             description  = 'Time since power up or last firmware reload',
             mode         = 'RO',
             dependencies = [self.UpTimeCnt],
-            linkedGet    = lambda: str(datetime.timedelta(seconds=self.UpTimeCnt.value())),
+            linkedGet    = lambda read: str(datetime.timedelta(seconds=self.UpTimeCnt.get(read))),
             units        = 'HH:MM:SS',
         ))
 
@@ -193,7 +193,7 @@ class AxiVersion(pr.Device):
             mode         = 'RO',
             dependencies = [self.GitHash],
             disp         = '{:07x}',
-            linkedGet    = lambda: self.GitHash.value() >> 132,
+            linkedGet    = lambda read: self.GitHash.get(read) >> 132,
         ))
 
         self.add(pr.RemoteVariable(   
@@ -267,8 +267,6 @@ class AxiVersion(pr.Device):
         
     def printStatus(self):
         try:
-            self.UpTimeCnt.get()
-            self.BuildStamp.get()
             gitHash = self.GitHash.get()
             print("FwVersion    = {}".format(hex(self.FpgaVersion.get())))
             print("UpTime       = {}".format(self.UpTime.get()))
@@ -277,11 +275,11 @@ class AxiVersion(pr.Device):
             else:
                 print("GitHash      = dirty (uncommitted code)")
             print("XilinxDnaId  = {}".format(hex(self.DeviceDna.get())))
-            print("FwTarget     = {}".format(self.ImageName.get()))
-            print("BuildEnv     = {}".format(self.BuildEnv.get()))
-            print("BuildServer  = {}".format(self.BuildServer.get()))
-            print("BuildDate    = {}".format(self.BuildDate.get()))
-            print("Builder      = {}".format(self.Builder.get()))
+            print("FwTarget     = {}".format(self.ImageName.get()))      # Read buildstamp here
+            print("BuildEnv     = {}".format(self.BuildEnv.value()))
+            print("BuildServer  = {}".format(self.BuildServer.value()))
+            print("BuildDate    = {}".format(self.BuildDate.value()))
+            print("Builder      = {}".format(self.Builder.value()))
         except Exception as e:
             print("Failed to get AxiVersion status")
 

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -84,6 +84,7 @@ class AxiVersion(pr.Device):
             name         = 'UpTime',
             description  = 'Time since power up or last firmware reload',
             mode         = 'RO',
+            disp         = '{}',
             variable     = self.UpTimeCnt,
             linkedGet    = lambda read: str(datetime.timedelta(seconds=self.UpTimeCnt.get(read))),
             units        = 'HH:MM:SS',


### PR DESCRIPTION

This update takes advantage of LinkVariables to parse the buildstring. A hardware read will only be called when the get() method is called on one of the link variables. I also updated the upTime link variable.