### PR TITLE
adding 185.71 MHz refClk support to pgp3/gthUs for 10.3125 Gb/s

### DIFF
--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -216,8 +216,10 @@ package Pgp3Pkg is
    type Pgp3RefClkType is (
       PGP3_REFCLK_125_C,                -- Used in 6.25Gbps only
       PGP3_REFCLK_156_C,                -- Used in 10.3125Gbps & 6.25Gbps
+      PGP3_REFCLK_186_C,                -- Used in 10.3125Gbps
       PGP3_REFCLK_250_C,                -- Used in 6.25Gbps only
-      PGP3_REFCLK_312_C);               -- Used in 10.3125Gbps & 6.25Gbps
+      PGP3_REFCLK_312_C,                -- Used in 10.3125Gbps & 6.25Gbps
+      PGP3_REFCLK_371_C);               -- Used in 10.3125Gbps
 
 end package Pgp3Pkg;
 

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
@@ -19,25 +19,27 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
+use surf.Pgp3Pkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
 
 entity Pgp3GthUsQpll is
    generic (
-      TPD_G    : time    := 1 ns;
-      RATE_G   : string  := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps" 
-      EN_DRP_G : boolean := true);
+      TPD_G             : time            := 1 ns;
+      REFCLK_TYPE_G     : Pgp3RefClkType  := PGP3_REFCLK_156_C;
+      RATE_G            : string          := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps" 
+      QPLL_REFCLK_SEL_G : slv(2 downto 0) := "001";
+      EN_DRP_G          : boolean         := true);
    port (
       -- Stable Clock and Reset
       stableClk       : in  sl;         -- GT needs a stable clock to "boot up"
       stableRst       : in  sl;
       -- QPLL Clocking
-      pgpRefClk       : in  sl;         -- 156.25 MHz
+      pgpRefClk       : in  sl;         -- REFCLK_TYPE_G
       qpllLock        : out Slv2Array(3 downto 0);
       qpllClk         : out Slv2Array(3 downto 0);
       qpllRefclk      : out Slv2Array(3 downto 0);
@@ -53,8 +55,95 @@ end Pgp3GthUsQpll;
 
 architecture mapping of Pgp3GthUsQpll is
 
-   constant QPLL_CP_C    : slv(9 downto 0) := ite((RATE_G = "10.3125Gbps"), "0000011111", "0111111111");
-   constant QPLL_FBDIV_C : positive        := ite((RATE_G = "10.3125Gbps"), 66, 80);
+   type QpllConfig is record
+      QPLL_CFG0        : slv(15 downto 0);
+      QPLL_CFG1        : slv(15 downto 0);
+      QPLL_CFG1_G3     : slv(15 downto 0);
+      QPLL_CFG2        : slv(15 downto 0);
+      QPLL_CFG2_G3     : slv(15 downto 0);
+      QPLL_CFG3        : slv(15 downto 0);
+      QPLL_CFG4        : slv(15 downto 0);
+      QPLL_CP          : slv(9 downto 0);
+      QPLL_CP_G3       : slv(9 downto 0);
+      QPLL_FBDIV       : natural;
+      QPLL_FBDIV_G3    : natural;
+      QPLL_INIT_CFG0   : slv(15 downto 0);
+      QPLL_INIT_CFG1   : slv(7 downto 0);
+      QPLL_LOCK_CFG    : slv(15 downto 0);
+      QPLL_LOCK_CFG_G3 : slv(15 downto 0);
+      QPLL_LPF         : slv(9 downto 0);
+      QPLL_LPF_G3      : slv(9 downto 0);
+      QPLL_REFCLK_DIV  : natural;
+   end record QpllConfig;
+   constant QPLL_CONFIG_INIT_C : QpllConfig := (
+      QPLL_CFG0        => "0011001000011100",
+      QPLL_CFG1        => "0001000000011000",
+      QPLL_CFG1_G3     => "0001000000011000",
+      QPLL_CFG2        => "0000000001001000",
+      QPLL_CFG2_G3     => "0000000001001000",
+      QPLL_CFG3        => "0000000100100000",
+      QPLL_CFG4        => "0000000000001001",
+      QPLL_CP          => "0000011111",
+      QPLL_CP_G3       => "1111111111",
+      QPLL_FBDIV       => 66,
+      QPLL_FBDIV_G3    => 80,
+      QPLL_INIT_CFG0   => "0000001010110010",
+      QPLL_INIT_CFG1   => "00000000",
+      QPLL_LOCK_CFG    => "0010000111101000",
+      QPLL_LOCK_CFG_G3 => "0010000111101000",
+      QPLL_LPF         => "1111111100",
+      QPLL_LPF_G3      => "0000010101",
+      QPLL_REFCLK_DIV  => 1);
+   function getQpllConfig (refClkType : Pgp3RefClkType; rate : string) return QpllConfig is
+      variable retVar : QpllConfig;
+   begin
+      -- Init
+      retVar := QPLL_CONFIG_INIT_C;
+
+      ----------------------------------------
+      -- Check for 156.25 MHz or 312.5 MHz OSC
+      ----------------------------------------
+      if (refClkType = PGP3_REFCLK_156_C) or (refClkType = PGP3_REFCLK_312_C) then
+
+         -- Check for non-10Gb/s rate
+         if (rate /= "10.3125Gbps") then
+            retVar.QPLL_CP    := "0111111111";
+            retVar.QPLL_FBDIV := 80;
+         end if;
+
+         -- Check for double rate OSC
+         if (refClkType = PGP3_REFCLK_312_C) then
+            retVar.QPLL_REFCLK_DIV := 2;
+         end if;
+
+      ------------------------------------
+      -- Else 185.71 MHz or 371.42 MHz OSC
+      ------------------------------------
+      else
+
+         -- Only support 10.3125 Gb/s
+         assert (rate = "10.3125Gbps")
+            report "Pgp3GthUsQpll.getQpllConfig(): (RATE_G = 10.3125Gbps) condition not meet"
+            severity error;
+
+         -- Init
+         retVar.QPLL_CP    := "0111111111";
+         retVar.QPLL_FBDIV := 111;
+
+         -- Check for OSC Frequency
+         if (refClkType = PGP3_REFCLK_186_C) then
+            retVar.QPLL_REFCLK_DIV := 2;
+         else
+            retVar.QPLL_REFCLK_DIV := 4;
+         end if;
+
+      end if;
+
+      -- Return the configuration
+      return(retVar);
+   end function;
+
+   constant QPLL_CONFIG_C : QpllConfig := getQpllConfig(REFCLK_TYPE_G, RATE_G);
 
    signal pllRefClk     : slv(1 downto 0);
    signal pllOutClk     : slv(1 downto 0);
@@ -72,6 +161,10 @@ begin
 
    assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps") or (RATE_G = "10.3125Gbps"))
       report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
+      severity error;
+
+   assert ((REFCLK_TYPE_G = PGP3_REFCLK_156_C) or (REFCLK_TYPE_G = PGP3_REFCLK_186_C) or (REFCLK_TYPE_G = PGP3_REFCLK_312_C) or (REFCLK_TYPE_G = PGP3_REFCLK_371_C))
+      report "REFCLK_TYPE_G: Must be either PGP3_REFCLK_156_C, PGP3_REFCLK_186_C, PGP3_REFCLK_312_C or PGP3_REFCLK_371_C"
       severity error;
 
    GEN_VEC :
@@ -113,26 +206,26 @@ begin
          -- AXI-Lite Parameters
          EN_DRP_G           => EN_DRP_G,
          -- QPLL Configuration Parameters
-         QPLL_CFG0_G        => (others => x"321C"),
-         QPLL_CFG1_G        => (others => x"1018"),
-         QPLL_CFG1_G3_G     => (others => x"1018"),
-         QPLL_CFG2_G        => (others => x"0048"),
-         QPLL_CFG2_G3_G     => (others => x"0048"),
-         QPLL_CFG3_G        => (others => x"0120"),
-         QPLL_CFG4_G        => (others => x"0009"),
-         QPLL_CP_G          => (others => QPLL_CP_C),
-         QPLL_CP_G3_G       => (others => "1111111111"),
-         QPLL_FBDIV_G       => (others => QPLL_FBDIV_C),
-         QPLL_FBDIV_G3_G    => (others => 80),
-         QPLL_INIT_CFG0_G   => (others => x"02B2"),
-         QPLL_INIT_CFG1_G   => (others => x"00"),
-         QPLL_LOCK_CFG_G    => (others => x"21E8"),
-         QPLL_LOCK_CFG_G3_G => (others => x"21E8"),
-         QPLL_LPF_G         => (others => "1111111100"),
-         QPLL_LPF_G3_G      => (others => "0000010101"),
-         QPLL_REFCLK_DIV_G  => (others => 1),
+         QPLL_CFG0_G        => (others => QPLL_CONFIG_C.QPLL_CFG0),
+         QPLL_CFG1_G        => (others => QPLL_CONFIG_C.QPLL_CFG1),
+         QPLL_CFG1_G3_G     => (others => QPLL_CONFIG_C.QPLL_CFG1_G3),
+         QPLL_CFG2_G        => (others => QPLL_CONFIG_C.QPLL_CFG2),
+         QPLL_CFG2_G3_G     => (others => QPLL_CONFIG_C.QPLL_CFG2_G3),
+         QPLL_CFG3_G        => (others => QPLL_CONFIG_C.QPLL_CFG3),
+         QPLL_CFG4_G        => (others => QPLL_CONFIG_C.QPLL_CFG4),
+         QPLL_CP_G          => (others => QPLL_CONFIG_C.QPLL_CP),
+         QPLL_CP_G3_G       => (others => QPLL_CONFIG_C.QPLL_CP_G3),
+         QPLL_FBDIV_G       => (others => QPLL_CONFIG_C.QPLL_FBDIV),
+         QPLL_FBDIV_G3_G    => (others => QPLL_CONFIG_C.QPLL_FBDIV_G3),
+         QPLL_INIT_CFG0_G   => (others => QPLL_CONFIG_C.QPLL_INIT_CFG0),
+         QPLL_INIT_CFG1_G   => (others => QPLL_CONFIG_C.QPLL_INIT_CFG1),
+         QPLL_LOCK_CFG_G    => (others => QPLL_CONFIG_C.QPLL_LOCK_CFG),
+         QPLL_LOCK_CFG_G3_G => (others => QPLL_CONFIG_C.QPLL_LOCK_CFG_G3),
+         QPLL_LPF_G         => (others => QPLL_CONFIG_C.QPLL_LPF),
+         QPLL_LPF_G3_G      => (others => QPLL_CONFIG_C.QPLL_LPF_G3),
+         QPLL_REFCLK_DIV_G  => (others => QPLL_CONFIG_C.QPLL_REFCLK_DIV),
          -- Clock Selects
-         QPLL_REFCLK_SEL_G  => (others => "001"))
+         QPLL_REFCLK_SEL_G  => (others => QPLL_REFCLK_SEL_G))
       port map (
          qPllRefClk       => pllRefClk,
          qPllOutClk       => pllOutClk,

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
@@ -38,6 +38,8 @@ entity Pgp3GthUsWrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps" 
+      REFCLK_TYPE_G               : Pgp3RefClkType              := PGP3_REFCLK_156_C;
+      QPLL_REFCLK_SEL_G           : slv(2 downto 0)             := "001";
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
       ----------------------------------------------------------------------------------------------
@@ -45,7 +47,7 @@ entity Pgp3GthUsWrapper is
       RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
       PGP_TX_ENABLE_G             : boolean                     := true;
       TX_CELL_WORDS_MAX_G         : integer                     := PGP3_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
-      TX_MUX_MODE_G               : string                      := "INDEXED";      -- Or "ROUTED"
+      TX_MUX_MODE_G               : string                      := "INDEXED";  -- Or "ROUTED"
       TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
       TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
       TX_MUX_ILEAVE_EN_G          : boolean                     := true;
@@ -67,9 +69,9 @@ entity Pgp3GthUsWrapper is
       pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
       pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
       -- GT Clocking
-      pgpRefClkP        : in  sl                                                     := '0';  -- 156.25 MHz
-      pgpRefClkN        : in  sl                                                     := '1';  -- 156.25 MHz
-      pgpRefClkIn       : in  sl                                                     := '0';  -- 156.25 MHz
+      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_TYPE_G
+      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_TYPE_G
+      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_TYPE_G
       pgpRefClkOut      : out sl;
       pgpRefClkDiv2Bufg : out sl;
       -- Clocking
@@ -177,9 +179,11 @@ begin
 
       U_QPLL : entity surf.Pgp3GthUsQpll
          generic map (
-            TPD_G    => TPD_G,
-            RATE_G   => RATE_G,
-            EN_DRP_G => EN_QPLL_DRP_G)
+            TPD_G             => TPD_G,
+            RATE_G            => RATE_G,
+            REFCLK_TYPE_G     => REFCLK_TYPE_G,
+            QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G,
+            EN_DRP_G          => EN_QPLL_DRP_G)
          port map (
             -- Stable Clock and Reset
             stableClk       => stableClk,                            -- [in]


### PR DESCRIPTION
### Description
- Required for `slaclab/l2si-drp` 
- Using the same Pgp3GthUsIp10G IP core as the 156.25 MHz but with different QPLL configurations
