### PR TITLE
AxiVersion.py: prevent rogue crash when timeout on buildStamp register transaction

### DIFF
--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -225,14 +225,17 @@ class AxiVersion(pr.Device):
             mode         = 'RO',
             hidden       = True,
         ))
-
         
         def parseBuildStamp(var,read):
-            p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", var.dependencies[0].get(read))
-            if p is None:
+            buildStamp = var.dependencies[0].get(read)
+            if buildStamp is None:
                 return ''
-            else:
-                return p[var.name]
+            else: 
+                p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", buildStamp)
+                if p is None:
+                    return ''
+                else:
+                    return p[var.name]
         
         self.add(pr.LinkVariable(
             name = 'ImageName',


### PR DESCRIPTION
### Description
- catch NONE if there was a timeout in the buildStamp register transaction
  - Example: a 'flaky' link with lots of register transaction timeouts
- Previously rogue would "crash" due to a `TypeError: expected string or bytes-like object` error