### PR TITLE
Optionally cache SPI memory in AxiSpiMaster

### DIFF
--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -39,6 +39,7 @@ entity AxiSpiMaster is
       ADDRESS_SIZE_G    : natural         := 15;
       DATA_SIZE_G       : natural         := 8;
       MODE_G            : string          := "RW";  -- Or "WO" (write only),  "RO" (read only)
+      SHADOW_EN_G       : boolean         := false;
       CPHA_G            : sl              := '0';
       CPOL_G            : sl              := '0';
       CLK_PERIOD_G      : real            := 6.4E-9;
@@ -71,7 +72,14 @@ architecture rtl of AxiSpiMaster is
    signal rdData : slv(PACKET_SIZE_C-1 downto 0);
    signal rdEn   : sl;
 
-   type StateType is (WAIT_AXI_TXN_S, WAIT_CYCLE_S, WAIT_SPI_TXN_DONE_S);
+   type StateType is (WAIT_AXI_TXN_S, WAIT_CYCLE_S, WAIT_CYCLE_SHADOW_S, WAIT_SPI_TXN_DONE_S);
+
+
+   type mem_type is array ((2**ADDRESS_SIZE_G)-1 downto 0) of slv(DATA_SIZE_G-1 downto 0);
+   signal mem     : mem_type := (others => (others => '0'));
+   signal memData : slv(DATA_SIZE_G-1 downto 0) := (others => '0');
+   signal memAddr : slv(ADDRESS_SIZE_G-1 downto 0) := (others => '0');
+   signal memWe   : sl := '0';
 
    -- Registers
    type RegType is record
@@ -98,7 +106,11 @@ architecture rtl of AxiSpiMaster is
 
 begin
 
-   comb : process (axiReadMaster, axiRst, axiWriteMaster, r, rdData, rdEn) is
+
+   memAddr <= r.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G);
+   memWe   <= r.wrEn;
+
+   comb : process (axiReadMaster, axiRst, axiWriteMaster, r, rdData, rdEn, memData) is
       variable v         : RegType;
       variable axiStatus : AxiLiteStatusType;
    begin
@@ -113,7 +125,6 @@ begin
                if (MODE_G = "RO") then
                   axiSlaveWriteResponse(v.axiWriteSlave, AXI_RESP_DECERR_C);
                else
-
                   -- No write bit when mode is write-only
                   if (MODE_G /= "WO") then
                      v.wrData(PACKET_SIZE_C-1) := '0';
@@ -135,13 +146,18 @@ begin
             if (axiStatus.readEnable = '1') then
                if (MODE_G = "WO") then
                   axiSlaveReadResponse(v.axiReadSlave, AXI_RESP_DECERR_C);
+               elsif (SHADOW_EN_G) then
+                  v.state                   := WAIT_CYCLE_SHADOW_S; -- just go to wait a cycle for memData to update 
+                  v.wrData(PACKET_SIZE_C-1) := '1';                 -- indicate axi lite read in WAIT_SPI_TXN_DONE_S checking
+                  if (ADDRESS_SIZE_G > 0) then
+                     v.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G) := axiReadMaster.araddr(2+ADDRESS_SIZE_G-1 downto 2); -- setup memAddr
+                  end if;
                else
-
                   -- No read bit when mode is read-only
                   if (MODE_G /= "RO") then
                      v.wrData(PACKET_SIZE_C-1) := '1';
                   end if;
-
+   
                   -- Address
                   if (ADDRESS_SIZE_G > 0) then
                      v.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G) := axiReadMaster.araddr(2+ADDRESS_SIZE_G-1 downto 2);
@@ -149,7 +165,7 @@ begin
                      -- in shared sdio configurations
                      v.wrData(DATA_SIZE_G-1 downto 0)                          := (others => '1');
                   end if;
-
+   
                   -- If there are no address bits, readback will reuse the last wrData when shifting
                   v.chipSel := axiReadMaster.araddr(CHIP_BITS_C+ADDRESS_SIZE_G+1 downto 2+ADDRESS_SIZE_G);
                   v.wrEn    := '1';
@@ -164,6 +180,10 @@ begin
                v.state := WAIT_SPI_TXN_DONE_S;
             end if;
 
+         when WAIT_CYCLE_SHADOW_S =>
+            -- wait for memData
+            v.state := WAIT_SPI_TXN_DONE_S;
+
          when WAIT_SPI_TXN_DONE_S =>
 
             if (rdEn = '1') then
@@ -171,6 +191,10 @@ begin
                
                if (MODE_G = "WO" or (MODE_G = "RW" and r.wrData(PACKET_SIZE_C-1) = '0')) then
                   axiSlaveWriteResponse(v.axiWriteSlave);
+               elsif (SHADOW_EN_G) then
+                  v.axiReadSlave.rdata                         := (others => '0');
+                  v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := memData;
+                  axiSlaveReadResponse(v.axiReadSlave);
                else
                   v.axiReadSlave.rdata                         := (others => '0');
                   v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := rdData(DATA_SIZE_G-1 downto 0);
@@ -196,6 +220,18 @@ begin
       axiReadSlave  <= r.axiReadSlave;
 
    end process comb;
+
+   shadow_mem : process (axiClk) is
+   begin
+      if (SHADOW_EN_G) then
+         if (rising_edge(axiClk)) then
+            if (memWe = '1') then
+               mem(conv_integer(memAddr)) <= r.wrData;
+            end if;
+            memData <= mem(conv_integer(memAddr));
+         end if;
+      end if;
+   end process shadow_mem;
 
    seq : process (axiClk) is
    begin


### PR DESCRIPTION
  Add SHADOW_EN_G to AxiSpiMaster.  If enabled will generate a single port RAM to shadow the SPI device memory
    - writes go to SPI and shadow memory
    - reads return shadow memory

<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
