### PR TITLE
Ethernet RAM optmizations

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
@@ -80,6 +80,7 @@ entity AxiStreamFifoV2 is
       -- output pipeline stages
       fifoPauseThresh : in  slv(FIFO_ADDR_WIDTH_G-1 downto 0) := (others => '1');
       fifoWrCnt       : out slv(FIFO_ADDR_WIDTH_G-1 downto 0);
+      fifoFull        : out sl;
 
       -- Master Port
       mAxisClk    : in  sl;
@@ -258,6 +259,7 @@ begin
          prog_full     => fifoPFull,
          progFullVec   => fifoPFullVec,
          almost_full   => fifoAFull,
+         full          => fifoFull,
          rd_clk        => mAxisClk,
          rd_en         => fifoRead,
          dout          => fifoDout,

--- a/ethernet/EthMacCore/rtl/EthMacPkg.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacPkg.vhd
@@ -61,6 +61,17 @@ package EthMacPkg is
       TKEEP_MODE_C  => TKEEP_COMP_C,
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+      
+   -- Ethernet AXI Stream Configuration that's optimized for 141-bit FIFO interface (2 x 72b input BRAMs)
+   constant INT_EMAC_AXIS_CONFIG_C : AxiStreamConfigType := (
+      -- TDEST_INTERLEAVE_C => EMAC_AXIS_CONFIG_C.TDEST_INTERLEAVE_C,
+      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TDATA_BYTES_C => EMAC_AXIS_CONFIG_C.TDATA_BYTES_C,
+      TDEST_BITS_C  => 0, -- TDEST not used internally of EthMacTop.vhd
+      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);      
 
    -- Generic XMAC Configuration
    type EthMacConfigType is record

--- a/ethernet/EthMacCore/rtl/EthMacRxCsum.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxCsum.vhd
@@ -149,26 +149,26 @@ begin
          -- Check if IPv4 is detected and being checked
          if (r.ipv4Det(EMAC_CSUM_PIPELINE_C+1) = '1') and (ipCsumEn = '1') then
             -- Forward the result of checksum calculation
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_IPERR_BIT_C, not(r.valid(0)));
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(0)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_IPERR_BIT_C, not(r.valid(0)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(0)));
          end if;
          -- Check if UDP is detected and being checked
          if (r.ipv4Det(EMAC_CSUM_PIPELINE_C+1) = '1') and (r.udpDet(EMAC_CSUM_PIPELINE_C+1) = '1') and (udpCsumEn = '1') and (r.fragDet(EMAC_CSUM_PIPELINE_C+1) = '0') then
             -- Forward the result of checksum calculation
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_UDPERR_BIT_C, not(r.valid(1)));
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(1)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_UDPERR_BIT_C, not(r.valid(1)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(1)));
             -- Check for mismatch in IPv4 length with UDP length
             if (r.ipv4Len(EMAC_CSUM_PIPELINE_C+1) /= (r.protLen(EMAC_CSUM_PIPELINE_C+1) + 20)) then
                -- Set the error flags
-               axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_UDPERR_BIT_C, '1');
-               axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, '1');
+               axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_UDPERR_BIT_C, '1');
+               axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, '1');
             end if;
          end if;
          -- Check if TCP is detected and being checked
          if (r.ipv4Det(EMAC_CSUM_PIPELINE_C+1) = '1') and (r.tcpDet(EMAC_CSUM_PIPELINE_C+1) = '1') and (tcpCsumEn = '1') and (r.fragDet(EMAC_CSUM_PIPELINE_C+1) = '0') then
             -- Forward the result of checksum calculation
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_TCPERR_BIT_C, not(r.valid(1)));
-            axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(1)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_TCPERR_BIT_C, not(r.valid(1)));
+            axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_EOFE_BIT_C, not(r.valid(1)));
          end if;
       end if;
 
@@ -213,7 +213,7 @@ begin
                -- Check for EOF
                if (sAxisMaster.tLast = '1') then
                   -- Set the error flag if IPv4 is detected and being checked
-                  axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMaster, EMAC_IPERR_BIT_C, r.ipv4Det(0));
+                  axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMaster, EMAC_IPERR_BIT_C, r.ipv4Det(0));
                   -- Next state
                   v.state := IDLE_S;
                else
@@ -310,7 +310,7 @@ begin
                      v.protLen(0)(7 downto 0)   := sAxisMaster.tData(63 downto 56);
                   end if;
                   -- Track the number of bytes (include IPv4 header offset from previous state)
-                  v.byteCnt := getTKeep(sAxisMaster.tKeep, EMAC_AXIS_CONFIG_C) + 18;
+                  v.byteCnt := getTKeep(sAxisMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) + 18;
                else
                   -- Fill in the IPv4 header checksum
                   v.ipv4Hdr(14) := sAxisMaster.tData(7 downto 0);  -- Source IP Address
@@ -331,7 +331,7 @@ begin
                      v.protLen(0)(7 downto 0)   := sAxisMaster.tData(95 downto 88);
                   end if;
                   -- Track the number of bytes (include IPv4 header offset from previous state)
-                  v.byteCnt := getTKeep(sAxisMaster.tKeep, EMAC_AXIS_CONFIG_C) + 14;
+                  v.byteCnt := getTKeep(sAxisMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) + 14;
                end if;
                -- Check for EOF
                if (sAxisMaster.tLast = '1') then
@@ -373,7 +373,7 @@ begin
                   end if;
                end if;
                -- Track the number of bytes 
-               v.byteCnt := r.byteCnt + getTKeep(sAxisMaster.tKeep, EMAC_AXIS_CONFIG_C);
+               v.byteCnt := r.byteCnt + getTKeep(sAxisMaster.tKeep, INT_EMAC_AXIS_CONFIG_C);
                -- Check for EOF
                if (sAxisMaster.tLast = '1') or (v.byteCnt > MAX_FRAME_SIZE_C) then
                   -- Check for overflow condition
@@ -381,7 +381,7 @@ begin
                      -- Force EOF
                      v.mAxisMaster.tLast := '1';
                      -- Set the error flag
-                     axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMaster, EMAC_EOFE_BIT_C, '1');
+                     axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMaster, EMAC_EOFE_BIT_C, '1');
                      -- Next state
                      v.state             := BLOWOFF_S;
                   else
@@ -401,9 +401,9 @@ begin
       end case;
 
       -- Check for first TUSER on the output AXIS stream
-      if (axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_SOF_BIT_C, 0) = '1') then
+      if (axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_SOF_BIT_C, 0) = '1') then
          -- Set the fragmentation flag
-         axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_FRAG_BIT_C, r.fragDet(EMAC_CSUM_PIPELINE_C), 0);
+         axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.mAxisMasters(EMAC_CSUM_PIPELINE_C+1), EMAC_FRAG_BIT_C, r.fragDet(EMAC_CSUM_PIPELINE_C), 0);
       end if;
 
       -- Reset

--- a/ethernet/EthMacCore/rtl/EthMacRxFifo.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxFifo.vhd
@@ -33,14 +33,14 @@ entity EthMacRxFifo is
       PIPE_STAGES_G     : natural                := 1;
       FIFO_ADDR_WIDTH_G : positive range 9 to 16 := 11;
       PRIM_COMMON_CLK_G : boolean                := false;
-      PRIM_CONFIG_G     : AxiStreamConfigType    := EMAC_AXIS_CONFIG_C;
+      PRIM_CONFIG_G     : AxiStreamConfigType    := INT_EMAC_AXIS_CONFIG_C;
       BYP_EN_G          : boolean                := false;
       BYP_COMMON_CLK_G  : boolean                := false;
-      BYP_CONFIG_G      : AxiStreamConfigType    := EMAC_AXIS_CONFIG_C;
+      BYP_CONFIG_G      : AxiStreamConfigType    := INT_EMAC_AXIS_CONFIG_C;
       VLAN_EN_G         : boolean                := false;
       VLAN_SIZE_G       : positive               := 1;
       VLAN_COMMON_CLK_G : boolean                := false;
-      VLAN_CONFIG_G     : AxiStreamConfigType    := EMAC_AXIS_CONFIG_C);
+      VLAN_CONFIG_G     : AxiStreamConfigType    := INT_EMAC_AXIS_CONFIG_C);
    port (
       -- Clock and Reset
       sClk         : in  sl;
@@ -113,7 +113,7 @@ begin
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
          FIFO_FIXED_THRESH_G => false,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => PRIM_CONFIG_G)
       port map (
          sAxisClk        => sClk,
@@ -148,7 +148,7 @@ begin
             FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
             FIFO_FIXED_THRESH_G => false,
             -- AXI Stream Port Configurations
-            SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+            SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,
             MASTER_AXI_CONFIG_G => BYP_CONFIG_G)
          port map (
             sAxisClk        => sClk,
@@ -185,7 +185,7 @@ begin
                FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
                FIFO_FIXED_THRESH_G => false,
                -- AXI Stream Port Configurations
-               SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+               SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,
                MASTER_AXI_CONFIG_G => VLAN_CONFIG_G)
             port map (
                sAxisClk        => sClk,

--- a/ethernet/EthMacCore/rtl/EthMacRxImportGmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImportGmii.vhd
@@ -47,13 +47,13 @@ architecture rtl of EthMacRxImportGmii is
 
    constant SFD_C : slv(7 downto 0) := x"D5";
    constant AXI_CONFIG_C : AxiStreamConfigType := (
-      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TSTRB_EN_C    => INT_EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
       TDATA_BYTES_C => 1,               -- 8-bit AXI stream interface
-      TDEST_BITS_C  => EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
-      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
-      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
-      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
-      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
+      TDEST_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
+      TID_BITS_C    => INT_EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
 
    type StateType is(
       WAIT_SFD_S,
@@ -117,7 +117,7 @@ begin
          FIFO_ADDR_WIDTH_G   => 4,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,  --  8-bit AXI stream interface  
-         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface          
+         MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface          
       port map (
          -- Slave Port
          sAxisClk    => ethClk,

--- a/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImportXgmii.vhd
@@ -44,13 +44,13 @@ end EthMacRxImportXgmii;
 architecture rtl of EthMacRxImportXgmii is
 
    constant AXI_CONFIG_C : AxiStreamConfigType := (
-      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TSTRB_EN_C    => INT_EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
       TDATA_BYTES_C => 8,               -- 64-bit AXI stream interface
-      TDEST_BITS_C  => EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
-      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
-      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
-      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
-      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
+      TDEST_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
+      TID_BITS_C    => INT_EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
 
    type RegType is record
       phyRxd      : slv(63 downto 0);
@@ -225,7 +225,7 @@ begin
          READY_EN_G          => false,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,  --  64-bit AXI stream interface  
-         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface     
+         MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface     
       port map (
          -- Clock and reset
          axisClk     => ethClk,

--- a/ethernet/EthMacCore/rtl/EthMacRxPause.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxPause.vhd
@@ -168,7 +168,7 @@ begin
                   -- Check for a EOF
                   if (sAxisMaster.tLast = '1') then
                      -- Set the pause
-                     v.pauseEn := not axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, sAxisMaster, EMAC_EOFE_BIT_C);
+                     v.pauseEn := not axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, sAxisMaster, EMAC_EOFE_BIT_C);
                      -- Next State
                      v.state   := IDLE_S;
                   else
@@ -181,7 +181,7 @@ begin
                -- Check for a valid EOF
                if (sAxisMaster.tValid = '1') and (sAxisMaster.tLast = '1') then
                   -- Set the pause
-                  v.pauseEn := not axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, sAxisMaster, EMAC_EOFE_BIT_C);
+                  v.pauseEn := not axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, sAxisMaster, EMAC_EOFE_BIT_C);
                   -- Next State
                   v.state   := IDLE_S;
                end if;

--- a/ethernet/EthMacCore/rtl/EthMacRxShift.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxShift.vhd
@@ -48,7 +48,7 @@ begin
       U_RxShift : entity surf.AxiStreamShift
          generic map (
             TPD_G          => TPD_G,
-            AXIS_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+            AXIS_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,
             ADD_VALID_EN_G => true) 
          port map (
             axisClk     => ethClk,

--- a/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
@@ -240,11 +240,11 @@ begin
                -- Move data
                v.sMaster        := rxMaster;
                -- Set the flag
-               v.fragDet(0)     := axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, rxMaster, EMAC_FRAG_BIT_C, 0);
+               v.fragDet(0)     := axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, rxMaster, EMAC_FRAG_BIT_C, 0);
                -- Check for EOF
                if (rxMaster.tLast = '1') then
                   -- Save the EOFE value
-                  v.eofeDet(0) := axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
+                  v.eofeDet(0) := axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
                   -- Write the transaction data
                   v.tranWr     := '1';
                else
@@ -284,7 +284,7 @@ begin
                      v.eofeDet(0) := '1';
                   else
                      -- Save the EOFE value
-                     v.eofeDet(0) := axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
+                     v.eofeDet(0) := axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
                   end if;
                   -- Write the transaction data
                   v.tranWr := '1';
@@ -364,8 +364,8 @@ begin
                      v.tData := rxMaster.tData(127 downto 80) & x"00000000" & rxMaster.tData(47 downto 0);
                   end if;
                   -- Track the number of bytes 
-                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C) - 2;
-                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C) - 2;
+                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 2;
+                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 2;
                else
                   -- Fill in the IPv4 header checksum
                   v.ipv4Hdr(14) := rxMaster.tData(7 downto 0);  -- Source IP Address
@@ -380,13 +380,13 @@ begin
                      v.tData := rxMaster.tData(127 downto 112) & x"00000000" & rxMaster.tData(79 downto 0);
                   end if;
                   -- Track the number of bytes 
-                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C) - 6;
-                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C) - 6;
+                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 6;
+                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 6;
                end if;
                -- Check for EOF
                if (rxMaster.tLast = '1') then
                   -- Save the EOFE value
-                  v.eofeDet(0) := axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
+                  v.eofeDet(0) := axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
                   -- Write the transaction data
                   v.tranWr     := '1';
                   -- Next state
@@ -421,12 +421,12 @@ begin
                   end if;
                end if;
                -- Track the number of bytes 
-               v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C);
-               v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,EMAC_AXIS_CONFIG_C);
+               v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C);
+               v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C);
                -- Check for EOF
                if (rxMaster.tLast = '1') or (v.ipv4Len(0) > MAX_FRAME_SIZE_C) then
                   -- Save the EOFE value
-                  v.eofeDet(0) := axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
+                  v.eofeDet(0) := axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, rxMaster, EMAC_EOFE_BIT_C);
                   -- Check for overflow
                   if (rxMaster.tLast = '0') then
                      -- Error detect
@@ -600,7 +600,7 @@ begin
                -- Reset the counter
                v.mvCnt  := 0;
                -- Forward the EOFE               
-               axiStreamSetUserBit(EMAC_AXIS_CONFIG_C, v.txMaster, EMAC_EOFE_BIT_C, eofeDet);
+               axiStreamSetUserBit(INT_EMAC_AXIS_CONFIG_C, v.txMaster, EMAC_EOFE_BIT_C, eofeDet);
                v.dbg(5) := eofeDet;
                -- Accept the data
                v.tranRd := '1';
@@ -647,8 +647,8 @@ begin
          CASCADE_SIZE_G      => ite(JUMBO_G, 2, 1),
          FIFO_ADDR_WIDTH_G   => 9,      -- 8kB per FIFO
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => ethClk,

--- a/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportGmii.vhd
@@ -48,13 +48,13 @@ end EthMacTxExportGmii;
 architecture rtl of EthMacTxExportGmii is
 
    constant AXI_CONFIG_C : AxiStreamConfigType := (
-      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TSTRB_EN_C    => INT_EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
       TDATA_BYTES_C => 1,               -- 8-bit AXI stream interface
-      TDEST_BITS_C  => EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
-      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
-      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
-      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
-      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
+      TDEST_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
+      TID_BITS_C    => INT_EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
 
    type StateType is(
       IDLE_S,
@@ -125,7 +125,7 @@ begin
          TPD_G               => TPD_G,
          READY_EN_G          => true,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,  -- 128-bit AXI stream interface  
+         SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,  -- 128-bit AXI stream interface  
          MASTER_AXI_CONFIG_G => AXI_CONFIG_C)  -- 8-bit AXI stream interface  
       port map (
          -- Clock and reset

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
@@ -48,13 +48,13 @@ architecture rtl of EthMacTxExportXgmii is
    constant INTERGAP_C : slv(3 downto 0) := x"3";
 
    constant AXI_CONFIG_C : AxiStreamConfigType := (
-      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TSTRB_EN_C    => INT_EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
       TDATA_BYTES_C => 8,               -- 64-bit AXI stream interface
-      TDEST_BITS_C  => EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
-      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
-      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
-      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
-      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);   
+      TDEST_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
+      TID_BITS_C    => INT_EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => INT_EMAC_AXIS_CONFIG_C.TUSER_MODE_C);   
 
    -- Local Signals
    signal macMaster        : AxiStreamMasterType;
@@ -151,7 +151,7 @@ begin
          CASCADE_SIZE_G      => 1,
          FIFO_ADDR_WIDTH_G   => 4,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,  -- 128-bit AXI stream interface  
+         SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,  -- 128-bit AXI stream interface  
          MASTER_AXI_CONFIG_G => AXI_CONFIG_C)        -- 64-bit AXI stream interface          
       port map (
          -- Slave Port
@@ -288,14 +288,14 @@ begin
             if macMaster.tLast = '1' and (exportWordCnt < 7) then
                nxtState  <= ST_PAD_C;
                txCountEn <= '1';
-               nxtError  <= intError or axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, macMaster, EMAC_EOFE_BIT_C);
+               nxtError  <= intError or axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, macMaster, EMAC_EOFE_BIT_C);
 
             elsif macMaster.tLast = '1' and (exportWordCnt >= 7) then
                intLastLine   <= '1';
                nxtState      <= ST_WAIT_C;
                txCountEn     <= '1';
                stateCountRst <= '1';
-               nxtError      <= intError or axiStreamGetUserBit(EMAC_AXIS_CONFIG_C, macMaster, EMAC_EOFE_BIT_C);
+               nxtError      <= intError or axiStreamGetUserBit(INT_EMAC_AXIS_CONFIG_C, macMaster, EMAC_EOFE_BIT_C);
 
             -- Detect underflow
             elsif macMaster.tValid = '0' then

--- a/ethernet/EthMacCore/rtl/EthMacTxFifo.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxFifo.vhd
@@ -25,14 +25,14 @@ entity EthMacTxFifo is
    generic (
       TPD_G             : time                := 1 ns;
       PRIM_COMMON_CLK_G : boolean             := false;
-      PRIM_CONFIG_G     : AxiStreamConfigType := EMAC_AXIS_CONFIG_C;
+      PRIM_CONFIG_G     : AxiStreamConfigType := INT_EMAC_AXIS_CONFIG_C;
       BYP_EN_G          : boolean             := false;
       BYP_COMMON_CLK_G  : boolean             := false;
-      BYP_CONFIG_G      : AxiStreamConfigType := EMAC_AXIS_CONFIG_C;
+      BYP_CONFIG_G      : AxiStreamConfigType := INT_EMAC_AXIS_CONFIG_C;
       VLAN_EN_G         : boolean             := false;
       VLAN_SIZE_G       : positive            := 1;
       VLAN_COMMON_CLK_G : boolean             := false;
-      VLAN_CONFIG_G     : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      VLAN_CONFIG_G     : AxiStreamConfigType := INT_EMAC_AXIS_CONFIG_C);
    port (
       -- Master Clock and Reset
       mClk         : in  sl;
@@ -64,12 +64,12 @@ architecture mapping of EthMacTxFifo is
 
 begin
 
-   PRIM_FIFO_BYPASS : if ((PRIM_COMMON_CLK_G = true) and (PRIM_CONFIG_G = EMAC_AXIS_CONFIG_C)) generate
+   PRIM_FIFO_BYPASS : if ((PRIM_COMMON_CLK_G = true) and (PRIM_CONFIG_G = INT_EMAC_AXIS_CONFIG_C)) generate
       mPrimMaster <= sPrimMaster;
       sPrimSlave  <= mPrimSlave;
    end generate;
 
-   PRIM_FIFO : if ((PRIM_COMMON_CLK_G = false) or (PRIM_CONFIG_G /= EMAC_AXIS_CONFIG_C)) generate
+   PRIM_FIFO : if ((PRIM_COMMON_CLK_G = false) or (PRIM_CONFIG_G /= INT_EMAC_AXIS_CONFIG_C)) generate
       U_Fifo : entity surf.AxiStreamFifoV2
          generic map (
             -- General Configurations
@@ -85,7 +85,7 @@ begin
             FIFO_ADDR_WIDTH_G   => 4,
             -- AXI Stream Port Configurations
             SLAVE_AXI_CONFIG_G  => PRIM_CONFIG_G,
-            MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)        
+            MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)        
          port map (
             sAxisClk    => sPrimClk,
             sAxisRst    => sPrimRst,
@@ -104,12 +104,12 @@ begin
 
    BYP_ENABLED : if (BYP_EN_G = true) generate
       
-      BYP_FIFO_BYPASS : if ((BYP_COMMON_CLK_G = true) and (BYP_CONFIG_G = EMAC_AXIS_CONFIG_C)) generate
+      BYP_FIFO_BYPASS : if ((BYP_COMMON_CLK_G = true) and (BYP_CONFIG_G = INT_EMAC_AXIS_CONFIG_C)) generate
          mBypMaster <= sBypMaster;
          sBypSlave  <= mBypSlave;
       end generate;
 
-      BYP_FIFO : if ((BYP_COMMON_CLK_G = false) or (BYP_CONFIG_G /= EMAC_AXIS_CONFIG_C)) generate
+      BYP_FIFO : if ((BYP_COMMON_CLK_G = false) or (BYP_CONFIG_G /= INT_EMAC_AXIS_CONFIG_C)) generate
          U_Fifo : entity surf.AxiStreamFifoV2
             generic map (
                -- General Configurations
@@ -125,7 +125,7 @@ begin
                FIFO_ADDR_WIDTH_G   => 4,
                -- AXI Stream Port Configurations
                SLAVE_AXI_CONFIG_G  => BYP_CONFIG_G,
-               MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)        
+               MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)        
             port map (
                sAxisClk    => sBypClk,
                sAxisRst    => sBypRst,
@@ -145,12 +145,12 @@ begin
    end generate;
 
    VLAN_ENABLED : if (VLAN_EN_G = true) generate
-      VLAN_FIFO_BYPASS : if ((VLAN_COMMON_CLK_G = true) and (VLAN_CONFIG_G = EMAC_AXIS_CONFIG_C)) generate
+      VLAN_FIFO_BYPASS : if ((VLAN_COMMON_CLK_G = true) and (VLAN_CONFIG_G = INT_EMAC_AXIS_CONFIG_C)) generate
          mVlanMasters <= sVlanMasters;
          sVlanSlaves  <= mVlanSlaves;
       end generate;
 
-      VLAN_FIFO : if ((VLAN_COMMON_CLK_G = false) or (VLAN_CONFIG_G /= EMAC_AXIS_CONFIG_C)) generate
+      VLAN_FIFO : if ((VLAN_COMMON_CLK_G = false) or (VLAN_CONFIG_G /= INT_EMAC_AXIS_CONFIG_C)) generate
          GEN_VEC : for i in (VLAN_SIZE_G-1) downto 0 generate
             U_Fifo : entity surf.AxiStreamFifoV2
                generic map (
@@ -167,7 +167,7 @@ begin
                   FIFO_ADDR_WIDTH_G   => 4,
                   -- AXI Stream Port Configurations
                   SLAVE_AXI_CONFIG_G  => VLAN_CONFIG_G,
-                  MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)        
+                  MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)        
                port map (
                   sAxisClk    => sVlanClk,
                   sAxisRst    => sVlanRst,

--- a/ethernet/EthMacCore/rtl/EthMacTxShift.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxShift.vhd
@@ -53,7 +53,7 @@ begin
       U_TxShift : entity surf.AxiStreamShift
          generic map (
             TPD_G         => TPD_G,
-            AXIS_CONFIG_G => EMAC_AXIS_CONFIG_C) 
+            AXIS_CONFIG_G => INT_EMAC_AXIS_CONFIG_C) 
          port map (
             axisClk     => ethClk,
             axisRst     => ethRst,

--- a/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale+/rtl/GigEthGthUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -25,12 +24,12 @@ use surf.GigEthPkg.all;
 
 entity GigEthGthUltraScale is
    generic (
-      TPD_G           : time                := 1 ns;
-      PAUSE_EN_G      : boolean             := true;
+      TPD_G         : time                := 1 ns;
+      PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean             := false;
+      EN_AXI_REG_G  : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -167,11 +166,14 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_C,
-         PHY_TYPE_G      => "GMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         PAUSE_512BITS_G   => PAUSE_512BITS_C,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "GMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -25,12 +24,12 @@ use surf.GigEthPkg.all;
 
 entity GigEthGtyUltraScale is
    generic (
-      TPD_G           : time                := 1 ns;
-      PAUSE_EN_G      : boolean             := true;
+      TPD_G         : time                := 1 ns;
+      PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean             := false;
+      EN_AXI_REG_G  : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -167,11 +166,14 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PAUSE_512BITS_G => PAUSE_512BITS_C,
-         PHY_TYPE_G      => "GMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         PAUSE_512BITS_G   => PAUSE_512BITS_C,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "GMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -25,12 +24,12 @@ use surf.EthMacPkg.all;
 
 entity TenGigEthGthUltraScale is
    generic (
-      TPD_G           : time                := 1 ns;
-      PAUSE_EN_G      : boolean             := true;
+      TPD_G         : time                := 1 ns;
+      PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean             := false;
+      EN_AXI_REG_G  : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -234,10 +233,13 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PHY_TYPE_G      => "XGMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "XGMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,
@@ -288,10 +290,10 @@ begin
          gtwiz_reset_qpll1lock_in            => qplllock(1),
          gtwiz_reset_qpll1reset_out          => qpllRst(1),
          -- MGT Ports      
-         gt_txp_out(0)                        => gtTxP,
-         gt_txn_out(0)                        => gtTxN,
-         gt_rxp_in(0)                         => gtRxP,
-         gt_rxn_in(0)                         => gtRxN,
+         gt_txp_out(0)                       => gtTxP,
+         gt_txn_out(0)                       => gtTxN,
+         gt_rxp_in(0)                        => gtRxP,
+         gt_rxn_in(0)                        => gtRxN,
          -- PHY Interface      
          tx_mii_d_0                          => phyTxd,
          tx_mii_c_0                          => phyTxc,

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -25,12 +24,12 @@ use surf.EthMacPkg.all;
 
 entity TenGigEthGtyUltraScale is
    generic (
-      TPD_G           : time                := 1 ns;
-      PAUSE_EN_G      : boolean             := true;
+      TPD_G         : time                := 1 ns;
+      PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean             := false;
+      EN_AXI_REG_G  : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -234,10 +233,13 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PHY_TYPE_G      => "XGMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "XGMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -28,14 +27,14 @@ use unisim.vcomponents.all;
 
 entity XauiGthUltraScale is
    generic (
-      TPD_G           : time                     := 1 ns;
-      PAUSE_EN_G      : boolean                  := true;
+      TPD_G          : time                := 1 ns;
+      PAUSE_EN_G     : boolean             := true;
       -- XAUI Configurations
-      REF_CLK_FREQ_G  : real                     := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      REF_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean                  := false;
+      EN_AXI_REG_G   : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType      := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G  : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -202,10 +201,13 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PHY_TYPE_G      => "XGMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "XGMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -28,14 +27,14 @@ use unisim.vcomponents.all;
 
 entity XauiGtyUltraScale is
    generic (
-      TPD_G           : time                := 1 ns;
-      PAUSE_EN_G      : boolean             := true;
+      TPD_G          : time                := 1 ns;
+      PAUSE_EN_G     : boolean             := true;
       -- XAUI Configurations
-      REF_CLK_FREQ_G  : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      REF_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
       -- AXI-Lite Configurations
-      EN_AXI_REG_G    : boolean             := false;
+      EN_AXI_REG_G   : boolean             := false;
       -- AXI Streaming Configurations
-      AXIS_CONFIG_G   : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
+      AXIS_CONFIG_G  : AxiStreamConfigType := EMAC_AXIS_CONFIG_C);
    port (
       -- Local Configurations
       localMac           : in  slv(47 downto 0)       := MAC_ADDR_INIT_C;
@@ -202,10 +201,13 @@ begin
    --------------------
    U_MAC : entity surf.EthMacTop
       generic map (
-         TPD_G           => TPD_G,
-         PAUSE_EN_G      => PAUSE_EN_G,
-         PHY_TYPE_G      => "XGMII",
-         PRIM_CONFIG_G   => AXIS_CONFIG_G)
+         TPD_G             => TPD_G,
+         PAUSE_EN_G        => PAUSE_EN_G,
+         FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
+         SYNTH_MODE_G      => "xpm",
+         MEMORY_TYPE_G     => "ultra",
+         PHY_TYPE_G        => "XGMII",
+         PRIM_CONFIG_G     => AXIS_CONFIG_G)
       port map (
          -- Primary Interface
          primClk         => dmaClk,

--- a/protocols/ssi/rtl/SsiFifo.vhd
+++ b/protocols/ssi/rtl/SsiFifo.vhd
@@ -234,10 +234,18 @@ begin
             when MON_S =>
                -- Check for lock up condition
                if (fifoFull = '1') and (txMaster.tValid = '0') then
-                  -- Reset the FIFO to get out of lockup state
-                  v.fifoRst := '1';
-                  -- Next state
-                  v.state   := WAIT_S;
+                  -- Increment the counter
+                  v.cnt := r.cnt + 1;
+                  -- Check for roll over (effectively a timeout)
+                  if (v.cnt = 0) then
+                     -- Reset the FIFO to get out of lockup state
+                     v.fifoRst := '1';
+                     -- Next state
+                     v.state   := WAIT_S;
+                  end if;
+               else
+                  -- Reset the counter
+                  v.cnt := x"0";
                end if;
          ----------------------------------------------------------------------
          end case;

--- a/protocols/ssi/rtl/SsiFifo.vhd
+++ b/protocols/ssi/rtl/SsiFifo.vhd
@@ -178,7 +178,7 @@ begin
          CASCADE_PAUSE_SEL_G    => CASCADE_PAUSE_SEL_G,
          CASCADE_SIZE_G         => CASCADE_SIZE_G,
          SLAVE_AXI_CONFIG_G     => SLAVE_AXI_CONFIG_G,
-         MASTER_AXI_CONFIG_G    => MASTER_AXI_CONFIG_G)
+         MASTER_AXI_CONFIG_G    => SLAVE_AXI_CONFIG_G)
       port map (
          -- Slave Interface (sAxisClk domain)
          sAxisClk        => sAxisClk,
@@ -281,7 +281,7 @@ begin
          TPD_G         => TPD_G,
          VALID_THOLD_G => VALID_THOLD_G,
          PIPE_STAGES_G => PIPE_STAGES_G,
-         AXIS_CONFIG_G => MASTER_AXI_CONFIG_G)
+         AXIS_CONFIG_G => SLAVE_AXI_CONFIG_G)
       port map (
          -- Slave Interface (sAxisClk domain)
          sAxisMaster    => txMaster,
@@ -310,9 +310,9 @@ begin
             SYNTH_MODE_G        => SYNTH_MODE_G,
             MEMORY_TYPE_G       => "distributed",
             GEN_SYNC_FIFO_G     => false,
-            FIFO_ADDR_WIDTH_G   => 5,
+            FIFO_ADDR_WIDTH_G   => 4,
             -- AXI Stream Port Configurations
-            SLAVE_AXI_CONFIG_G  => MASTER_AXI_CONFIG_G,
+            SLAVE_AXI_CONFIG_G  => SLAVE_AXI_CONFIG_G,
             MASTER_AXI_CONFIG_G => MASTER_AXI_CONFIG_G)
          port map (
             -- Slave Port

--- a/protocols/ssi/rtl/SsiObFrameFilter.vhd
+++ b/protocols/ssi/rtl/SsiObFrameFilter.vhd
@@ -22,7 +22,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;


### PR DESCRIPTION
### Description
- TDEST not used internally of EthMacTop.vhd
  - Doing this logic optimization to fit into two 72-bit width RAMs but also maintaining EMAC_AXIS_CONFIG_C with external application to prevent possible TDEST issues
- add support for (MEMORY_TYPE_G=ultra) and (GEN_SYNC_FIFO_G=false) in SsiFifo
- updating the Ultscale+ ETH module to use URAMs for ETH RX FIFO
  - 2 URAMs per ETH RX channel