### PR TITLE
SMURF PCIe Development Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 *._*
 *.db
 xvcSrv
+bin/
 doxygen/

--- a/ethernet/EthMacCore/rtl/EthMacPkg.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacPkg.vhd
@@ -77,7 +77,7 @@ package EthMacPkg is
       filtEnable  => '1',
       pauseEnable => '1',
       pauseTime   => x"00FF",
-      pauseThresh => toSlv(512, 16),
+      pauseThresh => toSlv(1024, 16),
       ipCsumEn    => '1',
       tcpCsumEn   => '1',
       udpCsumEn   => '1',

--- a/ethernet/EthMacCore/rtl/EthMacPkg.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacPkg.vhd
@@ -66,6 +66,7 @@ package EthMacPkg is
       filtEnable  : sl;
       pauseEnable : sl;
       pauseTime   : slv(15 downto 0);
+      pauseThresh : slv(15 downto 0);
       ipCsumEn    : sl;
       tcpCsumEn   : sl;
       udpCsumEn   : sl;
@@ -76,6 +77,7 @@ package EthMacPkg is
       filtEnable  => '1',
       pauseEnable => '1',
       pauseTime   => x"00FF",
+      pauseThresh => toSlv(512, 16),
       ipCsumEn    => '1',
       tcpCsumEn   => '1',
       udpCsumEn   => '1',

--- a/ethernet/EthMacCore/rtl/EthMacRxFifo.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxFifo.vhd
@@ -26,10 +26,8 @@ entity EthMacRxFifo is
       DROP_ERR_PKT_G      : boolean             := true;
       INT_PIPE_STAGES_G   : natural             := 1;
       PIPE_STAGES_G       : natural             := 1;
-      FIFO_ADDR_WIDTH_G   : positive            := 10;
-      CASCADE_SIZE_G      : positive            := 2;
-      FIFO_PAUSE_THRESH_G : positive            := 1000;
-      CASCADE_PAUSE_SEL_G : natural             := 0;
+      FIFO_ADDR_WIDTH_G   : positive            := 11;
+      FIFO_PAUSE_THRESH_G : positive            := 128;
       PRIM_COMMON_CLK_G   : boolean             := false;
       PRIM_CONFIG_G       : AxiStreamConfigType := EMAC_AXIS_CONFIG_C;
       BYP_EN_G            : boolean             := false;
@@ -104,8 +102,6 @@ begin
          -- FIFO configurations
          BRAM_EN_G           => true,
          GEN_SYNC_FIFO_G     => PRIM_COMMON_CLK_G,
-         CASCADE_SIZE_G      => CASCADE_SIZE_G,
-         CASCADE_PAUSE_SEL_G => CASCADE_PAUSE_SEL_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
          -- AXI Stream Port Configurations
@@ -141,8 +137,6 @@ begin
             -- FIFO configurations
             BRAM_EN_G           => true,
             GEN_SYNC_FIFO_G     => PRIM_COMMON_CLK_G,
-            CASCADE_SIZE_G      => CASCADE_SIZE_G,
-            CASCADE_PAUSE_SEL_G => CASCADE_PAUSE_SEL_G,
             FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
             FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
             -- AXI Stream Port Configurations
@@ -180,8 +174,6 @@ begin
                -- FIFO configurations
                BRAM_EN_G           => true,
                GEN_SYNC_FIFO_G     => PRIM_COMMON_CLK_G,
-               CASCADE_SIZE_G      => CASCADE_SIZE_G,
-               CASCADE_PAUSE_SEL_G => CASCADE_PAUSE_SEL_G,
                FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
                FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
                -- AXI Stream Port Configurations

--- a/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
@@ -85,8 +85,8 @@ begin
             -- AXIS Interface 
             macIbMaster => macIbMaster,
             -- XGMII PHY Interface
-            phyRxd      => xgmiiRxd,
-            phyRxc      => xgmiiRxc,
+            phyRxdata   => xgmiiRxd,
+            phyRxChar   => xgmiiRxc,
             -- Configuration and status
             phyReady    => phyReady,
             rxCountEn   => rxCountEn,

--- a/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
@@ -49,7 +49,7 @@ architecture rtl of EthMacRxImportXgmii is
       TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
       TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
       TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
-      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);   
+      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
 
    -- Local Signals
    signal macMaster    : AxiStreamMasterType;
@@ -130,33 +130,24 @@ architecture rtl of EthMacRxImportXgmii is
 
 begin
 
-   DATA_MUX : entity work.AxiStreamFifoV2
+   U_Resize : entity work.AxiStreamResize
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
-         PIPE_STAGES_G       => 0,
-         SLAVE_READY_EN_G    => true,
-         VALID_THOLD_G       => 1,
-         -- FIFO configurations
-         BRAM_EN_G           => false,
-         USE_BUILT_IN_G      => false,
-         GEN_SYNC_FIFO_G     => true,
-         CASCADE_SIZE_G      => 1,
-         FIFO_ADDR_WIDTH_G   => 4,
+         READY_EN_G          => false,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,        --  64-bit AXI stream interface  
-         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface          
+         SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,  --  64-bit AXI stream interface  
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface     
       port map (
+         -- Clock and reset
+         axisClk     => ethClk,
+         axisRst     => ethRst,
          -- Slave Port
-         sAxisClk    => ethClk,
-         sAxisRst    => ethRst,
-         sAxisMaster => macMaster,                   -- 64-bit AXI stream interface  
+         sAxisMaster => macMaster,      -- 64-bit AXI stream interface  
          sAxisSlave  => open,
          -- Master Port
-         mAxisClk    => ethClk,
-         mAxisRst    => ethRst,
-         mAxisMaster => macIbMaster,                 -- 128-bit AXI stream interface
-         mAxisSlave  => AXI_STREAM_SLAVE_FORCE_C);  
+         mAxisMaster => macIbMaster,    -- 128-bit AXI stream interface
+         mAxisSlave  => AXI_STREAM_SLAVE_FORCE_C);
 
    -- Convert to AXI stream
    process (ethClk) is
@@ -351,7 +342,7 @@ begin
          ADDR_WIDTH_G    => 4,
          INIT_G          => "0",
          FULL_THRES_G    => 1,
-         EMPTY_THRES_G   => 1) 
+         EMPTY_THRES_G   => 1)
       port map (
          rst           => ethRst,
          wr_clk        => ethClk,
@@ -485,13 +476,13 @@ begin
    U_Crc32 : entity work.Crc32Parallel
       generic map (
          TPD_G        => TPD_G,
-         BYTE_WIDTH_G => 8) 
+         BYTE_WIDTH_G => 8)
       port map (
          crcOut       => crcOut,
          crcClk       => ethClk,
          crcDataValid => crcDataValid,
          crcDataWidth => crcDataWidth,
          crcIn        => crcIn,
-         crcReset     => crcReset); 
+         crcReset     => crcReset);
 
 end rtl;

--- a/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
@@ -32,8 +32,8 @@ entity EthMacRxImportXgmii is
       -- AXIS Interface   
       macIbMaster : out AxiStreamMasterType;
       -- PHY Interface
-      phyRxd      : in  slv(63 downto 0);
-      phyRxc      : in  slv(7 downto 0);
+      phyRxdata   : in  slv(63 downto 0);
+      phyRxChar   : in  slv(7 downto 0);
       -- Configuration and status
       phyReady    : in  sl;
       rxCountEn   : out sl;
@@ -50,6 +50,24 @@ architecture rtl of EthMacRxImportXgmii is
       TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
       TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
       TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
+
+   type RegType is record
+      phyRxd      : slv(63 downto 0);
+      phyRxc      : slv(7 downto 0);
+      phyRxdDly   : slv(63 downto 0);
+      phyRxcDly   : slv(7 downto 0);
+      gapInserted : sl;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      phyRxd      => x"0707070707070707",
+      phyRxc      => x"FF",
+      phyRxdDly   => x"0707070707070707",
+      phyRxcDly   => x"FF",
+      gapInserted => '0');
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
    -- Local Signals
    signal macMaster    : AxiStreamMasterType;
@@ -88,6 +106,9 @@ architecture rtl of EthMacRxImportXgmii is
    signal crcOut       : slv(31 downto 0);
    signal macData      : slv(63 downto 0);
    signal macSize      : slv(2 downto 0);
+   
+   signal phyRxd : slv(63 downto 0);
+   signal phyRxc : slv(7 downto 0);   
 
    -- Debug Signals
    attribute dont_touch : string;
@@ -127,8 +148,70 @@ architecture rtl of EthMacRxImportXgmii is
    attribute dont_touch of crcOut       : signal is "true";
    attribute dont_touch of macData      : signal is "true";
    attribute dont_touch of macSize      : signal is "true";
-
+   attribute dont_touch of phyRxd       : signal is "true";
+   attribute dont_touch of phyRxc       : signal is "true";
+   
 begin
+
+   comb : process (phyRxChar, phyRxdata, r) is
+      variable v : RegType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Check delayed copy
+      v.phyRxcDly := phyRxChar;
+      v.phyRxdDly := phyRxdata;
+
+      -- Check if no gap inserted 
+      if r.gapInserted = '0' then
+
+         -- Check for no gap between two frames
+         if (phyRxChar /= x"FF" and phyRxChar /= x"00") and (r.phyRxcDly /= x"FF" and r.phyRxcDly /= x"00") then
+            -- Set the flag
+            v.gapInserted := '1';
+            -- Insert a gap
+            v.phyRxc      := x"FF";
+            v.phyRxd      := x"0707070707070707";
+         else
+            -- Moved the non-delayed copy
+            v.phyRxc := phyRxChar;
+            v.phyRxd := phyRxdata;
+         end if;
+
+      else
+
+         -- Moved the delayed copy
+         phyRxc <= r.phyRxcDly;
+         phyRxd <= r.phyRxdDly;
+
+         -- Check for two gaps in a row
+         if (r.phyRxcDly = x"FF") and (phyRxChar = x"FF") then
+            -- Reset the flag
+            v.gapInserted := '0';
+         end if;
+
+      end if;
+
+      -- Outputs
+      phyRxc <= r.phyRxc;
+      phyRxd <= r.phyRxd;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (ethClk) is
+   begin
+      if (rising_edge(ethClk)) then
+         if (ethRst = '1') then
+            r <= REG_INIT_C after TPD_G;
+         else
+            r <= rin after TPD_G;
+         end if;
+      end if;
+   end process seq;
 
    U_Resize : entity work.AxiStreamResize
       generic map (

--- a/ethernet/EthMacCore/rtl/EthMacRxPause.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxPause.vhd
@@ -110,8 +110,8 @@ begin
                if (sAxisMaster.tValid = '1') then
                   -- Check for pause frame
                   if (PAUSE_EN_G = true) and
-                     (sAxisMaster.tData(47 downto 0) = x"010000c28001") and  -- DST MAC (Pause MAC Address)
-                     (sAxisMaster.tData(127 downto 96) = x"01000888") then   -- Mac Type, Mac OpCode
+                     (sAxisMaster.tData(47 downto 0) = x"01_00_00_C2_80_01") and  -- DST MAC (Pause MAC Address)
+                     (sAxisMaster.tData(127 downto 96) = x"01_00_08_88") then   -- Mac Type, Mac OpCode
                      -- Check for no EOF
                      if (sAxisMaster.tLast = '0') then
                         -- Next State
@@ -156,9 +156,9 @@ begin
                end if;
             ----------------------------------------------------------------------
             when PAUSE_S =>
-               ----------------------------------------------------------------------------------------------------------
-               -- Refer to https://www.safaribooksonline.com/library/view/ethernet-the-definitive/1565926609/ch04s02.html
-               ----------------------------------------------------------------------------------------------------------            
+            --------------------------------------------------------------------------------------------------------------------
+            -- Refer to https://hasanmansur1.files.wordpress.com/2012/12/ethernet-flow-control-pause-frame-framing-structure.png
+            --------------------------------------------------------------------------------------------------------------------           
                -- Check for data
                if (sAxisMaster.tValid = '1') then
                   -- Latch the pause data

--- a/ethernet/EthMacCore/rtl/EthMacTop.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTop.vhd
@@ -35,8 +35,7 @@ entity EthMacTop is
       -- RX FIFO Configurations
       INT_PIPE_STAGES_G   : natural                  := 1;
       PIPE_STAGES_G       : natural                  := 1;
-      FIFO_ADDR_WIDTH_G   : positive            := 11;
-      FIFO_PAUSE_THRESH_G : positive            := 128;
+      FIFO_ADDR_WIDTH_G   : positive                 := 11;
       -- Non-VLAN Configurations
       FILT_EN_G           : boolean                  := false;
       PRIM_COMMON_CLK_G   : boolean                  := false;
@@ -309,7 +308,6 @@ begin
          INT_PIPE_STAGES_G   => INT_PIPE_STAGES_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
-         FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
          PRIM_COMMON_CLK_G   => PRIM_COMMON_CLK_G,
          PRIM_CONFIG_G       => PRIM_CONFIG_G,
          BYP_EN_G            => BYP_EN_G,
@@ -323,9 +321,10 @@ begin
          -- Slave Clock and Reset
          sClk         => ethClk,
          sRst         => ethRst,
-         -- Status (sClk domain)
+         -- Status/Config (sClk domain)
          phyReady     => phyReady,
          rxFifoDrop   => ethStatus.rxFifoDropCnt,
+         pauseThresh  => ethConfig.pauseThresh,
          -- Primary Interface
          mPrimClk     => primClk,
          mPrimRst     => primRst,

--- a/ethernet/EthMacCore/rtl/EthMacTop.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTop.vhd
@@ -35,10 +35,8 @@ entity EthMacTop is
       -- RX FIFO Configurations
       INT_PIPE_STAGES_G   : natural                  := 1;
       PIPE_STAGES_G       : natural                  := 1;
-      FIFO_ADDR_WIDTH_G   : positive                 := 10;
-      CASCADE_SIZE_G      : positive                 := 2;
-      FIFO_PAUSE_THRESH_G : positive                 := 1000;
-      CASCADE_PAUSE_SEL_G : natural                  := 0;
+      FIFO_ADDR_WIDTH_G   : positive            := 11;
+      FIFO_PAUSE_THRESH_G : positive            := 128;
       -- Non-VLAN Configurations
       FILT_EN_G           : boolean                  := false;
       PRIM_COMMON_CLK_G   : boolean                  := false;
@@ -311,9 +309,7 @@ begin
          INT_PIPE_STAGES_G   => INT_PIPE_STAGES_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
-         CASCADE_SIZE_G      => CASCADE_SIZE_G,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
-         CASCADE_PAUSE_SEL_G => CASCADE_PAUSE_SEL_G,
          PRIM_COMMON_CLK_G   => PRIM_COMMON_CLK_G,
          PRIM_CONFIG_G       => PRIM_CONFIG_G,
          BYP_EN_G            => BYP_EN_G,

--- a/ethernet/EthMacCore/rtl/EthMacTop.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTop.vhd
@@ -28,7 +28,7 @@ entity EthMacTop is
       TPD_G               : time                     := 1 ns;
       -- MAC Configurations
       PAUSE_EN_G          : boolean                  := true;
-      PAUSE_512BITS_G     : positive range 1 to 1024 := 8;
+      PAUSE_512BITS_G     : positive range 1 to 1024 := 8; -- For 10GbE: 8 clock cycles for 512 bits = one pause "quanta"
       PHY_TYPE_G          : string                   := "XGMII";  -- "GMII", "XGMII", or "XLGMII"
       DROP_ERR_PKT_G      : boolean                  := true;
       JUMBO_G             : boolean                  := true;

--- a/ethernet/EthMacCore/rtl/EthMacTx.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTx.vhd
@@ -228,7 +228,6 @@ begin
          gmiiTxEr       => gmiiTxEr,
          gmiiTxd        => gmiiTxd,
          -- Configuration and status
-         macAddress     => ethConfig.macAddress,
          phyReady       => phyReady,
          txCountEn      => txCountEn,
          txUnderRun     => txUnderRun,

--- a/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
@@ -44,7 +44,6 @@ entity EthMacTxExport is
       gmiiTxEr       : out sl;
       gmiiTxd        : out slv(7 downto 0);
       -- Configuration and status
-      macAddress     : in  slv(47 downto 0);
       phyReady       : in  sl;
       txCountEn      : out sl;
       txUnderRun     : out sl;
@@ -73,7 +72,6 @@ begin
             phyTxc         => xlgmiiTxc,
             -- Configuration and status
             phyReady       => phyReady,
-            macAddress     => macAddress,
             txCountEn      => txCountEn,
             txUnderRun     => txUnderRun,
             txLinkNotReady => txLinkNotReady);
@@ -101,7 +99,6 @@ begin
             phyTxc         => xgmiiTxc,
             -- Configuration and status
             phyReady       => phyReady,
-            macAddress     => macAddress,
             txCountEn      => txCountEn,
             txUnderRun     => txUnderRun,
             txLinkNotReady => txLinkNotReady);
@@ -131,7 +128,6 @@ begin
             gmiiTxd        => gmiiTxd,
             -- Configuration and status
             phyReady       => phyReady,
-            macAddress     => macAddress,
             txCountEn      => txCountEn,
             txUnderRun     => txUnderRun,
             txLinkNotReady => txLinkNotReady);

--- a/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
@@ -38,8 +38,6 @@ entity EthMacTxExportGmii is
       gmiiTxEr       : out sl;
       gmiiTxd        : out slv(7 downto 0);
       phyReady       : in  sl;
-      -- Configuration
-      macAddress     : in  slv(47 downto 0);
       -- Status
       txCountEn      : out sl;
       txUnderRun     : out sl;

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
@@ -47,7 +47,7 @@ end EthMacTxExportXgmii;
 
 architecture rtl of EthMacTxExportXgmii is
 
-   constant INTERGAP_C : slv(3 downto 0) := x"3";
+   constant INTERGAP_C : slv(3 downto 0) := x"F";
 
    constant AXI_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
@@ -37,8 +37,6 @@ entity EthMacTxExportXgmii is
       phyTxd         : out slv(63 downto 0);
       phyTxc         : out slv(7 downto 0);
       phyReady       : in  sl;
-      -- Configuration
-      macAddress     : in  slv(47 downto 0);
       -- Errors
       txCountEn      : out sl;
       txUnderRun     : out sl;
@@ -63,7 +61,6 @@ architecture rtl of EthMacTxExportXgmii is
    signal macSlave         : AxiStreamSlaveType;
    signal intAdvance       : sl;
    signal intDump          : sl;
-   signal intRunt          : sl;
    signal intPad           : sl;
    signal intLastLine      : sl;
    signal intLastValidByte : slv(2 downto 0);
@@ -78,6 +75,7 @@ architecture rtl of EthMacTxExportXgmii is
    signal intData          : slv(63 downto 0);
    signal stateCount       : slv(3 downto 0);
    signal stateCountRst    : sl;
+   signal wordCountRst     : sl;
    signal exportWordCnt    : slv(3 downto 0);
    signal crcFifoIn        : slv(71 downto 0);
    signal crcFifoOut       : slv(71 downto 0);
@@ -107,7 +105,6 @@ architecture rtl of EthMacTxExportXgmii is
 
    attribute dont_touch of intAdvance       : signal is "true";
    attribute dont_touch of intDump          : signal is "true";
-   attribute dont_touch of intRunt          : signal is "true";
    attribute dont_touch of intPad           : signal is "true";
    attribute dont_touch of intLastLine      : signal is "true";
    attribute dont_touch of intLastValidByte : signal is "true";
@@ -122,6 +119,7 @@ architecture rtl of EthMacTxExportXgmii is
    attribute dont_touch of intData          : signal is "true";
    attribute dont_touch of stateCount       : signal is "true";
    attribute dont_touch of stateCountRst    : signal is "true";
+   attribute dont_touch of wordCountRst     : signal is "true";
    attribute dont_touch of exportWordCnt    : signal is "true";
    attribute dont_touch of crcFifoIn        : signal is "true";
    attribute dont_touch of crcFifoOut       : signal is "true";
@@ -205,9 +203,9 @@ begin
                stateCount <= stateCount + 1 after TPD_G;
             end if;
 
-            if stateCountRst = '1' then
+            if wordCountRst = '1' then
                exportWordCnt <= (others => '0') after TPD_G;
-            elsif intAdvance = '1' and intRunt = '1' then
+            elsif intAdvance = '1' and exportWordCnt /= x"F" then
                exportWordCnt <= exportWordCnt + 1 after TPD_G;
             end if;
             
@@ -216,23 +214,27 @@ begin
    end process;
 
    -- Pad runt frames
-   intRunt          <= not exportWordCnt(3);
-   process (curState, intLastLine, macMaster)
+   process (curState, exportWordCnt, intLastLine, macMaster)
    begin
       if (curState = ST_PAD_C) then
          if intLastLine = '0' then
             intLastValidByte <= "111";
          else
-            -- "work around" for a Xilinx IP core bug fix???
-            intLastValidByte <= "000";
+            intLastValidByte <= "011";
          end if;
+      elsif (curState = ST_READ_C) then
+         if (macMaster.tLast = '1') and (exportWordCnt <= 7) and (macMaster.tKeep(7 downto 4) = x"0") then
+            intLastValidByte <= "011";
+         else
+            intLastValidByte <= onesCount(macMaster.tKeep(7 downto 1));
+         end if;   
       else
-         intLastValidByte <= onesCount(macMaster.tKeep(7 downto 1));
+         intLastValidByte <= onesCount(macMaster.tKeep(7 downto 1));      
       end if;   
    end process;   
    
    -- State machine
-   process (curState, ethRst, intError, intRunt, macMaster, phyReady, stateCount)
+   process (curState, ethRst, exportWordCnt, intError, macMaster, phyReady, stateCount)
    begin
       
       -- Init
@@ -247,6 +249,7 @@ begin
          -- IDLE, wait for data to be available
          when ST_IDLE_C =>
             stateCountRst <= '1';
+            wordCountRst  <= '0';
             intPad        <= '0';
             intAdvance    <= '0';
             intLastLine   <= '0';
@@ -256,6 +259,7 @@ begin
 
             -- Wait for start flag
             if macMaster.tValid = '1' and ethRst = '0' then
+               wordCountRst <= '1';
 
                -- Phy is ready
                if phyReady = '1' then
@@ -274,18 +278,19 @@ begin
          when ST_READ_C =>
             intDump       <= '0';
             stateCountRst <= '0';
+            wordCountRst  <= '0';
             intLastLine   <= '0';
             intPad        <= '0';
             intAdvance    <= '1';
             nxtState      <= curState;
 
             -- Read until we get last
-            if macMaster.tLast = '1' and intRunt = '1' then
+            if macMaster.tLast = '1' and (exportWordCnt < 7) then
                nxtState  <= ST_PAD_C;
                txCountEn <= '1';
                nxtError  <= intError or axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, macMaster, EMAC_EOFE_BIT_C);
 
-            elsif macMaster.tLast = '1' and intRunt = '0' then
+            elsif macMaster.tLast = '1' and (exportWordCnt >= 7) then
                intLastLine   <= '1';
                nxtState      <= ST_WAIT_C;
                txCountEn     <= '1';
@@ -307,6 +312,7 @@ begin
          when ST_DUMP_C =>
             intAdvance    <= '0';
             stateCountRst <= '0';
+            wordCountRst  <= '0';
             intPad        <= '0';
 
             -- Read until we get last
@@ -328,24 +334,26 @@ begin
             intDump       <= '0';
             intAdvance    <= '0';
             stateCountRst <= '0';
+            wordCountRst  <= '0';
             intPad        <= '0';
             intLastLine   <= '0';
 
             -- Wait for gap, min 3 clocks
             if stateCount >= INTERGAP_C and stateCount >= 3 then
-               nxtState <= ST_IDLE_C;
+               nxtState     <= ST_IDLE_C;
             else
-               nxtState <= curState;
+               nxtState     <= curState;
             end if;
 
          -- Padding frame
          when ST_PAD_C =>
             intDump       <= '0';
             stateCountRst <= '0';
+            wordCountRst  <= '0';
             intAdvance    <= '1';
             intPad        <= '1';
 
-            if intRunt = '1' then
+            if (exportWordCnt < 7) then
                intLastLine <= '0';
                nxtState    <= curState;
             else
@@ -359,6 +367,7 @@ begin
             intAdvance    <= '0';
             intDump       <= '0';
             stateCountRst <= '0';
+            wordCountRst  <= '0';
             intPad        <= '0';
             intLastLine   <= '0';
       end case;
@@ -405,21 +414,7 @@ begin
 
             -- CRC Valid
             crcDataValid <= intAdvance after TPD_G;
-
-            -- Word 0, set source mac address
-            if exportWordCnt = 0 then
-               crcIn(63 downto 48) <= macAddress(15 downto 0) after TPD_G;
-               crcIn(47 downto 0)  <= intData(47 downto 0)    after TPD_G;
-
-            -- Word 1, set source mac address
-            elsif exportWordCnt = 1 then
-               crcIn(63 downto 32) <= intData(63 downto 32)    after TPD_G;
-               crcIn(31 downto 0)  <= macAddress(47 downto 16) after TPD_G;
-
-            -- Normal data
-            else
-               crcIn <= intData after TPD_G;
-            end if;
+            crcIn        <= intData after TPD_G;
 
             -- Last line
             if intLastLine = '1' then

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
@@ -47,7 +47,7 @@ end EthMacTxExportXgmii;
 
 architecture rtl of EthMacTxExportXgmii is
 
-   constant INTERGAP_C : slv(3 downto 0) := x"F";
+   constant INTERGAP_C : slv(3 downto 0) := x"3";
 
    constant AXI_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXlgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXlgmii.vhd
@@ -36,8 +36,6 @@ entity EthMacTxExportXlgmii is
       phyTxd         : out slv(127 downto 0);
       phyTxc         : out slv(15 downto 0);
       phyReady       : in  sl;
-      -- Configuration
-      macAddress     : in  slv(47 downto 0);
       -- Errors
       txCountEn      : out sl;
       txUnderRun     : out sl;

--- a/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
@@ -58,7 +58,7 @@ end EthMacTxPause;
 
 architecture rtl of EthMacTxPause is
 
-   constant CNT_BITS_C : integer := bitSize(PAUSE_512BITS_G);
+   constant CNT_BITS_C : integer := bitSize(PAUSE_512BITS_G-1);
    constant SIZE_C     : natural := ite(VLAN_EN_G, (VLAN_SIZE_G+1), 1);
 
    type StateType is (

--- a/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxPause.vhd
@@ -189,9 +189,9 @@ begin
                end if;
             ----------------------------------------------------------------------
             when PAUSE_S =>
-               ----------------------------------------------------------------------------------------------------------
-               -- Refer to https://www.safaribooksonline.com/library/view/ethernet-the-definitive/1565926609/ch04s02.html
-               ----------------------------------------------------------------------------------------------------------
+               --------------------------------------------------------------------------------------------------------------------
+               -- Refer to https://hasanmansur1.files.wordpress.com/2012/12/ethernet-flow-control-pause-frame-framing-structure.png
+               --------------------------------------------------------------------------------------------------------------------
                -- Check if ready to move data
                if (v.mAxisMaster.tValid = '0') then
                   -- Reset the bus to defaults
@@ -203,13 +203,13 @@ begin
                   -- Check the flag
                   if (r.txCount = 0) then
                      -- DST MAC (Pause MAC Address)
-                     v.mAxisMaster.tData(47 downto 0)    := x"010000C28001";
-                     -- SRC MAC (local MAC address)
-                     v.mAxisMaster.tData(95 downto 48)   := macAddress;
+                     v.mAxisMaster.tData(47 downto 0)    := x"01_00_00_C2_80_01";
+                     -- SRC MAC (NULL MAC address)
+                     v.mAxisMaster.tData(95 downto 48)   := x"00_00_00_00_00_00";
                      -- MAC Control Type
-                     v.mAxisMaster.tData(111 downto 96)  := x"0888";
+                     v.mAxisMaster.tData(111 downto 96)  := x"08_88";
                      -- Pause Op-code
-                     v.mAxisMaster.tData(127 downto 112) := x"0100";                -- 2 bytes
+                     v.mAxisMaster.tData(127 downto 112) := x"01_00";                -- 2 bytes
                   elsif (r.txCount = 1) then
                      -- Pause length
                      v.mAxisMaster.tData(7 downto 0)    := pauseTime(15 downto 8);  -- 1 bytes

--- a/ethernet/EthMacCore/src/makefile
+++ b/ethernet/EthMacCore/src/makefile
@@ -1,0 +1,18 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the 
+## top-level directory of this distribution and at: 
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+## No part of 'SLAC Firmware Standard Library', including this file, 
+## may be copied, modified, propagated, or distributed except according to 
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+ARCH   := $(shell getconf LONG_BIT)
+CC     := g++
+CFLAGS := -Wall -m$(ARCH) -I$(PWD) -lpthread -lrt -lm
+
+all:
+	$(CC) $(CFLAGS) send_pause.cpp -o bin/send_pause
+
+clean:
+	rm -f send_pause

--- a/ethernet/EthMacCore/src/send_pause.cpp
+++ b/ethernet/EthMacCore/src/send_pause.cpp
@@ -1,0 +1,116 @@
+//-----------------------------------------------------------------------------
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the 
+// top-level directory of this distribution and at: 
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+// No part of 'SLAC Firmware Standard Library', including this file, 
+// may be copied, modified, propagated, or distributed except according to 
+// the terms contained in the LICENSE.txt file.
+//-----------------------------------------------------------------------------
+
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/ether.h>
+
+#define MY_DEST_MAC0	0x00
+#define MY_DEST_MAC1	0x00
+#define MY_DEST_MAC2	0x00
+#define MY_DEST_MAC3	0x00
+#define MY_DEST_MAC4	0x00
+#define MY_DEST_MAC5	0x00
+
+#define DEFAULT_IF	"eth0"
+#define BUF_SIZ		1024
+
+int main(int argc, char *argv[])
+{
+	int sockfd;
+	struct ifreq if_idx;
+	struct ifreq if_mac;
+	int tx_len = 0;
+	char sendbuf[BUF_SIZ];
+	struct ether_header *eh = (struct ether_header *) sendbuf;
+	struct sockaddr_ll socket_address;
+	char ifName[IFNAMSIZ];
+	
+	/* Get interface name */
+	if (argc > 1)
+		strcpy(ifName, argv[1]);
+	else
+		strcpy(ifName, DEFAULT_IF);
+
+	/* Open RAW socket to send on */
+	if ((sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW)) == -1) {
+	    perror("socket");
+	}
+
+	/* Get the index of the interface to send on */
+	memset(&if_idx, 0, sizeof(struct ifreq));
+	strncpy(if_idx.ifr_name, ifName, IFNAMSIZ-1);
+	if (ioctl(sockfd, SIOCGIFINDEX, &if_idx) < 0)
+	    perror("SIOCGIFINDEX");
+	/* Get the MAC address of the interface to send on */
+	memset(&if_mac, 0, sizeof(struct ifreq));
+	strncpy(if_mac.ifr_name, ifName, IFNAMSIZ-1);
+	if (ioctl(sockfd, SIOCGIFHWADDR, &if_mac) < 0)
+	    perror("SIOCGIFHWADDR");
+
+	/* Construct the Ethernet header */
+	memset(sendbuf, 0, BUF_SIZ);
+   
+	/* Destination MAC */
+	eh->ether_dhost[0] = 0x01;
+	eh->ether_dhost[1] = 0x80;
+	eh->ether_dhost[2] = 0xC2;
+	eh->ether_dhost[3] = 0x00;
+	eh->ether_dhost[4] = 0x00;
+	eh->ether_dhost[5] = 0x01;
+   
+	/* Source MAC */
+	eh->ether_shost[0] = 0x00;
+	eh->ether_shost[1] = 0x00;
+	eh->ether_shost[2] = 0x00;
+	eh->ether_shost[3] = 0x00;
+	eh->ether_shost[4] = 0x00;
+	eh->ether_shost[5] = 0x00;
+   
+	/* Ethertype field */
+	eh->ether_type = htons(ETH_P_IP);
+	// tx_len += sizeof(struct ether_header);
+	tx_len += 12;
+
+	/* Packet data */
+	sendbuf[tx_len++] = 0x88;
+	sendbuf[tx_len++] = 0x08;
+	sendbuf[tx_len++] = 0x00;
+	sendbuf[tx_len++] = 0x01;
+	sendbuf[tx_len++] = 0x00;
+	sendbuf[tx_len++] = 0xFF;
+   for (int n=0; n<42; n++) { 
+      sendbuf[tx_len++] = 0x00;
+   }
+
+	/* Index of the network device */
+	socket_address.sll_ifindex = if_idx.ifr_ifindex;
+	/* Address length*/
+	socket_address.sll_halen = ETH_ALEN;
+	/* Destination MAC */
+	socket_address.sll_addr[0] = MY_DEST_MAC0;
+	socket_address.sll_addr[1] = MY_DEST_MAC1;
+	socket_address.sll_addr[2] = MY_DEST_MAC2;
+	socket_address.sll_addr[3] = MY_DEST_MAC3;
+	socket_address.sll_addr[4] = MY_DEST_MAC4;
+	socket_address.sll_addr[5] = MY_DEST_MAC5;
+
+	/* Send packet */
+	if (sendto(sockfd, sendbuf, tx_len, 0, (struct sockaddr*)&socket_address, sizeof(struct sockaddr_ll)) < 0)
+	    printf("Send failed\n");
+
+	return 0;
+}

--- a/ethernet/GigEthCore/core/rtl/GigEthPkg.vhd
+++ b/ethernet/GigEthCore/core/rtl/GigEthPkg.vhd
@@ -21,7 +21,9 @@ use work.EthMacPkg.all;
 
 package GigEthPkg is
 
-   constant GIG_ETH_AN_ADV_CONFIG_INIT_C : slv(15 downto 0) := x"0021";-- Refer to PG047
+   constant PAUSE_512BITS_C : positive := 64;  -- For 1GbE: 64 clock cycles for 512 bits = one pause "quanta"
+
+   constant GIG_ETH_AN_ADV_CONFIG_INIT_C : slv(15 downto 0) := x"0021";  -- Refer to PG047
 
    type GigEthConfigType is record
       softRst    : sl;
@@ -38,5 +40,5 @@ package GigEthPkg is
       macStatus  : EthMacStatusType;
       coreStatus : slv(15 downto 0);
    end record;
-   
+
 end GigEthPkg;

--- a/ethernet/GigEthCore/core/rtl/GigEthReg.vhd
+++ b/ethernet/GigEthCore/core/rtl/GigEthReg.vhd
@@ -182,6 +182,8 @@ begin
          axiSlaveRegister(regCon, x"228", 0, v.config.macConfig.filtEnable);
          axiSlaveRegister(regCon, x"22C", 0, v.config.macConfig.pauseEnable);
 
+         axiSlaveRegister(regCon, x"800", 0, v.config.macConfig.pauseThresh);
+
          axiSlaveRegister(regCon, x"F00", 0, v.rollOverEn);
          axiSlaveRegister(regCon, x"FF4", 0, v.cntRst);
          axiSlaveRegister(regCon, x"FF8", 0, v.config.softRst);

--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
@@ -26,7 +26,6 @@ entity GigEthGth7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -171,7 +170,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGth7Wrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -161,7 +160,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
@@ -26,7 +26,6 @@ entity GigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -169,7 +168,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGthUltraScaleWrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -169,7 +168,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
@@ -26,7 +26,6 @@ entity GigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -183,7 +182,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGthUltraScaleWrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -169,7 +168,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
@@ -26,7 +26,6 @@ entity GigEthGtp7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -225,7 +224,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGtp7Wrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -199,7 +198,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
@@ -26,7 +26,6 @@ entity GigEthGtx7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -171,7 +170,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGtx7Wrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -161,7 +160,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
@@ -26,7 +26,6 @@ entity GigEthGtyUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -169,7 +168,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
@@ -31,7 +31,6 @@ entity GigEthGtyUltraScaleWrapper is
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
       PAUSE_EN_G         : boolean                          := true;
-      PAUSE_512BITS_G    : positive                         := 8;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       CLKIN_PERIOD_G     : real                             := 8.0;
@@ -169,7 +168,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
+++ b/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
@@ -26,7 +26,6 @@ entity GigEthLvdsUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -135,7 +134,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScaleWrapper.vhd
@@ -30,7 +30,6 @@ entity GigEthLvdsUltraScaleWrapper is
       TPD_G           : time                             := 1 ns;
       NUM_LANE_G      : positive                         := 1;
       PAUSE_EN_G      : boolean                          := true;
-      PAUSE_512BITS_G : positive                         := 8;
       -- Clocking Configurations
       USE_REFCLK_G    : boolean                          := false;  --  FALSE: sgmiiClkP/N,  TRUE: sgmiiRefClk
       CLKFBOUT_MULT_G : positive                         := 10;
@@ -213,7 +212,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
+++ b/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
@@ -186,7 +186,9 @@ begin
          axiSlaveRegister(regCon, x"238", 0, v.config.pma_reset);
          axiSlaveRegister(regCon, x"23C", 0, v.config.pcs_loopback);
          axiSlaveRegister(regCon, x"240", 0, v.config.pcs_reset);
-
+         
+         axiSlaveRegister(regCon, x"800", 0, v.config.macConfig.pauseThresh);
+         
          axiSlaveRegister(regCon, x"F00", 0, v.rollOverEn);
          axiSlaveRegister(regCon, x"FF4", 0, v.cntRst);
          axiSlaveRegister(regCon, x"FF8", 0, v.config.softRst);

--- a/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
+++ b/ethernet/TenGigEthCore/core/rtl/TenGigEthReg.vhd
@@ -167,8 +167,8 @@ begin
          --axiSlaveRegisterR(regCon, x"104", 0, status.macStatus.rxPauseValue);
          axiSlaveRegisterR(regCon, x"108", 0, status.core_status);
 
-         axiSlaveRegister(regCon, x"200", 0, v.config.macConfig.macAddress(31 downto 0));
-         axiSlaveRegister(regCon, x"204", 0, v.config.macConfig.macAddress(47 downto 32));
+         axiSlaveRegisterR(regCon, x"200", 0, r.config.macConfig.macAddress(31 downto 0));
+         axiSlaveRegisterR(regCon, x"204", 0, r.config.macConfig.macAddress(47 downto 32));
          --axiSlaveRegister(regCon, x"208", 0, v.config.macConfig.byteSwap);
 
          --axiSlaveRegister(regCon, x"210", 0, v.config.macConfig.txShift);

--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
@@ -26,7 +26,6 @@ entity TenGigEthGth7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -209,7 +208,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
@@ -28,7 +28,6 @@ entity TenGigEthGth7Wrapper is
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
-      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G     : boolean                          := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -127,7 +126,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
@@ -26,7 +26,6 @@ entity TenGigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -236,7 +235,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -28,7 +28,6 @@ entity TenGigEthGthUltraScaleWrapper is
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
-      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       EXT_REF_G         : boolean                          := false;
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
@@ -144,7 +143,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
@@ -26,7 +26,6 @@ entity TenGigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -249,7 +248,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
+         PAUSE_512BITS_G => 8, -- 8 clock cycles for 512 bits = pause "quanta"
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
@@ -248,7 +248,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => 8, -- 8 clock cycles for 512 bits = pause "quanta"
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
@@ -24,10 +24,12 @@ use unisim.vcomponents.all;
 entity TenGigEthGthUltraScaleClk is
    generic (
       TPD_G             : time            := 1 ns;
+      EXT_REF_G         : boolean         := false;
       QPLL_REFCLK_SEL_G : slv(2 downto 0) := "001");
    port (
       -- MGT Clock Port (156.25 MHz)
       gtRefClk      : in  sl := '0';
+      gtRefClkBufg  : in  sl := '0';
       gtClkP        : in  sl := '1';
       gtClkN        : in  sl := '0';
       coreClk       : out sl;
@@ -74,8 +76,8 @@ begin
          DIV     => "000",
          O       => coreClock);
 
-   refClock  <= gtRefClk when(QPLL_REFCLK_SEL_G = "111") else refClk;
-   coreClk   <= gtRefClk when(QPLL_REFCLK_SEL_G = "111") else coreClock;
+   refClock  <= gtRefClk    when(EXT_REF_G) else refClk;
+   coreClk   <= gtRefClkBufg when(EXT_REF_G) else coreClock;
    qpllReset <= qpllRst or coreRst;
 
    GthUltraScaleQuadPll_Inst : entity work.GthUltraScaleQuadPll

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -28,7 +28,6 @@ entity TenGigEthGthUltraScaleWrapper is
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
-      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
@@ -143,7 +142,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -29,6 +29,7 @@ entity TenGigEthGthUltraScaleWrapper is
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
+      EXT_REF_G         : boolean                          := false;
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
       EN_AXI_REG_G      : boolean                          := false;
@@ -71,6 +72,7 @@ entity TenGigEthGthUltraScaleWrapper is
       gtTxPolarity        : in  sl                                             := '0';
       -- MGT Clock Port (156.25 MHz)
       gtRefClk            : in  sl                                             := '0';
+      gtRefClkBufg        : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
       -- MGT Ports
@@ -115,10 +117,12 @@ begin
    TenGigEthGthUltraScaleClk_Inst : entity work.TenGigEthGthUltraScaleClk
       generic map (
          TPD_G             => TPD_G,
+         EXT_REF_G         => EXT_REF_G,
          QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G)
       port map (
          -- MGT Clock Port (156.25 MHz)
          gtRefClk      => gtRefClk,
+         gtRefClkBufg  => gtRefClkBufg,
          gtClkP        => gtClkP,
          gtClkN        => gtClkN,
          coreClk       => coreClock,

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
@@ -26,7 +26,6 @@ entity TenGigEthGtx7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -235,7 +234,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
@@ -28,7 +28,6 @@ entity TenGigEthGtx7Wrapper is
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
-      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G     : boolean                          := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -135,7 +134,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
@@ -26,7 +26,6 @@ entity TenGigEthGtyUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -236,7 +235,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
@@ -29,7 +29,6 @@ entity TenGigEthGtyUltraScaleWrapper is
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
       PAUSE_EN_G        : boolean                          := true;
-      PAUSE_512BITS_G   : positive                         := 8;
       -- QUAD PLL Configurations
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
       -- AXI-Lite Configurations
@@ -141,7 +140,6 @@ begin
          generic map (
             TPD_G           => TPD_G,
             PAUSE_EN_G      => PAUSE_EN_G,
-            PAUSE_512BITS_G => PAUSE_512BITS_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,
             -- AXI Streaming Configurations

--- a/ethernet/XauiCore/core/rtl/XauiReg.vhd
+++ b/ethernet/XauiCore/core/rtl/XauiReg.vhd
@@ -176,6 +176,8 @@ begin
          axiSlaveRegister(regCon, x"22C", 0, v.config.macConfig.pauseEnable);
 
          axiSlaveRegister(regCon, x"230", 0, v.config.configVector);
+         
+         axiSlaveRegister(regCon, x"800", 0, v.config.macConfig.pauseThresh);
 
          axiSlaveRegister(regCon, x"F00", 0, v.rollOverEn);
          axiSlaveRegister(regCon, x"FF4", 0, v.cntRst);

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
@@ -26,7 +26,6 @@ entity XauiGth7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -93,7 +92,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
@@ -29,7 +29,6 @@ entity XauiGth7Wrapper is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G   : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -96,7 +95,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
@@ -29,7 +29,6 @@ entity XauiGthUltraScale is
    generic (
       TPD_G           : time                     := 1 ns;
       PAUSE_EN_G      : boolean                  := true;
-      PAUSE_512BITS_G : positive range 1 to 1024 := 8;
       -- XAUI Configurations
       REF_CLK_FREQ_G  : real                     := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
@@ -204,7 +203,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
@@ -29,7 +29,6 @@ entity XauiGthUltraScaleWrapper is
    generic (
       TPD_G             : time                     := 1 ns;
       PAUSE_EN_G        : boolean                  := true;
-      PAUSE_512BITS_G   : positive range 1 to 1024 := 8;
       EN_WDT_G          : boolean                  := false;
       STABLE_CLK_FREQ_G : real                     := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
@@ -135,7 +134,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
@@ -29,7 +29,6 @@ entity XauiGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -196,7 +195,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
@@ -29,7 +29,6 @@ entity XauiGthUltraScaleWrapper is
    generic (
       TPD_G             : time                := 1 ns;
       PAUSE_EN_G        : boolean             := true;
-      PAUSE_512BITS_G   : positive            := 8;
       EN_WDT_G          : boolean             := false;
       STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
@@ -135,7 +134,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations

--- a/ethernet/XauiCore/gtx7/rtl/XauiGtx7.vhd
+++ b/ethernet/XauiCore/gtx7/rtl/XauiGtx7.vhd
@@ -26,7 +26,6 @@ entity XauiGtx7 is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
       -- AXI Streaming Configurations
@@ -93,7 +92,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
+++ b/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
@@ -29,7 +29,6 @@ entity XauiGtx7Wrapper is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
       REFCLK_DIV2_G   : boolean             := false;  --  FALSE: gtClkP/N = 156.25 MHz,  TRUE: gtClkP/N = 312.5 MHz
@@ -96,7 +95,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
@@ -29,7 +29,6 @@ entity XauiGtyUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
       PAUSE_EN_G      : boolean             := true;
-      PAUSE_512BITS_G : positive            := 8;
       -- XAUI Configurations
       REF_CLK_FREQ_G  : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
@@ -204,7 +203,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
@@ -31,7 +31,6 @@ entity XauiGtyUltraScaleWrapper is
       EN_WDT_G          : boolean             := false;
       STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       PAUSE_EN_G        : boolean             := true;
-      PAUSE_512BITS_G   : positive            := 8;
       -- AXI-Lite Configurations
       EN_AXI_REG_G      : boolean             := false;
       -- AXI Streaming Configurations
@@ -135,7 +134,6 @@ begin
       generic map (
          TPD_G           => TPD_G,
          PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,
          -- AXI Streaming Configurations

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -36,7 +36,7 @@ entity SrpV3AxiLite is
       INT_PIPE_STAGES_G     : natural range 0 to 16   := 1;
       PIPE_STAGES_G         : natural range 0 to 16   := 1;
       FIFO_PAUSE_THRESH_G   : positive range 1 to 511 := 256;
-      TX_VALID_THOLD_G      : positive range 1 to 511 := 256;   -- >1 = only when frame ready or # entries
+      TX_VALID_THOLD_G      : positive range 1 to 511 := 500;   -- >1 = only when frame ready or # entries
       TX_VALID_BURST_MODE_G : boolean                 := true;  -- only used in VALID_THOLD_G>1
       SLAVE_READY_EN_G      : boolean                 := false;
       GEN_SYNC_FIFO_G       : boolean                 := false;
@@ -799,9 +799,10 @@ begin
          USE_BUILT_IN_G      => false,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          ALTERA_SYN_G        => ALTERA_SYN_G,
-         ALTERA_RAM_G        => ALTERA_RAM_G,
-         CASCADE_SIZE_G      => 1,
-         FIFO_ADDR_WIDTH_G   => 9,
+         ALTERA_RAM_G        => ALTERA_RAM_G,         
+         INT_WIDTH_SELECT_G  => "CUSTOM",
+         INT_DATA_WIDTH_G    => 16,     -- 128-bit         
+         FIFO_ADDR_WIDTH_G   => 9,      -- 8kB/FIFO = 128-bits x 512 entries         
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => AXI_STREAM_CONFIG_G)

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -94,6 +94,8 @@ architecture rtl of SsiPrbsTx is
       length         : slv(31 downto 0);
       packetLength   : slv(31 downto 0);
       dataCnt        : slv(31 downto 0);
+      trigDly        : slv(31 downto 0);
+      trigDlyCnt     : slv(31 downto 0);
       eventCnt       : slv(PRBS_SEED_SIZE_G-1 downto 0);
       randomData     : slv(PRBS_SEED_SIZE_G-1 downto 0);
       txAxisMaster   : AxiStreamMasterType;
@@ -101,6 +103,7 @@ architecture rtl of SsiPrbsTx is
       axiEn          : sl;
       oneShot        : sl;
       trig           : sl;
+      trigger        : sl;
       cntData        : sl;
       tDest          : slv(7 downto 0);
       tId            : slv(7 downto 0);
@@ -114,6 +117,8 @@ architecture rtl of SsiPrbsTx is
       length         => (others => '0'),
       packetLength   => x"00000FFF",
       dataCnt        => (others => '0'),
+      trigDly        => (others => '0'),
+      trigDlyCnt     => (others => '0'),
       eventCnt       => toSlv(1, PRBS_SEED_SIZE_G),
       randomData     => (others => '0'),
       txAxisMaster   => AXI_STREAM_MASTER_INIT_C,
@@ -121,6 +126,7 @@ architecture rtl of SsiPrbsTx is
       axiEn          => AXI_EN_G,
       oneShot        => '0',
       trig           => '0',
+      trigger        => '0',
       cntData        => toSl(PRBS_INCREMENT_G),
       tDest          => X"00",
       tId            => X"00",
@@ -146,10 +152,7 @@ begin
    begin
       -- Latch the current value
       v := r;
-
-      -- Reset the one shot
-      v.oneShot := '0';
-
+      
       ----------------------------------------------------------------------------------------------
       -- Axi-Lite interface
       ----------------------------------------------------------------------------------------------
@@ -168,10 +171,12 @@ begin
             when X"04" =>
                v.packetLength := axilWriteMaster.wdata(31 downto 0);
             when X"08" =>
-               v.tDest := axilWriteMaster.wdata(7 downto 0);
-               v.tId   := axilWriteMaster.wdata(15 downto 8);
+               v.tDest   := axilWriteMaster.wdata(7 downto 0);
+               v.tId     := axilWriteMaster.wdata(15 downto 8);
             when X"18" =>
                v.oneShot := axilWriteMaster.wdata(0);
+            when X"1C" =>
+               v.trigDly := axilWriteMaster.wdata(31 downto 0);
             when others =>
                axilWriteResp := AXI_RESP_DECERR_C;
          end case;
@@ -208,15 +213,25 @@ begin
                else
                   v.axilReadSlave.rdata(31 downto 0) := r.randomData(31 downto 0);
                end if;
+            when X"1C" =>
+               v.axilReadSlave.rdata(31 downto 0):= r.trigDly;
             when others =>
                axilReadResp := AXI_RESP_DECERR_C;
          end case;
          axiSlaveReadResponse(v.axilReadSlave);
       end if;
 
+      -- Check for delay between AXI triggers
+      if (r.trigDlyCnt = r.trigDly) or (r.trigDly /= v.trigDly) then
+         v.trigDlyCnt := (others=>'0');
+         v.trigger    := r.trig;
+      elsif (r.trigger = '0') then
+         v.trigDlyCnt := r.trigDlyCnt + 1;
+      end if;
+
       -- Override axi settings if axi not enabled
       if (v.axiEn = '0') then
-         v.trig         := trig;
+         v.trigger      := trig;
          v.packetLength := packetLength;
          v.tDest        := tDest;
          v.tId          := tId;
@@ -243,7 +258,10 @@ begin
             -- Reset the busy flag
             v.busy := '0';
             -- Check for a trigger
-            if (r.trig = '1') or (r.oneShot = '1') then
+            if (r.trigger = '1') or (r.oneShot = '1') then
+               -- Reset the one shot
+               v.oneShot := '0';
+               v.trigger := '0';
                -- Latch the generator seed
                v.randomData         := r.eventCnt;
                -- Set the busy flag

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -29,7 +29,7 @@ entity SsiPrbsTx is
       -- General Configurations
       TPD_G                      : time                    := 1 ns;
       AXI_EN_G                   : sl                      := '1';
-      AXI_DEFAULT_PKT_LEN_C      : slv(31 downto 0)        := x"00000FFF";
+      AXI_DEFAULT_PKT_LEN_G      : slv(31 downto 0)        := x"00000FFF";
       -- FIFO Configurations
       VALID_THOLD_G              : natural                 := 1;
       VALID_BURST_MODE_G         : boolean                 := false;
@@ -116,7 +116,7 @@ architecture rtl of SsiPrbsTx is
       busy           => '1',
       overflow       => '0',
       length         => (others => '0'),
-      packetLength   => AXI_DEFAULT_PKT_LEN_C,
+      packetLength   => AXI_DEFAULT_PKT_LEN_G,
       dataCnt        => (others => '0'),
       trigDly        => (others => '0'),
       trigDlyCnt     => (others => '0'),

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -29,6 +29,7 @@ entity SsiPrbsTx is
       -- General Configurations
       TPD_G                      : time                    := 1 ns;
       AXI_EN_G                   : sl                      := '1';
+      AXI_DEFAULT_PKT_LEN_C      : slv(31 downto 0)        := x"00000FFF";
       -- FIFO Configurations
       VALID_THOLD_G              : natural                 := 1;
       VALID_BURST_MODE_G         : boolean                 := false;
@@ -115,7 +116,7 @@ architecture rtl of SsiPrbsTx is
       busy           => '1',
       overflow       => '0',
       length         => (others => '0'),
-      packetLength   => x"00000FFF",
+      packetLength   => AXI_DEFAULT_PKT_LEN_C,
       dataCnt        => (others => '0'),
       trigDly        => (others => '0'),
       trigDlyCnt     => (others => '0'),

--- a/python/surf/axi/_AxiStreamMonitoring.py
+++ b/python/surf/axi/_AxiStreamMonitoring.py
@@ -27,13 +27,13 @@ class AxiStreamMonitoring(pr.Device):
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
-        self.add(pr.RemoteVariable(
-            name         = "CntRst",                 
+        self.add(pr.RemoteCommand(   
+            name         = 'CntRst',
             description  = "Counter Reset",
-            mode         = 'WO',
             offset       = 0x0,
-            hidden       = True,
-        ))             
+            bitSize      = 1,
+            function     = lambda cmd: cmd.post(1),
+        ))        
         
         def addPair(name,offset,bitSize,units,bitOffset,description,function,pollInterval = 0,):
             self.add(pr.RemoteVariable(  
@@ -135,10 +135,10 @@ class AxiStreamMonitoring(pr.Device):
         return var.dependencies[0].value() * 8e-6
         
     def hardReset(self):
-        self.CntRst.set(0x1)
+        self.CntRst()
 
     def softReset(self):
-        self.CntRst.set(0x1)
+        self.CntRst()
 
     def countReset(self):
-        self.CntRst.set(0x1)
+        self.CntRst()

--- a/python/surf/ethernet/ten_gig/_TenGigEthReg.py
+++ b/python/surf/ethernet/ten_gig/_TenGigEthReg.py
@@ -19,10 +19,13 @@
 
 import pyrogue as pr
 
+import surf.ethernet.udp as udp
+
 class TenGigEthReg(pr.Device):
     def __init__(   self,       
-            name        = "TenGigEthReg",
-            description = "TenGigEthReg",
+            name        = 'TenGigEthReg',
+            description = 'TenGigEthReg',
+            writeEn     = False,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs) 
 
@@ -30,165 +33,168 @@ class TenGigEthReg(pr.Device):
         # Variables
         ##############################
 
-        self.addRemoteVariables(   
-            name         = "StatusCounters",
-            description  = "Status Counters",
-            offset       =  0x00,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
-            number       =  19,
-            stride       =  4,
-        )
+        allowAccess = 'RW' if writeEn else 'RO'
+
+        statusName = [
+            'phyReady',  # 0
+            'rxPause',   # 1
+            'txPause',   # 2
+            'rxFrame',   # 3
+            'rxOverFlow',# 4
+            'rxCrcError',# 5
+            'txFrame',   # 6
+            'txUnderRun',# 7
+            'txNotReady',# 8
+            'txDisable', # 9
+            'sigDet',    # 10
+            'txFault',   # 11
+            'gtTxRst',   # 12
+            'gtRxRst',   # 13
+            'rstCntDone',# 14
+            'qplllock',  # 15
+            'txRstdone', # 16
+            'rxRstdone', # 17
+            'txUsrRdy',  # 18
+        ]
+        
+        for i in range(19):
+        
+            self.add(pr.RemoteVariable(   
+                name         = statusName[i]+'Cnt',
+                offset       = 4*i,
+                mode         = 'RO',
+                pollInterval = 1,            
+            ))
+            
+        for i in range(19):
+            self.add(pr.RemoteVariable(   
+                name         = statusName[i],
+                offset       = 0x100,
+                mode         = 'RO',
+                bitSize      = 1,
+                bitOffset    = i,
+                pollInterval = 1,            
+            ))
 
         self.add(pr.RemoteVariable(   
-            name         = "StatusVector",
-            description  = "Status Vector",
-            offset       =  0x100,
-            bitSize      =  19,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "PhyStatus",
-            description  = "PhyStatus",
+            name         = 'PhyStatus',
             offset       =  0x108,
             bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            mode         = 'RO',
+            pollInterval = 1,            
+        ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = 'MacAddress',
+            description  = 'MacAddress (big-Endian configuration)',
+            offset       = 0x200,
+            bitSize      = 48,
+            mode         = 'RO',
+            hidden       = True,
+        ))
+        
+        self.add(pr.LinkVariable(
+            name         = 'MAC_ADDRESS', 
+            description  = 'MacAddress (human readable)',
+            mode         = 'RO', 
+            linkedGet    = udp.getMacValue,
+            dependencies = [self.variables['MacAddress']],
+        ))         
+
+        self.add(pr.RemoteVariable(   
+            name         = 'PauseTime',
+            offset       = 0x21C,
+            bitSize      = 16,
+            mode         = allowAccess,
         ))
 
         self.add(pr.RemoteVariable(   
-            name         = "MacAddress",
-            description  = "MAC Address (big-Endian)",
-            offset       =  0x200,
-            bitSize      =  48,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'FilterEnable',
+            offset       = 0x228,
+            bitSize      = 1,
+            mode         = allowAccess,
         ))
 
         self.add(pr.RemoteVariable(   
-            name         = "PauseTime",
-            description  = "PauseTime",
-            offset       =  0x21C,
-            bitSize      =  16,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'PauseEnable',
+            offset       = 0x22C,
+            bitSize      = 1,
+            mode         = allowAccess,
         ))
 
-        self.add(pr.RemoteVariable(   
-            name         = "FilterEnable",
-            description  = "FilterEnable",
-            offset       =  0x228,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
-        ))
+        if writeEn:
+        
+            self.add(pr.RemoteVariable(   
+                name         = 'pma_pmd_type',
+                offset       =  0x230,
+                bitSize      =  3,
+                mode         = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(   
+                name         = 'pma_loopback',
+                offset       =  0x234,
+                bitSize      =  1,
+                mode         = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(   
+                name         = 'pma_reset',
+                offset       =  0x238,
+                bitSize      =  1,
+                mode         = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(   
+                name         = 'pcs_loopback',
+                offset       =  0x23C,
+                bitSize      =  1,
+                mode         = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(   
+                name         = 'pcs_reset',
+                offset       =  0x240,
+                bitSize      =  1,
+                mode         = 'RW',
+            ))
 
         self.add(pr.RemoteVariable(   
-            name         = "PauseEnable",
-            description  = "PauseEnable",
-            offset       =  0x22C,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "pma_pmd_type",
-            description  = "pma_pmd_type",
-            offset       =  0x230,
-            bitSize      =  3,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "pma_loopback",
-            description  = "pma_loopback",
-            offset       =  0x234,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "pma_reset",
-            description  = "pma_reset",
-            offset       =  0x238,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "pcs_loopback",
-            description  = "pcs_loopback",
-            offset       =  0x23C,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "pcs_reset",
-            description  = "pcs_reset",
-            offset       =  0x240,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
-
-        self.add(pr.RemoteVariable(   
-            name         = "RollOverEn",
-            description  = "RollOverEn",
+            name         = 'RollOverEn',
             offset       =  0xF00,
             bitSize      =  19,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
+            mode         = 'RW',
         ))
 
-        self.add(pr.RemoteVariable(   
-            name         = "CounterReset",
-            description  = "CounterReset",
-            offset       =  0xFF4,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "WO",
-        ))
+        self.add(pr.RemoteCommand(   
+            name         = 'CounterReset',
+            offset       = 0xFF4,
+            bitSize      = 1,
+            function     = lambda cmd: cmd.post(1),
+            hidden       = False,
+        ))           
 
-        self.add(pr.RemoteVariable(   
-            name         = "SoftReset",
-            description  = "SoftReset",
-            offset       =  0xFF8,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "WO",
-        ))
+        self.add(pr.RemoteCommand(   
+            name         = 'SoftReset',
+            offset       = 0xFF8,
+            bitSize      = 1,
+            function     = lambda cmd: cmd.post(1),
+            hidden       = False,
+        ))        
+        
+        self.add(pr.RemoteCommand(   
+            name         = 'HardReset',
+            offset       = 0xFFC,
+            bitSize      = 1,
+            function     = lambda cmd: cmd.post(1),
+            hidden       = False,
+        ))        
 
-        self.add(pr.RemoteVariable(   
-            name         = "HardReset",
-            description  = "HardReset",
-            offset       =  0xFFC,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "WO",
-        ))
+    def hardReset(self):
+        self.HardReset()
 
+    def softReset(self):
+        self.SoftReset()
+
+    def countReset(self):
+        self.CounterReset()

--- a/python/surf/ethernet/ten_gig/_TenGigEthReg.py
+++ b/python/surf/ethernet/ten_gig/_TenGigEthReg.py
@@ -121,6 +121,13 @@ class TenGigEthReg(pr.Device):
             bitSize      = 1,
             mode         = allowAccess,
         ))
+        
+        self.add(pr.RemoteVariable(   
+            name         = 'PauseFifoThreshold',
+            offset       = 0x800,
+            bitSize      = 16,
+            mode         = allowAccess,
+        ))        
 
         if writeEn:
         

--- a/python/surf/protocols/rssi/_RssiCore.py
+++ b/python/surf/protocols/rssi/_RssiCore.py
@@ -98,6 +98,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -108,6 +109,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -118,6 +120,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -128,6 +131,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -138,6 +142,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -148,6 +153,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -158,6 +164,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -168,6 +175,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -178,6 +186,7 @@ class RssiCore(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
+            disp         = '{:d}',
         ))
 
         self.add(pr.RemoteVariable(    
@@ -352,13 +361,19 @@ class RssiCore(pr.Device):
         ##############################
         @self.command(name="C_OpenConn", description="Open connection request",)
         def C_OpenConn():        
-           self.OpenConn.set(0)
+           self.CloseConn.set(0)
+           self.OpenConn.set(1)
 
         @self.command(name="C_CloseConn", description="Close connection request",)
         def C_CloseConn():                        
+           self.OpenConn.set(0)
            self.CloseConn.set(1)
-           self.CloseConn.set(0)
-                        
+                    
+        @self.command(name="C_RestartConn", description="Restart connection request",)
+        def C_RestartConn():        
+           self.C_CloseConn()
+           self.C_OpenConn()
+           
         @self.command(name="C_InjectFault", description="Inject a single fault(for debug and test purposes only). Corrupts checksum during transmission",)
         def C_InjectFault():                        
            self.InjectFault.set(1)

--- a/python/surf/protocols/rssi/_RssiCore.py
+++ b/python/surf/protocols/rssi/_RssiCore.py
@@ -80,26 +80,26 @@ class RssiCore(pr.Device):
             mode         = "RW",
         ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "InitSeqN",
-            description  = "Initial sequence number [7:0]",
-            offset       =  0x04,
-            bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "InitSeqN",
+            # description  = "Initial sequence number [7:0]",
+            # offset       =  0x04,
+            # bitSize      =  8,
+            # bitOffset    =  0x00,
+            # base         = pr.UInt,
+            # mode         = "RW",
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "Version",
-            description  = "Version register [3:0]",
-            offset       =  0x08,
-            bitSize      =  4,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "Version",
+            # description  = "Version register [3:0]",
+            # offset       =  0x08,
+            # bitSize      =  4,
+            # bitOffset    =  0x00,
+            # base         = pr.UInt,
+            # mode         = "RW",
+            # disp         = '{:d}',
+        # ))
 
         self.add(pr.RemoteVariable(    
             name         = "MaxOutsSeg",
@@ -178,16 +178,16 @@ class RssiCore(pr.Device):
             disp         = '{:d}',
         ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "MaxOutOfSeq",
-            description  = "Max out of sequence segments (EACK) [7:0]",
-            offset       =  0x28,
-            bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "MaxOutOfSeq",
+            # description  = "Max out of sequence segments (EACK) [7:0]",
+            # offset       =  0x28,
+            # bitSize      =  8,
+            # bitOffset    =  0x00,
+            # base         = pr.UInt,
+            # mode         = "RW",
+            # disp         = '{:d}',
+        # ))
 
         self.add(pr.RemoteVariable(    
             name         = "ConnectionActive",
@@ -200,71 +200,71 @@ class RssiCore(pr.Device):
             pollInterval = 1,
         ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ErrMaxRetrans",
-            description  = "Maximum retransmissions exceeded retransMax.",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x01,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ErrMaxRetrans",
+            # description  = "Maximum retransmissions exceeded retransMax.",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x01,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ErrNullTout",
-            description  = "Null timeout reached (server) nullTout.",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x02,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ErrNullTout",
+            # description  = "Null timeout reached (server) nullTout.",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x02,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ErrAck",
-            description  = "Error in acknowledgment mechanism.",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x03,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ErrAck",
+            # description  = "Error in acknowledgment mechanism.",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x03,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ErrSsiFrameLen",
-            description  = "SSI Frame length too long",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x04,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ErrSsiFrameLen",
+            # description  = "SSI Frame length too long",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x04,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ErrConnTout",
-            description  = "Connection to peer timed out. Timeout defined in generic PEER_CONN_TIMEOUT_G (Default: 1000 ms)",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x05,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ErrConnTout",
+            # description  = "Connection to peer timed out. Timeout defined in generic PEER_CONN_TIMEOUT_G (Default: 1000 ms)",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x05,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
-        self.add(pr.RemoteVariable(    
-            name         = "ParamRejected",
-            description  = "Client rejected the connection (parameters out of range), Server proposed new parameters (parameters out of range)",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x06,
-            base         = pr.UInt,
-            mode         = "RO",
-            pollInterval = 1,
-        ))
+        # self.add(pr.RemoteVariable(    
+            # name         = "ParamRejected",
+            # description  = "Client rejected the connection (parameters out of range), Server proposed new parameters (parameters out of range)",
+            # offset       =  0x40,
+            # bitSize      =  1,
+            # bitOffset    =  0x06,
+            # base         = pr.UInt,
+            # mode         = "RO",
+            # pollInterval = 1,
+        # ))
 
         self.add(pr.RemoteVariable(    
             name         = "ValidCnt",

--- a/python/surf/protocols/ssi/_SsiPrbsTx.py
+++ b/python/surf/protocols/ssi/_SsiPrbsTx.py
@@ -155,3 +155,9 @@ class SsiPrbsTx(pr.Device):
             function     = pr.BaseCommand.touchOne
         ))
         
+        self.add(pr.RemoteVariable(    
+            name         = "TrigDly",
+            offset       =  0x1C,
+            bitSize      =  32,
+            mode         = "RW",
+        ))        


### PR DESCRIPTION
### Bug Fixes
- flow control bug fix when using multiple servers or multiple clients (major bug fix)
- work around for back-to-back ETH frames (major bug fix)
- updating PAUSE_512BITS_G for 1 GbE (minor bug fix)
- Fixed the EthMacTxPause's CNT_BITS_C calculation: bitSize(8) = 4 != 3 (minor bug fix)
- Fixed the ETH pause in TX direction

### New Features
- updating for programmable pause threshold
- polishing and clean up of TenGigEthReg.py, RssiCore.py and AxiStreamMonitoring.py 
- adding TrigDly register to SsiPrbsTx module
- optimized XGMII TX for a 64byte min L2 ETH frame