### PR TITLE
Downgrade TKEEP_MODE = FIXED on master but not slave to a warning

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
@@ -176,8 +176,9 @@ begin
    -- Cant use tkeep_fixed on master side when resizing or if not on slave side
    assert (not (MASTER_AXI_CONFIG_G.TKEEP_MODE_C = TKEEP_FIXED_C and
                 SLAVE_AXI_CONFIG_G.TKEEP_MODE_C /= TKEEP_FIXED_C))
-      report "AxiStreamFifoV2: Can't have TKEEP_MODE = TKEEP_FIXED on master side if not on slave side"
-      severity error;
+      report "AxiStreamFifoV2: TKEEP_MODE = TKEEP_FIXED on master side if not on slave side. "&
+      "This is dangerous as odd sized frames will be padded with garbage data."
+      severity warning;
 
    -------------------------
    -- Slave Resize


### PR DESCRIPTION
### Description
AxiStreamFifoV2 now gives a `warning` instead of an `error` if the master side config specifies `TKEEP_FIXED_C` but the slave side does not.

### Details
The hazard of this mode of operation is that a frame on the slave side that is not an even multiple word size of the master side will be padded with garbage data. But sometimes it is necessary to transition streams this way.

#### Note
It seems like this check should actually be done in `AxiStreamResize` instead?

Also, when the master side is `TKEEP_FIXED_C`, maybe `FIFO_CONFIG_C.TKEEP_MODE_C` should be set to TKEEP_FIXED_C instead of whatever is one the slave side? This would allow TKEEP logic to optimized out of the FIFO.