### PR TITLE
BoxcarIntegrator.vhd: bug fix for writing to RAM

### DIFF
--- a/dsp/fixed/BoxcarIntegrator.vhd
+++ b/dsp/fixed/BoxcarIntegrator.vhd
@@ -87,7 +87,7 @@ begin
       port map (
          -- Port A     
          clka  => clk,
-         wea   => ibValid,
+         wea   => r.ibValid,
          addra => r.wAddr,
          dina  => r.ibData,
          -- Port B


### PR DESCRIPTION
### Description
- The RAM write enable strobe was previously 1 cycle out of phase of the write data bus
- This change uses the registered value of `wea`, `aaddra` and `dina` 