### PR TITLE
weByte bug fix for AxiDualPortRam.GEN_INFERRED.AXI_RW_SYS_RW

### DIFF
--- a/axi/axi-lite/rtl/AxiDualPortRam.vhd
+++ b/axi/axi-lite/rtl/AxiDualPortRam.vhd
@@ -258,7 +258,7 @@ begin
                clkb    => clk,                                       -- [in]
                enb     => en,                                        -- [in]
                web     => we,                                        -- [in]
-               webByte => weByte,                                    -- [in]
+               webByte => weByteMask,                                -- [in]
                rstb    => '0',                                       -- [in]
                addrb   => addr,                                      -- [in]
                dinb    => din,                                       -- [in]


### PR DESCRIPTION
### Description
- weByte bug fix for AxiDualPortRam.GEN_INFERRED.AXI_RW_SYS_RW