### PR TITLE
exposing the GigE MMCM's clk/rst

### DIFF
--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
@@ -69,6 +69,9 @@ entity GigEthGth7Wrapper is
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;
       -- Switch Polarity of TxN/TxP, RxN/RxP
       gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
@@ -94,6 +97,9 @@ begin
 
    phyClk <= sysClk125;
    phyRst <= sysRst125;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;
 
    -----------------------------
    -- Select the Reference Clock

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -66,9 +66,6 @@ entity GigEthGthUltraScaleWrapper is
       phyRst              : out sl;
       phyReady            : out slv(NUM_LANE_G-1 downto 0);
       sigDet              : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '1');
-      -- Switch Polarity of TxN/TxP, RxN/RxP
-      gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
-      gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       -- MGT Clock Port 
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
@@ -77,6 +74,12 @@ entity GigEthGthUltraScaleWrapper is
       extPll125Rst        : in  sl                                             := '0';
       extPll62Clk         : in  sl                                             := '0';
       extPll62Rst         : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;      
+      -- Switch Polarity of TxN/TxP, RxN/RxP
+      gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
+      gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       -- MGT Ports
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
@@ -105,6 +108,9 @@ begin
 
    phyClk <= sysClk125;
    phyRst <= sysRst125;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;
 
    -----------------------------
    -- Select the Reference Clock

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -74,6 +74,9 @@ entity GigEthGthUltraScaleWrapper is
       extPll125Rst        : in  sl                                             := '0';
       extPll62Clk         : in  sl                                             := '0';
       extPll62Rst         : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;      
       -- Switch Polarity of TxN/TxP, RxN/RxP
       gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
@@ -105,6 +108,9 @@ begin
 
    phyClk <= sysClk125;
    phyRst <= sysRst125;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;
 
    -----------------------------
    -- Select the Reference Clock

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
@@ -75,6 +75,9 @@ entity GigEthGtp7Wrapper is
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;      
       -- Switch Polarity of TxN/TxP, RxN/RxP
       gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
@@ -112,6 +115,9 @@ begin
    ethRst125 <= sysRst125;
    ethClk62  <= sysClk62;
    ethRst62  <= sysRst62;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;   
 
    -----------------------------
    -- Select the Reference Clock

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
@@ -69,6 +69,9 @@ entity GigEthGtx7Wrapper is
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;      
       -- Switch Polarity of TxN/TxP, RxN/RxP
       gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
@@ -94,6 +97,9 @@ begin
 
    phyClk <= sysClk125;
    phyRst <= sysRst125;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;
 
    -----------------------------
    -- Select the Reference Clock

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
@@ -65,13 +65,16 @@ entity GigEthGtyUltraScaleWrapper is
       phyRst              : out sl;
       phyReady            : out slv(NUM_LANE_G-1 downto 0);
       sigDet              : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '1');
-      -- Switch Polarity of TxN/TxP, RxN/RxP
-      gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
-      gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       -- MGT Clock Port 
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
+      -- Copy of internal MMCM reference clock and Reset
+      refClkOut           : out sl;
+      refRstOut           : out sl;      
+      -- Switch Polarity of TxN/TxP, RxN/RxP
+      gtTxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
+      gtRxPolarity        : in  slv(NUM_LANE_G-1 downto 0)                     := (others => '0');
       -- MGT Ports
       gtTxP               : out slv(NUM_LANE_G-1 downto 0);
       gtTxN               : out slv(NUM_LANE_G-1 downto 0);
@@ -94,6 +97,9 @@ begin
 
    phyClk <= sysClk125;
    phyRst <= sysRst125;
+   
+   refClkOut <= refClk;
+   refRstOut <= refRst;
 
    -----------------------------
    -- Select the Reference Clock


### PR DESCRIPTION
### Description
- Useful to get access to this clk/rst in some applications
  - Instead of dropping down another MMCM (or PLL) to generate the same clk/rst