### PR TITLE
missing surf library

### DIFF
--- a/xilinx/7Series/gtx7/rtl/Gtx7AutoPhaseAligner.vhd
+++ b/xilinx/7Series/gtx7/rtl/Gtx7AutoPhaseAligner.vhd
@@ -77,6 +77,8 @@ library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use IEEE.NUMERIC_STD.ALL;
 
+library surf;
+
 entity Gtx7AutoPhaseAligner is     
   Generic( 
            GT_TYPE                  : string  := "GTX"


### PR DESCRIPTION
Added surf library to avoid compilation error. Needed for the surf.Synchronizer.
