### PR TITLE
updating Clink internal UART AXIS bus from 4B to 1B

### DIFF
--- a/protocols/clink/hdl/ClinkUart.vhd
+++ b/protocols/clink/hdl/ClinkUart.vhd
@@ -50,7 +50,7 @@ architecture rtl of ClinkUart is
 
    constant INT_FREQ_C : integer := 200000000;
 
-   constant INT_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(dataBytes=>4,tDestBits=>0);
+   constant INT_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(dataBytes=>1,tDestBits=>0); -- 1-byte tData Interface
 
    type RegType is   record
       count  : integer;


### PR DESCRIPTION
### Description
- Updating Clink internal UART AXIS bus from 4B to 1B

