### PR TITLE
Make sure GitHashShort always displays 7 characters

### DIFF
--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -193,7 +193,7 @@ class AxiVersion(pr.Device):
             name         = 'GitHashShort',
             mode         = 'RO',
             dependencies = [self.GitHash],
-            linkedGet    = lambda read: f'{(self.GitHash.get(read) >> 132):x}',
+            linkedGet    = lambda read: f'{(self.GitHash.get(read) >> 132):07x}',
         ))
 
         self.add(pr.RemoteVariable(   


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
GitHashShort was truncating any leading zeros. These should be displayed in order to show shortened git hashes the way that the `git` program does.