### PR TITLE
Add external blowoff input to AxiStreamBatcherEventBuilder

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -255,8 +255,8 @@ begin
       axiSlaveRegister (axilEp, x"FF0", 0, v.timeout);
       axiSlaveRegisterR(axilEp, x"FF4", 0, toSlv(NUM_SLAVES_G, 8));
       axiSlaveRegisterR(axilEp, x"FF4", 8, dbg);
+      axiSlaveRegisterR(axilEp, X"FF4", 16, blowoffExt);
       axiSlaveRegister (axilEp, x"FF8", 0, v.blowoffReg);
-      axiSlaveRegisterR(axilEp, X"FF8", 1, blowoffExt);
       axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);
       axiSlaveRegister (axilEp, x"FFC", 1, v.timerRst);
       axiSlaveRegister (axilEp, x"FFC", 2, v.hardRst);

--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -80,6 +80,7 @@ architecture rtl of AxiStreamBatcherEventBuilder is
       softRst        : sl;
       hardRst        : sl;
       blowoffReg     : sl;
+      blowoff        : sl;
       timerRst       : sl;
       cntRst         : sl;
       ready          : sl;
@@ -107,6 +108,7 @@ architecture rtl of AxiStreamBatcherEventBuilder is
       softRst        => '0',
       hardRst        => '0',
       blowoffReg     => '0',
+      blowoff        => '0',
       timerRst       => '0',
       cntRst         => '0',
       ready          => '0',
@@ -263,14 +265,14 @@ begin
       -- Closeout the transaction
       axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
 
-      v.blowoffReg := v.blowoffReg or blowoffExt;
+      v.blowoff := v.blowoffReg or blowoffExt;
 
       -- Check for change in configuration
       if (r.timeout /= v.timeout) or (r.timerRst = '1') then
          -- Reset the timer
          v.timer := (others => '0');
       end if;
-      if (r.bypass /= v.bypass) or (r.blowoffReg /= v.blowoffReg) then
+      if (r.bypass /= v.bypass) or (r.blowoff /= v.blowoff) then
          -- Perform a soft-reset
          v.softRst := '1';
       end if;
@@ -357,7 +359,7 @@ begin
             end if;
 
             -- Check if ready to move data and not blowing off the data
-            if (batcherIdle = '1') and (r.ready = '1') and (r.blowoffReg = '0') then
+            if (batcherIdle = '1') and (r.ready = '1') and (r.blowoff = '0') then
 
                -- Check for transition
                if (r.transDet /= 0) then
@@ -412,7 +414,7 @@ begin
                v.state := MOVE_S;
 
             -- Check for blowoff flag 
-            elsif (r.blowoffReg = '1') then
+            elsif (r.blowoff = '1') then
 
                -- Blow off the inbound data
                for i in (NUM_SLAVES_G-1) downto 0 loop

--- a/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
+++ b/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
@@ -114,6 +114,16 @@ class AxiStreamBatcherEventBuilder(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
+            name         = "BlowoffExt",
+            description  = "Status of external blowoff input",
+            offset       =  0xFF4,
+            bitSize      =  1,
+            bitOffset    =  16,
+            base         = pr.Bool,
+            mode         = "RO",
+        ))
+
+        self.add(pr.RemoteVariable(
             name         = "Blowoff",
             description  = "Blows off the inbound AXIS stream (for debugging)",
             offset       =  0xFF8,
@@ -123,15 +133,6 @@ class AxiStreamBatcherEventBuilder(pr.Device):
             mode         = "RW",
         ))
 
-        self.add(pr.RemoteVariable(
-            name         = "BlowoffExt",
-            description  = "Status of external blowoff input",
-            offset       =  0xFF8,
-            bitSize      =  1,
-            bitOffset    =  1,
-            base         = pr.Bool,
-            mode         = "RO",
-        ))
 
         self.add(pr.RemoteCommand(
             name         = "CntRst",

--- a/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
+++ b/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
@@ -122,7 +122,7 @@ class AxiStreamBatcherEventBuilder(pr.Device):
             base         = pr.Bool,
             mode         = "RW",
         ))
-        
+
         self.add(pr.RemoteVariable(
             name         = "BlowoffExt",
             description  = "Status of external blowoff input",

--- a/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
+++ b/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
@@ -122,6 +122,16 @@ class AxiStreamBatcherEventBuilder(pr.Device):
             base         = pr.Bool,
             mode         = "RW",
         ))
+        
+        self.add(pr.RemoteVariable(
+            name         = "BlowoffExt",
+            description  = "Status of external blowoff input",
+            offset       =  0xFF8,
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         = pr.Bool,
+            mode         = "RO",
+        ))
 
         self.add(pr.RemoteCommand(
             name         = "CntRst",


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
This adds an external `blowoff` input to the `AxiStreamBatcherEventBuilder` and creates a new register for viewing the external input status.

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
