### PR TITLE
Refactor RELEASE_DELAY_G Generic in Synchronization Modules

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteRamSyncStatusVector.vhd
+++ b/axi/axi-lite/rtl/AxiLiteRamSyncStatusVector.vhd
@@ -37,7 +37,6 @@ entity AxiLiteRamSyncStatusVector is
       RST_POLARITY_G  : sl                     := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G     : boolean                := false;  -- true if reset is asynchronous, false if reset is synchronous
       COMMON_CLK_G    : boolean                := false;  -- True if wrClk and rdClk are the same clock
-      RELEASE_DELAY_G : positive               := 3;  -- Delay between deassertion of async and sync resets
       IN_POLARITY_G   : slv                    := "1";  -- 0 for active LOW, 1 for active HIGH (for statusIn port)
       OUT_POLARITY_G  : sl                     := '1';  -- 0 for active LOW, 1 for active HIGH (for irqOut port)
       SYNTH_CNT_G     : slv                    := "1";  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter

--- a/base/sync/rtl/SyncStatusVector.vhd
+++ b/base/sync/rtl/SyncStatusVector.vhd
@@ -23,27 +23,27 @@ use surf.StdRtlPkg.all;
 
 entity SyncStatusVector is
    generic (
-      TPD_G           : time     := 1 ns; -- Simulation FF output delay
-      RST_POLARITY_G  : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G     : boolean  := false;-- true if reset is asynchronous, false if reset is synchronous
-      COMMON_CLK_G    : boolean  := false;-- True if wrClk and rdClk are the same clock
-      RELEASE_DELAY_G : positive := 3;    -- Delay between deassertion of async and sync resets
-      IN_POLARITY_G   : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (for statusIn port)
-      OUT_POLARITY_G  : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (for irqOut port)
-      USE_DSP_G       : string   := "no"; -- "no" for no DSP implementation, "yes" to use DSP slices
-      SYNTH_CNT_G     : slv      := "1";  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter
-      CNT_RST_EDGE_G  : boolean  := true; -- true if counter reset should be edge detected, else level detected
-      CNT_WIDTH_G     : positive := 32;   -- Counters' width
-      WIDTH_G         : positive := 16);  -- Status vector width
+      TPD_G          : time     := 1 ns;  -- Simulation FF output delay
+      RST_POLARITY_G : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean  := false;  -- true if reset is asynchronous, false if reset is synchronous
+      COMMON_CLK_G   : boolean  := false;  -- True if wrClk and rdClk are the same clock
+      SYNC_STAGES_G  : positive := 3;   -- Synchronization stages between statusIn and statusOut
+      IN_POLARITY_G  : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (for statusIn port)
+      OUT_POLARITY_G : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (for irqOut port)
+      USE_DSP_G      : string   := "no";  -- "no" for no DSP implementation, "yes" to use DSP slices
+      SYNTH_CNT_G    : slv      := "1";  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter
+      CNT_RST_EDGE_G : boolean  := true;  -- true if counter reset should be edge detected, else level detected
+      CNT_WIDTH_G    : positive := 32;  -- Counters' width
+      WIDTH_G        : positive := 16);  -- Status vector width
    port (
       ---------------------------------------------
       -- Input Status bit Signals (wrClk domain)      
       ---------------------------------------------
-      statusIn     : in  slv(WIDTH_G-1 downto 0);-- Data to be 'synced'
+      statusIn     : in  slv(WIDTH_G-1 downto 0);                     -- Data to be 'synced'
       ---------------------------------------------
       -- Output Status bit Signals (rdClk domain)      
       ---------------------------------------------
-      statusOut    : out slv(WIDTH_G-1 downto 0);-- Synced data
+      statusOut    : out slv(WIDTH_G-1 downto 0);                     -- Synced data
       ---------------------------------------------
       -- Status Bit Counters Signals (rdClk domain)      
       ---------------------------------------------
@@ -87,9 +87,9 @@ entity SyncStatusVector is
       -- Clocks and Reset Ports
       ---------------------------------------------
       wrClk        : in  sl;
-      wrRst        : in  sl := '0';
+      wrRst        : in  sl                      := '0';
       rdClk        : in  sl;
-      rdRst        : in  sl := '0');
+      rdRst        : in  sl                      := '0');
 end SyncStatusVector;
 
 architecture rtl of SyncStatusVector is
@@ -98,7 +98,7 @@ architecture rtl of SyncStatusVector is
       irqOut    : sl;
       hitVector : slv(WIDTH_G-1 downto 0);
    end record RegType;
-   
+
    constant REG_INIT_C : RegType := (
       not(OUT_POLARITY_G),
       (others => '0'));
@@ -107,14 +107,14 @@ architecture rtl of SyncStatusVector is
    signal rin : RegType;
 
    signal statusStrobe : slv(WIDTH_G-1 downto 0);
-   
+
 begin
 
    SyncVec_Inst : entity surf.SynchronizerVector
       generic map (
          TPD_G         => TPD_G,
          BYPASS_SYNC_G => COMMON_CLK_G,
-         STAGES_G      => RELEASE_DELAY_G,
+         STAGES_G      => SYNC_STAGES_G,
          WIDTH_G       => WIDTH_G)
       port map (
          clk     => rdClk,
@@ -123,31 +123,29 @@ begin
 
    SyncOneShotCntVec_Inst : entity surf.SynchronizerOneShotCntVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => RST_POLARITY_G,
-         RST_ASYNC_G     => RST_ASYNC_G,
-         COMMON_CLK_G    => COMMON_CLK_G,
-         RELEASE_DELAY_G => RELEASE_DELAY_G,
-         IN_POLARITY_G   => IN_POLARITY_G,
-         OUT_POLARITY_G  => "1",
-         USE_DSP_G       => USE_DSP_G,
-         SYNTH_CNT_G     => SYNTH_CNT_G,
-         CNT_RST_EDGE_G  => CNT_RST_EDGE_G,
-         CNT_WIDTH_G     => CNT_WIDTH_G,
-         WIDTH_G         => WIDTH_G)      
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
+         COMMON_CLK_G   => COMMON_CLK_G,
+         IN_POLARITY_G  => IN_POLARITY_G,
+         OUT_POLARITY_G => "1",
+         USE_DSP_G      => USE_DSP_G,
+         SYNTH_CNT_G    => SYNTH_CNT_G,
+         CNT_RST_EDGE_G => CNT_RST_EDGE_G,
+         CNT_WIDTH_G    => CNT_WIDTH_G,
+         WIDTH_G        => WIDTH_G)
       port map (
-         -- Write Ports (wrClk domain)    
+         -- Write Ports (wrClk domain)
+         wrClk      => wrClk,
+         wrRst      => wrRst,
          dataIn     => statusIn,
          -- Read Ports (rdClk domain)    
+         rdClk      => rdClk,
+         rdRst      => rdRst,
          rollOverEn => rollOverEnIn,
          cntRst     => cntRstIn,
          dataOut    => statusStrobe,
-         cntOut     => cntOut,
-         -- Clocks and Reset Ports
-         wrClk      => wrClk,
-         wrRst      => wrRst,
-         rdClk      => rdClk,
-         rdRst      => rdRst);           
+         cntOut     => cntOut);
 
    comb : process (irqEnIn, r, rdRst, statusStrobe) is
       variable i : integer;
@@ -178,7 +176,7 @@ begin
 
       -- Outputs
       irqOut <= r.irqOut;
-      
+
    end process comb;
 
    seq : process (rdClk, rdRst) is

--- a/base/sync/rtl/SynchronizerOneShotCnt.vhd
+++ b/base/sync/rtl/SynchronizerOneShotCnt.vhd
@@ -27,7 +27,6 @@ entity SynchronizerOneShotCnt is
       RST_POLARITY_G  : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G     : boolean  := false;  -- true if reset is asynchronous, false if reset is synchronous
       COMMON_CLK_G    : boolean  := false;  -- True if wrClk and rdClk are the same clock
-      RELEASE_DELAY_G : positive := 3;  -- Delay between deassertion of async and sync resets
       IN_POLARITY_G   : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (dataIn port)
       OUT_POLARITY_G  : sl       := '1';  -- 0 for active LOW, 1 for active HIGH (dataOut port)
       USE_DSP_G       : string   := "no";  -- "no" for no DSP implementation, "yes" to use DSP slices
@@ -116,8 +115,7 @@ begin
             RST_POLARITY_G => RST_POLARITY_G,
             OUT_POLARITY_G => '1',
             RST_ASYNC_G    => RST_ASYNC_G,
-            BYPASS_SYNC_G  => COMMON_CLK_G,
-            STAGES_G       => (RELEASE_DELAY_G-1))
+            BYPASS_SYNC_G  => COMMON_CLK_G)
          port map (
             clk     => wrClk,
             rst     => wrRst,
@@ -132,8 +130,7 @@ begin
          RST_POLARITY_G => RST_POLARITY_G,
          OUT_POLARITY_G => '1',
          RST_ASYNC_G    => RST_ASYNC_G,
-         BYPASS_SYNC_G  => COMMON_CLK_G,
-         STAGES_G       => (RELEASE_DELAY_G-1))
+         BYPASS_SYNC_G  => COMMON_CLK_G)
       port map (
          clk     => wrClk,
          rst     => wrRst,
@@ -214,7 +211,6 @@ begin
          generic map (
             TPD_G         => TPD_G,
             COMMON_CLK_G  => COMMON_CLK_G,
-            SYNC_STAGES_G => RELEASE_DELAY_G,
             DATA_WIDTH_G  => CNT_WIDTH_G)
          port map (
             -- Asynchronous Reset

--- a/base/sync/rtl/SynchronizerOneShotCntVector.vhd
+++ b/base/sync/rtl/SynchronizerOneShotCntVector.vhd
@@ -22,18 +22,17 @@ use surf.StdRtlPkg.all;
 
 entity SynchronizerOneShotCntVector is
    generic (
-      TPD_G           : time     := 1 ns;  -- Simulation FF output delay
-      RST_POLARITY_G  : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G     : boolean  := false;  -- true if reset is asynchronous, false if reset is synchronous
-      COMMON_CLK_G    : boolean  := false;  -- True if wrClk and rdClk are the same clock
-      RELEASE_DELAY_G : positive := 3;  -- Delay between deassertion of async and sync resets
-      IN_POLARITY_G   : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (dataIn port)
-      OUT_POLARITY_G  : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (dataOut port)
-      USE_DSP_G       : string   := "no";  -- "no" for no DSP implementation, "yes" to use DSP slices
-      SYNTH_CNT_G     : slv      := "1";  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter
-      CNT_RST_EDGE_G  : boolean  := true;  -- true if counter reset should be edge detected, else level detected
-      CNT_WIDTH_G     : positive := 16;
-      WIDTH_G         : positive := 16);
+      TPD_G          : time     := 1 ns;  -- Simulation FF output delay
+      RST_POLARITY_G : sl       := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean  := false;  -- true if reset is asynchronous, false if reset is synchronous
+      COMMON_CLK_G   : boolean  := false;  -- True if wrClk and rdClk are the same clock
+      IN_POLARITY_G  : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (dataIn port)
+      OUT_POLARITY_G : slv      := "1";  -- 0 for active LOW, 1 for active HIGH (dataOut port)
+      USE_DSP_G      : string   := "no";  -- "no" for no DSP implementation, "yes" to use DSP slices
+      SYNTH_CNT_G    : slv      := "1";  -- Set to 1 for synthesising counter RTL, '0' to not synthesis the counter
+      CNT_RST_EDGE_G : boolean  := true;  -- true if counter reset should be edge detected, else level detected
+      CNT_WIDTH_G    : positive := 16;
+      WIDTH_G        : positive := 16);
    port (
 
       -- Write Ports (wrClk domain)          
@@ -94,16 +93,15 @@ architecture rtl of SynchronizerOneShotCntVector is
 begin
 
    CNT_RST_EDGE : if (CNT_RST_EDGE_G = true) generate
-      
+
       SyncOneShot_1 : entity surf.SynchronizerOneShot
          generic map (
-            TPD_G             => TPD_G,
-            RST_POLARITY_G    => RST_POLARITY_G,
-            RST_ASYNC_G       => RST_ASYNC_G,
-            BYPASS_SYNC_G     => COMMON_CLK_G,
-            OUT_DELAY_G       => RELEASE_DELAY_G,
-            IN_POLARITY_G     => RST_POLARITY_G,
-            OUT_POLARITY_G    => RST_POLARITY_G)      
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            BYPASS_SYNC_G  => COMMON_CLK_G,
+            IN_POLARITY_G  => RST_POLARITY_G,
+            OUT_POLARITY_G => RST_POLARITY_G)
          port map (
             clk     => wrClk,
             rst     => wrRst,
@@ -113,20 +111,19 @@ begin
    end generate;
 
    CNT_RST_LEVEL : if (CNT_RST_EDGE_G = false) generate
-      
+
       Synchronizer_0 : entity surf.Synchronizer
          generic map (
             TPD_G          => TPD_G,
             RST_POLARITY_G => RST_POLARITY_G,
             OUT_POLARITY_G => '1',
             RST_ASYNC_G    => RST_ASYNC_G,
-            BYPASS_SYNC_G  => COMMON_CLK_G,
-            STAGES_G       => (RELEASE_DELAY_G-1))      
+            BYPASS_SYNC_G  => COMMON_CLK_G)
          port map (
             clk     => wrClk,
             rst     => wrRst,
             dataIn  => cntRst,
-            dataOut => cntRstSync);       
+            dataOut => cntRstSync);
 
    end generate;
 
@@ -140,22 +137,21 @@ begin
             RST_POLARITY_G => RST_POLARITY_G,
             OUT_POLARITY_G => '1',
             RST_ASYNC_G    => RST_ASYNC_G,
-            BYPASS_SYNC_G  => COMMON_CLK_G,         
-            STAGES_G       => (RELEASE_DELAY_G-1))      
+            BYPASS_SYNC_G  => COMMON_CLK_G)
          port map (
             clk     => wrClk,
             rst     => wrRst,
             dataIn  => rollOverEn(i),
-            dataOut => rollOverEnSync(i));   
+            dataOut => rollOverEnSync(i));
 
       U_SyncOneShot : entity surf.SynchronizerOneShot
          generic map (
-            TPD_G           => TPD_G,
-            RST_POLARITY_G  => RST_POLARITY_G,
-            RST_ASYNC_G     => RST_ASYNC_G,
-            BYPASS_SYNC_G   => COMMON_CLK_G,
-            IN_POLARITY_G   => IN_POLARITY_C(i),
-            OUT_POLARITY_G  => OUT_POLARITY_C(i))
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            BYPASS_SYNC_G  => COMMON_CLK_G,
+            IN_POLARITY_G  => IN_POLARITY_C(i),
+            OUT_POLARITY_G => OUT_POLARITY_C(i))
          port map (
             clk     => rdClk,
             rst     => rdRst,
@@ -164,30 +160,29 @@ begin
 
       SyncOneShotCnt_Inst : entity surf.SynchronizerOneShotCnt
          generic map (
-            TPD_G           => TPD_G,
-            RST_POLARITY_G  => RST_POLARITY_G,
-            RST_ASYNC_G     => RST_ASYNC_G,
-            COMMON_CLK_G    => true,    -- status counter bus synchronization done outside
-            RELEASE_DELAY_G => RELEASE_DELAY_G,
-            IN_POLARITY_G   => IN_POLARITY_C(i),
-            OUT_POLARITY_G  => OUT_POLARITY_C(i),
-            USE_DSP_G       => USE_DSP_G,
-            SYNTH_CNT_G     => SYNTH_CNT_C(i),
-            CNT_RST_EDGE_G  => CNT_RST_EDGE_G,
-            CNT_WIDTH_G     => CNT_WIDTH_G)
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            COMMON_CLK_G   => true,     -- status counter bus synchronization done outside
+            IN_POLARITY_G  => IN_POLARITY_C(i),
+            OUT_POLARITY_G => OUT_POLARITY_C(i),
+            USE_DSP_G      => USE_DSP_G,
+            SYNTH_CNT_G    => SYNTH_CNT_C(i),
+            CNT_RST_EDGE_G => CNT_RST_EDGE_G,
+            CNT_WIDTH_G    => CNT_WIDTH_G)
          port map (
-            -- Write Ports (wrClk domain)    
+            -- Write Ports (wrClk domain)
+            wrClk      => wrClk,
+            wrRst      => wrRst,
             dataIn     => dataIn(i),
-            -- Read Ports (rdClk domain)    
+            -- Read Ports (rdClk domain)
+            rdClk      => wrClk,        -- status counter bus synchronization done outside
+            rdRst      => wrRst,
             rollOverEn => rollOverEnSync(i),
             cntRst     => cntRstSync,
             dataOut    => open,
-            cntOut     => cntWrDomain(i),
-            -- Clocks and Reset Ports
-            wrClk      => wrClk,
-            wrRst      => wrRst,
-            rdClk      => wrClk,        -- status counter bus synchronization done outside
-            rdRst      => wrRst);
+            cntOut     => cntWrDomain(i));
+
 
       GEN_MAP :
       for j in (CNT_WIDTH_G-1) downto 0 generate

--- a/base/sync/rtl/SynchronizerOneShotVector.vhd
+++ b/base/sync/rtl/SynchronizerOneShotVector.vhd
@@ -21,15 +21,15 @@ use surf.StdRtlPkg.all;
 
 entity SynchronizerOneShotVector is
    generic (
-      TPD_G           : time     := 1 ns;   -- Simulation FF output delay
-      RST_POLARITY_G  : sl       := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G     : boolean  := false;  -- Reset is asynchronous
-      BYPASS_SYNC_G   : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
-      RELEASE_DELAY_G : positive := 3;  -- Delay between deassertion of async and sync resets
-      IN_POLARITY_G   : slv      := "1";    -- 0 for active LOW, 1 for active HIGH
-      OUT_POLARITY_G  : slv      := "1";    -- 0 for active LOW, 1 for active HIGH
-      PULSE_WIDTH_G   : positive := 1;  -- one-shot pulse width duration (units of clk cycles)
-      WIDTH_G         : positive := 16);
+      TPD_G          : time     := 1 ns;   -- Simulation FF output delay
+      RST_POLARITY_G : sl       := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean  := false;  -- Reset is asynchronous
+      BYPASS_SYNC_G  : boolean  := false;  -- Bypass RstSync module for synchronous data configuration
+      OUT_DELAY_G    : positive := 3;   -- Delay between deassertion of async and sync resets
+      IN_POLARITY_G  : slv      := "1";    -- 0 for active LOW, 1 for active HIGH
+      OUT_POLARITY_G : slv      := "1";    -- 0 for active LOW, 1 for active HIGH
+      PULSE_WIDTH_G  : positive := 1;   -- one-shot pulse width duration (units of clk cycles)
+      WIDTH_G        : positive := 16);
    port (
       clk     : in  sl;                 -- Clock to be SYNC'd to
       rst     : in  sl := not RST_POLARITY_G;  -- Optional reset
@@ -57,28 +57,28 @@ architecture mapping of SynchronizerOneShotVector is
 
    constant IN_POLARITY_C  : PolarityVectorArray := FillVectorArray(IN_POLARITY_G);
    constant OUT_POLARITY_C : PolarityVectorArray := FillVectorArray(OUT_POLARITY_G);
-   
+
 begin
 
    GEN_VEC :
    for i in (WIDTH_G-1) downto 0 generate
-      
+
       SyncOneShot_Inst : entity surf.SynchronizerOneShot
          generic map (
-            TPD_G           => TPD_G,
-            RST_POLARITY_G  => RST_POLARITY_G,
-            RST_ASYNC_G     => RST_ASYNC_G,
-            BYPASS_SYNC_G   => BYPASS_SYNC_G,
-            OUT_DELAY_G     => RELEASE_DELAY_G,
-            IN_POLARITY_G   => IN_POLARITY_C(i),
-            OUT_POLARITY_G  => OUT_POLARITY_C(i),
-            PULSE_WIDTH_G   => PULSE_WIDTH_G)      
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            BYPASS_SYNC_G  => BYPASS_SYNC_G,
+            OUT_DELAY_G    => OUT_DELAY_G,
+            IN_POLARITY_G  => IN_POLARITY_C(i),
+            OUT_POLARITY_G => OUT_POLARITY_C(i),
+            PULSE_WIDTH_G  => PULSE_WIDTH_G)
          port map (
             clk     => clk,
             rst     => rst,
             dataIn  => dataIn(i),
-            dataOut => dataOut(i)); 
+            dataOut => dataOut(i));
 
    end generate GEN_VEC;
-   
+
 end architecture mapping;

--- a/base/sync/tb/SynchronizerOneShotTb.vhd
+++ b/base/sync/tb/SynchronizerOneShotTb.vhd
@@ -30,13 +30,13 @@ end entity SynchronizerOneShotTb;
 architecture sim of SynchronizerOneShotTb is
 
    -- component generics
-   constant TPD_G           : time     := 1 ns;
-   constant RST_POLARITY_G  : sl       := '1';
-   constant RST_ASYNC_G     : boolean  := false;
-   constant BYPASS_SYNC_G   : boolean  := false;
-   constant RELEASE_DELAY_G : positive := 3;
-   constant IN_POLARITY_G   : sl       := '1';
-   constant OUT_POLARITY_G  : sl       := '1';
+   constant TPD_G          : time    := 1 ns;
+   constant RST_POLARITY_G : sl      := '1';
+   constant RST_ASYNC_G    : boolean := false;
+   constant BYPASS_SYNC_G  : boolean := false;
+   constant OUT_DELAY_G    : integer := 3;
+   constant IN_POLARITY_G  : sl      := '1';
+   constant OUT_POLARITY_G : sl      := '1';
 
    -- component ports
    signal clk     : sl;                        -- [in]
@@ -47,22 +47,22 @@ architecture sim of SynchronizerOneShotTb is
 begin
 
    -- component instantiation
-   U_SynchronizerOneShot: entity surf.SynchronizerOneShot
+   U_SynchronizerOneShot : entity surf.SynchronizerOneShot
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => RST_POLARITY_G,
-         RST_ASYNC_G     => RST_ASYNC_G,
-         BYPASS_SYNC_G   => BYPASS_SYNC_G,
-         OUT_DELAY_G     => RELEASE_DELAY_G,
-         IN_POLARITY_G   => IN_POLARITY_G,
-         OUT_POLARITY_G  => OUT_POLARITY_G)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
+         BYPASS_SYNC_G  => BYPASS_SYNC_G,
+         OUT_DELAY_G    => OUT_DELAY_G,
+         IN_POLARITY_G  => IN_POLARITY_G,
+         OUT_POLARITY_G => OUT_POLARITY_G)
       port map (
          clk     => clk,                -- [in]
          rst     => rst,                -- [in]
          dataIn  => dataIn,             -- [in]
          dataOut => dataOut);           -- [out]
 
-   
+
    U_ClkRst_1 : entity surf.ClkRst
       generic map (
          CLK_PERIOD_G      => 5 ns,
@@ -73,7 +73,7 @@ begin
       port map (
          clkP => clk,
          rst  => rst);
-   
+
    U_ClkRst_2 : entity surf.ClkRst
       generic map (
          CLK_PERIOD_G      => 5 ns,
@@ -82,7 +82,7 @@ begin
          RST_HOLD_TIME_G   => 5 ns,
          SYNC_RESET_G      => true)
       port map (
-         rst  => dataIn);
+         rst => dataIn);
 
 end architecture sim;
 

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
@@ -208,7 +208,7 @@ architecture structure of Pgp2bAxi is
       linkPolarity    : slv(1 downto 0);
       locLinkReady    : sl;
       remLinkReady    : sl;
-      remLinkReadyCnt : slv(ERROR_CNT_WIDTH_G-1 downto 0);      
+      remLinkReadyCnt : slv(ERROR_CNT_WIDTH_G-1 downto 0);
       remLinkData     : slv(7 downto 0);
       cellErrorCount  : slv(ERROR_CNT_WIDTH_G-1 downto 0);
       linkDownCount   : slv(ERROR_CNT_WIDTH_G-1 downto 0);
@@ -301,16 +301,16 @@ begin
    -- Errror counters and non counted values
    U_RxError : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_RX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "111110000111110000",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => ERROR_CNT_WIDTH_G,
-         WIDTH_G         => 18)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_RX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "111110000111110000",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => ERROR_CNT_WIDTH_G,
+         WIDTH_G        => 18)
       port map (
          statusIn(0)           => pgpRxOut.phyRxReady,
          statusIn(1)           => pgpRxOut.linkReady,
@@ -371,16 +371,16 @@ begin
    -- Status counters
    U_RxStatus : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_RX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "1",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => STATUS_CNT_WIDTH_G,
-         WIDTH_G         => 1)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_RX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "1",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => STATUS_CNT_WIDTH_G,
+         WIDTH_G        => 1)
       port map (
          statusIn(0)  => pgpRxOut.frameRx,
          statusOut    => open,
@@ -441,16 +441,16 @@ begin
    -- Errror counters and non counted values
    U_TxError : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_TX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "110000111100",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => ERROR_CNT_WIDTH_G,
-         WIDTH_G         => 12)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_TX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "110000111100",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => ERROR_CNT_WIDTH_G,
+         WIDTH_G        => 12)
       port map (
          statusIn(0)          => pgpTxOut.phyTxReady,
          statusIn(1)          => pgpTxOut.linkReady,
@@ -486,16 +486,16 @@ begin
    -- Status counters
    U_TxStatus : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_TX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "1",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => STATUS_CNT_WIDTH_G,
-         WIDTH_G         => 1)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_TX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "1",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => STATUS_CNT_WIDTH_G,
+         WIDTH_G        => 1)
       port map (
          statusIn(0)  => pgpTxOut.frameTx,
          statusOut    => open,

--- a/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3AxiL.vhd
@@ -33,7 +33,7 @@ entity Pgp3AxiL is
       WRITE_EN_G         : boolean               := false;  -- Set to false when on remote end of a link
       STATUS_CNT_WIDTH_G : natural range 1 to 32 := 16;
       ERROR_CNT_WIDTH_G  : natural range 1 to 32 := 8;
-      AXIL_CLK_FREQ_G     : real                 := 125.0E+6);
+      AXIL_CLK_FREQ_G    : real                  := 125.0E+6);
    port (
 
       -- TX PGP Interface (pgpTxClk)
@@ -205,16 +205,16 @@ begin
    -- Errror counters and non counted values
    U_RxError : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_RX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => X"0030000FFFF7C",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => ERROR_CNT_WIDTH_G,
-         WIDTH_G         => RX_ERROR_COUNTERS_C)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_RX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => X"0030000FFFF7C",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => ERROR_CNT_WIDTH_G,
+         WIDTH_G        => RX_ERROR_COUNTERS_C)
       port map (
          statusIn(0)            => pgpRxOut.phyRxActive,
          statusIn(1)            => pgpRxOut.linkReady,
@@ -281,16 +281,16 @@ begin
    -- Status counters
    U_RxStatus : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_RX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "1",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => STATUS_CNT_WIDTH_G,
-         WIDTH_G         => RX_STATUS_COUNTERS_C)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_RX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "1",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => STATUS_CNT_WIDTH_G,
+         WIDTH_G        => RX_STATUS_COUNTERS_C)
       port map (
          statusIn(0)  => pgpRxOut.frameRx,
          statusOut    => open,
@@ -362,16 +362,16 @@ begin
 
    U_RxGearboxStatus : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => false,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "1",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => 8,
-         WIDTH_G         => 1)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => false,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "1",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => 8,
+         WIDTH_G        => 1)
       port map (
          statusIn(0)  => pgpRxOut.gearboxAligned,
          statusOut(0) => rxStatusSync.gearboxAligned,
@@ -422,16 +422,16 @@ begin
    -- Errror counters and non counted values
    U_TxError : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_TX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => X"0000FFFFE",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => ERROR_CNT_WIDTH_G,
-         WIDTH_G         => TX_ERROR_COUNTERS_C)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_TX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => X"0000FFFFE",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => ERROR_CNT_WIDTH_G,
+         WIDTH_G        => TX_ERROR_COUNTERS_C)
       port map (
          statusIn(0)            => pgpTxOut.phyTxActive,
          statusIn(1)            => pgpTxOut.linkReady,
@@ -467,16 +467,16 @@ begin
    -- Status counters
    U_TxStatus : entity surf.SyncStatusVector
       generic map (
-         TPD_G           => TPD_G,
-         RST_POLARITY_G  => '1',
-         COMMON_CLK_G    => COMMON_TX_CLK_G,
-         RELEASE_DELAY_G => 3,
-         IN_POLARITY_G   => "1",
-         OUT_POLARITY_G  => '1',
-         SYNTH_CNT_G     => "1",
-         CNT_RST_EDGE_G  => false,
-         CNT_WIDTH_G     => STATUS_CNT_WIDTH_G,
-         WIDTH_G         => 1)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         COMMON_CLK_G   => COMMON_TX_CLK_G,
+         SYNC_STAGES_G  => 3,
+         IN_POLARITY_G  => "1",
+         OUT_POLARITY_G => '1',
+         SYNTH_CNT_G    => "1",
+         CNT_RST_EDGE_G => false,
+         CNT_WIDTH_G    => STATUS_CNT_WIDTH_G,
+         WIDTH_G        => 1)
       port map (
          statusIn(0)  => pgpTxOut.frameTx,
          statusOut    => open,
@@ -548,7 +548,7 @@ begin
    pgpTxIn.opCodeEn     <= locTxIn.opCodeEn;
    pgpTxIn.opCodeData   <= locTxIn.opCodeData;
    pgpTxIn.opCodeNumber <= locTxIn.opCodeNumber;
-   pgpTxIn.locData      <= locTxIn.locData;   
+   pgpTxIn.locData      <= locTxIn.locData;
    pgpTxIn.flowCntlDis  <= locTxIn.flowCntlDis or syncFlowCntlDis;
    pgpTxIn.skpInterval  <= syncSkpInterval;
 
@@ -633,7 +633,7 @@ begin
       axiSlaveRegisterR(axilEp, X"120", 8, rxStatusSync.gearboxAlignCnt);
 
       axiSlaveRegisterR(axilEp, X"130", 0, rxStatusSync.phyRxInitCnt);
-      
+
       axiSlaveRegisterR(axilEp, X"138", 0, rxStatusSync.remLinkData);
 
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

The `RELEASE_DELAY_G` generic was either not used, not necessary, or improperly named in several modules.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

The `RELEASE_DELAY_G` generic has been modified in the following modules:
 - `AxiLiteSyncStatusVector` - Unused, removed.
 - `SyncStatusVector` - Renamed to `SYNC_STAGES_G`
 - `SynchronizerOneShotCnt` - Unnecessary, removed
 - `SynchronizerOneShotCntVector` - Unnecessary, removed
 - `SynchronizerOneShotVector` - Renamed to `OUT_DELAY_G`

Any modules that instantiate the affected modules above have also been refactors to reflect the changes.

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
