### PR TITLE
encoding a "PGPv2b-like" locData/remData into the unused 56-bit skip code payload

### DIFF
--- a/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
@@ -133,6 +133,7 @@ architecture rtl of Pgp3AxiL is
       cellErrorCount     : ErrorCountSlv;
       linkDownCount      : ErrorCountSlv;
       linkErrorCount     : ErrorCountSlv;
+      remLinkData        : slv(55 downto 0);
       remRxOverflow      : slv(15 downto 0);
       remRxOverflowCnt   : ErrorCountSlvArray(15 downto 0);
       frameErrCount      : ErrorCountSlv;
@@ -390,6 +391,15 @@ begin
 
    rxStatusSync.gearboxAlignCnt <= muxSlVectorArray(gearboxAlignCnt, 0);
 
+   U_remLinkData : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         DATA_WIDTH_G => 56)
+      port map (
+         wr_clk => pgpRxClk,
+         din    => pgpRxOut.remLinkData,
+         rd_clk => axilClk,
+         dout   => rxStatusSync.remLinkData);
 
    ---------------------------------------
    -- Transmit Status
@@ -544,6 +554,7 @@ begin
    pgpTxIn.opCodeEn     <= locTxIn.opCodeEn;
    pgpTxIn.opCodeData   <= locTxIn.opCodeData;
    pgpTxIn.opCodeNumber <= locTxIn.opCodeNumber;
+   pgpTxIn.locData      <= locTxIn.locData;   
    pgpTxIn.flowCntlDis  <= locTxIn.flowCntlDis or syncFlowCntlDis;
    pgpTxIn.skpInterval  <= syncSkpInterval;
 
@@ -628,6 +639,8 @@ begin
       axiSlaveRegisterR(axilEp, X"120", 8, rxStatusSync.gearboxAlignCnt);
 
       axiSlaveRegisterR(axilEp, X"130", 0, rxStatusSync.phyRxInitCnt);
+      
+      axiSlaveRegisterR(axilEp, X"138", 0, rxStatusSync.remLinkData);
 
 
 

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -77,6 +77,7 @@ package Pgp3Pkg is
    subtype PGP3_EOFC_CRC_FIELD_C is natural range 55 downto 24;
    subtype PGP3_USER_CHECKSUM_FIELD_C is natural range 55 downto 48;
    subtype PGP3_USER_OPCODE_FIELD_C is natural range 47 downto 0;
+   subtype PGP3_SKIP_DATA_FIELD_C is natural range 55 downto 0;
 
    constant PGP3_CRC_POLY_C : slv(31 downto 0) := X"04C11DB7";
 
@@ -103,6 +104,7 @@ package Pgp3Pkg is
       opCodeEn     : sl;
       opCodeNumber : slv(2 downto 0);
       opCodeData   : slv(47 downto 0);
+      locData      : slv(55 downto 0);      
    end record Pgp3TxInType;
 
    type Pgp3TxInArray is array (natural range<>) of Pgp3TxInType;
@@ -113,7 +115,8 @@ package Pgp3Pkg is
       skpInterval  => toSlv(5000, 32),
       opCodeEn     => '0',
       opCodeNumber => (others => '0'),
-      opCodeData   => (others => '0'));
+      opCodeData   => (others => '0'),
+      locData      => (others => '0'));
 
 
    type Pgp3TxOutType is record
@@ -160,6 +163,7 @@ package Pgp3Pkg is
       opCodeEn       : sl;                -- Opcode valid
       opCodeNumber   : slv(2 downto 0);   -- Opcode number
       opCodeData     : slv(47 downto 0);  -- Opcode data
+      remLinkData    : slv(55 downto 0);  -- Far end side User Data
       remRxLinkReady : sl;                -- Far end RX has link
       remRxOverflow  : slv(15 downto 0);  -- Far end RX overflow status
       remRxPause     : slv(15 downto 0);  -- Far end pause status
@@ -191,6 +195,7 @@ package Pgp3Pkg is
       opCodeEn       => '0',
       opCodeNumber   => (others => '0'),
       opCodeData     => (others => '0'),
+      remLinkData    => (others => '0'),
       remRxLinkReady => '0',
       remRxOverflow  => (others => '0'),
       remRxPause     => (others => '0'),

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
@@ -70,6 +70,7 @@ architecture rtl of Pgp3Rx is
    signal unscrambledValid       : sl;
    signal unscrambledData        : slv(63 downto 0);
    signal unscrambledHeader      : slv(1 downto 0);
+   signal remLinkData            : slv(55 downto 0);
    signal ebValid                : sl;
    signal ebData                 : slv(63 downto 0);
    signal ebHeader               : slv(1 downto 0);
@@ -141,6 +142,7 @@ begin
          pgpRxValid  => ebValid,            -- [out]
          pgpRxData   => ebData,             -- [out]
          pgpRxHeader => ebHeader,           -- [out]
+         remLinkData => remLinkData,        -- [out]
          overflow    => ebOverflow,         -- [out]
          status      => ebStatus);          -- [out]
 
@@ -210,6 +212,7 @@ begin
    pgpRxOut.opCodeEn       <= pgpRxOutProtocol.opCodeEn;
    pgpRxOut.opCodeNumber   <= pgpRxOutProtocol.opCodeNumber;
    pgpRxOut.opCodeData     <= pgpRxOutProtocol.opCodeData;
+   pgpRxOut.remLinkData    <= remLinkData;
    pgpRxOut.remRxLinkReady <= remRxLinkReadyInt;
 
    pgpRxOut.phyRxData   <= phyRxData;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3TxProtocol.vhd
@@ -257,12 +257,12 @@ begin
             resetEventMetaData := false;
          -- SKIP codes override data
          elsif (r.skpCount = r.skpInterval) then
-            v.skpCount                     := (others => '0');
-            v.pgpTxSlave.tReady            := '0';            -- Override any data acceptance.
-            v.protTxData                   := (others => '0');
-            v.protTxData(PGP3_BTF_FIELD_C) := PGP3_SKP_C;
-            v.protTxHeader                 := PGP3_K_HEADER_C;
-            resetEventMetaData             := false;
+            v.skpCount                           := (others => '0');
+            v.pgpTxSlave.tReady                  := '0';            -- Override any data acceptance.
+            v.protTxData(PGP3_SKIP_DATA_FIELD_C) := pgpTxIn.locData;
+            v.protTxData(PGP3_BTF_FIELD_C)       := PGP3_SKP_C;
+            v.protTxHeader                       := PGP3_K_HEADER_C;
+            resetEventMetaData                   := false;
          else
             -- A local rx pause going high causes an IDLE char to be sent mid frame
             -- So that the sending end is notified with minimum latency

--- a/python/surf/protocols/pgp/_Pgp3AxiL.py
+++ b/python/surf/protocols/pgp/_Pgp3AxiL.py
@@ -334,6 +334,14 @@ class Pgp3AxiL(pr.Device):
             pollInterval = 1,
         ))
         
+        self.add(pr.RemoteVariable(
+            name         = 'RemLinkData',
+            mode         = 'RO',            
+            offset       = 0x138,
+            bitSize      = 56,
+            pollInterval = 1,
+        ))        
+        
         ################
         # TX
         ################


### PR DESCRIPTION
### Description
- encoding a `PGPv2b-like` locData/remData into the unused 56-bit skip code payload