### PR TITLE
Remove Xilinx library dependencies from generic modules

### DIFF
--- a/axi/axi-stream/tb/AxiStreamBytePackerTb.vhd
+++ b/axi/axi-stream/tb/AxiStreamBytePackerTb.vhd
@@ -13,11 +13,9 @@
 ------------------------------------------------------------------------------
 
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-library unisim;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;

--- a/axi/axi-stream/tb/fifo_tb.vhd
+++ b/axi/axi-stream/tb/fifo_tb.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 ------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/axi-stream/tb/fifo_tb.vhd
+++ b/axi/axi-stream/tb/fifo_tb.vhd
@@ -18,8 +18,6 @@ USE work.ALL;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-Library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;

--- a/axi/axi-stream/tb/stream_tb.vhd
+++ b/axi/axi-stream/tb/stream_tb.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 ------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/axi-stream/tb/stream_tb.vhd
+++ b/axi/axi-stream/tb/stream_tb.vhd
@@ -18,8 +18,6 @@ USE work.ALL;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-Library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;

--- a/axi/axi-stream/tb/vcs_tb.vhd
+++ b/axi/axi-stream/tb/vcs_tb.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 ------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/axi-stream/tb/vcs_tb.vhd
+++ b/axi/axi-stream/tb/vcs_tb.vhd
@@ -18,8 +18,6 @@ USE work.ALL;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-Library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;

--- a/axi/dma/tb/dma_read_tb.vhd
+++ b/axi/dma/tb/dma_read_tb.vhd
@@ -14,7 +14,6 @@
 ------------------------------------------------------------------------------
 
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/dma/tb/dma_read_tb.vhd
+++ b/axi/dma/tb/dma_read_tb.vhd
@@ -18,8 +18,6 @@ use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.AxiPkg.all;

--- a/axi/dma/tb/dma_tb.vhd
+++ b/axi/dma/tb/dma_tb.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 ------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/dma/tb/dma_tb.vhd
+++ b/axi/dma/tb/dma_tb.vhd
@@ -18,8 +18,6 @@ USE work.ALL;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-Library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.AxiPkg.all;

--- a/axi/simlink/sim/RogueSideBand.vhd
+++ b/axi/simlink/sim/RogueSideBand.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/simlink/sim/RogueTcpMemory.vhd
+++ b/axi/simlink/sim/RogueTcpMemory.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/axi/simlink/sim/RogueTcpMemoryWrap.vhd
+++ b/axi/simlink/sim/RogueTcpMemoryWrap.vhd
@@ -14,10 +14,10 @@
 -------------------------------------------------------------------------------
 
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
+
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
 

--- a/axi/simlink/sim/RogueTcpStream.vhd
+++ b/axi/simlink/sim/RogueTcpStream.vhd
@@ -13,8 +13,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/devices/AnalogDevices/ad9249/core/StreamPatternTester.vhd
+++ b/devices/AnalogDevices/ad9249/core/StreamPatternTester.vhd
@@ -15,8 +15,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
-LIBRARY ieee;
-use work.all;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 

--- a/devices/Micron/mt28ew/rtl/AxiMicronMt28ewReg.vhd
+++ b/devices/Micron/mt28ew/rtl/AxiMicronMt28ewReg.vhd
@@ -21,9 +21,6 @@ use ieee.std_logic_arith.all;
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity AxiMicronMt28ewReg is
    generic (
       TPD_G              : time             := 1 ns;

--- a/devices/Micron/p30/rtl/AxiMicronP30Reg.vhd
+++ b/devices/Micron/p30/rtl/AxiMicronP30Reg.vhd
@@ -21,9 +21,6 @@ use ieee.std_logic_arith.all;
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity AxiMicronP30Reg is
    generic (
       TPD_G              : time             := 1 ns;

--- a/ethernet/EthMacCore/tb/EthMacRxCsumFragTb.vhd
+++ b/ethernet/EthMacCore/tb/EthMacRxCsumFragTb.vhd
@@ -23,9 +23,6 @@ use work.AxiStreamPkg.all;
 use work.SsiPkg.all;
 use work.EthMacPkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity EthMacRxCsumFragTb is end EthMacRxCsumFragTb;
 
 architecture testbed of EthMacRxCsumFragTb is

--- a/ethernet/EthMacCore/tb/EthMacTb.vhd
+++ b/ethernet/EthMacCore/tb/EthMacTb.vhd
@@ -18,9 +18,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
 use work.SsiPkg.all;

--- a/ethernet/UdpEngine/tb/UdpEngineTb.vhd
+++ b/ethernet/UdpEngine/tb/UdpEngineTb.vhd
@@ -18,9 +18,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
 use work.SsiPkg.all;

--- a/protocols/clink/tb/ClinkFramerTb.vhd
+++ b/protocols/clink/tb/ClinkFramerTb.vhd
@@ -13,11 +13,9 @@
 ------------------------------------------------------------------------------
 
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-library unisim;
 
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;

--- a/protocols/pgp/pgp2b/core/tb/RoguePgp2bSim.vhd
+++ b/protocols/pgp/pgp2b/core/tb/RoguePgp2bSim.vhd
@@ -25,9 +25,6 @@ use work.AxiLitePkg.all;
 use work.AxiStreamPkg.all;
 use work.Pgp2bPkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity RoguePgp2bSim is
    generic (
       TPD_G         : time                        := 1 ns;

--- a/protocols/pgp/pgp2b/core/tb/pgp_test.vhd
+++ b/protocols/pgp/pgp2b/core/tb/pgp_test.vhd
@@ -15,8 +15,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
-LIBRARY ieee;
-USE work.ALL;
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/protocols/pgp/pgp2b/core/tb/pgp_test.vhd
+++ b/protocols/pgp/pgp2b/core/tb/pgp_test.vhd
@@ -20,8 +20,6 @@ USE work.ALL;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
-Library unisim;
-use unisim.vcomponents.all;
 
 use work.StdRtlPkg.all;
 use work.Pgp2bPkg.all;

--- a/protocols/pgp/pgp3/core/tb/RoguePgp3Sim.vhd
+++ b/protocols/pgp/pgp3/core/tb/RoguePgp3Sim.vhd
@@ -25,9 +25,6 @@ use work.AxiLitePkg.all;
 use work.AxiStreamPkg.all;
 use work.Pgp3Pkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity RoguePgp3Sim is
    generic (
       TPD_G         : time                        := 1 ns;

--- a/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
+++ b/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
@@ -22,9 +22,6 @@ use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
 use work.I2cPkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity AxiLitePMbusMasterCore is
    generic (
       TPD_G           : time            := 1 ns;


### PR DESCRIPTION
### Description
- Remove Xilinx library dependencies from generic modules that didn't have any Xilinx vcomponents

### Note
- There are still some generic modules that have vcomponents.  We can resolve these on a case-by-case in the future when we have a non-Xilinx FPGA that uses one of these generic modules