### PR TITLE
bug fix for LOAD_C_S subtraction

### DIFF
--- a/protocols/clink/rtl/ClinkData.vhd
+++ b/protocols/clink/rtl/ClinkData.vhd
@@ -75,7 +75,7 @@ architecture rtl of ClinkData is
    constant REG_INIT_C : RegType := (
       state   => RESET_S,
       lastClk => (others => '0'),
-      delay   => "00001",
+      delay   => toSlv(10,5),
       delayLd => '0',
       bitSlip => '0',
       count   => 99,


### PR DESCRIPTION
### Description
- Prevent the delay counter from rolling over when the subtract by 10 happens in the LOAD_C_S state