### PR TITLE
Modify ClinkSerial to show string in sendString and response

### DIFF
--- a/python/surf/protocols/clink/_ClinkSerialRx.py
+++ b/python/surf/protocols/clink/_ClinkSerialRx.py
@@ -35,5 +35,7 @@ class ClinkSerialRx(rogue.interfaces.stream.Slave):
             if c == '\n':
                 print("Got Response: {}".format(''.join(self._cur)))
                 self._cur = []
-            elif c != '\r':
+            elif c == '\r':
+                print("recvString: {}".format(''.join(self._cur)))
+            elif c != '':
                 self._cur.append(c)

--- a/python/surf/protocols/clink/_ClinkSerialTx.py
+++ b/python/surf/protocols/clink/_ClinkSerialTx.py
@@ -19,6 +19,8 @@
 import pyrogue as pr
 import rogue.interfaces.stream
 
+import pdb
+
 class ClinkSerialTx(rogue.interfaces.stream.Master):
 
     def __init__(self):
@@ -33,6 +35,9 @@ class ClinkSerialTx(rogue.interfaces.stream.Master):
         self._sendFrame(frame)
 
     def sendString(self,st):
+        print( 'sendString: %s' % st )
+        if st.startswith( '@SN?' ):
+            pdb.set_trace()
         ba = bytearray((len(st)+1)*4)
         i = 0
         for c in st:

--- a/python/surf/protocols/clink/_UartOpal1000.py
+++ b/python/surf/protocols/clink/_UartOpal1000.py
@@ -33,14 +33,16 @@ class UartOpal1000Rx(clink.ClinkSerialRx):
             c = chr(ba[i])
 
             if c == '\n':
-                print("Got Response: {}".format(''.join(self._cur)))
+                print("Got NL Response" )
                 self._cur = []
             elif ba[i] == 0x6:
-                print("Got ACK Response: {}".format(''.join(self._cur)))
+                print("Got ACK Response" )
                 self._cur = []
             elif ba[i] == 0x25:
-                print("Got NAK Response: {}".format(''.join(self._cur)))
+                print("Got NAK Response" )
                 self._cur = []
+            elif c == '\r':
+                print("recvString: {}".format(''.join(self._cur)))
             elif c != '':
                 self._cur.append(c)
 


### PR DESCRIPTION
Camera testing and support is easier if we can see the string being sent and the response.


### Description
Adds a print statement in ClinkSerialTx::sendString() to show the msg being sent.
Also adds support for printing the response after the ACK so we can see response
to queries such as serialNumber, camera model ID, etc.

Example output:
sendString: @ID?
Got ACK Response
recvString: @"OPAL-1000m/CL S/N:135043
