### PR TITLE
Enable synchronizer on status bits for TenGigEth Axil registers.

### DIFF
--- a/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
+++ b/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
@@ -104,7 +104,7 @@ begin
             TPD_G          => TPD_G,
             OUT_POLARITY_G => '1',
             CNT_RST_EDGE_G => false,
-            COMMON_CLK_G   => true,
+            COMMON_CLK_G   => false,
             CNT_WIDTH_G    => 32,
             WIDTH_G        => STATUS_SIZE_C)
          port map (


### PR DESCRIPTION
### Description
The TenGigEthReg module feature a synchronizer for status bits which are read
into AXIL registers. The module assumes that all status bits originate in the
same clock domain as the module itself and disables the synchronizer.

However, there are some bits which originate in a different clock domain. This
PR simply enables the (already coded) synchronizer.

### Details
Some of the status bits:

  gtTxRst,
  gtRxRst,
  rstCntDone,
  rxRstdone,
  txRstdone

are not generated in the target clock domain (phyClk).
Probably not that critical, but nevertheless...

(bits 17, 16, 12, 13, 14)