### PR TITLE
Updates for epix development (SACI, ssi_printf, AnalogDevices/ad9249)

### DIFF
--- a/protocols/saci/rtl/SaciMaster2.vhd
+++ b/protocols/saci/rtl/SaciMaster2.vhd
@@ -68,7 +68,7 @@ architecture rtl of SaciMaster2 is
       shiftCount : slv(5 downto 0);
 
       --Saci clk gen
-      clkCount       : slv(SACI_CLK_COUNTER_SIZE_C-1 downto 0);
+      clkCount       : slv(SACI_CLK_COUNTER_SIZE_C downto 0);
       saciClkRising  : sl;
       saciClkFalling : sl;
 

--- a/xilinx/general/sdk/common/ssi_printf.c
+++ b/xilinx/general/sdk/common/ssi_printf.c
@@ -35,7 +35,12 @@ void ssi_putc ( void* p, char c) {
    
    // Dual port ram buffer if enabled
    if ( pp->buffSize > 0 ) {
-      Xil_Out8(pp->buffBase+4+pp->buffPtr, c);
+      //Xil_Out8(pp->buffBase+4+pp->buffPtr, c);
+      if (pp->buffPtr%4 == 0)
+         pp->buffWord = c;
+      else
+         pp->buffWord |= (c << (pp->buffPtr%4)*8);
+      Xil_Out32(pp->buffBase+4+(pp->buffPtr/4)*4, pp->buffWord);
 
       // Adjust pointer
       pp->buffPtr++;

--- a/xilinx/general/sdk/common/ssi_printf.h
+++ b/xilinx/general/sdk/common/ssi_printf.h
@@ -22,6 +22,7 @@ struct ssi_printf_type {
    uint16_t buffSize;
    uint16_t buffPtr;
    uint16_t buffTot;
+   uint32_t buffWord;
 };
 
 void ssi_putc ( void* p, const char c);


### PR DESCRIPTION
### Description
- Fixing saciClk not present (when SACI_CLK_HALF_PERIOD_C=64)
- help to close timing at higher clock frequency
- Microblaze cannot make 1 byte writes to the AxiDualPortRam anymore.
  - ixing in the ssi_printf by changingXil_Out8 to Xil_Out32.