### PR TITLE
performance optimization for SyncMinMax.vhd

### DIFF
--- a/base/sync/rtl/SyncMinMax.vhd
+++ b/base/sync/rtl/SyncMinMax.vhd
@@ -107,7 +107,8 @@ begin
          -- Outbound Interface
          obValid => valid,
          aout    => data,
-         gt      => gt);                --  (a >  b)
+         -- gt      => gt);                --  (a >  b)
+         gtEq    => gt);  --  Using gtEq because better performance than gt in the DspComparator.vhd, and gtEq give the same result as gt with respect to this module's implementation
 
    process (data, gt, ls, r, resetStat, valid, wrRst) is
       variable v : RegType;


### PR DESCRIPTION
### Description
- performance optimization for SyncMinMax.vhd
- Here's the logic in DspComparator.vhd:
  - `gt   <= '1' when (r.diff(WIDTH_G-1) = '0' and r.diff(WIDTH_G-2 downto 0) /= 0) else '0';`
  - `gtEq <= '1' when (r.diff(WIDTH_G-1) = '0')                                     else '0';`
- Using `gtEq` because better performance than `gt` in the DspComparator.vhd, and `gtEq` give the same result as `gt` with respect to this module's implementation
