### PR TITLE
adding current autoneg values to RSSI AXI-Lite interface

### DIFF
--- a/protocols/rssi/v1/rtl/RssiAxiLiteRegItf.vhd
+++ b/protocols/rssi/v1/rtl/RssiAxiLiteRegItf.vhd
@@ -75,101 +75,99 @@ use work.AxiLitePkg.all;
 use work.RssiPkg.all;
 
 entity RssiAxiLiteRegItf is
-generic (
-   -- General Configurations
-   TPD_G                : time            := 1 ns;
-   COMMON_CLK_G         : boolean         := false;  -- true if axiClk_i = devClk_i
-   SEGMENT_ADDR_SIZE_G  : positive        := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
-   -- Defaults form generics
-   TIMEOUT_UNIT_G   : real     := 1.0E-6;
-   INIT_SEQ_N_G     : natural  := 16#80#;
-   CONN_ID_G   : positive := 16#12345678#;
-   VERSION_G   : positive := 1;
-   HEADER_CHKSUM_EN_G : boolean  := true;
-   MAX_NUM_OUTS_SEG_G  : positive := 8; --   <=(2**WINDOW_ADDR_SIZE_G)
-   MAX_SEG_SIZE_G      : positive := 1024;  -- Number of bytes
-   RETRANS_TOUT_G        : positive := 50;  -- unit depends on TIMEOUT_UNIT_G  
-   ACK_TOUT_G            : positive := 25;  -- unit depends on TIMEOUT_UNIT_G  
-   NULL_TOUT_G           : positive := 200; -- unit depends on TIMEOUT_UNIT_G  
-   MAX_RETRANS_CNT_G     : positive := 2;
-   MAX_CUM_ACK_CNT_G     : positive := 3;
-   MAX_OUT_OF_SEQUENCE_G : natural  := 3);
-      
-port (
-   -- AXI Clk
-   axiClk_i : in sl;
-   axiRst_i : in sl;
+   generic (
+      -- General Configurations
+      TPD_G                 : time     := 1 ns;
+      COMMON_CLK_G          : boolean  := false;  -- true if axiClk_i = devClk_i
+      SEGMENT_ADDR_SIZE_G   : positive := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
+      -- Defaults form generics
+      TIMEOUT_UNIT_G        : real     := 1.0E-6;
+      INIT_SEQ_N_G          : natural  := 16#80#;
+      CONN_ID_G             : positive := 16#12345678#;
+      VERSION_G             : positive := 1;
+      HEADER_CHKSUM_EN_G    : boolean  := true;
+      MAX_NUM_OUTS_SEG_G    : positive := 8;  --   <=(2**WINDOW_ADDR_SIZE_G)
+      MAX_SEG_SIZE_G        : positive := 1024;   -- Number of bytes
+      RETRANS_TOUT_G        : positive := 50;  -- unit depends on TIMEOUT_UNIT_G  
+      ACK_TOUT_G            : positive := 25;  -- unit depends on TIMEOUT_UNIT_G  
+      NULL_TOUT_G           : positive := 200;  -- unit depends on TIMEOUT_UNIT_G  
+      MAX_RETRANS_CNT_G     : positive := 2;
+      MAX_CUM_ACK_CNT_G     : positive := 3;
+      MAX_OUT_OF_SEQUENCE_G : natural  := 3);
 
-   -- Axi-Lite Register Interface (locClk domain)
-   axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
-   axilReadSlave   : out AxiLiteReadSlaveType;
-   axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
-   axilWriteSlave  : out AxiLiteWriteSlaveType;
+   port (
+      -- AXI Clk
+      axiClk_i : in sl;
+      axiRst_i : in sl;
 
-   -- Rssi Clk
-   devClk_i : in sl;
-   devRst_i : in sl;
+      -- Axi-Lite Register Interface (locClk domain)
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType;
 
-   -- Registers
-   -- Control (RW)   
-   openRq_o       : out sl;
-   closeRq_o      : out sl;
-   mode_o         : out sl;
-   injectFault_o  : out sl;
-   
-   initSeqN_o     : out slv(7 downto 0);
-   appRssiParam_o : out RssiParamType;
-   
-   -- Status (RO)
-   frameRate_i    : in Slv32Array(1 downto 0);   
-   bandwidth_i    : in Slv64Array(1 downto 0);   
-   status_i       : in slv(6 downto 0);  
-   dropCnt_i      : in slv(31 downto 0);
-   validCnt_i     : in slv(31 downto 0);
-   resendCnt_i    : in slv(31 downto 0);
-   reconCnt_i     : in slv(31 downto 0)
-);   
+      -- Rssi Clk
+      devClk_i : in sl;
+      devRst_i : in sl;
+
+      -- Registers
+      -- Control (RW)   
+      openRq_o      : out sl;
+      closeRq_o     : out sl;
+      mode_o        : out sl;
+      injectFault_o : out sl;
+
+      initSeqN_o     : out slv(7 downto 0);
+      appRssiParam_o : out RssiParamType;
+      negRssiParam_i : in  RssiParamType;
+
+      -- Status (RO)
+      frameRate_i : in Slv32Array(1 downto 0);
+      bandwidth_i : in Slv64Array(1 downto 0);
+      status_i    : in slv(6 downto 0);
+      dropCnt_i   : in slv(31 downto 0);
+      validCnt_i  : in slv(31 downto 0);
+      resendCnt_i : in slv(31 downto 0);
+      reconCnt_i  : in slv(31 downto 0)
+      );
 end RssiAxiLiteRegItf;
 
 architecture rtl of RssiAxiLiteRegItf is
 
-  type RegType is record
-   -- Control (RW)
-   control       : slv(4 downto 0);
-   
-   -- Parameters (RW)  
-   initSeqN      : slv(7 downto 0);
-   version       : slv(3 downto 0);
-   maxOutsSeg    : slv(7 downto 0);       
-   maxSegSize    : slv(15 downto 0);
-   retransTout   : slv(15 downto 0);
-   cumulAckTout  : slv(15 downto 0);
-   nullSegTout   : slv(15 downto 0);      
-   maxRetrans    : slv(7 downto 0);
-   maxCumAck     : slv(7 downto 0);
-   maxOutofseq   : slv(7 downto 0);
-   connectionId  : slv(31 downto 0);
-   
-   -- AXI lite
-   axilReadSlave  : AxiLiteReadSlaveType;
-   axilWriteSlave : AxiLiteWriteSlaveType;
+   type RegType is record
+      -- Control (RW)
+      control : slv(4 downto 0);
+
+      -- Parameters (RW)  
+      initSeqN     : slv(7 downto 0);
+      appRssiParam : RssiParamType;
+
+      -- AXI lite
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
    --
-  end record;
-  
+   end record;
+
    constant REG_INIT_C : RegType := (
-      control     => "01000",
-      initSeqN     => toSlv(INIT_SEQ_N_G, 8),
-      version      => toSlv(VERSION_G, 4),
-      maxOutsSeg   => toSlv(MAX_NUM_OUTS_SEG_G, 8),
-      maxSegSize   => toSlv(MAX_SEG_SIZE_G, 16),
-      retransTout  => toSlv(RETRANS_TOUT_G, 16),
-      cumulAckTout => toSlv(ACK_TOUT_G, 16),
-      nullSegTout  => toSlv(NULL_TOUT_G, 16),
-      maxRetrans   => toSlv(MAX_RETRANS_CNT_G, 8),
-      maxCumAck    => toSlv(MAX_CUM_ACK_CNT_G, 8),
-      maxOutofseq  => toSlv(MAX_OUT_OF_SEQUENCE_G, 8),
-      connectionId => toSlv(CONN_ID_G, 32),
-      
+      -- Control (RW)
+      control => "01000",
+
+      -- Parameters (RW)  
+      initSeqN        => toSlv(INIT_SEQ_N_G, 8),
+      appRssiParam    => (
+         version      => toSlv(VERSION_G, 4),
+         chksumEn     => "1",
+         timeoutUnit  => toSlv(integer(0.0 - (ieee.math_real.log(TIMEOUT_UNIT_G)/ieee.math_real.log(10.0))), 8),
+         maxOutsSeg   => toSlv(MAX_NUM_OUTS_SEG_G, 8),
+         maxSegSize   => toSlv(MAX_SEG_SIZE_G, 16),
+         retransTout  => toSlv(RETRANS_TOUT_G, 16),
+         cumulAckTout => toSlv(ACK_TOUT_G, 16),
+         nullSegTout  => toSlv(NULL_TOUT_G, 16),
+         maxRetrans   => toSlv(MAX_RETRANS_CNT_G, 8),
+         maxCumAck    => toSlv(MAX_CUM_ACK_CNT_G, 8),
+         maxOutofseq  => toSlv(MAX_OUT_OF_SEQUENCE_G, 8),
+         connectionId => toSlv(CONN_ID_G, 32)),
+
       -- AXI lite      
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
@@ -181,409 +179,261 @@ architecture rtl of RssiAxiLiteRegItf is
    signal s_RdAddr : natural := 0;
    signal s_WrAddr : natural := 0;
 
-  -- Synced status signals
-   signal s_status   : slv(status_i'range);  
-   signal s_dropCnt  : slv(31 downto 0);
-   signal s_validCnt : slv(31 downto 0);
-   signal s_reconCnt : slv(31 downto 0);
-   signal s_resendCnt: slv(31 downto 0);
-   
+   -- Synced status signals
+   signal s_status    : slv(status_i'range);
+   signal s_dropCnt   : slv(31 downto 0);
+   signal s_validCnt  : slv(31 downto 0);
+   signal s_reconCnt  : slv(31 downto 0);
+   signal s_resendCnt : slv(31 downto 0);
+
+   signal dummyBit     : sl;
+   signal negRssiParam : RssiParamType;
+
 begin
 
-  -- Convert address to integer (lower two bits of address are always '0')
-  s_RdAddr <= conv_integer(axilReadMaster.araddr(9 downto 2));
-  s_WrAddr <= conv_integer(axilWriteMaster.awaddr(9 downto 2));
+   -- Convert address to integer (lower two bits of address are always '0')
+   s_RdAddr <= conv_integer(axilReadMaster.araddr(9 downto 2));
+   s_WrAddr <= conv_integer(axilWriteMaster.awaddr(9 downto 2));
 
-   comb : process (axiRst_i, axilReadMaster, axilWriteMaster, bandwidth_i, frameRate_i, r, s_RdAddr,
-                   s_WrAddr, s_dropCnt, s_reconCnt, s_resendCnt, s_status, s_validCnt) is
+   comb : process (axiRst_i, axilReadMaster, axilWriteMaster, bandwidth_i,
+                   frameRate_i, negRssiParam, r, s_RdAddr, s_WrAddr, s_dropCnt,
+                   s_reconCnt, s_resendCnt, s_status, s_validCnt) is
       variable v             : RegType;
       variable axilStatus    : AxiLiteStatusType;
       variable axilWriteResp : slv(1 downto 0);
       variable axilReadResp  : slv(1 downto 0);
    begin
-    -- Latch the current value
-    v := r;
+      -- Latch the current value
+      v := r;
 
-    ----------------------------------------------------------------------------------------------
-    -- Axi-Lite interface
-    ----------------------------------------------------------------------------------------------
-    axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
+      ----------------------------------------------------------------------------------------------
+      -- Axi-Lite interface
+      ----------------------------------------------------------------------------------------------
+      axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
 
-    if (axilStatus.writeEnable = '1') then
-      axilWriteResp := ite(axilWriteMaster.awaddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
-      case (s_WrAddr) is
-        when 16#00# =>                  -- ADDR (0)
-          v.control     := axilWriteMaster.wdata(4 downto 0);
-        when 16#01# =>                  -- ADDR (4)
-          v.initSeqN    := axilWriteMaster.wdata(7 downto 0);
-        when 16#02# =>                  -- ADDR (8)
-          v.version     := axilWriteMaster.wdata(3 downto 0);
-        when 16#03# =>                  -- ADDR (12)
-          v.maxOutsSeg  := axilWriteMaster.wdata(7 downto 0);
-        when 16#04# =>                  -- ADDR (16)
-          v.maxSegSize  := axilWriteMaster.wdata(15 downto 0);
-          if (unsigned(v.maxSegSize) < 8) then
-             v.maxSegSize := toSlv( 8, v.maxSegSize'length);
-          elsif (unsigned(v.maxSegSize) > (2**SEGMENT_ADDR_SIZE_G)*8 ) then
-             v.maxSegSize := toSlv( (2**SEGMENT_ADDR_SIZE_G)*8, v.maxSegSize'length );
-          end if;
-        when 16#05# =>                  
-          v.retransTout := axilWriteMaster.wdata(15 downto 0);
-        when 16#06# =>                  
-          v.cumulAckTout:= axilWriteMaster.wdata(15 downto 0);
-        when 16#07# =>                  
-          v.nullSegTout := axilWriteMaster.wdata(15 downto 0);
-        when 16#08# =>                  
-          v.maxRetrans  := axilWriteMaster.wdata(7 downto 0);
-        when 16#09# =>                  
-          v.maxCumAck   := axilWriteMaster.wdata(7 downto 0);
-        when 16#0A# =>                  
-          v.maxOutofseq := axilWriteMaster.wdata(7 downto 0);
-        when 16#0B# =>                  
-          v.connectionId:= axilWriteMaster.wdata(31 downto 0);
-        when others =>
-          axilWriteResp := AXI_RESP_DECERR_C;
-      end case;
-      axiSlaveWriteResponse(v.axilWriteSlave);
-    end if;
+      if (axilStatus.writeEnable = '1') then
+         axilWriteResp := ite(axilWriteMaster.awaddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
+         case (s_WrAddr) is
+            when 16#00# =>              -- ADDR (0)
+               v.control := axilWriteMaster.wdata(4 downto 0);
+            when 16#01# =>              -- ADDR (4)
+               v.initSeqN := axilWriteMaster.wdata(7 downto 0);
+            when 16#02# =>              -- ADDR (8)
+               v.appRssiParam.version := axilWriteMaster.wdata(3 downto 0);
+            when 16#03# =>              -- ADDR (12)
+               v.appRssiParam.maxOutsSeg := axilWriteMaster.wdata(7 downto 0);
+            when 16#04# =>              -- ADDR (16)
+               v.appRssiParam.maxSegSize := axilWriteMaster.wdata(15 downto 0);
+               if (unsigned(v.appRssiParam.maxSegSize) < 8) then
+                  v.appRssiParam.maxSegSize := toSlv(8, v.appRssiParam.maxSegSize'length);
+               elsif (unsigned(v.appRssiParam.maxSegSize) > (2**SEGMENT_ADDR_SIZE_G)*8) then
+                  v.appRssiParam.maxSegSize := toSlv((2**SEGMENT_ADDR_SIZE_G)*8, v.appRssiParam.maxSegSize'length);
+               end if;
+            when 16#05# =>
+               v.appRssiParam.retransTout := axilWriteMaster.wdata(15 downto 0);
+            when 16#06# =>
+               v.appRssiParam.cumulAckTout := axilWriteMaster.wdata(15 downto 0);
+            when 16#07# =>
+               v.appRssiParam.nullSegTout := axilWriteMaster.wdata(15 downto 0);
+            when 16#08# =>
+               v.appRssiParam.maxRetrans := axilWriteMaster.wdata(7 downto 0);
+            when 16#09# =>
+               v.appRssiParam.maxCumAck := axilWriteMaster.wdata(7 downto 0);
+            when 16#0A# =>
+               v.appRssiParam.maxOutofseq := axilWriteMaster.wdata(7 downto 0);
+            when 16#0B# =>
+               v.appRssiParam.connectionId := axilWriteMaster.wdata(31 downto 0);
+            when others =>
+               axilWriteResp := AXI_RESP_DECERR_C;
+         end case;
+         axiSlaveWriteResponse(v.axilWriteSlave);
+      end if;
 
-    if (axilStatus.readEnable = '1') then
-      axilReadResp          := ite(axilReadMaster.araddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
-      v.axilReadSlave.rdata := (others => '0');
-      case (s_RdAddr) is
-        when 16#00# =>                  -- ADDR (0)
-          v.axilReadSlave.rdata(4 downto 0) := r.control;
-        when 16#01# =>                  -- ADDR (4)
-          v.axilReadSlave.rdata(7 downto 0) := r.initSeqN;
-        when 16#02# =>                  -- ADDR (8)
-          v.axilReadSlave.rdata(3 downto 0) := r.version;
-        when 16#03# =>                  -- ADDR (12)
-          v.axilReadSlave.rdata(7 downto 0) := r.maxOutsSeg;
-        when 16#04# =>                  -- ADDR (16)
-          v.axilReadSlave.rdata(15 downto 0) := r.maxSegSize;
-        when 16#05# =>                  -- ADDR (20)
-          v.axilReadSlave.rdata(15 downto 0) := r.retransTout;
-        when 16#06# =>                  -- ADDR (24)
-          v.axilReadSlave.rdata(15 downto 0) := r.cumulAckTout;
-        when 16#07# =>                  -- ADDR (28)
-          v.axilReadSlave.rdata(15 downto 0) := r.nullSegTout;
-        when 16#08# =>                  -- ADDR (32)
-          v.axilReadSlave.rdata(7 downto 0) := r.maxRetrans;
-        when 16#09# =>                  -- ADDR (36)
-          v.axilReadSlave.rdata(7 downto 0) := r.maxCumAck;
-        when 16#0A# =>                  -- ADDR (40)
-          v.axilReadSlave.rdata(7 downto 0) := r.maxOutofseq;
-        when 16#0B# =>                  -- ADDR (44)
-          v.axilReadSlave.rdata(31 downto 0) := r.connectionId;
-        when 16#10# =>                  -- ADDR (64)
-          v.axilReadSlave.rdata(status_i'range)  := s_status;
-        when 16#11# =>                  -- ADDR (68)
-          v.axilReadSlave.rdata(31 downto 0) := s_validCnt;          
-        when 16#12# =>                  -- ADDR (72)
-          v.axilReadSlave.rdata(31 downto 0) := s_dropCnt;
-        when 16#13# =>                  -- ADDR (76)
-          v.axilReadSlave.rdata(31 downto 0) := s_resendCnt;          
-        when 16#14# =>                  -- ADDR (80)
-          v.axilReadSlave.rdata(31 downto 0) := s_reconCnt;  
-        when 16#15# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := frameRate_i(0);  
-        when 16#16# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := frameRate_i(1);
-        when 16#17# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(0)(31 downto 0);  
-        when 16#18# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(0)(63 downto 32);    
-        when 16#19# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(31 downto 0);  
-        when 16#20# =>                  
-          v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(63 downto 32);              
-        when others =>
-          axilReadResp := AXI_RESP_DECERR_C;
-      end case;
-      axiSlaveReadResponse(v.axilReadSlave);
-    end if;
+      if (axilStatus.readEnable = '1') then
+         axilReadResp          := ite(axilReadMaster.araddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
+         v.axilReadSlave.rdata := (others => '0');
+         case (s_RdAddr) is
+            when 16#00# =>              -- ADDR (0)
+               v.axilReadSlave.rdata(4 downto 0) := r.control;
+            when 16#01# =>              -- ADDR (4)
+               v.axilReadSlave.rdata(7 downto 0) := r.initSeqN;
+            when 16#02# =>              -- ADDR (8)
+               v.axilReadSlave.rdata(3 downto 0)   := r.appRssiParam.version;
+               v.axilReadSlave.rdata(19 downto 16) := negRssiParam.version;
+            when 16#03# =>              -- ADDR (12)
+               v.axilReadSlave.rdata(7 downto 0)   := r.appRssiParam.maxOutsSeg;
+               v.axilReadSlave.rdata(23 downto 16) := negRssiParam.maxOutsSeg;
+            when 16#04# =>              -- ADDR (16)
+               v.axilReadSlave.rdata(15 downto 0)  := r.appRssiParam.maxSegSize;
+               v.axilReadSlave.rdata(31 downto 16) := negRssiParam.maxSegSize;
+            when 16#05# =>              -- ADDR (20)
+               v.axilReadSlave.rdata(15 downto 0)  := r.appRssiParam.retransTout;
+               v.axilReadSlave.rdata(31 downto 16) := negRssiParam.retransTout;
+            when 16#06# =>              -- ADDR (24)
+               v.axilReadSlave.rdata(15 downto 0)  := r.appRssiParam.cumulAckTout;
+               v.axilReadSlave.rdata(31 downto 16) := negRssiParam.cumulAckTout;
+            when 16#07# =>              -- ADDR (28)
+               v.axilReadSlave.rdata(15 downto 0)  := r.appRssiParam.nullSegTout;
+               v.axilReadSlave.rdata(31 downto 16) := negRssiParam.nullSegTout;
+            when 16#08# =>              -- ADDR (32)
+               v.axilReadSlave.rdata(7 downto 0)   := r.appRssiParam.maxRetrans;
+               v.axilReadSlave.rdata(23 downto 16) := negRssiParam.maxRetrans;
+            when 16#09# =>              -- ADDR (36)
+               v.axilReadSlave.rdata(7 downto 0)   := r.appRssiParam.maxCumAck;
+               v.axilReadSlave.rdata(23 downto 16) := negRssiParam.maxCumAck;
+            when 16#0A# =>              -- ADDR (40)
+               v.axilReadSlave.rdata(7 downto 0)   := r.appRssiParam.maxOutofseq;
+               v.axilReadSlave.rdata(23 downto 16) := negRssiParam.maxOutofseq;
+            when 16#0B# =>              -- ADDR (44)
+               v.axilReadSlave.rdata(31 downto 0) := r.appRssiParam.connectionId;
+            when 16#0C# =>              -- ADDR (48)
+               v.axilReadSlave.rdata(31 downto 0) := negRssiParam.connectionId;
+            when 16#10# =>              -- ADDR (64)
+               v.axilReadSlave.rdata(status_i'range) := s_status;
+            when 16#11# =>              -- ADDR (68)
+               v.axilReadSlave.rdata(31 downto 0) := s_validCnt;
+            when 16#12# =>              -- ADDR (72)
+               v.axilReadSlave.rdata(31 downto 0) := s_dropCnt;
+            when 16#13# =>              -- ADDR (76)
+               v.axilReadSlave.rdata(31 downto 0) := s_resendCnt;
+            when 16#14# =>              -- ADDR (80)
+               v.axilReadSlave.rdata(31 downto 0) := s_reconCnt;
+            when 16#15# =>
+               v.axilReadSlave.rdata(31 downto 0) := frameRate_i(0);
+            when 16#16# =>
+               v.axilReadSlave.rdata(31 downto 0) := frameRate_i(1);
+            when 16#17# =>
+               v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(0)(31 downto 0);
+            when 16#18# =>
+               v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(0)(63 downto 32);
+            when 16#19# =>
+               v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(31 downto 0);
+            when 16#20# =>
+               v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(63 downto 32);
+            when others =>
+               axilReadResp := AXI_RESP_DECERR_C;
+         end case;
+         axiSlaveReadResponse(v.axilReadSlave);
+      end if;
 
-    -- Reset
-    if (axiRst_i = '1') then
-      v := REG_INIT_C;
-    end if;
+      -- Map to chksumEn
+      v.appRssiParam.chksumEn(0) := v.control(3);
 
-    -- Register the variable for next clock cycle
-    rin <= v;
+      -- Outputs
+      axilReadSlave  <= r.axilReadSlave;
+      axilWriteSlave <= r.axilWriteSlave;
 
-    -- Outputs
-    axilReadSlave  <= r.axilReadSlave;
-    axilWriteSlave <= r.axilWriteSlave;
-    
-  end process comb;
+      -- Reset
+      if (axiRst_i = '1') then
+         v := REG_INIT_C;
+      end if;
 
-  seq : process (axiClk_i) is
-  begin
-    if rising_edge(axiClk_i) then
-      r <= rin after TPD_G;
-    end if;
-  end process seq; 
+      -- Register the variable for next clock cycle
+      rin <= v;
 
-   -- Input assignment and synchronization
-   SyncFifo_IN0 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => status_i'length
-   )
-   port map (
-      wr_clk => devClk_i,
-      din    => status_i,
-      rd_clk => axiClk_i,
-      dout   => s_status
-   );
+   end process comb;
 
-   SyncFifo_IN1 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => validCnt_i'length
-   )
-   port map (
-      wr_clk => devClk_i,
-      din    => validCnt_i,
-      rd_clk => axiClk_i,
-      dout   => s_validCnt
-   );   
-   
-   SyncFifo_IN2 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => dropCnt_i'length
-   )
-   port map (
-      wr_clk => devClk_i,
-      din    => dropCnt_i,
-      rd_clk => axiClk_i,
-      dout   => s_dropCnt
-   );
-  
-   SyncFifo_IN3 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => resendCnt_i'length
-   )
-   port map (
-      wr_clk => devClk_i,
-      din    => resendCnt_i,
-      rd_clk => axiClk_i,
-      dout   => s_resendCnt
-   );   
-   
-   SyncFifo_IN4 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => reconCnt_i'length
-   )
-   port map (
-      wr_clk => devClk_i,
-      din    => reconCnt_i,
-      rd_clk => axiClk_i,
-      dout   => s_reconCnt
-   );
+   seq : process (axiClk_i) is
+   begin
+      if rising_edge(axiClk_i) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
 
-  -- Output assignment and synchronization
-  Sync_OUT0 : entity work.Synchronizer
-   generic map (
-      TPD_G         => TPD_G,
-      BYPASS_SYNC_G => COMMON_CLK_G)
-   port map (
-      dataIn    => r.control(0),
-      clk       => devClk_i,
-      dataOut   => openRq_o
-   );
-   
-   Sync_OUT1 : entity work.Synchronizer
-   generic map (
-      TPD_G         => TPD_G,
-      BYPASS_SYNC_G => COMMON_CLK_G)
-    port map (
-      dataIn    => r.control(1),
-      clk       => devClk_i,
-      dataOut   => closeRq_o
-   );
-   
-   Sync_OUT2 : entity work.Synchronizer
-   generic map (
-      TPD_G         => TPD_G,
-      BYPASS_SYNC_G => COMMON_CLK_G)
-    port map (
-      dataIn    => r.control(2),
-      clk       => devClk_i,
-      dataOut   => mode_o
-   );
-   
-   Sync_OUT3 : entity work.Synchronizer
-   generic map (
-      TPD_G         => TPD_G,
-      BYPASS_SYNC_G => COMMON_CLK_G)
-    port map (
-      dataIn    => r.control(3),
-      clk       => devClk_i,
-      dataOut   => appRssiParam_o.chksumEn(0)
-   );
-   
-   Sync_OUT4 : entity work.Synchronizer
-   generic map (
-      TPD_G         => TPD_G,
-      BYPASS_SYNC_G => COMMON_CLK_G)
-    port map (
-      dataIn    => r.control(4),
-      clk       => devClk_i,
-      dataOut   => injectFault_o
-   );
-   
-   SyncFifo_OUT5 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 8
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.initSeqN,
-      rd_clk => devClk_i,
-      dout   => initSeqN_o
-   );
-   
-   SyncFifo_OUT6 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 4
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.version,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.version
-   );
-   
-   SyncFifo_OUT7 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 8
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.maxOutsSeg,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.maxOutsSeg
-   );
-   
-   SyncFifo_OUT8 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 16
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.maxSegSize,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.maxSegSize
-   );
-   
-   SyncFifo_OUT9 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 16
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.retransTout,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.retransTout
-   );
-   
-   SyncFifo_OUT10 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 16
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.cumulAckTout,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.cumulAckTout
-   );
-   
-   SyncFifo_OUT11 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 16
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.nullSegTout,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.nullSegTout
-   );
-   
-   SyncFifo_OUT12 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 8
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.maxRetrans,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.maxRetrans
-   );
-   
-   SyncFifo_OUT13 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 8
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.maxCumAck,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.maxCumAck
-   );
-   
-   SyncFifo_OUT14 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 8
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.maxOutofseq,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.maxOutofseq
-   );
-    
-   SyncFifo_OUT15 : entity work.SynchronizerFifo
-   generic map (
-      TPD_G        => TPD_G,
-      COMMON_CLK_G => COMMON_CLK_G,
-      DATA_WIDTH_G => 32
-   )
-   port map (
-      wr_clk => axiClk_i,
-      din    => r.connectionId,
-      rd_clk => devClk_i,
-      dout   => appRssiParam_o.connectionId
-   );
-   
-   appRssiParam_o.timeoutUnit <= toSlv(integer(0.0 - (ieee.math_real.log(TIMEOUT_UNIT_G)/ieee.math_real.log(10.0))), 8); 
----------------------------------------------------------------------
+   U_status : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => status_i'length)
+      port map (
+         clk     => devClk_i,
+         dataIn  => status_i,
+         dataOut => s_status);
+
+   U_validCnt : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G,
+         DATA_WIDTH_G => validCnt_i'length)
+      port map (
+         wr_clk => devClk_i,
+         din    => validCnt_i,
+         rd_clk => axiClk_i,
+         dout   => s_validCnt);
+
+   U_dropCnt : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G,
+         DATA_WIDTH_G => dropCnt_i'length)
+      port map (
+         wr_clk => devClk_i,
+         din    => dropCnt_i,
+         rd_clk => axiClk_i,
+         dout   => s_dropCnt);
+
+   U_resendCnt : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G,
+         DATA_WIDTH_G => resendCnt_i'length)
+      port map (
+         wr_clk => devClk_i,
+         din    => resendCnt_i,
+         rd_clk => axiClk_i,
+         dout   => s_resendCnt);
+
+   U_reconCnt : entity work.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G,
+         DATA_WIDTH_G => reconCnt_i'length)
+      port map (
+         wr_clk => devClk_i,
+         din    => reconCnt_i,
+         rd_clk => axiClk_i,
+         dout   => s_reconCnt);
+
+   U_SyncVecOut : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 5)
+      port map (
+         clk        => devClk_i,
+         dataIn     => r.control,
+         dataOut(0) => openRq_o,
+         dataOut(1) => closeRq_o,
+         dataOut(2) => mode_o,
+         dataOut(3) => dummyBit,        -- appRssiParam_o.chksumEn(0)
+         dataOut(4) => injectFault_o);
+
+   U_initSeqN : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => devClk_i,
+         dataIn  => r.initSeqN,
+         dataOut => initSeqN_o);
+
+   U_RssiParamSync_In : entity work.RssiParamSync
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G)
+      port map (
+         clk         => devClk_i,
+         rssiParam_i => negRssiParam_i,
+         rssiParam_o => negRssiParam);
+
+   U_RssiParamSync_Out : entity work.RssiParamSync
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_CLK_G)
+      port map (
+         clk         => devClk_i,
+         rssiParam_i => r.appRssiParam,
+         rssiParam_o => appRssiParam_o);
+
 end rtl;

--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -328,6 +328,7 @@ begin
          mode_o         => s_modeReg,
          initSeqN_o     => s_initSeqNReg,
          appRssiParam_o => s_appRssiParamReg,
+         negRssiParam_i => s_rssiParam,
          injectFault_o  => s_injectFaultReg,
 
          -- Status (RO)

--- a/protocols/rssi/v1/rtl/RssiParamSync.vhd
+++ b/protocols/rssi/v1/rtl/RssiParamSync.vhd
@@ -1,0 +1,165 @@
+-------------------------------------------------------------------------------
+-- Title      : RSSI Protocol: https://confluence.slac.stanford.edu/x/1IyfD
+-------------------------------------------------------------------------------
+-- File       : RssiParamSync.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description:  Sync the RSSI parameter across clock doamins
+------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'SLAC Firmware Standard Library', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+use work.StdRtlPkg.all;
+use work.AxiLitePkg.all;
+use work.RssiPkg.all;
+
+entity RssiParamSync is
+   generic (
+      TPD_G        : time    := 1 ns;
+      COMMON_CLK_G : boolean := false);
+   port (
+      clk         : in  sl;
+      rssiParam_i : in  RssiParamType;
+      rssiParam_o : out RssiParamType);
+end RssiParamSync;
+
+architecture rtl of RssiParamSync is
+
+   signal rssiParam : RssiParamType;
+
+begin
+
+   rssiParam_o <= rssiParam;
+
+   U_version : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 4)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.version,
+         dataOut => rssiParam.version);
+
+   U_chksumEn : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 1)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.chksumEn,
+         dataOut => rssiParam.chksumEn);
+
+   U_timeoutUnit : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.timeoutUnit,
+         dataOut => rssiParam.timeoutUnit);
+
+   U_maxOutsSeg : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.maxOutsSeg,
+         dataOut => rssiParam.maxOutsSeg);
+
+   U_maxSegSize : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 16)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.maxSegSize,
+         dataOut => rssiParam.maxSegSize);
+
+   U_retransTout : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 16)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.retransTout,
+         dataOut => rssiParam.retransTout);
+
+   U_cumulAckTout : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 16)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.cumulAckTout,
+         dataOut => rssiParam.cumulAckTout);
+
+   U_nullSegTout : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 16)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.nullSegTout,
+         dataOut => rssiParam.nullSegTout);
+
+   U_maxRetrans : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.maxRetrans,
+         dataOut => rssiParam.maxRetrans);
+
+   U_maxCumAck : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.maxCumAck,
+         dataOut => rssiParam.maxCumAck);
+
+   U_maxOutofseq : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 8)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.maxOutofseq,
+         dataOut => rssiParam.maxOutofseq);
+
+   U_connectionId : entity work.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_CLK_G,
+         WIDTH_G       => 32)
+      port map (
+         clk     => clk,
+         dataIn  => rssiParam_i.connectionId,
+         dataOut => rssiParam.connectionId);
+
+end rtl;

--- a/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
@@ -265,6 +265,7 @@ begin
          mode_o          => s_modeReg,
          initSeqN_o      => s_initSeqNReg,
          appRssiParam_o  => s_appRssiParamReg,
+         negRssiParam_i  => s_rssiParam,
          injectFault_o   => s_injectFaultReg,
          -- Status (RO)
          frameRate_i     => s_frameRate,

--- a/python/surf/protocols/rssi/_RssiCore.py
+++ b/python/surf/protocols/rssi/_RssiCore.py
@@ -3,7 +3,6 @@
 # Title      : PyRogue RSSI module
 #-----------------------------------------------------------------------------
 # File       : RssiCore.py
-# Created    : 2017-04-12
 #-----------------------------------------------------------------------------
 # Description:
 # PyRogue RSSI module
@@ -21,8 +20,8 @@ import pyrogue as pr
 
 class RssiCore(pr.Device):
     def __init__(   self,       
-            name        = "RssiCore",
-            description = "RSSI module",
+            name        = 'RssiCore',
+            description = 'RSSI module',
             **kwargs):
         super().__init__(name=name, description=description, **kwargs) 
 
@@ -31,282 +30,269 @@ class RssiCore(pr.Device):
         ##############################
 
         self.add(pr.RemoteVariable(    
-            name         = "OpenConn",
-            description  = "Open Connection Request (Server goes to listen state, Client actively requests the connection by sending SYN segment)",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
+            name         = 'OpenConn',
+            description  = 'Open Connection Request (Server goes to listen state, Client actively requests the connection by sending SYN segment)',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0,
+            mode         = 'RW',
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "CloseConn",
-            description  = "Close Connection Request (Send a RST Segment to peer and close the connection)",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x01,
-            base         = pr.UInt,
-            mode         = "RW",
+            name         = 'CloseConn',
+            description  = 'Close Connection Request (Send a RST Segment to peer and close the connection)',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0x01,
+            mode         = 'RW',
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "Mode",
-            description  = "Mode:'0': Use internal parameters from generics,'1': Use parameters from registers",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x02,
-            base         = pr.UInt,
-            mode         = "RW",
+            name         = 'Mode',
+            description  = 'Mode: 0x0 = Use internal parameters from generics, 0x1 = Use parameters from registers',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0x02,
+            mode         = 'RW',
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "HeaderChksumEn",
-            description  = "Header checksum: '1': Enable calculation and check, '0': Disable check and insert 0 in place of header checksum",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x03,
-            base         = pr.UInt,
-            mode         = "RW",
+            name         = 'HeaderChksumEn',
+            description  = 'Header checksum: 0x1 = Enable calculation and check, 0x0: Disable check and insert 0 in place of header checksum',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0x03,
+            mode         = 'RW',
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "InjectFault",
-            description  = "Inject fault to the next packet header checksum (Default '0'). Acts on rising edge - injects exactly one fault in next segment",
-            offset       =  0x00,
-            bitSize      =  1,
-            bitOffset    =  0x04,
-            base         = pr.UInt,
-            mode         = "RW",
+            name         = 'InjectFault',
+            description  = 'Inject fault to the next packet header checksum (Default 0x0). Acts on rising edge - injects exactly one fault in next segment',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0x04,
+            mode         = 'RW',
         ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "InitSeqN",
-            # description  = "Initial sequence number [7:0]",
-            # offset       =  0x04,
-            # bitSize      =  8,
-            # bitOffset    =  0x00,
-            # base         = pr.UInt,
-            # mode         = "RW",
+            # name         = 'InitSeqN',
+            # description  = 'Initial sequence number [7:0]',
+            # offset       = 0x04,
+            # bitSize      = 8,
+            # bitOffset    = 0,
+            # mode         = 'RW',
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "Version",
-            # description  = "Version register [3:0]",
-            # offset       =  0x08,
-            # bitSize      =  4,
-            # bitOffset    =  0x00,
-            # base         = pr.UInt,
-            # mode         = "RW",
+            # name         = 'locVersion',
+            # description  = 'Version register [3:0]',
+            # offset       = 0x08,
+            # bitSize      = 4,
+            # bitOffset    = 0,
+            # mode         = 'RW',
             # disp         = '{:d}',
         # ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "MaxOutsSeg",
-            description  = "Maximum out standing segments [7:0]",
-            offset       =  0x0C,
-            bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "MaxSegSize",
-            description  = "Maximum segment size [15:0]",
-            offset       =  0x10,
-            bitSize      =  16,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "RetransTimeout",
-            description  = "Retransmission timeout [15:0]",
-            offset       =  0x14,
-            bitSize      =  16,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "CumAckTimeout",
-            description  = "Cumulative acknowledgment timeout [15:0]",
-            offset       =  0x18,
-            bitSize      =  16,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "NullSegTimeout",
-            description  = "Null segment timeout [15:0]",
-            offset       =  0x1C,
-            bitSize      =  16,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "MaxNumRetrans",
-            description  = "Maximum number of retransmissions [7:0]",
-            offset       =  0x20,
-            bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
-        self.add(pr.RemoteVariable(    
-            name         = "MaxCumAck",
-            description  = "Maximum cumulative acknowledgments [7:0]",
-            offset       =  0x24,
-            bitSize      =  8,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RW",
-            disp         = '{:d}',
-        ))
-
+        
         # self.add(pr.RemoteVariable(    
-            # name         = "MaxOutOfSeq",
-            # description  = "Max out of sequence segments (EACK) [7:0]",
-            # offset       =  0x28,
-            # bitSize      =  8,
-            # bitOffset    =  0x00,
-            # base         = pr.UInt,
-            # mode         = "RW",
+            # name         = 'curVersion',
+            # description  = 'Version register [3:0]',
+            # offset       = 0x08,
+            # bitSize      = 4,
+            # bitOffset    = 16,
+            # mode         = 'RO',
             # disp         = '{:d}',
-        # ))
+        # ))        
+
+        varPrefix = ['loc','cur']
+        for i in range(2):
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'MaxOutsSeg'),
+                description  = 'Maximum out standing segments [7:0]',
+                offset       = 0x0C,
+                bitSize      = 8,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'MaxSegSize'),
+                description  = 'Maximum segment size [15:0]',
+                offset       = 0x10,
+                bitSize      = 16,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'RetransTimeout'),
+                description  = 'Retransmission timeout [15:0]',
+                offset       = 0x14,
+                bitSize      = 16,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'CumAckTimeout'),
+                description  = 'Cumulative acknowledgment timeout [15:0]',
+                offset       = 0x18,
+                bitSize      = 16,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'NullSegTimeout'),
+                description  = 'Null segment timeout [15:0]',
+                offset       = 0x1C,
+                bitSize      = 16,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'MaxNumRetrans'),
+                description  = 'Maximum number of retransmissions [7:0]',
+                offset       = 0x20,
+                bitSize      = 8,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            self.add(pr.RemoteVariable(    
+                name         = (varPrefix[i]+'MaxCumAck'),
+                description  = 'Maximum cumulative acknowledgments [7:0]',
+                offset       = 0x24,
+                bitSize      = 8,
+                bitOffset    = i*16,
+                mode         = ('RW' if i==0 else 'RO'),
+                disp         = '{:d}',
+            ))
+
+            # self.add(pr.RemoteVariable(    
+                # name         = (varPrefix[i]+'MaxOutOfSeq'),
+                # description  = 'Max out of sequence segments (EACK) [7:0]',
+                # offset       = 0x28,
+                # bitSize      = 8,
+                # bitOffset    = i*16,
+                # mode         = ('RW' if i==0 else 'RO')',
+                # disp         = '{:d}',
+            # ))
 
         self.add(pr.RemoteVariable(    
-            name         = "ConnectionActive",
-            description  = "Connection Active",
-            offset       =  0x40,
-            bitSize      =  1,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'ConnectionActive',
+            description  = 'Connection Active',
+            offset       = 0x40,
+            bitSize      = 1,
+            bitOffset    = 0,
+            mode         = 'RO',
             pollInterval = 1,
         ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ErrMaxRetrans",
-            # description  = "Maximum retransmissions exceeded retransMax.",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x01,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ErrMaxRetrans',
+            # description  = 'Maximum retransmissions exceeded retransMax.',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x01,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ErrNullTout",
-            # description  = "Null timeout reached (server) nullTout.",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x02,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ErrNullTout',
+            # description  = 'Null timeout reached (server) nullTout.',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x02,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ErrAck",
-            # description  = "Error in acknowledgment mechanism.",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x03,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ErrAck',
+            # description  = 'Error in acknowledgment mechanism.',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x03,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ErrSsiFrameLen",
-            # description  = "SSI Frame length too long",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x04,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ErrSsiFrameLen',
+            # description  = 'SSI Frame length too long',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x04,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ErrConnTout",
-            # description  = "Connection to peer timed out. Timeout defined in generic PEER_CONN_TIMEOUT_G (Default: 1000 ms)",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x05,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ErrConnTout',
+            # description  = 'Connection to peer timed out. Timeout defined in generic PEER_CONN_TIMEOUT_G (Default: 1000 ms)',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x05,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         # self.add(pr.RemoteVariable(    
-            # name         = "ParamRejected",
-            # description  = "Client rejected the connection (parameters out of range), Server proposed new parameters (parameters out of range)",
-            # offset       =  0x40,
-            # bitSize      =  1,
-            # bitOffset    =  0x06,
-            # base         = pr.UInt,
-            # mode         = "RO",
+            # name         = 'ParamRejected',
+            # description  = 'Client rejected the connection (parameters out of range), Server proposed new parameters (parameters out of range)',
+            # offset       = 0x40,
+            # bitSize      = 1,
+            # bitOffset    = 0x06,
+            # mode         = 'RO',
             # pollInterval = 1,
         # ))
 
         self.add(pr.RemoteVariable(    
-            name         = "ValidCnt",
-            description  = "Number of valid segments [31:0]",
-            offset       =  0x44,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'ValidCnt',
+            description  = 'Number of valid segments [31:0]',
+            offset       = 0x44,
+            bitSize      = 32,
+            bitOffset    = 0,
+            mode         = 'RO',
             pollInterval = 1,
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "DropCnt",
-            description  = "Number of dropped segments [31:0]",
-            offset       =  0x48,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'DropCnt',
+            description  = 'Number of dropped segments [31:0]',
+            offset       = 0x48,
+            bitSize      = 32,
+            bitOffset    = 0,
+            mode         = 'RO',
             pollInterval = 1,
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "RetransmitCnt",
-            description  = "Counts all retransmission requests within the active connection [31:0]",
-            offset       =  0x4C,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'RetransmitCnt',
+            description  = 'Counts all retransmission requests within the active connection [31:0]',
+            offset       = 0x4C,
+            bitSize      = 32,
+            bitOffset    = 0,
+            mode         = 'RO',
             pollInterval = 1,
         ))
 
         self.add(pr.RemoteVariable(    
-            name         = "ReconnectCnt",
-            description  = "Counts all reconnections from reset [31:0]",
-            offset       =  0x50,
-            bitSize      =  32,
-            bitOffset    =  0x00,
-            base         = pr.UInt,
-            mode         = "RO",
+            name         = 'ReconnectCnt',
+            description  = 'Counts all reconnections from reset [31:0]',
+            offset       = 0x50,
+            bitSize      = 32,
+            bitOffset    = 0,
+            mode         = 'RO',
             pollInterval = 1,
         ))
         
@@ -314,9 +300,8 @@ class RssiCore(pr.Device):
             name         = 'TxFrameRate',
             description  = 'Outbound Frame Rate',
             units        = 'Hz',
-            offset       =  0x54,
-            base         = pr.UInt,
-            mode         = "RO",
+            offset       = 0x54,
+            mode         = 'RO',
             disp         = '{:d}',
             pollInterval = 1,
         ))   
@@ -325,10 +310,9 @@ class RssiCore(pr.Device):
             name         = 'TxBandwidth',
             description  = 'Outbound Bandwidth',
             units        = 'B/s',
-            offset       =  0x5C,
-            bitSize      =  64,
-            base         = pr.UInt,
-            mode         = "RO",
+            offset       = 0x5C,
+            bitSize      = 64,
+            mode         = 'RO',
             disp         = '{:d}',
             pollInterval = 1,
         ))           
@@ -337,9 +321,8 @@ class RssiCore(pr.Device):
             name         = 'RxFrameRate',
             description  = 'Inbound Frame Rate',
             units        = 'Hz',
-            offset       =  0x58,
-            base         = pr.UInt,
-            mode         = "RO",
+            offset       = 0x58,
+            mode         = 'RO',
             disp         = '{:d}',
             pollInterval = 1,
         ))           
@@ -348,10 +331,9 @@ class RssiCore(pr.Device):
             name         = 'RxBandwidth',
             description  = 'Inbound Bandwidth',
             units        = 'B/s',
-            offset       =  0x64,
-            bitSize      =  64,
-            base         = pr.UInt,
-            mode         = "RO",
+            offset       = 0x64,
+            bitSize      = 64,
+            mode         = 'RO',
             disp         = '{:d}',
             pollInterval = 1,
         ))           
@@ -359,22 +341,22 @@ class RssiCore(pr.Device):
         ##############################
         # Commands
         ##############################
-        @self.command(name="C_OpenConn", description="Open connection request",)
+        @self.command(name='C_OpenConn', description='Open connection request',)
         def C_OpenConn():        
            self.CloseConn.set(0)
            self.OpenConn.set(1)
 
-        @self.command(name="C_CloseConn", description="Close connection request",)
+        @self.command(name='C_CloseConn', description='Close connection request',)
         def C_CloseConn():                        
            self.OpenConn.set(0)
            self.CloseConn.set(1)
                     
-        @self.command(name="C_RestartConn", description="Restart connection request",)
+        @self.command(name='C_RestartConn', description='Restart connection request',)
         def C_RestartConn():        
            self.C_CloseConn()
            self.C_OpenConn()
            
-        @self.command(name="C_InjectFault", description="Inject a single fault(for debug and test purposes only). Corrupts checksum during transmission",)
+        @self.command(name='C_InjectFault', description='Inject a single fault(for debug and test purposes only). Corrupts checksum during transmission',)
         def C_InjectFault():                        
            self.InjectFault.set(1)
            self.InjectFault.set(0)


### PR DESCRIPTION
### Description
- Add current autoneg values to RSSI AXI-Lite interface
- Redo synchronization
  - Previous version used a HUGE amount of LUTRAM for clock synchronization of configuration registers that 99.9% of the time never change. 
  - And if changed, it’s a “set and forget” type of configuration. 
  - Therefore we can get away with SynchronizerVector instead of SynchronizerFifo. 
  - This will help minimize the resource requirements on small FPGAs like Artix-7.