### PR TITLE
Zynq GTP vs. GTX

### DIFF
--- a/ethernet/GigEthCore/ruckus.tcl
+++ b/ethernet/GigEthCore/ruckus.tcl
@@ -11,9 +11,16 @@ if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"
 }
 
-if { ${family} eq {kintex7} ||
-     ${family} eq {zynq} } {
+if { ${family} eq {kintex7} } {
    loadRuckusTcl "$::DIR_PATH/gtx7"
+}
+
+if { ${family} eq {zynq} } {
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
 }
 
 if { ${family} eq {virtex7} } {

--- a/protocols/glink/ruckus.tcl
+++ b/protocols/glink/ruckus.tcl
@@ -20,5 +20,9 @@ if { ${family} == "kintex7" } {
 }
 
 if { ${family} == "zynq" } {
-   loadRuckusTcl "$::DIR_PATH/gtx7"
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
 }

--- a/protocols/pgp/pgp2b/ruckus.tcl
+++ b/protocols/pgp/pgp2b/ruckus.tcl
@@ -11,9 +11,16 @@ if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"
 }
 
-if { ${family} eq {kintex7} ||
-     ${family} eq {zynq} } {
+if { ${family} eq {kintex7} } {
    loadRuckusTcl "$::DIR_PATH/gtx7"
+}
+
+if { ${family} eq {zynq} } {
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
 }
 
 if { ${family} eq {virtex7} } {

--- a/protocols/pgp/pgp3/ruckus.tcl
+++ b/protocols/pgp/pgp3/ruckus.tcl
@@ -11,9 +11,16 @@ if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"
 }
 
-if { ${family} eq {kintex7} ||
-     ${family} eq {zynq} } {
+if { ${family} eq {kintex7} } {
    loadRuckusTcl "$::DIR_PATH/gtx7"
+}
+
+if { ${family} eq {zynq} } {
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
 }
 
 # if { ${family} eq {virtex7} } {

--- a/xilinx/7Series/ruckus.tcl
+++ b/xilinx/7Series/ruckus.tcl
@@ -22,6 +22,10 @@ if { ${family} == "virtex7" } {
 }
 
 if { ${family} == "zynq" } {
-   loadRuckusTcl "$::DIR_PATH/gtx7"
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
 }
 


### PR DESCRIPTION
ruckus.tcl assumed that all zynq devices have GTX transceivers but some have GTPs

### Description
Added a check that inspects PRJ_PART and selects GTP if a match with XC7Z012 or XC7C015 is detected (the only low-end devices that have GTPs). Otherwise it assumes GTX. The check applies only if `${family} eq {zynq}`.