### PR TITLE
Fix bug in _Xadc.py

### DIFF
--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -25,7 +25,7 @@ class Xadc(pr.Device):
                  **kwargs):
         super().__init__(description=description, **kwargs)
 
-        def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval):
+        def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
             self.add(pr.RemoteVariable(
                 name         = ("Raw"+name),
                 offset       = offset,


### PR DESCRIPTION
Add default arg to `pollInterval` in `addPair()` so it doesn't need to be specified.

Not sure how this wasn't noticed before.

<!--- Provide a one sentence summary of your changes in the Title above -->
