### PR TITLE
increasing the SRPv3 TX FIFO config

### DIFF
--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
@@ -24,10 +24,12 @@ use unisim.vcomponents.all;
 entity TenGigEthGthUltraScaleClk is
    generic (
       TPD_G             : time            := 1 ns;
+      EXT_REF_G         : boolean         := false;
       QPLL_REFCLK_SEL_G : slv(2 downto 0) := "001");
    port (
       -- MGT Clock Port (156.25 MHz)
       gtRefClk      : in  sl := '0';
+      gtRefClkBufg  : in  sl := '0';
       gtClkP        : in  sl := '1';
       gtClkN        : in  sl := '0';
       coreClk       : out sl;
@@ -74,8 +76,8 @@ begin
          DIV     => "000",
          O       => coreClock);
 
-   refClock  <= gtRefClk when(QPLL_REFCLK_SEL_G = "111") else refClk;
-   coreClk   <= gtRefClk when(QPLL_REFCLK_SEL_G = "111") else coreClock;
+   refClock  <= gtRefClk    when(EXT_REF_G) else refClk;
+   coreClk   <= gtRefClkBufg when(EXT_REF_G) else coreClock;
    qpllReset <= qpllRst or coreRst;
 
    GthUltraScaleQuadPll_Inst : entity work.GthUltraScaleQuadPll

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -30,6 +30,7 @@ entity TenGigEthGthUltraScaleWrapper is
       PAUSE_EN_G        : boolean                          := true;
       PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
+      EXT_REF_G         : boolean                          := false;
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
       EN_AXI_REG_G      : boolean                          := false;
@@ -72,6 +73,7 @@ entity TenGigEthGthUltraScaleWrapper is
       gtTxPolarity        : in  sl                                             := '0';
       -- MGT Clock Port (156.25 MHz)
       gtRefClk            : in  sl                                             := '0';
+      gtRefClkBufg        : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
       -- MGT Ports
@@ -116,10 +118,12 @@ begin
    TenGigEthGthUltraScaleClk_Inst : entity work.TenGigEthGthUltraScaleClk
       generic map (
          TPD_G             => TPD_G,
+         EXT_REF_G         => EXT_REF_G,
          QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)
       port map (
          -- MGT Clock Port (156.25 MHz)
          gtRefClk      => gtRefClk,
+         gtRefClkBufg  => gtRefClkBufg,
          gtClkP        => gtClkP,
          gtClkN        => gtClkN,
          coreClk       => coreClock,

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -36,7 +36,7 @@ entity SrpV3AxiLite is
       INT_PIPE_STAGES_G     : natural range 0 to 16   := 1;
       PIPE_STAGES_G         : natural range 0 to 16   := 1;
       FIFO_PAUSE_THRESH_G   : positive range 1 to 511 := 256;
-      TX_VALID_THOLD_G      : positive range 1 to 511 := 256;   -- >1 = only when frame ready or # entries
+      TX_VALID_THOLD_G      : positive range 1 to 511 := 500;   -- >1 = only when frame ready or # entries
       TX_VALID_BURST_MODE_G : boolean                 := true;  -- only used in VALID_THOLD_G>1
       SLAVE_READY_EN_G      : boolean                 := false;
       GEN_SYNC_FIFO_G       : boolean                 := false;
@@ -799,9 +799,10 @@ begin
          USE_BUILT_IN_G      => false,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          ALTERA_SYN_G        => ALTERA_SYN_G,
-         ALTERA_RAM_G        => ALTERA_RAM_G,
-         CASCADE_SIZE_G      => 1,
-         FIFO_ADDR_WIDTH_G   => 9,
+         ALTERA_RAM_G        => ALTERA_RAM_G,         
+         INT_WIDTH_SELECT_G  => "CUSTOM",
+         INT_DATA_WIDTH_G    => 16,     -- 128-bit         
+         FIFO_ADDR_WIDTH_G   => 9,      -- 8kB/FIFO = 128-bits x 512 entries         
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => AXI_STREAM_CONFIG_G)


### PR DESCRIPTION
### Description
- Increasing the SRPv3 TX FIFO config
- For the 4kB read/write case (95% CASE), this will make the SRPv3 cache the full response before sending the response onto the transport layer

### Background
dev-board-example testing with RUDP if I transmit 9008B as fast as possible on the TX PRBS.  If the auto-polling enabled then the rate would go from a stable ~70kHz to an average of 1kHz.  With this new configuration the TX PRBS is now able to be ~70kHz