### PR TITLE
Clean up SynchronizerOneShot

### DIFF
--- a/base/sync/rtl/SynchronizerOneShot.vhd
+++ b/base/sync/rtl/SynchronizerOneShot.vhd
@@ -22,6 +22,7 @@ use surf.StdRtlPkg.all;
 entity SynchronizerOneShot is
    generic (
       TPD_G          : time     := 1 ns;   -- Simulation FF output delay
+      RST_POLARITY_G : sl       := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       BYPASS_SYNC_G  : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
       IN_POLARITY_G  : sl       := '1';    -- 0 for active LOW, 1 for active HIGH
       OUT_POLARITY_G : sl       := '1';    -- 0 for active LOW, 1 for active HIGH
@@ -29,13 +30,24 @@ entity SynchronizerOneShot is
       PULSE_WIDTH_G  : positive := 1);  -- one-shot pulse width duration (units of clk cycles)
    port (
       clk     : in  sl;                 -- Clock to be SYNC'd to
+      rst     : in  sl := not RST_POLARITY_G;  --Optional reset
       dataIn  : in  sl;                 -- Trigger to be sync'd
       dataOut : out sl);                -- synced one-shot pulse
 end SynchronizerOneShot;
 
 architecture rtl of SynchronizerOneShot is
 
-   constant NOT_OUT_POLARITY_C : sl := not OUT_POLARITY_G;
+   type RegType is record
+      dataOut : sl;
+      counter : integer range 0 to PULSE_WIDTH_G;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      dataOut => '0',
+      counter => 0);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
    signal pulseRst : sl;
    signal edgeDet  : sl;
@@ -70,6 +82,7 @@ begin
          BYPASS_SYNC_G  => BYPASS_SYNC_G)
       port map (
          clk        => clk,
+         rst        => rst,
          dataIn     => pulseRst,
          risingEdge => edgeDet);
 
@@ -82,20 +95,44 @@ begin
       -- Strech the pulse using a simple synchronously reset register chain
       -- Using PULSE_WIDTH_G > 1 will incur 1 extra cycle of OUT_DELAY_G
 
-      U_Synchronizer_1 : entity surf.Synchronizer
-         generic map (
-            TPD_G          => TPD_G,
-            RST_POLARITY_G => OUT_POLARITY_G
-            OUT_POLARITY_G => OUT_POLARITY_G,
-            RST_ASYNC_G    => false,
-            STAGES_G       => PULSE_WIDTH_G,
-            BYPASS_SYNC_G  => false,
-            INIT_G         => OUT_POLARITY_G)
-         port map (
-            clk     => clk,                 -- [in]
-            rst     => edgeDet,             -- [in]
-            dataIn  => NOT_OUT_POLARITY_C,  -- [in]
-            dataOut => dataOut);            -- [out]
+      comb : process (edgeDet, r, rst) is
+         variable v : RegType;
+      begin
+         v := r;
+
+         -- Assert output and start counting when edge seen
+         if (edgeDet = OUT_POLARITY_G) then
+            v.dataOut := OUT_POLARITY_G;
+            v.counter := r.counter + 1;
+         end if;
+
+         -- Keep counting
+         if (r.dataOut = OUT_POLARITY_G) then
+            v.counter := r.counter + 1;
+         end if;
+
+         -- Stop counting when PULSE_WIDTH_G counter to
+         if (r.counter = PULSE_WIDTH_G) then
+            v.dataOut := not OUT_POLARITY_G;
+            v.counter := 0;
+         end if;
+
+         if (rst = RST_POLARITY_G) then
+            v := REG_INIT_C;
+         end if;
+
+         rin <= v;
+
+         dataOut <= r.dataOut;
+
+      end process comb;
+
+      seq : process (clk) is
+      begin
+         if (rising_edge(clk)) then
+            r <= rin after TPD_G;
+         end if;
+      end process seq;
 
    end generate;
 

--- a/base/sync/rtl/SynchronizerOneShot.vhd
+++ b/base/sync/rtl/SynchronizerOneShot.vhd
@@ -57,6 +57,8 @@ architecture rtl of SynchronizerOneShot is
 
 begin
 
+   assert (OUT_DELAY_G >= 3) report "SynchronizerOneShot: OUT_DELAY_G must be >= 3" severity failure;
+
    GEN_SYNC : if (BYPASS_SYNC_G = true) generate
       pulseRst <= dataIn when(IN_POLARITY_G = '1') else not(dataIn);
    end generate;

--- a/base/sync/rtl/SynchronizerOneShot.vhd
+++ b/base/sync/rtl/SynchronizerOneShot.vhd
@@ -21,40 +21,21 @@ use surf.StdRtlPkg.all;
 
 entity SynchronizerOneShot is
    generic (
-      TPD_G           : time     := 1 ns;   -- Simulation FF output delay
-      RST_POLARITY_G  : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G     : boolean  := false;  -- Reset is asynchronous
-      BYPASS_SYNC_G   : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
-      RELEASE_DELAY_G : positive := 3;  -- Delay between deassertion of async and sync resets
-      IN_POLARITY_G   : sl       := '1';  -- 0 for active LOW, 1 for active HIGH
-      OUT_POLARITY_G  : sl       := '1';  -- 0 for active LOW, 1 for active HIGH
-      PULSE_WIDTH_G   : positive := 1);  -- one-shot pulse width duration (units of clk cycles)
+      TPD_G          : time     := 1 ns;   -- Simulation FF output delay
+      BYPASS_SYNC_G  : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
+      IN_POLARITY_G  : sl       := '1';    -- 0 for active LOW, 1 for active HIGH
+      OUT_POLARITY_G : sl       := '1';    -- 0 for active LOW, 1 for active HIGH
+      OUT_DELAY_G    : positive := 3;   -- Stages in output sync chain
+      PULSE_WIDTH_G  : positive := 1);  -- one-shot pulse width duration (units of clk cycles)
    port (
       clk     : in  sl;                 -- Clock to be SYNC'd to
-      rst     : in  sl := not RST_POLARITY_G;  -- Optional reset
       dataIn  : in  sl;                 -- Trigger to be sync'd
       dataOut : out sl);                -- synced one-shot pulse
 end SynchronizerOneShot;
 
 architecture rtl of SynchronizerOneShot is
 
-   type StateType is (
-      IDLE_S,
-      CNT_S);
-
-   type RegType is record
-      cnt     : natural range 0 to (PULSE_WIDTH_G-1);
-      dataOut : sl;
-      state   : StateType;
-   end record RegType;
-
-   constant REG_INIT_C : RegType := (
-      cnt     => 0,
-      dataOut => not(OUT_POLARITY_G),
-      state   => IDLE_S);
-
-   signal r   : RegType := REG_INIT_C;
-   signal rin : RegType;
+   constant NOT_OUT_POLARITY_C : sl := not OUT_POLARITY_G;
 
    signal pulseRst : sl;
    signal edgeDet  : sl;
@@ -71,10 +52,9 @@ begin
    GEN_ASYNC : if (BYPASS_SYNC_G = false) generate
       RstSync_Inst : entity surf.RstSync
          generic map (
-            TPD_G           => TPD_G,
-            RELEASE_DELAY_G => RELEASE_DELAY_G,
-            IN_POLARITY_G   => IN_POLARITY_G,
-            OUT_POLARITY_G  => '1')
+            TPD_G          => TPD_G,
+            IN_POLARITY_G  => IN_POLARITY_G,
+            OUT_POLARITY_G => '1')
          port map (
             clk      => clk,
             asyncRst => dataIn,
@@ -86,7 +66,7 @@ begin
          TPD_G          => TPD_G,
          RST_POLARITY_G => RST_POLARITY_G,
          OUT_POLARITY_G => OUT_POLARITY_G,
-         RST_ASYNC_G    => RST_ASYNC_G,
+         STAGES_G       => OUT_DELAY_G,
          BYPASS_SYNC_G  => BYPASS_SYNC_G)
       port map (
          clk        => clk,
@@ -97,61 +77,25 @@ begin
       dataOut <= edgeDet;
    end generate;
 
+
    U_PulseStretcher : if (PULSE_WIDTH_G > 1) generate
+      -- Strech the pulse using a simple synchronously reset register chain
+      -- Using PULSE_WIDTH_G > 1 will incur 1 extra cycle of OUT_DELAY_G
 
-      comb : process (edgeDet, r, rst) is
-         variable v : RegType;
-      begin
-         -- Latch the current value
-         v := r;
-
-         -- State Machine
-         case r.state is
-            ----------------------------------------------------------------------   
-            when IDLE_S =>
-               -- Reset the flag
-               v.dataOut := not(OUT_POLARITY_G);
-               -- Check for edge detection
-               if (edgeDet = OUT_POLARITY_G) then
-                  -- Next state
-                  v.state := CNT_S;
-               end if;
-            ----------------------------------------------------------------------   
-            when CNT_S =>
-               -- Set the flag
-               v.dataOut := OUT_POLARITY_G;
-               -- Check the counter
-               if r.cnt = (PULSE_WIDTH_G-1) then
-                  -- Reset the counter
-                  v.cnt   := 0;
-                  -- Next state
-                  v.state := IDLE_S;
-               else
-                  -- Increment the counter
-                  v.cnt := r.cnt + 1;
-               end if;
-         ----------------------------------------------------------------------   
-         end case;
-
-         -- Combinatorial outputs before the reset
-         dataOut <= v.dataOut;
-
-         -- Reset
-         if (rst = RST_POLARITY_G) then
-            v := REG_INIT_C;
-         end if;
-
-         -- Register the variable for next clock cycle
-         rin <= v;
-
-      end process;
-
-      seq : process (clk) is
-      begin
-         if rising_edge(clk) then
-            r <= rin after TPD_G;
-         end if;
-      end process seq;
+      U_Synchronizer_1 : entity surf.Synchronizer
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => OUT_POLARITY_G
+            OUT_POLARITY_G => OUT_POLARITY_G,
+            RST_ASYNC_G    => false,
+            STAGES_G       => PULSE_WIDTH_G,
+            BYPASS_SYNC_G  => false,
+            INIT_G         => OUT_POLARITY_G)
+         port map (
+            clk     => clk,                 -- [in]
+            rst     => edgeDet,             -- [in]
+            dataIn  => NOT_OUT_POLARITY_C,  -- [in]
+            dataOut => dataOut);            -- [out]
 
    end generate;
 

--- a/base/sync/rtl/SynchronizerOneShot.vhd
+++ b/base/sync/rtl/SynchronizerOneShot.vhd
@@ -22,6 +22,7 @@ use surf.StdRtlPkg.all;
 entity SynchronizerOneShot is
    generic (
       TPD_G          : time     := 1 ns;   -- Simulation FF output delay
+      RST_ASYNC_G    : boolean  := false;
       RST_POLARITY_G : sl       := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       BYPASS_SYNC_G  : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
       IN_POLARITY_G  : sl       := '1';    -- 0 for active LOW, 1 for active HIGH
@@ -80,6 +81,7 @@ begin
          TPD_G          => TPD_G,
          RST_POLARITY_G => RST_POLARITY_G,
          OUT_POLARITY_G => OUT_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
          STAGES_G       => OUT_DELAY_G,
          BYPASS_SYNC_G  => BYPASS_SYNC_G)
       port map (
@@ -119,7 +121,7 @@ begin
             v.counter := 0;
          end if;
 
-         if (rst = RST_POLARITY_G) then
+         if (RST_ASYNC_G and rst = RST_POLARITY_G) then
             v := REG_INIT_C;
          end if;
 
@@ -129,10 +131,14 @@ begin
 
       end process comb;
 
-      seq : process (clk) is
+      seq : process (clk, rst) is
       begin
          if (rising_edge(clk)) then
             r <= rin after TPD_G;
+         end if;
+
+         if (RST_ASYNC_G and rst = RST_POLARITY_G) then
+            r <= REG_INIT_C after TPD_G;
          end if;
       end process seq;
 

--- a/base/sync/rtl/SynchronizerOneShotCnt.vhd
+++ b/base/sync/rtl/SynchronizerOneShotCnt.vhd
@@ -23,31 +23,29 @@ use surf.StdRtlPkg.all;
 
 entity SynchronizerOneShotCnt is
    generic (
-      TPD_G           : time     := 1 ns; -- Simulation FF output delay
+      TPD_G           : time     := 1 ns;  -- Simulation FF output delay
       RST_POLARITY_G  : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G     : boolean  := false;-- true if reset is asynchronous, false if reset is synchronous
-      COMMON_CLK_G    : boolean  := false;-- True if wrClk and rdClk are the same clock
-      RELEASE_DELAY_G : positive := 3;    -- Delay between deassertion of async and sync resets
+      RST_ASYNC_G     : boolean  := false;  -- true if reset is asynchronous, false if reset is synchronous
+      COMMON_CLK_G    : boolean  := false;  -- True if wrClk and rdClk are the same clock
+      RELEASE_DELAY_G : positive := 3;  -- Delay between deassertion of async and sync resets
       IN_POLARITY_G   : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (dataIn port)
       OUT_POLARITY_G  : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (dataOut port)
-      USE_DSP_G       : string   := "no"; -- "no" for no DSP implementation, "yes" to use DSP slices
+      USE_DSP_G       : string   := "no";  -- "no" for no DSP implementation, "yes" to use DSP slices
       SYNTH_CNT_G     : sl       := '1';  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter
-      CNT_RST_EDGE_G  : boolean  := true; -- true if counter reset should be edge detected, else level detected
+      CNT_RST_EDGE_G  : boolean  := true;  -- true if counter reset should be edge detected, else level detected
       CNT_WIDTH_G     : positive := 16);
    port (
-      -- Write Ports (wrClk domain)    
-      dataIn     : in  sl;                         -- trigger to be sync'd
-      -- Read Ports (rdClk domain)    
-      rollOverEn : in  sl;                         -- '1' allows roll over of the counter
-      cntRst     : in  sl := not RST_POLARITY_G;   -- Optional counter reset
-      dataOut    : out sl;                         -- synced one-shot pulse
-      cntOut     : out slv(CNT_WIDTH_G-1 downto 0);-- synced counter
-      -- Clocks and Reset Ports
+      -- Write Ports (wrClk domain)
       wrClk      : in  sl;
       wrRst      : in  sl := not RST_POLARITY_G;
-      rdClk      : in  sl;                         -- clock to be SYNC'd to
-      rdRst      : in  sl := not RST_POLARITY_G);   
-begin
+      dataIn     : in  sl;              -- trigger to be sync'd
+      -- Read Ports (rdClk domain)
+      rdClk      : in  sl;              -- clock to be SYNC'd to
+      rdRst      : in  sl := not RST_POLARITY_G;
+      rollOverEn : in  sl;              -- '1' allows roll over of the counter
+      cntRst     : in  sl := not RST_POLARITY_G;      -- Optional counter reset
+      dataOut    : out sl;              -- synced one-shot pulse
+      cntOut     : out slv(CNT_WIDTH_G-1 downto 0));  -- synced counter
 
 end SynchronizerOneShotCnt;
 
@@ -59,31 +57,33 @@ architecture rtl of SynchronizerOneShotCnt is
       dataInDly : sl;
       cntOut    : slv(CNT_WIDTH_G-1 downto 0);
    end record RegType;
+
    constant REG_INIT_C : RegType := (
-      not(IN_POLARITY_G),
-      (others => '0'));
-   signal r   : RegType := REG_INIT_C;
-   signal rin : RegType;
-   signal syncRst,
-      cntRstSync,
-      rollOverEnSync : sl;
-   signal cntOutSync : slv(CNT_WIDTH_G-1 downto 0);
+      dataInDly => not(IN_POLARITY_G),
+      cntOut    => (others => '0'));
+
+   signal r              : RegType := REG_INIT_C;
+   signal rin            : RegType;
+   
+   signal syncRst        : sl;
+   signal cntRstSync     : sl;
+   signal rollOverEnSync : sl;
+   signal cntOutSync     : slv(CNT_WIDTH_G-1 downto 0);
 
    -- Attribute for XST
    attribute use_dsp      : string;
    attribute use_dsp of r : signal is USE_DSP_G;
-   
+
 begin
 
    SyncOneShot_0 : entity surf.SynchronizerOneShot
       generic map (
-         TPD_G             => TPD_G,
-         RST_POLARITY_G    => RST_POLARITY_G,
-         RST_ASYNC_G       => RST_ASYNC_G,
-         BYPASS_SYNC_G     => COMMON_CLK_G,
-         RELEASE_DELAY_G   => RELEASE_DELAY_G,
-         IN_POLARITY_G     => IN_POLARITY_G,
-         OUT_POLARITY_G    => OUT_POLARITY_G)      
+         TPD_G           => TPD_G,
+         RST_POLARITY_G  => RST_POLARITY_G,
+         RST_ASYNC_G     => RST_ASYNC_G,
+         BYPASS_SYNC_G   => COMMON_CLK_G,
+         IN_POLARITY_G   => IN_POLARITY_G,
+         OUT_POLARITY_G  => OUT_POLARITY_G)
       port map (
          clk     => rdClk,
          rst     => rdRst,
@@ -91,16 +91,15 @@ begin
          dataOut => dataOut);
 
    CNT_RST_EDGE : if (CNT_RST_EDGE_G = true) generate
-      
+
       SyncOneShot_1 : entity surf.SynchronizerOneShot
          generic map (
-            TPD_G             => TPD_G,
-            RST_POLARITY_G    => RST_POLARITY_G,
-            RST_ASYNC_G       => RST_ASYNC_G,
-            BYPASS_SYNC_G     => COMMON_CLK_G,
-            RELEASE_DELAY_G   => RELEASE_DELAY_G,
-            IN_POLARITY_G     => RST_POLARITY_G,
-            OUT_POLARITY_G    => RST_POLARITY_G)      
+            TPD_G           => TPD_G,
+            RST_POLARITY_G  => RST_POLARITY_G,
+            RST_ASYNC_G     => RST_ASYNC_G,
+            BYPASS_SYNC_G   => COMMON_CLK_G,
+            IN_POLARITY_G   => RST_POLARITY_G,
+            OUT_POLARITY_G  => RST_POLARITY_G)
          port map (
             clk     => wrClk,
             rst     => wrRst,
@@ -110,7 +109,7 @@ begin
    end generate;
 
    CNT_RST_LEVEL : if (CNT_RST_EDGE_G = false) generate
-      
+
       Synchronizer_0 : entity surf.Synchronizer
          generic map (
             TPD_G          => TPD_G,
@@ -118,12 +117,12 @@ begin
             OUT_POLARITY_G => '1',
             RST_ASYNC_G    => RST_ASYNC_G,
             BYPASS_SYNC_G  => COMMON_CLK_G,
-            STAGES_G       => (RELEASE_DELAY_G-1))      
+            STAGES_G       => (RELEASE_DELAY_G-1))
          port map (
             clk     => wrClk,
             rst     => wrRst,
             dataIn  => cntRst,
-            dataOut => cntRstSync);       
+            dataOut => cntRstSync);
 
    end generate;
 
@@ -133,18 +132,18 @@ begin
          RST_POLARITY_G => RST_POLARITY_G,
          OUT_POLARITY_G => '1',
          RST_ASYNC_G    => RST_ASYNC_G,
-         BYPASS_SYNC_G  => COMMON_CLK_G,         
-         STAGES_G       => (RELEASE_DELAY_G-1))      
+         BYPASS_SYNC_G  => COMMON_CLK_G,
+         STAGES_G       => (RELEASE_DELAY_G-1))
       port map (
          clk     => wrClk,
          rst     => wrRst,
          dataIn  => rollOverEn,
-         dataOut => rollOverEnSync);   
+         dataOut => rollOverEnSync);
 
    BYPASS_CNT : if (SYNTH_CNT_G = '0') generate
-      
+
       cntOut <= (others => '0');
-      
+
    end generate;
 
    GEN_CNT : if (SYNTH_CNT_G = '1') generate
@@ -187,8 +186,8 @@ begin
 
          -- Sync Reset
          if (RST_ASYNC_G = false and wrRst = RST_POLARITY_G) then
-            v.cntOut      := (others => '0');
-            v.dataInDly   := dataIn;  -- prevent accidental edge detection
+            v.cntOut    := (others => '0');
+            v.dataInDly := dataIn;      -- prevent accidental edge detection
          end if;
 
          -- Register the variable for next clock cycle
@@ -196,7 +195,7 @@ begin
 
          -- Outputs
          cntOutSync <= r.cntOut;
-         
+
       end process comb;
 
       seq : process (dataIn, wrClk, wrRst) is
@@ -225,8 +224,8 @@ begin
             din    => cntOutSync,
             --Read Ports (rd_clk domain)
             rd_clk => rdClk,
-            dout   => cntOut);      
+            dout   => cntOut);
 
    end generate;
-   
+
 end architecture rtl;

--- a/base/sync/rtl/SynchronizerOneShotCntVector.vhd
+++ b/base/sync/rtl/SynchronizerOneShotCntVector.vhd
@@ -35,18 +35,18 @@ entity SynchronizerOneShotCntVector is
       CNT_WIDTH_G     : positive := 16;
       WIDTH_G         : positive := 16);
    port (
-      -- Write Ports (wrClk domain)    
-      dataIn     : in  slv(WIDTH_G-1 downto 0);  -- Data to be 'synced'
-      -- Read Ports (rdClk domain)    
-      rollOverEn : in  slv(WIDTH_G-1 downto 0);  -- '1' allows roll over of the counter
-      cntRst     : in  sl := not RST_POLARITY_G;  -- Optional counter reset
-      dataOut    : out slv(WIDTH_G-1 downto 0);  -- Synced data
-      cntOut     : out SlVectorArray(WIDTH_G-1 downto 0, CNT_WIDTH_G-1 downto 0);  -- Synced counter
-      -- Clocks and Reset Ports
+
+      -- Write Ports (wrClk domain)          
       wrClk      : in  sl;
       wrRst      : in  sl := not RST_POLARITY_G;
+      dataIn     : in  slv(WIDTH_G-1 downto 0);   -- Data to be 'synced'
+      -- Read Ports (rdClk domain)
       rdClk      : in  sl;              -- clock to be SYNC'd to
-      rdRst      : in  sl := not RST_POLARITY_G);
+      rdRst      : in  sl := not RST_POLARITY_G;
+      rollOverEn : in  slv(WIDTH_G-1 downto 0);   -- '1' allows roll over of the counter
+      cntRst     : in  sl := not RST_POLARITY_G;  -- Optional counter reset
+      dataOut    : out slv(WIDTH_G-1 downto 0);   -- Synced data
+      cntOut     : out SlVectorArray(WIDTH_G-1 downto 0, CNT_WIDTH_G-1 downto 0));  -- Synced counter
 end SynchronizerOneShotCntVector;
 
 architecture rtl of SynchronizerOneShotCntVector is
@@ -99,7 +99,6 @@ begin
             RST_POLARITY_G  => RST_POLARITY_G,
             RST_ASYNC_G     => RST_ASYNC_G,
             BYPASS_SYNC_G   => COMMON_CLK_G,
-            RELEASE_DELAY_G => RELEASE_DELAY_G,
             IN_POLARITY_G   => IN_POLARITY_C(i),
             OUT_POLARITY_G  => OUT_POLARITY_C(i))
          port map (
@@ -113,7 +112,7 @@ begin
             TPD_G           => TPD_G,
             RST_POLARITY_G  => RST_POLARITY_G,
             RST_ASYNC_G     => RST_ASYNC_G,
-            COMMON_CLK_G    => true,  -- status counter bus synchronization done outside
+            COMMON_CLK_G    => true,    -- status counter bus synchronization done outside
             RELEASE_DELAY_G => RELEASE_DELAY_G,
             IN_POLARITY_G   => IN_POLARITY_C(i),
             OUT_POLARITY_G  => OUT_POLARITY_C(i),
@@ -132,7 +131,7 @@ begin
             -- Clocks and Reset Ports
             wrClk      => wrClk,
             wrRst      => wrRst,
-            rdClk      => wrClk,  -- status counter bus synchronization done outside
+            rdClk      => wrClk,        -- status counter bus synchronization done outside
             rdRst      => wrRst);
 
       GEN_MAP :

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
@@ -577,26 +577,7 @@ begin
       locTxData   <= r.locData;
    end generate;
 
-   -- Flush Sync
---    U_TxFlushSync : entity surf.SynchronizerOneShot
---       generic map (
---          TPD_G         => TPD_G,
---          PULSE_WIDTH_G => 10)
---       port map (
---          clk     => pgpTxClk,
---          dataIn  => r.flush,
---          dataOut => txFlush);
    txFlush <= r.flush;
-
-   -- Flush Sync
---    U_TxResetSync : entity surf.SynchronizerOneShot
---       generic map (
---          TPD_G         => TPD_G,
---          PULSE_WIDTH_G => 10)
---       port map (
---          clk     => pgpTxClk,
---          dataIn  => r.resetTx,
---          dataout => txReset);
    txReset <= r.resetTx;
 
 
@@ -613,29 +594,7 @@ begin
    -------------------------------------
    -- Rx Control Sync
    -------------------------------------
-
-   -- Flush Sync
---    U_RxFlushSync : entity surf.SynchronizerOneShot
---       generic map (
---          TPD_G         => TPD_G,
---          PULSE_WIDTH_G => 10)
---       port map (
---          clk     => pgpRxClk,
---          dataIn  => r.flush,
---          dataOut => rxFlush);
-
    rxFlush <= r.flush;
-
-   -- Reset Rx Sync
---    U_ResetRxSync : entity surf.SynchronizerOneShot
---       generic map (
---          TPD_G         => TPD_G,
---          PULSE_WIDTH_G => 10)
---       port map (
---          clk     => pgpRxClk,
---          dataIn  => r.resetRx,
---          dataOut => rxReset);
-
    rxReset <= r.resetRx;
 
    -- Set rx input

--- a/protocols/pgp/pgp2b/gthUltraScale+/rtl/Pgp2bGthUltra.vhd
+++ b/protocols/pgp/pgp2b/gthUltraScale+/rtl/Pgp2bGthUltra.vhd
@@ -77,12 +77,12 @@ entity Pgp2bGthUltra is
       pgpRxMasterMuxed : out AxiStreamMasterType;
       pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0);
       -- AXI-Lite DRP interface
-      axilClk         : in  sl                     := '0';
-      axilRst         : in  sl                     := '0';
-      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
-      axilReadSlave   : out AxiLiteReadSlaveType;
-      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
-      axilWriteSlave  : out AxiLiteWriteSlaveType);
+      axilClk          : in  sl                               := '0';
+      axilRst          : in  sl                               := '0';
+      axilReadMaster   : in  AxiLiteReadMasterType            := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave    : out AxiLiteReadSlaveType;
+      axilWriteMaster  : in  AxiLiteWriteMasterType           := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave   : out AxiLiteWriteSlaveType);
 end Pgp2bGthUltra;
 
 architecture mapping of Pgp2bGthUltra is
@@ -110,47 +110,47 @@ begin
    pgpTxResetDone <= phyTxReady;
    pgpRxResetDone <= phyRxReady;
 
-   U_RstSync_1 : entity surf.SynchronizerOneShot
+   U_RstSync_1 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpTxIn.resetGt,    -- [in]
-         dataOut => resetGtSync);       -- [out]
+         arst   => pgpTxIn.resetGt,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => resetGtSync);        -- [out]
 
    gtHardReset <= resetGtSync or stableRst;
 
-   U_RstSync_4 : entity surf.SynchronizerOneShot
+   U_RstSync_4 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 12500000)
+         TPD_G      => TPD_G,
+         DURATION_G => 12500000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => phyRxInit,          -- [in]
-         dataOut => phyRxInitSync);     -- [out]
+         arst   => phyRxInit,           -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => phyRxInitSync);      -- [out]
 
 
    -- Sync pgpRxIn.rxReset to stableClk and tie to gtRxUserReset
-   U_RstSync_2 : entity surf.SynchronizerOneShot
+   U_RstSync_2 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpRxIn.resetRx,    -- [in]
-         dataOut => resetRxSync);       -- [out]
+         arst   => pgpRxIn.resetRx,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => resetRxSync);        -- [out]
 
    gtRxUserReset <= phyRxInitSync or resetRxSync;
 
-   U_RstSync_3 : entity surf.SynchronizerOneShot
+   U_RstSync_3 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpTxIn.resetTx,    -- [in]
-         dataOut => gtTxUserReset);     -- [out]
+         arst   => pgpTxIn.resetTx,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => gtTxUserReset);      -- [out]
 
    U_Pgp2bLane : entity surf.Pgp2bLane
       generic map (
@@ -186,7 +186,7 @@ begin
    --------------------------
    PgpGthCoreWrapper_1 : entity surf.PgpGthCoreWrapper
       generic map (
-         TPD_G             => TPD_G)
+         TPD_G => TPD_G)
       port map (
          stableClk       => stableClk,
          stableRst       => gtHardReset,

--- a/protocols/pgp/pgp2b/gthUltraScale/rtl/Pgp2bGthUltra.vhd
+++ b/protocols/pgp/pgp2b/gthUltraScale/rtl/Pgp2bGthUltra.vhd
@@ -77,12 +77,12 @@ entity Pgp2bGthUltra is
       pgpRxMasterMuxed : out AxiStreamMasterType;
       pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0);
       -- AXI-Lite DRP interface
-      axilClk         : in  sl                     := '0';
-      axilRst         : in  sl                     := '0';
-      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
-      axilReadSlave   : out AxiLiteReadSlaveType;
-      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
-      axilWriteSlave  : out AxiLiteWriteSlaveType);
+      axilClk          : in  sl                               := '0';
+      axilRst          : in  sl                               := '0';
+      axilReadMaster   : in  AxiLiteReadMasterType            := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave    : out AxiLiteReadSlaveType;
+      axilWriteMaster  : in  AxiLiteWriteMasterType           := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave   : out AxiLiteWriteSlaveType);
 end Pgp2bGthUltra;
 
 architecture mapping of Pgp2bGthUltra is
@@ -110,47 +110,47 @@ begin
    pgpTxResetDone <= phyTxReady;
    pgpRxResetDone <= phyRxReady;
 
-   U_RstSync_1 : entity surf.SynchronizerOneShot
+   U_RstSync_1 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpTxIn.resetGt,    -- [in]
-         dataOut => resetGtSync);       -- [out]
+         arst   => pgpTxIn.resetGt,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => resetGtSync);        -- [out]
 
    gtHardReset <= resetGtSync or stableRst;
 
-   U_RstSync_4 : entity surf.SynchronizerOneShot
+   U_RstSync_4 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 12500000)
+         TPD_G      => TPD_G,
+         DURATION_G => 12500000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => phyRxInit,          -- [in]
-         dataOut => phyRxInitSync);     -- [out]
+         arst   => phyRxInit,           -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => phyRxInitSync);      -- [out]
 
 
    -- Sync pgpRxIn.rxReset to stableClk and tie to gtRxUserReset
-   U_RstSync_2 : entity surf.SynchronizerOneShot
+   U_RstSync_2 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpRxIn.resetRx,    -- [in]
-         dataOut => resetRxSync);       -- [out]
+         arst   => pgpRxIn.resetRx,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => resetRxSync);        -- [out]
 
    gtRxUserReset <= phyRxInitSync or resetRxSync;
 
-   U_RstSync_3 : entity surf.SynchronizerOneShot
+   U_RstSync_3 : entity surf.PwrUpRst
       generic map (
-         TPD_G         => TPD_G,
-         PULSE_WIDTH_G => 125000000)
+         TPD_G      => TPD_G,
+         DURATION_G => 125000000)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => pgpTxIn.resetTx,    -- [in]
-         dataOut => gtTxUserReset);     -- [out]
+         arst   => pgpTxIn.resetTx,     -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => gtTxUserReset);      -- [out]
 
    U_Pgp2bLane : entity surf.Pgp2bLane
       generic map (
@@ -186,7 +186,7 @@ begin
    --------------------------
    PgpGthCoreWrapper_1 : entity surf.PgpGthCoreWrapper
       generic map (
-         TPD_G             => TPD_G)
+         TPD_G => TPD_G)
       port map (
          stableClk       => stableClk,
          stableRst       => gtHardReset,

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -222,16 +222,16 @@ begin
    -------------------------------------------------------------------------------------------------
    -- Oneshot the phy init because clock may drop out and leave it stuck high
    -------------------------------------------------------------------------------------------------
-   U_SynchronizerOneShot_1 : entity surf.SynchronizerOneShot
+   U_SynchronizerOneShot_1 : entity surf.PwrUpRst
       generic map (
          TPD_G          => TPD_G,
          IN_POLARITY_G  => '1',
          OUT_POLARITY_G => '1',
-         PULSE_WIDTH_G  => 100)
+         DURATION_G     => 100)
       port map (
-         clk     => stableClk,          -- [in]
-         dataIn  => phyRxInit,          -- [in]
-         dataOut => gtRxUserReset);     -- [out]
+         arst   => phyRxInit,           -- [in]
+         clk    => stableClk,           -- [in]
+         rstOut => gtRxUserReset);      -- [out]
 
    --------------------------------------------------------------------------------------------------
    -- Rx Data Path

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -222,7 +222,7 @@ begin
    -------------------------------------------------------------------------------------------------
    -- Oneshot the phy init because clock may drop out and leave it stuck high
    -------------------------------------------------------------------------------------------------
-   U_SynchronizerOneShot_1 : entity surf.PwrUpRst
+   U_PwrUpRst : entity surf.PwrUpRst
       generic map (
          TPD_G          => TPD_G,
          IN_POLARITY_G  => '1',


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

A code-breaking cleanup of `SynchronizerOneShot`.

The part that might break existing code is the removal of generics. Simply cutting them from any instantiation should fix it.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
 - Fixed `rst` input and `RST_ASYNC_G` generic
   -  `rst` was not being driven to the SynchronizerEdge.
   - Pulse stretch logic did not obey `RST_ASYC_G`.
 - Removed `RELEASE_DELAY_G` generic
    - Was applied to a `RstSync` attached to an edge detector. 
    - In that setup, the release delay of `RstSync` doesn't matter, since we're only looking at the edge.
 - Added `OUT_DELAY_G` generic
   - Allows the output pulse to be delayed by a configurable number of clock cycles.
   - Must be >= 3 because the internal `SynchronizerEdge` is used to do the delay.
 - Optimized pulse stretch logic
   - No longer driven by combinatorial output. 
   - No more state machine. Just looks at the state of r.dataOut to determine if it should be counting.

#### Misc
 - Changed some `SynchronizerOneShot` instances to `PwrUpRst` which is more appropriate to use.
 - Port declaration of `SynchronizerOneShotCnt` and `SynchronizerOneShotCntVector` rearranged according to clock domains.