### PR TITLE
SRPv0 Updates

### DIFF
--- a/axi/axi-stream/tb/AxiStreamMuxTb.vhd
+++ b/axi/axi-stream/tb/AxiStreamMuxTb.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Simulation Testbed for testing the SsiFifo module
+-- Description: Simulation Testbed for testing the AxiStreamMux module
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the 
@@ -188,36 +188,6 @@ begin
          -- Master
          mAxisMaster  => obMaster,
          mAxisSlave   => obSlave);
-
---    SsiFifo_Inst : entity surf.SsiFifo
---       generic map (
---          -- General Configurations
---          TPD_G               => TPD_C,
---          PIPE_STAGES_G       => AXI_PIPE_STAGES_C,
---          VALID_THOLD_G       => 1,
---          -- FIFO configurations
---          MEMORY_TYPE_G       => MEMORY_TYPE_C,
---          GEN_SYNC_FIFO_G     => false,
---          CASCADE_SIZE_G      => CASCADE_SIZE_C,
---          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_C,
---          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_C,
---          -- AXI Stream Port Configurations
---          SLAVE_AXI_CONFIG_G  => AXI_STREAM_CONFIG_C,
---          MASTER_AXI_CONFIG_G => AXI_STREAM_CONFIG_C)
---       port map (
---          -- Slave Port
---          sAxisClk       => fastClk,
---          sAxisRst       => fastRst,
---          sAxisMaster    => obMaster,
---          sAxisSlave     => obSlave,
---          sAxisCtrl      => open,
---          sAxisDropWord  => dropWrite,
---          sAxisDropFrame => dropFrame,
---          -- Master Port
---          mAxisClk       => slowClk,
---          mAxisRst       => slowRst,
---          mAxisMaster    => ibMaster,
---          mAxisSlave     => ibSlave);
 
    process(fastClk)
    begin

--- a/base/sync/rtl/SynchronizerOneShotCntVector.vhd
+++ b/base/sync/rtl/SynchronizerOneShotCntVector.vhd
@@ -101,7 +101,7 @@ begin
             RST_POLARITY_G    => RST_POLARITY_G,
             RST_ASYNC_G       => RST_ASYNC_G,
             BYPASS_SYNC_G     => COMMON_CLK_G,
-            RELEASE_DELAY_G   => RELEASE_DELAY_G,
+            OUT_DELAY_G       => RELEASE_DELAY_G,
             IN_POLARITY_G     => RST_POLARITY_G,
             OUT_POLARITY_G    => RST_POLARITY_G)      
          port map (

--- a/base/sync/rtl/SynchronizerOneShotVector.vhd
+++ b/base/sync/rtl/SynchronizerOneShotVector.vhd
@@ -69,7 +69,7 @@ begin
             RST_POLARITY_G  => RST_POLARITY_G,
             RST_ASYNC_G     => RST_ASYNC_G,
             BYPASS_SYNC_G   => BYPASS_SYNC_G,
-            RELEASE_DELAY_G => RELEASE_DELAY_G,
+            OUT_DELAY_G     => RELEASE_DELAY_G,
             IN_POLARITY_G   => IN_POLARITY_C(i),
             OUT_POLARITY_G  => OUT_POLARITY_C(i),
             PULSE_WIDTH_G   => PULSE_WIDTH_G)      

--- a/base/sync/tb/SynchronizerOneShotTb.vhd
+++ b/base/sync/tb/SynchronizerOneShotTb.vhd
@@ -53,7 +53,7 @@ begin
          RST_POLARITY_G  => RST_POLARITY_G,
          RST_ASYNC_G     => RST_ASYNC_G,
          BYPASS_SYNC_G   => BYPASS_SYNC_G,
-         RELEASE_DELAY_G => RELEASE_DELAY_G,
+         OUT_DELAY_G     => RELEASE_DELAY_G,
          IN_POLARITY_G   => IN_POLARITY_G,
          OUT_POLARITY_G  => OUT_POLARITY_G)
       port map (

--- a/protocols/srp/rtl/SrpV0AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV0AxiLite.vhd
@@ -136,7 +136,7 @@ begin
    -------------
    -- Input FIFO
    -------------
-   SlaveAxiStreamFifo : entity surf.AxiStreamFifoV2
+   SlaveAxiStreamFifo : entity surf.SsiFifo
       generic map (
          TPD_G               => TPD_G,
          PIPE_STAGES_G       => 0,

--- a/protocols/srp/tb/AxiLiteSrpV0Tb.vhd
+++ b/protocols/srp/tb/AxiLiteSrpV0Tb.vhd
@@ -186,10 +186,10 @@ begin
       for i in 0 to 256 loop
 
          -- Write AXI-Lite Transaction
-         axiLiteBusSimWrite (axilClk, uutAxilWriteMaster, uutAxilWriteSlave, toSlv(i, 32), toSlv(i, 32), true);
+         axiLiteBusSimWrite (axilClk, uutAxilWriteMaster, uutAxilWriteSlave, toSlv(4*i, 32), toSlv(i, 32), true);
 
          -- Read AXI-Lite Transaction
-         axiLiteBusSimRead (axilClk, uutAxilReadMaster, uutAxilReadSlave, toSlv(i, 32), data, true);
+         axiLiteBusSimRead (axilClk, uutAxilReadMaster, uutAxilReadSlave, toSlv(4*i, 32), data, true);
 
          -- Check for failure
          if (data /= i) then

--- a/protocols/srp/tb/AxiLiteSrpV0Tb.vhd
+++ b/protocols/srp/tb/AxiLiteSrpV0Tb.vhd
@@ -23,6 +23,7 @@ use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
 use surf.AxiStreamPkg.all;
 use surf.SsiPkg.all;
+use surf.EthMacPkg.all;
 
 ----------------------------------------------------------------------------------------------------
 
@@ -42,26 +43,26 @@ architecture tb of AxiLiteSrpV0Tb is
    constant GEN_SYNC_FIFO_G     : boolean                    := false;
    constant FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 9;
    constant FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 2**8;
-   constant AXI_STREAM_CONFIG_G : AxiStreamConfigType        := ssiAxiStreamConfig(4);
+   constant AXI_STREAM_CONFIG_G : AxiStreamConfigType        := EMAC_AXIS_CONFIG_C;
 
    -- component ports
-   signal axisClk            : sl;                                                      -- [in]
-   signal axisRst            : sl                     := '0';                           -- [in]
-   signal txAxisMaster       : AxiStreamMasterType;                                     -- [out]
-   signal txAxisSlave        : AxiStreamSlaveType;                                      -- [in]
-   signal rxAxisMaster       : AxiStreamMasterType;                                     -- [in]
-   signal rxAxisSlave        : AxiStreamSlaveType;                                      -- [out]
-   signal rxAxisCtrl         : AxiStreamCtrlType;                                       -- [out]
-   signal axilClk            : sl;                                                      -- [in]
-   signal axilRst            : sl;                                                      -- [in]
+   signal axisClk            : sl;      -- [in]
+   signal axisRst            : sl                     := '0';  -- [in]
+   signal txAxisMaster       : AxiStreamMasterType;            -- [out]
+   signal txAxisSlave        : AxiStreamSlaveType;             -- [in]
+   signal rxAxisMaster       : AxiStreamMasterType;            -- [in]
+   signal rxAxisSlave        : AxiStreamSlaveType;             -- [out]
+   signal rxAxisCtrl         : AxiStreamCtrlType;              -- [out]
+   signal axilClk            : sl;      -- [in]
+   signal axilRst            : sl;      -- [in]
    signal uutAxilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;  -- [in]
-   signal uutAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;   -- [out]
-   signal uutAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;   -- [in]
-   signal uutAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;    -- [out]
+   signal uutAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;  -- [out]
+   signal uutAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;  -- [in]
+   signal uutAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;  -- [out]
    signal srpAxilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;  -- [in]
-   signal srpAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;   -- [out]
-   signal srpAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;   -- [in]
-   signal srpAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;    -- [out]
+   signal srpAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;  -- [out]
+   signal srpAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;  -- [in]
+   signal srpAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;  -- [out]
 
 begin
 
@@ -183,9 +184,24 @@ begin
       wait for 1 us;
 
       for i in 0 to 256 loop
+
+         -- Write AXI-Lite Transaction
          axiLiteBusSimWrite (axilClk, uutAxilWriteMaster, uutAxilWriteSlave, toSlv(i, 32), toSlv(i, 32), true);
+
+         -- Read AXI-Lite Transaction
          axiLiteBusSimRead (axilClk, uutAxilReadMaster, uutAxilReadSlave, toSlv(i, 32), data, true);
+
+         -- Check for failure
+         if (data /= i) then
+            -- Simulation failed
+            assert false report "Simulation Failed!" severity failure;
+         end if;
+
       end loop;
+
+      -- Simulation Passed
+      assert false report "Simulation Passed!" severity failure;
+
    end process test;
 
 end architecture tb;

--- a/protocols/ssi/rtl/SsiFifo.vhd
+++ b/protocols/ssi/rtl/SsiFifo.vhd
@@ -331,8 +331,24 @@ begin
    -- sAxisClk = mAxisClk
    ----------------------
    GEN_SYNC : if (GEN_SYNC_FIFO_G = true) generate
-      mAxisMaster <= obAxisMaster;
-      obAxisSlave <= mAxisSlave;
+      U_Resize : entity surf.AxiStreamResize
+         generic map (
+            -- General Configurations
+            TPD_G               => TPD_G,
+            READY_EN_G          => SLAVE_READY_EN_G,
+            -- AXI Stream Port Configurations
+            SLAVE_AXI_CONFIG_G  => SLAVE_AXI_CONFIG_G,
+            MASTER_AXI_CONFIG_G => MASTER_AXI_CONFIG_G)
+         port map (
+            -- Clock and reset
+            axisClk     => sAxisClk,
+            axisRst     => sAxisRst,
+            -- Slave Port
+            sAxisMaster => obAxisMaster,
+            sAxisSlave  => obAxisSlave,
+            -- Master Port
+            mAxisMaster => mAxisMaster,
+            mAxisSlave  => mAxisSlave);
    end generate;
 
 end rtl;


### PR DESCRIPTION
### Description
- SsiFifo bug fix when GEN_SYNC_FIFO_G=true and SLAVE_AXI_CONFIG_G/=MASTER_AXI_CONFIG_G
- SrpV0AxiLite code clean up
- Updating AxiLiteSrpV0Tb.vhd to have a non-32b AXIS interface
- Updating AxiLiteSrpV0Tb.vhd to 32-bit word addressing
- AxiStreamMuxTb code clean up
  - Does not use SssiFifo