### PR TITLE
changed MEMORY_TYPE_G from block to distributed

### DIFF
--- a/protocols/ssi/rtl/SsiCmdMaster.vhd
+++ b/protocols/ssi/rtl/SsiCmdMaster.vhd
@@ -44,7 +44,7 @@ entity SsiCmdMaster is
       MEMORY_TYPE_G       : string                     := "distributed";
       GEN_SYNC_FIFO_G     : boolean                    := false;
       CASCADE_SIZE_G      : integer range 1 to (2**24) := 1;
-      FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 4;
+      FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 5;
       FIFO_FIXED_THRESH_G : boolean                    := true;
       FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 8;
 

--- a/protocols/ssi/rtl/SsiCmdMaster.vhd
+++ b/protocols/ssi/rtl/SsiCmdMaster.vhd
@@ -41,7 +41,7 @@ entity SsiCmdMaster is
 
       -- AXI Stream FIFO Config
       SLAVE_READY_EN_G    : boolean                    := false;
-      MEMORY_TYPE_G       : string                     := "block";
+      MEMORY_TYPE_G       : string                     := "distributed";
       GEN_SYNC_FIFO_G     : boolean                    := false;
       CASCADE_SIZE_G      : integer range 1 to (2**24) := 1;
       FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 4;


### PR DESCRIPTION
### Description
- updating default FIFO_ADDR_WIDTH_G=5
  - compensate for RD/WR latency when GEN_SYNC_FIFO_G=false
- optimized for LUTRAM (instead of BRAM) since the default `FIFO_ADDR_WIDTH_G=5`