### PR TITLE
prevent a MAC address = 0x0 doing a DHCP request

### DIFF
--- a/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
@@ -543,11 +543,13 @@ begin
       rxSlave <= v.rxSlave;
 
       -- Reset
-      if (rst = '1') or (r.localMac /= v.localMac) then
+      if (rst = '1') or (r.localMac /= v.localMac) or (r.localMac = 0) then
          -- Reset the DHCP FSM
-         v          := REG_INIT_C;
+         v                := REG_INIT_C;
          -- Don't touch the delayed copy of local MAC
-         v.localMac := localMac;
+         v.localMac       := localMac;
+         -- Prevent locking up the ETH stack
+         v.rxSlave.tReady := '1';
       end if;
 
       -- Register the variable for next clock cycle


### PR DESCRIPTION
### Description
-  While MAC address = 00:00:00:00:00:00 is technically a valid Ethernet MAC address, we are using MAC = 00:00:00:00:00:00 (0x0) as an invalid MAC address in the SURF FW
