### PR TITLE
AxiStreamMon Overhaul

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamMon.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMon.vhd
@@ -36,6 +36,7 @@ entity AxiStreamMon is
       -- Status Interface
       statusClk    : in  sl;
       statusRst    : in  sl;
+      frameCnt     : out slv(63 downto 0);             -- units of frames
       frameRate    : out slv(31 downto 0);             -- units of Hz
       frameRateMax : out slv(31 downto 0);             -- units of Hz
       frameRateMin : out slv(31 downto 0);             -- units of Hz
@@ -50,31 +51,25 @@ architecture rtl of AxiStreamMon is
    constant TIMEOUT_C : natural := getTimeRatio(AXIS_CLK_FREQ_G, 1.0)-1;
 
    type RegType is record
-      armed        : sl;
-      frameSent    : sl;
-      tValid       : sl;
-      tKeep        : slv(AXI_STREAM_MAX_TKEEP_WIDTH_C-1 downto 0);
-      updated      : sl;
-      updateStat   : sl;
-      timer        : natural range 0 to TIMEOUT_C;
-      accum        : slv(39 downto 0);
-      bandwidth    : slv(39 downto 0);
-      bandwidthMax : slv(39 downto 0);
-      bandwidthMin : slv(39 downto 0);
+      frameSent : sl;
+      tValid    : sl;
+      tKeep     : slv(AXI_STREAM_MAX_TKEEP_WIDTH_C-1 downto 0);
+      updated   : sl;
+      timer     : natural range 0 to TIMEOUT_C;
+      accum     : slv(39 downto 0);
+      bandwidth : slv(39 downto 0);
+      frameCnt  : slv(63 downto 0);
    end record;
 
    constant REG_INIT_C : RegType := (
-      armed        => '0',
-      frameSent    => '0',
-      tValid       => '0',
-      tKeep        => (others => '0'),
-      updated      => '0',
-      updateStat   => '0',
-      timer        => 0,
-      accum        => (others => '0'),
-      bandwidth    => (others => '0'),
-      bandwidthMax => (others => '0'),
-      bandwidthMin => (others => '0'));
+      frameSent => '0',
+      tValid    => '0',
+      tKeep     => (others => '0'),
+      updated   => '0',
+      timer     => 0,
+      accum     => (others => '0'),
+      bandwidth => (others => '0'),
+      frameCnt  => (others => '0'));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -150,6 +145,17 @@ begin
          rd_clk => statusClk,
          dout   => frameRateMin);
 
+   SyncOut_frameCnt : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G,
+         DATA_WIDTH_G => 64)
+      port map (
+         wr_clk => axisClk,
+         din    => r.frameCnt,
+         rd_clk => statusClk,
+         dout   => frameCnt);
+
    comb : process (axisMaster, axisRst, axisSlave, r) is
       variable v : RegType;
    begin
@@ -159,10 +165,14 @@ begin
       -- Reset strobing signals
       v.tValid     := '0';
       v.updated    := '0';
-      v.updateStat := '0';
 
       -- Check for end of frame
       v.frameSent := axisMaster.tValid and axisMaster.tLast and axisSlave.tReady;
+
+      -- Increment frame counter if end of frame detected
+      if (r.frameSent = '1') then
+         v.frameCnt := r.frameCnt + 1;
+      end if;
 
       -- Check for data moving
       if (axisMaster.tValid = '1') and (axisSlave.tReady = '1') then
@@ -204,37 +214,9 @@ begin
          end if;
       end if;
 
-      -- Check for update previous clock cycle
-      if (r.updated = '1') then
-         -- Set the flag
-         v.updateStat := '1';
-         -- Check if first time after reset
-         if (r.armed = '0') then
-            -- Set the flag
-            v.armed        := '1';
-            -- Pass the current values to the statistics measurements
-            v.bandwidthMax := r.bandwidth;
-            v.bandwidthMin := r.bandwidth;
-         else
-            -- Compare for max. value
-            if (r.bandwidth > r.bandwidthMax) then
-               -- Update the statistics measurement
-               v.bandwidthMax := r.accum;
-            end if;
-            -- Compare for min. value
-            if (r.bandwidth < r.bandwidthMin) then
-               -- Update the statistics measurement
-               v.bandwidthMin := r.bandwidth;
-            end if;
-         end if;
-      end if;
-
       -- Reset
       if axisRst = '1' then
-         -- Re-arm and reset statistics measurements only
-         v.armed        := '0';
-         v.bandwidthMax := r.bandwidth;
-         v.bandwidthMin := r.bandwidth;
+         v := REG_INIT_C;
       end if;
 
       -- Register the variable for next clock cycle
@@ -249,41 +231,23 @@ begin
       end if;
    end process seq;
 
-   SyncOut_bandwidth : entity work.SynchronizerFifo
+   Sync_bandwidth : entity work.SyncMinMax
       generic map (
          TPD_G        => TPD_G,
          COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => 40)
+         WIDTH_G      => 40)
       port map (
-         wr_clk => axisClk,
-         wr_en  => r.updated,
-         din    => r.bandwidth,
-         rd_clk => statusClk,
-         dout   => bw);
-
-   SyncOut_bandwidthMax : entity work.SynchronizerFifo
-      generic map (
-         TPD_G        => TPD_G,
-         COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => 40)
-      port map (
-         wr_clk => axisClk,
-         wr_en  => r.updateStat,
-         din    => r.bandwidthMax,
-         rd_clk => statusClk,
-         dout   => bwMax);
-
-   SyncOut_bandwidthMin : entity work.SynchronizerFifo
-      generic map (
-         TPD_G        => TPD_G,
-         COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => 40)
-      port map (
-         wr_clk => axisClk,
-         wr_en  => r.updateStat,
-         din    => r.bandwidthMin,
-         rd_clk => statusClk,
-         dout   => bwMin);
+         -- ASYNC statistics reset    
+         rstStat => axisRst,
+         -- Write Interface (wrClk domain)
+         wrClk   => axisClk,
+         wrEn    => r.updated,
+         dataIn  => r.bandwidth,
+         -- Read Interface (rdClk domain)
+         rdClk   => statusClk,
+         dataOut => bw,
+         dataMin => bwMin,
+         dataMax => bwMax);
 
    bandwidth    <= x"000000" & bw;
    bandwidthMax <= x"000000" & bwMax;

--- a/base/sync/rtl/SyncTrigRate.vhd
+++ b/base/sync/rtl/SyncTrigRate.vhd
@@ -22,15 +22,14 @@ use work.StdRtlPkg.all;
 
 entity SyncTrigRate is
    generic (
-      TPD_G          : time     := 1 ns;  -- Simulation FF output delay
+      TPD_G          : time     := 1 ns;   -- Simulation FF output delay
       COMMON_CLK_G   : boolean  := false;  -- true if locClk & refClk are the same clock
       ONE_SHOT_G     : boolean  := false;
-      IN_POLARITY_G  : sl       := '1';   -- 0 for active LOW, 1 for active HIGH
+      IN_POLARITY_G  : sl       := '1';  -- 0 for active LOW, 1 for active HIGH
       COUNT_EDGES_G  : boolean  := false;  -- Count edges or high time
       REF_CLK_FREQ_G : real     := 200.0E+6;              -- units of Hz
       REFRESH_RATE_G : real     := 1.0E+0;                -- units of Hz
-      USE_DSP48_G    : string   := "no";  -- "no" for no DSP48 implementation, "yes" to use DSP48 slices
-      CNT_WIDTH_G    : positive := 32);   -- Counters' width
+      CNT_WIDTH_G    : positive := 32);  -- Counters' width
    port (
       -- Trigger Input (locClk domain)
       trigIn          : in  sl;
@@ -42,7 +41,7 @@ entity SyncTrigRate is
       -- Clocks
       locClkEn        : in  sl := '1';
       locClk          : in  sl;
-      locRst          : in  sl := '1';
+      locRst          : in  sl := '0';
       refClk          : in  sl;
       refRst          : in  sl := '0');
 end SyncTrigRate;
@@ -52,25 +51,17 @@ architecture rtl of SyncTrigRate is
    constant TIMEOUT_C : natural := getTimeRatio(REF_CLK_FREQ_G, REFRESH_RATE_G)-1;
 
    type RegType is record
-      armed      : sl;
       updated    : sl;
-      updateStat : sl;
       timer      : natural range 0 to TIMEOUT_C;
       trigCntDly : slv(CNT_WIDTH_G-1 downto 0);
       rate       : slv(CNT_WIDTH_G-1 downto 0);
-      rateMax    : slv(CNT_WIDTH_G-1 downto 0);
-      rateMin    : slv(CNT_WIDTH_G-1 downto 0);
    end record;
 
    constant REG_INIT_C : RegType := (
-      armed      => '0',
       updated    => '0',
-      updateStat => '0',
       timer      => 0,
       trigCntDly => (others => '0'),
-      rate       => (others => '0'),
-      rateMax    => (others => '0'),
-      rateMin    => (others => '0'));
+      rate       => (others => '0'));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -80,6 +71,7 @@ architecture rtl of SyncTrigRate is
    signal updated     : sl                          := '0';
    signal trigCnt     : slv(CNT_WIDTH_G-1 downto 0) := (others => '0');
    signal trigCntSync : slv(CNT_WIDTH_G-1 downto 0) := (others => '0');
+   signal rstStat     : sl;
 
 begin
 
@@ -130,15 +122,14 @@ begin
          rd_clk => refClk,
          dout   => trigCntSync);
 
-   comb : process (r, refRst, trigCntSync) is
+   comb : process (r, trigCntSync) is
       variable v : RegType;
    begin
       -- Latch the current value
       v := r;
 
       -- Reset strobing signals
-      v.updated    := '0';
-      v.updateStat := '0';
+      v.updated := '0';
 
       -- Check for timeout 
       if r.timer = TIMEOUT_C then
@@ -154,39 +145,6 @@ begin
          v.timer := r.timer + 1;
       end if;
 
-      -- Check for update previous clock cycle
-      if (r.updated = '1') then
-         -- Set the flag
-         v.updateStat := '1';
-         -- Check if first time after reset
-         if (r.armed = '0') then
-            -- Set the flag
-            v.armed   := '1';
-            -- Pass the current values to the statistics measurements
-            v.rateMax := r.rate;
-            v.rateMin := r.rate;
-         else
-            -- Compare for max. value
-            if (r.rate > r.rateMax) then
-               -- Update the statistics measurement
-               v.rateMax := r.rate;
-            end if;
-            -- Compare for min. value
-            if (r.rate < r.rateMin) then
-               -- Update the statistics measurement
-               v.rateMin := r.rate;
-            end if;
-         end if;
-      end if;
-
-      -- Reset
-      if refRst = '1' then
-         -- Re-arm and reset statistics measurements only
-         v.armed   := '0';
-         v.rateMax := r.rate;
-         v.rateMin := r.rate;
-      end if;
-
       -- Register the variable for next clock cycle
       rin <= v;
 
@@ -199,41 +157,25 @@ begin
       end if;
    end process seq;
 
-   SyncOut_rate : entity work.SynchronizerFifo
-      generic map (
-         TPD_G        => TPD_G,
-         COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => CNT_WIDTH_G)
-      port map (
-         wr_clk => refClk,
-         wr_en  => r.updated,
-         din    => r.rate,
-         rd_clk => locClk,
-         valid  => trigRateUpdated,
-         dout   => trigRateOut);
+   rstStat <= refRst or locRst;
 
-   SyncOut_rateMax : entity work.SynchronizerFifo
+   U_Sync : entity work.SyncMinMax
       generic map (
          TPD_G        => TPD_G,
          COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => CNT_WIDTH_G)
+         WIDTH_G      => CNT_WIDTH_G)
       port map (
-         wr_clk => refClk,
-         wr_en  => r.updateStat,
-         din    => r.rateMax,
-         rd_clk => locClk,
-         dout   => trigRateOutMax);
-
-   SyncOut_rateMin : entity work.SynchronizerFifo
-      generic map (
-         TPD_G        => TPD_G,
-         COMMON_CLK_G => COMMON_CLK_G,
-         DATA_WIDTH_G => CNT_WIDTH_G)
-      port map (
-         wr_clk => refClk,
-         wr_en  => r.updateStat,
-         din    => r.rateMin,
-         rd_clk => locClk,
-         dout   => trigRateOutMin);
+         -- ASYNC statistics reset    
+         rstStat => rstStat,
+         -- Write Interface (wrClk domain)
+         wrClk   => refClk,
+         wrEn    => r.updated,
+         dataIn  => r.rate,
+         -- Read Interface (rdClk domain)
+         rdClk   => locClk,
+         updated => trigRateUpdated,
+         dataOut => trigRateOut,
+         dataMin => trigRateOutMin,
+         dataMax => trigRateOutMax);
 
 end rtl;

--- a/dsp/fixed/DspComparator.vhd
+++ b/dsp/fixed/DspComparator.vhd
@@ -37,6 +37,8 @@ entity DspComparator is
       -- Outbound Interface
       obValid : out sl;
       obReady : in  sl := '1';
+      aout    : out slv(WIDTH_G-1 downto 0);  -- Registered copy of ain
+      bout    : out slv(WIDTH_G-1 downto 0);  -- Registered copy of bin
       eq      : out sl;                 -- equal                    (a =  b)
       gt      : out sl;                 -- greater than             (a >  b)
       gtEq    : out sl;                 -- greater than or equal to (a >= b)
@@ -46,14 +48,21 @@ end DspComparator;
 
 architecture rtl of DspComparator is
 
+   subtype PIPE_AOUT_RANGE_C is integer range WIDTH_G-1+5 downto 5;
+   subtype PIPE_BOUT_RANGE_C is integer range 2*WIDTH_G-1+5 downto WIDTH_G+5;
+
    type RegType is record
       ibReady : sl;
       tValid  : sl;
+      aout    : slv(WIDTH_G-1 downto 0);
+      bout    : slv(WIDTH_G-1 downto 0);
       diff    : signed(WIDTH_G - 1 downto 0);
    end record RegType;
    constant REG_INIT_C : RegType := (
       ibReady => '0',
       tValid  => '0',
+      aout    => (others => '0'),
+      bout    => (others => '0'),
       diff    => (others => '0'));
 
    signal r   : RegType := REG_INIT_C;
@@ -83,7 +92,7 @@ begin
       a := signed(ain);
       b := signed(bin);
 
-      -- Reset the flags
+      -- Flow Control
       v.ibReady := '0';
       if tReady = '1' then
          v.tValid := '0';
@@ -91,16 +100,23 @@ begin
 
       -- Check if ready to process data
       if (v.tValid = '0') and (ibValid = '1') then
+
          -- Set the flow control flags
          v.ibReady := '1';
          v.tValid  := '1';
+
          -- Process the data
-         v.diff    := a - b;
+         v.diff := a - b;
+
+         -- Registered copy
+         v.aout := ain;
+         v.bout := bin;
+
       end if;
-      
+
       -- Outputs              
       ibReady <= v.ibReady;
-      
+
       -- Reset
       if (rst = RST_POLARITY_G) then
          v := REG_INIT_C;
@@ -108,8 +124,6 @@ begin
 
       -- Register the variable for next clock cycle
       rin <= v;
-
-    
 
    end process comb;
 
@@ -130,27 +144,31 @@ begin
       generic map (
          TPD_G          => TPD_G,
          RST_POLARITY_G => RST_POLARITY_G,
-         DATA_WIDTH_G   => 5,
+         DATA_WIDTH_G   => 5+2*WIDTH_G,
          PIPE_STAGES_G  => PIPE_STAGES_G)
       port map (
          -- Slave Port         
-         sData(0) => eqInt,
-         sData(1) => gtInt,
-         sData(2) => gtEqInt,
-         sData(3) => lsInt,
-         sData(4) => lsEqInt,
-         sValid   => r.tValid,
-         sRdEn    => tReady,
+         sData(0)                 => eqInt,
+         sData(1)                 => gtInt,
+         sData(2)                 => gtEqInt,
+         sData(3)                 => lsInt,
+         sData(4)                 => lsEqInt,
+         sData(PIPE_AOUT_RANGE_C) => r.aout,
+         sData(PIPE_BOUT_RANGE_C) => r.bout,
+         sValid                   => r.tValid,
+         sRdEn                    => tReady,
          -- Master Port
-         mData(0) => eq,
-         mData(1) => gt,
-         mData(2) => gtEq,
-         mData(3) => ls,
-         mData(4) => lsEq,
-         mValid   => obValid,
-         mRdEn    => obReady,
+         mData(0)                 => eq,
+         mData(1)                 => gt,
+         mData(2)                 => gtEq,
+         mData(3)                 => ls,
+         mData(4)                 => lsEq,
+         mData(PIPE_AOUT_RANGE_C) => aout,
+         mData(PIPE_BOUT_RANGE_C) => bout,
+         mValid                   => obValid,
+         mRdEn                    => obReady,
          -- Clock and Reset
-         clk      => clk,
-         rst      => rst);
+         clk                      => clk,
+         rst                      => rst);
 
 end rtl;

--- a/dsp/fixed/DspComparator.vhd
+++ b/dsp/fixed/DspComparator.vhd
@@ -75,6 +75,9 @@ architecture rtl of DspComparator is
    signal lsInt   : sl;
    signal lsEqInt : sl;
 
+   signal sData : slv(2*WIDTH_G-1+5 downto 0);
+   signal mData : slv(2*WIDTH_G-1+5 downto 0);
+
    attribute use_dsp48      : string;
    attribute use_dsp48 of r : signal is USE_DSP_G;
 
@@ -148,27 +151,33 @@ begin
          PIPE_STAGES_G  => PIPE_STAGES_G)
       port map (
          -- Slave Port         
-         sData(0)                 => eqInt,
-         sData(1)                 => gtInt,
-         sData(2)                 => gtEqInt,
-         sData(3)                 => lsInt,
-         sData(4)                 => lsEqInt,
-         sData(PIPE_AOUT_RANGE_C) => r.aout,
-         sData(PIPE_BOUT_RANGE_C) => r.bout,
-         sValid                   => r.tValid,
-         sRdEn                    => tReady,
+         sData  => sData,
+         sValid => r.tValid,
+         sRdEn  => tReady,
          -- Master Port
-         mData(0)                 => eq,
-         mData(1)                 => gt,
-         mData(2)                 => gtEq,
-         mData(3)                 => ls,
-         mData(4)                 => lsEq,
-         mData(PIPE_AOUT_RANGE_C) => aout,
-         mData(PIPE_BOUT_RANGE_C) => bout,
-         mValid                   => obValid,
-         mRdEn                    => obReady,
+         mData  => mData,
+         mValid => obValid,
+         mRdEn  => obReady,
          -- Clock and Reset
-         clk                      => clk,
-         rst                      => rst);
+         clk    => clk,
+         rst    => rst);
+
+   -- Slave Port Mapping
+   sData(0)                 <= eqInt;
+   sData(1)                 <= gtInt;
+   sData(2)                 <= gtEqInt;
+   sData(3)                 <= lsInt;
+   sData(4)                 <= lsEqInt;
+   sData(PIPE_AOUT_RANGE_C) <= r.aout;
+   sData(PIPE_BOUT_RANGE_C) <= r.bout;
+
+   -- Master Port Mapping
+   eq   <= mData(0);
+   gt   <= mData(1);
+   gtEq <= mData(2);
+   ls   <= mData(3);
+   lsEq <= mData(4);
+   aout <= mData(PIPE_AOUT_RANGE_C);
+   bout <= mData(PIPE_BOUT_RANGE_C);
 
 end rtl;

--- a/python/surf/axi/_AxiStreamMonitoring.py
+++ b/python/surf/axi/_AxiStreamMonitoring.py
@@ -63,7 +63,7 @@ class AxiStreamMonitoring(pr.Device):
         for i in range(numberLanes):
         
             self.add(pr.RemoteVariable(
-                name         = 'FrameCnt', 
+                name         = f'FrameCnt[{i}]', 
                 description  = 'Increments every time a tValid + tLast + tReady detected',
                 offset       = (i*0x40 + 0x04), 
                 bitSize      = 64, 

--- a/python/surf/axi/_AxiStreamMonitoring.py
+++ b/python/surf/axi/_AxiStreamMonitoring.py
@@ -61,10 +61,20 @@ class AxiStreamMonitoring(pr.Device):
         #############################################
         
         for i in range(numberLanes):
+        
             self.add(pr.RemoteVariable(
-                name         = ('FrameRate[%d]'%i),       
+                name         = 'FrameCnt', 
+                description  = 'Increments every time a tValid + tLast + tReady detected',
+                offset       = (i*0x40 + 0x04), 
+                bitSize      = 64, 
+                mode         = 'RO',
+                pollInterval = 1,
+            ))        
+        
+            self.add(pr.RemoteVariable(
+                name         = f'FrameRate[{i}]',       
                 description  = "Current Frame Rate",
-                offset       = (16 + i*48), 
+                offset       = (i*0x40 + 0x0C), 
                 bitSize      = 32, 
                 bitOffset    = 0, 
                 mode         = "RO",
@@ -74,9 +84,9 @@ class AxiStreamMonitoring(pr.Device):
             ))     
 
             self.add(pr.RemoteVariable(
-                name         = ('FrameRateMax[%d]'%i),       
+                name         = f'FrameRateMax[{i}]',       
                 description  = "Max Frame Rate",
-                offset       = (20 + i*48), 
+                offset       = (i*0x40 + 0x10), 
                 bitSize      = 32, 
                 bitOffset    = 0, 
                 mode         = "RO",
@@ -86,9 +96,9 @@ class AxiStreamMonitoring(pr.Device):
             )) 
 
             self.add(pr.RemoteVariable(
-                name         = ('FrameRateMin[%d]'%i),       
+                name         = f'FrameRateMin[{i}]',       
                 description  = "Min Frame Rate",
-                offset       = (24 + i*48), 
+                offset       = (i*0x40 + 0x14), 
                 bitSize      = 32, 
                 bitOffset    = 0, 
                 mode         = "RO",
@@ -98,9 +108,9 @@ class AxiStreamMonitoring(pr.Device):
             ))
             
             addPair(
-                name         = ('Bandwidth[%d]'%i),       
+                name         = f'Bandwidth[{i}]',       
                 description  = "Current Bandwidth",
-                offset       = (28 + i*48), 
+                offset       = (i*0x40 + 0x18), 
                 bitSize      = 64, 
                 bitOffset    = 0, 
                 function     = self.convMbps,
@@ -109,9 +119,9 @@ class AxiStreamMonitoring(pr.Device):
             )
 
             addPair(
-                name         = ('BandwidthMax[%d]'%i),       
+                name         = f'BandwidthMax[{i}]',       
                 description  = "Max Bandwidth",
-                offset       = (36 + i*48), 
+                offset       = (i*0x40 + 0x20), 
                 bitSize      = 64, 
                 bitOffset    = 0, 
                 function     = self.convMbps,
@@ -120,16 +130,16 @@ class AxiStreamMonitoring(pr.Device):
             )
 
             addPair(
-                name         = ('BandwidthMin[%d]'%i),       
+                name         = f'BandwidthMin[{i}]',       
                 description  = "Min Bandwidth",
-                offset       = (44 + i*48), 
+                offset       = (i*0x40 + 0x28), 
                 bitSize      = 64, 
                 bitOffset    = 0, 
                 function     = self.convMbps,
                 units        = 'Mbps', 
                 pollInterval = 1,
             )
-            
+                        
     @staticmethod
     def convMbps(var):
         return var.dependencies[0].value() * 8e-6


### PR DESCRIPTION
### Description
- Adding frameCnt register
- Replacing the redundant min/max logic with the common  SyncMinMax.vhd module
- Using AxiDualPortRam for AXI-Lite address decode
  - Help with making timing when AXIS_NUM_SLOTS_G is large
- For AxiStreamMonAxiL, using AxiDualPortRam as the one module for clock crossing
  - Instead of the many LUTRAM (SynchronizerFifo) in the submodule
  - Note: SynchronizerFifo optimizes away if SynchronizerFifo.COMMON_CLK_G = true
-  Implementing the SyncMinMax with DSP48 primitives 