### PR TITLE
AxiStreamFifoV2: resolved bug in mTLastTUser

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
@@ -163,6 +163,8 @@ architecture rtl of AxiStreamFifoV2 is
    signal burstLast : sl;
    signal burstCnt  : natural range 0 to VALID_THOLD_G := 0;
 
+   signal sideBand : Slv8Array(1 downto 0);
+
    ---------------
    -- Sync Signals
    ---------------
@@ -357,7 +359,7 @@ begin
       fifoValid     <= fifoValidInt;
    end generate;
 
-   mTLastTUser <= resize(fifoReadUser, 8);
+   sideBand(0) <= resize(fifoReadUser, 8); -- mTLastTUser
 
    -- Map output Signals
    fifoReadMaster <= toAxiStreamMaster (fifoDout, fifoValid, FIFO_CONFIG_C);
@@ -372,15 +374,18 @@ begin
       generic map (
          TPD_G               => TPD_G,
          READY_EN_G          => true,
+         SIDE_BAND_WIDTH_G   => 8,
          SLAVE_AXI_CONFIG_G  => FIFO_CONFIG_C,
          MASTER_AXI_CONFIG_G => MASTER_AXI_CONFIG_G) 
       port map (
-            axisClk     => mAxisClk,
-            axisRst     => mAxisRst,
-            sAxisMaster => fifoReadMaster,
-            sAxisSlave  => fifoReadSlave,
-            mAxisMaster => axisMaster,
-            mAxisSlave  => axisSlave);
+         axisClk     => mAxisClk,
+         axisRst     => mAxisRst,
+         sAxisMaster => fifoReadMaster,
+         sSideBand   => sideBand(0),
+         sAxisSlave  => fifoReadSlave,
+         mAxisMaster => axisMaster,
+         mSideBand   => sideBand(1),
+         mAxisSlave  => axisSlave);
 
    -------------------------
    -- Idle Generation
@@ -403,18 +408,20 @@ begin
 
    U_Pipe : entity surf.AxiStreamPipeline
       generic map (
-         TPD_G         => TPD_G,
-         PIPE_STAGES_G => PIPE_STAGES_G)
+         TPD_G             => TPD_G,
+         SIDE_BAND_WIDTH_G => 8,
+         PIPE_STAGES_G     => PIPE_STAGES_G)
       port map (
          -- Clock and Reset
          axisClk     => mAxisClk,
          axisRst     => mAxisRst,
          -- Slave Port
          sAxisMaster => axisMaster,
+         sSideBand   => sideBand(1),
          sAxisSlave  => axisSlave,
          -- Master Port
          mAxisMaster => mAxisMaster,
+         mSideBand   => mTLastTUser,
          mAxisSlave  => mAxisSlave);
 
 end rtl;
-

--- a/axi/axi-stream/rtl/AxiStreamPipeline.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPipeline.vhd
@@ -23,17 +23,20 @@ use surf.AxiStreamPkg.all;
 
 entity AxiStreamPipeline is
    generic (
-      TPD_G         : time                  := 1 ns;
-      PIPE_STAGES_G : natural range 0 to 16 := 0);
+      TPD_G             : time     := 1 ns;
+      SIDE_BAND_WIDTH_G : positive := 1;  -- General purpose sideband
+      PIPE_STAGES_G     : natural  := 0);
    port (
       -- Clock and Reset
       axisClk     : in  sl;
       axisRst     : in  sl;
       -- Slave Port
       sAxisMaster : in  AxiStreamMasterType;
+      sSideBand   : in  slv(SIDE_BAND_WIDTH_G-1 downto 0) := (others => '0');
       sAxisSlave  : out AxiStreamSlaveType;
       -- Master Port
       mAxisMaster : out AxiStreamMasterType;
+      mSideBand   : out slv(SIDE_BAND_WIDTH_G-1 downto 0);
       mAxisSlave  : in  AxiStreamSlaveType);
 end AxiStreamPipeline;
 
@@ -41,14 +44,18 @@ architecture rtl of AxiStreamPipeline is
 
    constant PIPE_STAGES_C : natural := PIPE_STAGES_G+1;
 
+   type SideBandArray is array (natural range <>) of slv(SIDE_BAND_WIDTH_G-1 downto 0);
+
    type RegType is record
       sAxisSlave  : AxiStreamSlaveType;
       mAxisMaster : AxiStreamMasterArray(0 to PIPE_STAGES_C);
+      mSideBand   : SideBandArray(0 to PIPE_STAGES_C);
    end record RegType;
 
    constant REG_INIT_C : RegType := (
       sAxisSlave  => AXI_STREAM_SLAVE_INIT_C,
-      mAxisMaster => (others => AXI_STREAM_MASTER_INIT_C));
+      mAxisMaster => (others => AXI_STREAM_MASTER_INIT_C),
+      mSideBand   => (others => (others => '0')));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -58,13 +65,14 @@ begin
    ZERO_LATENCY : if (PIPE_STAGES_G = 0) generate
 
       mAxisMaster <= sAxisMaster;
+      mSideBand   <= sSideBand;
       sAxisSlave  <= mAxisSlave;
 
    end generate;
 
    PIPE_REG : if (PIPE_STAGES_G > 0) generate
 
-      comb : process (axisRst, mAxisSlave, r, sAxisMaster) is
+      comb : process (axisRst, mAxisSlave, r, sAxisMaster, sSideBand) is
          variable v : RegType;
          variable i : natural;
       begin
@@ -76,6 +84,7 @@ begin
             -- Shift the data up the pipeline
             for i in PIPE_STAGES_C downto 2 loop
                v.mAxisMaster(i) := r.mAxisMaster(i-1);
+               v.mSideBand(i)   := r.mSideBand(i-1);
             end loop;
             -- Check if the lowest cell is empty
             if r.mAxisMaster(0).tValid = '0' then
@@ -85,6 +94,7 @@ begin
                if r.sAxisSlave.tReady = '1' then
                   -- Shift the FIFO data
                   v.mAxisMaster(1) := sAxisMaster;
+                  v.mSideBand(1)   := sSideBand;
                else
                   -- Clear valid in stage 1
                   v.mAxisMaster(1).tValid := '0';
@@ -92,12 +102,14 @@ begin
             else
                -- Shift the lowest cell
                v.mAxisMaster(1) := r.mAxisMaster(0);
+               v.mSideBand(1)   := r.mSideBand(0);
                -- Check if we were pulling the FIFO last clock cycle
                if r.sAxisSlave.tReady = '1' then
                   -- Reset the ready bit
                   v.sAxisSlave.tReady := '0';
                   -- Fill the lowest cell
                   v.mAxisMaster(0)    := sAxisMaster;
+                  v.mSideBand(0)      := sSideBand;
                else
                   -- Set the ready bit
                   v.sAxisSlave.tReady     := '1';
@@ -112,6 +124,7 @@ begin
             if r.sAxisSlave.tReady = '1' then
                -- Fill the lowest cell
                v.mAxisMaster(0) := sAxisMaster;
+               v.mSideBand(0)   := sSideBand;
             elsif r.mAxisMaster(0).tValid = '0' then
                -- Set the ready bit
                v.sAxisSlave.tReady := '1';
@@ -122,11 +135,17 @@ begin
                if (r.mAxisMaster(i).tValid = '0') and (r.mAxisMaster(i-1).tValid = '1') then
                   -- Shift the lowest cell
                   v.mAxisMaster(i)          := r.mAxisMaster(i-1);
+                  v.mSideBand(i)            := r.mSideBand(i-1);
                   -- Reset the flag
                   v.mAxisMaster(i-1).tValid := '0';
                end if;
             end loop;
          end if;
+
+         -- Outputs
+         sAxisSlave  <= r.sAxisSlave;
+         mAxisMaster <= r.mAxisMaster(PIPE_STAGES_C);
+         mSideBand   <= r.mSideBand(PIPE_STAGES_C);
 
          -- Synchronous Reset
          if axisRst = '1' then
@@ -135,10 +154,6 @@ begin
 
          -- Register the variable for next clock cycle
          rin <= v;
-
-         -- Outputs
-         sAxisSlave  <= r.sAxisSlave;
-         mAxisMaster <= r.mAxisMaster(PIPE_STAGES_C);
 
       end process comb;
 

--- a/axi/axi-stream/rtl/AxiStreamResize.vhd
+++ b/axi/axi-stream/rtl/AxiStreamResize.vhd
@@ -28,9 +28,9 @@ entity AxiStreamResize is
    generic (
 
       -- General Configurations
-      TPD_G             : time    := 1 ns;
-      READY_EN_G        : boolean := true;
-      PIPE_STAGES_G     : natural := 0;
+      TPD_G             : time     := 1 ns;
+      READY_EN_G        : boolean  := true;
+      PIPE_STAGES_G     : natural  := 0;
       SIDE_BAND_WIDTH_G : positive := 1;  -- General purpose sideband
 
       -- AXI Stream Port Configurations
@@ -102,7 +102,7 @@ begin
       report "AxiStreamFifoV2: Can't have TKEEP_MODE = TKEEP_FIXED on master side if not on slave side"
       severity error;
 
-   comb : process (pipeAxisSlave, r, sAxisMaster) is
+   comb : process (pipeAxisSlave, r, sAxisMaster, sSideBand) is
       variable v       : RegType;
       variable ibM     : AxiStreamMasterType;
       variable ibSide  : slv(SIDE_BAND_WIDTH_G-1 downto 0);

--- a/axi/axi-stream/rtl/AxiStreamResize.vhd
+++ b/axi/axi-stream/rtl/AxiStreamResize.vhd
@@ -28,9 +28,10 @@ entity AxiStreamResize is
    generic (
 
       -- General Configurations
-      TPD_G         : time    := 1 ns;
-      READY_EN_G    : boolean := true;
-      PIPE_STAGES_G : natural := 0;
+      TPD_G             : time    := 1 ns;
+      READY_EN_G        : boolean := true;
+      PIPE_STAGES_G     : natural := 0;
+      SIDE_BAND_WIDTH_G : positive := 1;  -- General purpose sideband
 
       -- AXI Stream Port Configurations
       SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
@@ -44,12 +45,13 @@ entity AxiStreamResize is
 
       -- Slave Port
       sAxisMaster : in  AxiStreamMasterType;
+      sSideBand   : in  slv(SIDE_BAND_WIDTH_G-1 downto 0) := (others => '0');
       sAxisSlave  : out AxiStreamSlaveType;
 
       -- Master Port
       mAxisMaster : out AxiStreamMasterType;
-      mAxisSlave  : in  AxiStreamSlaveType
-      );
+      mSideBand   : out slv(SIDE_BAND_WIDTH_G-1 downto 0);
+      mAxisSlave  : in  AxiStreamSlaveType);
 end AxiStreamResize;
 
 architecture rtl of AxiStreamResize is
@@ -65,12 +67,14 @@ architecture rtl of AxiStreamResize is
    type RegType is record
       count    : slv(bitSize(COUNT_C)-1 downto 0);
       obMaster : AxiStreamMasterType;
+      sideBand : slv(SIDE_BAND_WIDTH_G-1 downto 0);
       ibSlave  : AxiStreamSlaveType;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
       count    => (others => '0'),
       obMaster => axiStreamMasterInit(MASTER_AXI_CONFIG_G),
+      sideBand => (others => '0'),
       ibSlave  => AXI_STREAM_SLAVE_INIT_C
       );
 
@@ -78,6 +82,7 @@ architecture rtl of AxiStreamResize is
    signal rin : RegType;
 
    signal pipeAxisMaster : AxiStreamMasterType;
+   signal pipeSideBand   : slv(SIDE_BAND_WIDTH_G-1 downto 0);
    signal pipeAxisSlave  : AxiStreamSlaveType;
 
 begin
@@ -100,6 +105,7 @@ begin
    comb : process (pipeAxisSlave, r, sAxisMaster) is
       variable v       : RegType;
       variable ibM     : AxiStreamMasterType;
+      variable ibSide  : slv(SIDE_BAND_WIDTH_G-1 downto 0);
       variable idx     : integer;       -- index version of counter
       variable byteCnt : integer;  -- Number of valid bytes in incoming bus
       variable bytes   : integer;       -- byte version of counter
@@ -123,6 +129,7 @@ begin
 
       -- Inbound data with normalized user bits (8 user bits)
       ibM       := sAxisMaster;
+      ibSide    := sSideBand;
       ibM.tUser := (others => '0');
       if (SLAVE_AXI_CONFIG_G.TKEEP_MODE_C = TKEEP_COUNT_C) then
          ibM.tKeep := genTKeep(byteCnt);
@@ -161,6 +168,7 @@ begin
             v.obMaster.tId   := ibM.tId;
             v.obMaster.tDest := ibM.tDest;
             v.obMaster.tLast := ibM.tLast;
+            v.sideBand       := ibSide;
 
             -- Determine if we move data
             if ibM.tValid = '1' then
@@ -184,6 +192,7 @@ begin
 
             v.obMaster.tId   := ibM.tId;
             v.obMaster.tDest := ibM.tDest;
+            v.sideBand       := ibSide;
 
             -- Determine if we move data
             if ibM.tValid = '1' then
@@ -208,6 +217,7 @@ begin
       if SLV_BYTES_C = MST_BYTES_C then
          sAxisSlave     <= pipeAxisSlave;
          pipeAxisMaster <= sAxisMaster;
+         pipeSideBand   <= sSideBand;
 
          -- Check for TKEEP_COUNT_C mode on either side
          if (SLAVE_AXI_CONFIG_G.TKEEP_MODE_C = TKEEP_COUNT_C) or (MASTER_AXI_CONFIG_G.TKEEP_MODE_C = TKEEP_COUNT_C) then
@@ -241,6 +251,7 @@ begin
 
          -- Outbound data with proper user bits
          pipeAxisMaster       <= r.obMaster;
+         pipeSideBand         <= r.sideBand;
          pipeAxisMaster.tUser <= (others => '0');
          if (MASTER_AXI_CONFIG_G.TKEEP_MODE_C = TKEEP_COUNT_C) then
             pipeAxisMaster.tKeep <= toSlv(getTKeep(r.obMaster.tKeep, MASTER_AXI_CONFIG_G), AXI_STREAM_MAX_TKEEP_WIDTH_C);
@@ -269,14 +280,17 @@ begin
    -- Optional output pipeline registers to ease timing
    AxiStreamPipeline_1 : entity surf.AxiStreamPipeline
       generic map (
-         TPD_G         => TPD_G,
-         PIPE_STAGES_G => PIPE_STAGES_G)
+         TPD_G             => TPD_G,
+         SIDE_BAND_WIDTH_G => SIDE_BAND_WIDTH_G,
+         PIPE_STAGES_G     => PIPE_STAGES_G)
       port map (
          axisClk     => axisClk,
          axisRst     => axisRst,
          sAxisMaster => pipeAxisMaster,
+         sSideBand   => pipeSideBand,
          sAxisSlave  => pipeAxisSlave,
          mAxisMaster => mAxisMaster,
+         mSideBand   => mSideBand,
          mAxisSlave  => mAxisSlave);
 
 end rtl;


### PR DESCRIPTION
### Description
- mTLastTUser can be out of phase of mAxisMaster when (VALID_THOLD_G/=1) and ( (FIFO_CONFIG_C.TDATA_BYTES_C /= MASTER_AXI_CONFIG_G.TDATA_BYTES_C) or (PIPE_STAGES_G/=0) )
  - mapping mTLastTUser through the AxiStreamResize/AxiStreamPipeline sideband to resovle this issue
- adding AxiStreamPipeline sideband feature
- adding AxiStreamResize sideband feature
