### PR TITLE
missing surf library causing VCS error

### DIFF
--- a/xilinx/7Series/gtp7/rtl/Gtp7AutoPhaseAligner.vhd
+++ b/xilinx/7Series/gtp7/rtl/Gtp7AutoPhaseAligner.vhd
@@ -77,6 +77,8 @@ library IEEE;
 use IEEE.STD_LOGIC_1164.all;
 use IEEE.NUMERIC_STD.all;
 
+library surf;
+
 entity Gtp7AutoPhaseAligner is
    generic(
       GT_TYPE : string := "GTX"


### PR DESCRIPTION
Just added surf library to Gtp7AutoPhaseAligner.vhd to avoid VCS failed compilation.