### PR TITLE
SsiPrbsTx-bug-fix

### DIFF
--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -292,6 +292,7 @@ begin
             if v.txAxisMaster.tvalid = '0' then
                -- Send the upper packetLength value
                v.txAxisMaster.tvalid             := '1';
+               v.txAxisMaster.tData              := (others => '0');
                v.txAxisMaster.tData(31 downto 0) := r.length;
                -- Increment the counter
                v.dataCnt                         := r.dataCnt + 1;


### PR DESCRIPTION
### Description
If the rest of the tData bus is not zero'd out in the LENGTH_S, the SsiPrbsRx will report a "databus error" when PRBS_SEED_SIZE_G>32B and eventCnt >= 2^32.