### PR TITLE
Use TKEEP_FIXED_C for Pgp2b streams

### DIFF
--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bPkg.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bPkg.vhd
@@ -25,7 +25,8 @@ package Pgp2bPkg is
    -----------------------------------------------------
    -- Constants
    -----------------------------------------------------
-   constant SSI_PGP2B_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(2, TKEEP_COMP_C);
+   constant SSI_PGP2B_CONFIG_C       : AxiStreamConfigType := ssiAxiStreamConfig(2, TKEEP_FIXED_C);
+   constant SSI_PGP2B_2LANE_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(4, TKEEP_FIXED_C);
 
    -- 8B10B Characters
    constant K_COM_C  : slv(7 downto 0) := "10111100";  -- K28.5, 0xBC


### PR DESCRIPTION

### Description
The Pgp2b AxiStreamConfig constant is now TKEEP_FIXED_C. This will hopefully allow better optimization through FIFOs.

Also added new constant for 2-lane Pgp2b streams.