### PR TITLE
Exposing SYNTH_MODE_G in FifoMux.vhd

### DIFF
--- a/base/fifo/rtl/FifoMux.vhd
+++ b/base/fifo/rtl/FifoMux.vhd
@@ -28,6 +28,7 @@ entity FifoMux is
       RST_POLARITY_G     : sl                         := '1';  -- '1' for active high rst, '0' for active low
       RST_ASYNC_G        : boolean                    := false;
       GEN_SYNC_FIFO_G    : boolean                    := false;
+      SYNTH_MODE_G       : string                     := "inferred";
       MEMORY_TYPE_G      : string                     := "block";
       FWFT_EN_G          : boolean                    := true;
       SYNC_STAGES_G      : integer range 3 to (2**24) := 3;
@@ -259,7 +260,8 @@ begin
          RST_POLARITY_G     => RST_POLARITY_G,
          RST_ASYNC_G        => RST_ASYNC_G,
          GEN_SYNC_FIFO_G    => GEN_SYNC_FIFO_G,
-         MEMORY_TYPE_G      => MEMORY_TYPE_G,
+         SYNTH_MODE_G       => SYNTH_MODE_G,
+         MEMORY_TYPE_G      => MEMORY_TYPE_G,         
          FWFT_EN_G          => FWFT_EN_G,
          SYNC_STAGES_G      => SYNC_STAGES_G,
          PIPE_STAGES_G      => PIPE_STAGES_G,


### PR DESCRIPTION
### Description
- Allows the user to build the FifoMux with XPM