### PR TITLE
removed space in Ltc2945.py variable name

### DIFF
--- a/python/surf/devices/linear/_Ltc4151.py
+++ b/python/surf/devices/linear/_Ltc4151.py
@@ -134,7 +134,7 @@ class Ltc4151(pr.Device):
         ))          
         
         self.add(pr.LinkVariable(
-            name         = 'ADC Input', 
+            name         = 'AdcInput', 
             description  = 'ADC Voltage Measurement',
             mode         = 'RO', 
             units        = 'V',


### PR DESCRIPTION
### Description
- Updating to CamelCase variable name
- Resolves this bug in rogue software:
```
Rogue/pyrogue version v4.6.0-1-g382ece2c. https://github.com/slaclab/rogue
WARNING:pyrogue.Device.Ltc4151.BoardPwr:Node ADC Input with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ltc4151.BoardPwr:Node ADC Input with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ltc4151.BoardPwr:Node ADC Input with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ltc4151.BoardPwr:Node ADC Input with one or more special characters will cause lookup errors.
```