### PR TITLE
VHDL lib bug fix for GigEthLvdsUltraScale.vhd using SaltUltraScaleCore.dcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *._*
 *.db
 *.log
+*.vho
 xvcSrv
 doxygen/
 ghdl/

--- a/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
+++ b/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
@@ -71,6 +71,47 @@ end GigEthLvdsUltraScale;
 
 architecture mapping of GigEthLvdsUltraScale is
 
+   component SaltUltraScaleCore
+      port (
+         -----------------------------
+         -- LVDS transceiver Interface
+         -----------------------------
+         txp                  : out std_logic;  -- Differential +ve of serial transmission from PMA to PMD.
+         txn                  : out std_logic;  -- Differential -ve of serial transmission from PMA to PMD.
+         rxp                  : in  std_logic;  -- Differential +ve for serial reception from PMD to PMA.
+         rxn                  : in  std_logic;  -- Differential -ve for serial reception from PMD to PMA.
+         clk125m              : in  std_logic;
+         mmcm_locked          : in  std_logic;
+         sgmii_clk_r          : out std_logic;  -- Clock for client MAC (125Mhz, 12.5MHz or 1.25MHz).
+         sgmii_clk_f          : out std_logic;  -- Clock for client MAC (125Mhz, 12.5MHz or 1.25MHz).
+         sgmii_clk_en         : out std_logic;  -- Clock enable for client MAC
+         ----------------
+         -- Speed Control
+         ----------------
+         speed_is_10_100      : in  std_logic;  -- Core should operate at either 10Mbps or 100Mbps speeds
+         speed_is_100         : in  std_logic;  -- Core should operate at 100Mbps speed
+         clk625               : in  std_logic;
+         clk312               : in  std_logic;
+         idelay_rdy_in        : in  std_logic;
+         -----------------
+         -- GMII Interface
+         -----------------
+         gmii_txd             : in  std_logic_vector(7 downto 0);  -- Transmit data from client MAC.
+         gmii_tx_en           : in  std_logic;  -- Transmit control signal from client MAC.
+         gmii_tx_er           : in  std_logic;  -- Transmit control signal from client MAC.
+         gmii_rxd             : out std_logic_vector(7 downto 0);  -- Received Data to client MAC.
+         gmii_rx_dv           : out std_logic;  -- Received control signal to client MAC.
+         gmii_rx_er           : out std_logic;  -- Received control signal to client MAC.
+         gmii_isolate         : out std_logic;  -- Tristate control to electrically isolate GMII.
+         ---------------
+         -- General IO's
+         ---------------
+         configuration_vector : in  std_logic_vector(4 downto 0);  -- Alternative to MDIO interface.
+         status_vector        : out std_logic_vector(15 downto 0);  -- Core status.
+         reset                : in  std_logic;  -- Asynchronous reset for entire core.
+         signal_detect        : in  std_logic);  -- Input from PMD to indicate presence of optical input.
+   end component;
+
    signal config : GigEthConfigType;
    signal status : GigEthStatusType;
 
@@ -170,7 +211,7 @@ begin
    ------------------
    -- gmii - sgmii
    ------------------
-   U_GigEthLvdsUltraScaleCore : entity work.SaltUltraScaleCore
+   U_GigEthLvdsUltraScaleCore : SaltUltraScaleCore
       port map (
          -- Clocks and Resets
          clk125m              => sysClk125,


### PR DESCRIPTION
### Description
- VHDL lib bug fix for GigEthLvdsUltraScale.vhd using SaltUltraScaleCore.dcp
- adding .vho to .gitignore
  - Prevent accidental revision control of `CreateDcpVhoFiles ()` files, which have unique headers each time you generate it.
  - https://jira.slac.stanford.edu/browse/ESCORE-504