### PR TITLE
passing the XPM MEMORY_INIT_FILE/MEMORY_INIT_PARAM to the top-level of AxiDualPortRam.vhd

### DIFF
--- a/base/ram/xilinx/SimpleDualPortRamXpm.vhd
+++ b/base/ram/xilinx/SimpleDualPortRamXpm.vhd
@@ -25,15 +25,17 @@ use xpm.vcomponents.all;
 
 entity SimpleDualPortRamXpm is
    generic (
-      TPD_G          : time                       := 1 ns;
-      COMMON_CLK_G   : boolean                    := false;
-      RST_POLARITY_G : sl                         := '1';  -- '1' for active high rst, '0' for active low       
-      MEMORY_TYPE_G  : string                     := "block";
-      READ_LATENCY_G : natural range 0 to 100     := 1;
-      DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
-      BYTE_WR_EN_G   : boolean                    := false;
-      BYTE_WIDTH_G   : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9
-      ADDR_WIDTH_G   : integer range 1 to (2**24) := 4);
+      TPD_G               : time                       := 1 ns;
+      COMMON_CLK_G        : boolean                    := false;
+      RST_POLARITY_G      : sl                         := '1';  -- '1' for active high rst, '0' for active low       
+      MEMORY_TYPE_G       : string                     := "block";
+      MEMORY_INIT_FILE_G  : string                     := "none";
+      MEMORY_INIT_PARAM_G : string                     := "0";
+      READ_LATENCY_G      : natural range 0 to 100     := 1;
+      DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
+      BYTE_WR_EN_G        : boolean                    := false;
+      BYTE_WIDTH_G        : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9
+      ADDR_WIDTH_G        : integer range 1 to (2**24) := 4);
    port (
       -- Port A     
       clka   : in  sl                                                                          := '0';
@@ -64,6 +66,8 @@ begin
          BYTE_WRITE_WIDTH_A      => ite(BYTE_WR_EN_G, BYTE_WIDTH_G, DATA_WIDTH_G),
          CLOCKING_MODE           => ite(COMMON_CLK_G, "common_clock", "independent_clock"),
          ECC_MODE                => "no_ecc",         -- Default value = no_ecc
+         MEMORY_INIT_FILE        => MEMORY_INIT_FILE_G,
+         MEMORY_INIT_PARAM       => MEMORY_INIT_PARAM_G,
          MEMORY_OPTIMIZATION     => "true",           -- Default value = true
          MEMORY_PRIMITIVE        => MEMORY_TYPE_G,
          MEMORY_SIZE             => (DATA_WIDTH_G*(2**ADDR_WIDTH_G)),
@@ -74,7 +78,7 @@ begin
          USE_MEM_INIT            => 1,  -- Default value = 1
          WAKEUP_TIME             => "disable_sleep",  -- "disable_sleep" to disable dynamic power saving option
          WRITE_DATA_WIDTH_A      => DATA_WIDTH_G,
-         WRITE_MODE_B            => ite(READ_LATENCY_G = 0, "read_first", ite(MEMORY_TYPE_G="block","no_change","read_first"))) -- Default value = no_change
+         WRITE_MODE_B            => ite(READ_LATENCY_G = 0, "read_first", ite(MEMORY_TYPE_G = "block", "no_change", "read_first")))  -- Default value = no_change
       port map (
          -- Write Interface
          ena            => ena,

--- a/base/ram/xilinx/TrueDualPortRamXpm.vhd
+++ b/base/ram/xilinx/TrueDualPortRamXpm.vhd
@@ -25,15 +25,17 @@ use xpm.vcomponents.all;
 
 entity TrueDualPortRamXpm is
    generic (
-      TPD_G          : time                       := 1 ns;
-      COMMON_CLK_G   : boolean                    := false;
-      RST_POLARITY_G : sl                         := '1';  -- '1' for active high rst, '0' for active low       
-      MEMORY_TYPE_G  : string                     := "block";
-      READ_LATENCY_G : natural range 0 to 100     := 1;
-      DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
-      BYTE_WR_EN_G   : boolean                    := false;
-      BYTE_WIDTH_G   : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9
-      ADDR_WIDTH_G   : integer range 1 to (2**24) := 4);
+      TPD_G               : time                       := 1 ns;
+      COMMON_CLK_G        : boolean                    := false;
+      RST_POLARITY_G      : sl                         := '1';  -- '1' for active high rst, '0' for active low       
+      MEMORY_TYPE_G       : string                     := "block";
+      MEMORY_INIT_FILE_G  : string                     := "none";
+      MEMORY_INIT_PARAM_G : string                     := "0";
+      READ_LATENCY_G      : natural range 0 to 100     := 1;
+      DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
+      BYTE_WR_EN_G        : boolean                    := false;
+      BYTE_WIDTH_G        : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9
+      ADDR_WIDTH_G        : integer range 1 to (2**24) := 4);
    port (
       -- Port A     
       clka   : in  sl                                                                          := '0';
@@ -71,6 +73,8 @@ begin
          BYTE_WRITE_WIDTH_B      => ite(BYTE_WR_EN_G, BYTE_WIDTH_G, DATA_WIDTH_G),
          CLOCKING_MODE           => ite(COMMON_CLK_G, "common_clock", "independent_clock"),
          ECC_MODE                => "no_ecc",         -- Default value = no_ecc
+         MEMORY_INIT_FILE        => MEMORY_INIT_FILE_G,
+         MEMORY_INIT_PARAM       => MEMORY_INIT_PARAM_G,
          MEMORY_OPTIMIZATION     => "true",           -- Default value = true
          MEMORY_PRIMITIVE        => MEMORY_TYPE_G,
          MEMORY_SIZE             => (DATA_WIDTH_G*(2**ADDR_WIDTH_G)),


### PR DESCRIPTION
### Description
- passing the XPM MEMORY_INIT_FILE/MEMORY_INIT_PARAM to the top-level of AxiDualPortRam.vhd