### PR TITLE
Enable flexible baud rate multiplier in UART

### DIFF
--- a/protocols/clink/rtl/ClinkUart.vhd
+++ b/protocols/clink/rtl/ClinkUart.vhd
@@ -5,11 +5,11 @@
 -- CameraLink UART RX/TX
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'SLAC Firmware Standard Library', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -152,7 +152,7 @@ begin
       port map (
          clk     => intClk,                          -- [in]
          rst     => intRst,                          -- [in]
-         baud16x => r.clkEn,                         -- [in]
+         clkEn   => r.clkEn,                         -- [in]
          wrData  => txMasters(1).tData(7 downto 0),  -- [in]
          wrValid => txMasters(1).tValid,             -- [in]
          wrReady => txSlaves(1).tReady,              -- [out]
@@ -167,7 +167,7 @@ begin
       port map (
          clk     => intClk,             -- [in]
          rst     => intRst,             -- [in]
-         baud16x => r.clkEn,            -- [in]
+         clkEn   => r.clkEn,            -- [in]
          rdData  => rdData,             -- [out]
          rdValid => rdValid,            -- [out]
          rdReady => '1',                -- [in]

--- a/protocols/uart/rtl/UartRx.vhd
+++ b/protocols/uart/rtl/UartRx.vhd
@@ -4,11 +4,11 @@
 -- Description: UART Receiver
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'SLAC Firmware Standard Library', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -22,13 +22,14 @@ use surf.StdRtlPkg.all;
 
 entity UartRx is
    generic (
-      TPD_G        : time                 := 1 ns;
-      PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
-      DATA_WIDTH_G : integer range 5 to 8 := 8);
+      TPD_G        : time                  := 1 ns;
+      PARITY_G     : string                := "NONE";  -- "NONE" "ODD" "EVEN"
+      BAUD_MULT_G  : integer range 1 to 16 := 16;
+      DATA_WIDTH_G : integer range 5 to 8  := 8);
    port (
       clk         : in  sl;
       rst         : in  sl;
-      baud16x     : in  sl;
+      clkEn       : in  sl;
       rdData      : out slv(DATA_WIDTH_G-1 downto 0);
       rdValid     : out sl;
       parityError : out sl;
@@ -38,7 +39,7 @@ end entity UartRx;
 
 architecture rtl of UartRx is
 
-   type StateType is (WAIT_START_BIT_S, WAIT_8_S, WAIT_16_S, SAMPLE_RX_S, PARITY_S, WAIT_STOP_S, WRITE_OUT_S);
+   type StateType is (WAIT_START_BIT_S, WAIT_HALF_S, WAIT_FULL_S, SAMPLE_RX_S, PARITY_S, WAIT_STOP_S, WRITE_OUT_S);
 
    type RegType is
    record
@@ -48,7 +49,7 @@ architecture rtl of UartRx is
       waitState    : StateType;
       rxShiftReg   : slv(DATA_WIDTH_G-1 downto 0);
       rxShiftCount : slv(3 downto 0);
-      baud16xCount : slv(3 downto 0);
+      clkEnCount   : slv(3 downto 0);
       parity       : sl;
       parityError  : sl;
    end record regType;
@@ -60,7 +61,7 @@ architecture rtl of UartRx is
       waitState    => SAMPLE_RX_S,
       rxShiftReg   => (others => '0'),
       rxShiftCount => (others => '0'),
-      baud16xCount => (others => '0'),
+      clkEnCount   => (others => '0'),
       parity       => '0',
       parityError  => '0');
 
@@ -86,7 +87,7 @@ begin
          risingEdge  => open,           -- [out]
          fallingEdge => rxFall);        -- [out]
 
-   comb : process (baud16x, r, rdReady, rst, rxFall, rxSync) is
+   comb : process (clkEn, r, rdReady, rst, rxFall, rxSync) is
       variable v : RegType;
    begin
       v := r;
@@ -109,28 +110,29 @@ begin
          -- Wait for RX to drop to indicate start bit
          when WAIT_START_BIT_S =>
             if (rxFall = '1') then
-               v.rxState      := WAIT_8_S;
-               v.baud16xCount := "0000";
+               v.rxState      := WAIT_HALF_S;
+               v.clkEnCount   := "0000";
                v.rxShiftCount := "0000";
             end if;
 
-         -- Wait 8 baud16x counts to find center of start bit
-         -- Every rx bit is 16 baud16x pulses apart
-         when WAIT_8_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = "0111") then
-                  v.baud16xCount := "0000";
-                  v.rxState      := WAIT_16_S;
+         -- Wait BAUD_MULT_G/2 clkEn counts to find center of start bit
+         -- Every rx bit is BAUD_MULT_G clkEn pulses apart
+         when WAIT_HALF_S =>
+            if (clkEn = '1') then
+               v.clkEnCount := r.clkEnCount + 1;
+               if (r.clkEnCount = (BAUD_MULT_G/2-1)) then
+                  v.clkEnCount := "0000";
+                  v.rxState    := WAIT_FULL_S;
                end if;
             end if;
 
-         -- Wait 16 baud16x counts (center of next bit)
-         when WAIT_16_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = "1111") then
-                  v.rxState := r.waitState;
+         -- Wait BAUD_MULT_G clkEn counts (center of next bit)
+         when WAIT_FULL_S =>
+            if (clkEn = '1') then
+               v.clkEnCount := r.clkEnCount + 1;
+               if (r.clkEnCount = (BAUD_MULT_G-1)) then
+                  v.clkEnCount := "0000";
+                  v.rxState    := r.waitState;
                end if;
             end if;
 
@@ -139,7 +141,7 @@ begin
          when SAMPLE_RX_S =>
             v.rxShiftReg   := rxSync & r.rxShiftReg(DATA_WIDTH_G-1 downto 1);
             v.rxShiftCount := r.rxShiftCount + 1;
-            v.rxState      := WAIT_16_S;
+            v.rxState      := WAIT_FULL_S;
             v.waitState    := SAMPLE_RX_S;
             if (r.rxShiftCount = DATA_WIDTH_G-1) then
                if(PARITY_G /= "NONE") then
@@ -150,9 +152,9 @@ begin
             end if;
 
          -- Samples parity bit on rx line and compare it to the calculated parity
-         -- raises a parityError flag if it does not match          
+         -- raises a parityError flag if it does not match
          when PARITY_S =>
-            v.rxState     := WAIT_16_S;
+            v.rxState     := WAIT_FULL_S;
             v.waitState   := WAIT_STOP_S;
             v.parityError := toSl(r.parity = rxSync);
 

--- a/protocols/uart/rtl/UartTx.vhd
+++ b/protocols/uart/rtl/UartTx.vhd
@@ -4,11 +4,11 @@
 -- Description: Uart Transmitter
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'SLAC Firmware Standard Library', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -22,18 +22,19 @@ use surf.StdRtlPkg.all;
 
 entity UartTx is
    generic (
-      TPD_G        : time                 := 1 ns;
-      STOP_BITS_G  : integer range 1 to 2 := 1;
-      PARITY_G     : string               := "NONE";  -- "NONE" "ODD" "EVEN"
-      DATA_WIDTH_G : integer range 5 to 8 := 8);
+      TPD_G        : time                  := 1 ns;
+      STOP_BITS_G  : integer range 1 to 2  := 1;
+      PARITY_G     : string                := "NONE";  -- "NONE" "ODD" "EVEN"
+      BAUD_MULT_G  : integer range 1 to 16 := 16;
+      DATA_WIDTH_G : integer range 5 to 8  := 8);
    port (
-      clk     : in  sl;
-      rst     : in  sl;
-      baud16x : in  sl;
-      wrData  : in  slv(DATA_WIDTH_G-1 downto 0);
-      wrValid : in  sl;
-      wrReady : out sl;
-      tx      : out sl);
+      clk      : in  sl;
+      rst      : in  sl;
+      clkEn    : in  sl;
+      wrData   : in  slv(DATA_WIDTH_G-1 downto 0);
+      wrValid  : in  sl;
+      wrReady  : out sl;
+      tx       : out sl);
 end entity UartTx;
 
 architecture RTL of UartTx is
@@ -41,34 +42,34 @@ architecture RTL of UartTx is
    constant START_BIT_C       : integer := 1;
    constant SHIFT_REG_WIDTH_C : integer := START_BIT_C + DATA_WIDTH_G + PARITY_BITS_C + STOP_BITS_G;
 
-   type StateType is (WAIT_DATA_S, SYNC_EN_16_S, WAIT_16_S, TX_BIT_S);
+   type StateType is (WAIT_DATA_S, SYNC_EN_S, WAIT_S, TX_BIT_S);
 
    type RegType is record
-      wrReady      : sl;
-      holdReg      : slv(DATA_WIDTH_G-1 downto 0);
-      parity       : sl;
-      txState      : StateType;
-      baud16xCount : slv(3 downto 0);
-      shiftReg     : slv(SHIFT_REG_WIDTH_C-1 downto 0);
-      shiftCount   : slv(3 downto 0);
+      wrReady    : sl;
+      holdReg    : slv(DATA_WIDTH_G-1 downto 0);
+      parity     : sl;
+      txState    : StateType;
+      clkEnCount : slv(3 downto 0);
+      shiftReg   : slv(SHIFT_REG_WIDTH_C-1 downto 0);
+      shiftCount : slv(3 downto 0);
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      wrReady      => '0',
-      holdReg      => (others => '0'),
-      parity       => '0',
-      txState      => WAIT_DATA_S,
-      baud16xCount => (others => '0'),
-      shiftReg     => (others => '1'),
-      shiftCount   => (others => '0'));
+      wrReady    => '0',
+      holdReg    => (others => '0'),
+      parity     => '0',
+      txState    => WAIT_DATA_S,
+      clkEnCount => (others => '0'),
+      shiftReg   => (others => '1'),
+      shiftCount => (others => '0'));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
 
 begin  -- architecture RTL
-   
 
-   comb : process (baud16x, r, rst, wrData, wrValid) is
+
+   comb : process (clkEn, r, rst, wrData, wrValid) is
       variable v : RegType;
    begin
       v := r;
@@ -80,15 +81,15 @@ begin  -- architecture RTL
             if (wrValid = '1' and r.wrReady = '1') then
                v.wrReady := '0';
                v.holdReg := wrData;
-               v.txState := SYNC_EN_16_S;
+               v.txState := SYNC_EN_S;
                v.parity  := oddParity(wrData);  -- returns 1 if wrData is odd, 0 if even
             end if;
 
-            -- Wait for next baud16x to synchronize
+            -- Wait for next clkEn to synchronize
             -- Then load the shift reg
             -- LSB is the start bit, MSB is stop bit, MSB-1 is parity/stop
-         when SYNC_EN_16_S =>
-            if (baud16x = '1') then
+         when SYNC_EN_S =>
+            if (clkEn = '1') then
                if(STOP_BITS_G = 1 and PARITY_G = "NONE") then
                   v.shiftReg := '1' & r.holdReg & '0';
                elsif(STOP_BITS_G = 1 and PARITY_G = "EVEN") then
@@ -102,17 +103,17 @@ begin  -- architecture RTL
                      report "Invalid stopbit:parity combination" severity failure;
                end if;
 
-               v.baud16xCount := (others => '0');
-               v.shiftCount   := (others => '0');
-               v.txState      := WAIT_16_S;
+               v.clkEnCount := (others => '0');
+               v.shiftCount    := (others => '0');
+               v.txState       := WAIT_S;
             end if;
 
-            -- Wait 16 baud_16x counts (the baud rate)
+            -- Wait BAUD_MULT_G counts (the baud rate)
             -- When shifted all bits, wait for next tx data
-         when WAIT_16_S =>
-            if (baud16x = '1') then
-               v.baud16xCount := r.baud16xCount + 1;
-               if (r.baud16xCount = 15) then
+         when WAIT_S =>
+            if (clkEn = '1') then
+               v.clkEnCount := r.clkEnCount + 1;
+               if (r.clkEnCount = (BAUD_MULT_G-1)) then
                   v.txState := TX_BIT_S;
                   if (r.shiftCount = SHIFT_REG_WIDTH_C-1) then
                      v.txState := WAIT_DATA_S;
@@ -124,7 +125,7 @@ begin  -- architecture RTL
          when TX_BIT_S =>
             v.shiftReg   := '0' & r.shiftReg(SHIFT_REG_WIDTH_C-1 downto 1);
             v.shiftCount := r.shiftCount + 1;
-            v.txState    := WAIT_16_S;
+            v.txState    := WAIT_S;
 
       end case;
 


### PR DESCRIPTION
This enables the uart to have a flexible baud rate multiplier instead of the default 16x.