### PR TITLE
GenericMemoryArray.yaml: fixed merge node

### DIFF
--- a/yaml/GenericMemory.yaml
+++ b/yaml/GenericMemory.yaml
@@ -24,7 +24,7 @@ GenericMemory: &GenericMemory
   children:
     #########################################################
     MemoryArray:
-      <<: MemoryArray
+      <<: *MemoryArray
       at:
         offset: 0x0
         nelms: 1


### PR DESCRIPTION
### Description
Fixed typo on GenericMemoryArray.yaml which rendered the definition of the memory useless.
### Details
The merged node must be an alias

       <<: *MemoryArray

not

      <<: MemoryArray
### JIRA
[jira ticket ESCORE-419](https://jira.slac.stanford.edu/browse/ESCORE-419?jql=resolution%20%3D%20Unresolved%20AND%20reporter%20%3D%20currentUser())