### PR TITLE
bug fix for repeated MEMORY_TYPE_G generic in SsiPrbsRx.vhd

### DIFF
--- a/protocols/ssi/rtl/SsiPrbsRx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRx.vhd
@@ -35,7 +35,6 @@ entity SsiPrbsRx is
       STATUS_CNT_WIDTH_G         : natural range 1 to 32    := 32;
       -- FIFO configurations
       SLAVE_READY_EN_G           : boolean                  := true;
-      MEMORY_TYPE_G              : string                   := "block";
       GEN_SYNC_FIFO_G            : boolean                  := false;
       CASCADE_SIZE_G             : positive                 := 1;
       FIFO_ADDR_WIDTH_G          : positive                 := 9;
@@ -222,7 +221,6 @@ begin
          PIPE_STAGES_G       => SLAVE_AXI_PIPE_STAGES_G,
          SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
          -- FIFO configurations
-         MEMORY_TYPE_G       => MEMORY_TYPE_G,
          GEN_SYNC_FIFO_G     => true,
          CASCADE_SIZE_G      => CASCADE_SIZE_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,


### PR DESCRIPTION
### Description
- bug fix for repeated MEMORY_TYPE_G generic in SsiPrbsRx.vhd
- bug generated during PR https://github.com/slaclab/surf/pull/543