### PR TITLE
Remove std_ulogic_vector variant of StdMatch()

### DIFF
--- a/base/general/rtl/StdRtlPkg.vhd
+++ b/base/general/rtl/StdRtlPkg.vhd
@@ -151,7 +151,6 @@ package StdRtlPkg is
   function StdMatch (L, R: unsigned) return boolean;
   function StdMatch (L, R: signed) return boolean;
   function StdMatch (L, R: slv) return boolean;
-  function StdMatch (L, R: std_ulogic_vector) return boolean;
    
    -- Some synthesis tools wont accept unit types
    -- pragma translate_off
@@ -1392,10 +1391,6 @@ package body StdRtlPkg is
       return std_match(L,R);
    end function StdMatch;  
 
-   function StdMatch (L, R: std_ulogic_vector) return boolean is
-   begin
-      return std_match(L,R);
-   end function StdMatch;  
   
    function toBuildInfo (din : slv) return BuildInfoRetType is
       variable ret : BuildInfoRetType;


### PR DESCRIPTION
Remove a StdMatch overload that was causing a compile error.

### Description
This line:
```vhdl
function StdMatch (L, R: std_ulogic_vector) return boolean;
```
was causing this error:
```
The following error(s) were detected during synthesis:
 a homograph of stdmatch is already declared in this region [/u/re/bareese/projects/heavy-photon-daq/firmware/submodules/surf/base/general/rtl/StdRtlPkg.vhd:154]
ERROR: [Common 17-69] Command failed: Synthesis failed - please see the console or run log file for details
```

This overloaded `StdMatch` function has been removed.