### PR TITLE
Update SrpV3Axi.vhd and AXI_CONFIG_G/AXI_STREAM_CONFIG_G clean up

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamFifo.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifo.vhd
@@ -54,9 +54,8 @@ entity AxiStreamFifo is
       CASCADE_PAUSE_SEL_G : integer range 0 to (2**24) := 0;
 
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C
-      );
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Slave Port

--- a/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
@@ -64,9 +64,8 @@ entity AxiStreamFifoV2 is
       CASCADE_SIZE_G      : integer range 1 to (2**24) := 1;
 
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C
-      );
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Slave Port

--- a/axi/axi-stream/rtl/AxiStreamFlush.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFlush.vhd
@@ -29,7 +29,7 @@ use surf.SsiPkg.all;
 entity AxiStreamFlush is
    generic (
       TPD_G         : time                 := 1 ns;
-      AXIS_CONFIG_G : AxiStreamConfigType  := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G : AxiStreamConfigType;
       SSI_EN_G      : boolean              := false);
    port (
 

--- a/axi/axi-stream/rtl/AxiStreamGearboxPack.vhd
+++ b/axi/axi-stream/rtl/AxiStreamGearboxPack.vhd
@@ -27,7 +27,7 @@ entity AxiStreamGearboxPack is
 
    generic (
       TPD_G               : time := 1 ns;
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := SSI_CONFIG_INIT_C;
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       RANGE_HIGH_G        : integer := 13;
       RANGE_LOW_G         : integer := 2);
    port (

--- a/axi/axi-stream/rtl/AxiStreamGearboxUnpack.vhd
+++ b/axi/axi-stream/rtl/AxiStreamGearboxUnpack.vhd
@@ -28,7 +28,7 @@ entity AxiStreamGearboxUnpack is
 
    generic (
       TPD_G               : time := 1 ns;
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       RANGE_HIGH_G        : integer := 119;
       RANGE_LOW_G         : integer := 8);
 --      PACK_SIZE_G         : integer);

--- a/axi/axi-stream/rtl/AxiStreamMon.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMon.vhd
@@ -26,7 +26,7 @@ entity AxiStreamMon is
       TPD_G           : time                := 1 ns;
       COMMON_CLK_G    : boolean             := false;  -- true if axisClk = statusClk
       AXIS_CLK_FREQ_G : real                := 156.25E+6;  -- units of Hz
-      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G   : AxiStreamConfigType);
    port (
       -- AXIS Stream Interface
       axisClk      : in  sl;

--- a/axi/axi-stream/rtl/AxiStreamMonAxiL.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMonAxiL.vhd
@@ -28,7 +28,7 @@ entity AxiStreamMonAxiL is
       COMMON_CLK_G     : boolean             := false;  -- true if axisClk = statusClk
       AXIS_CLK_FREQ_G  : real                := 156.25E+6;  -- units of Hz
       AXIS_NUM_SLOTS_G : positive            := 1;
-      AXIS_CONFIG_G    : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G    : AxiStreamConfigType);
    port (
       -- AXIS Stream Interface
       axisClk          : in  sl;

--- a/axi/axi-stream/rtl/AxiStreamResize.vhd
+++ b/axi/axi-stream/rtl/AxiStreamResize.vhd
@@ -34,9 +34,8 @@ entity AxiStreamResize is
       SIDE_BAND_WIDTH_G : positive := 1;  -- General purpose sideband
 
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C
-      );
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Clock and reset

--- a/axi/axi-stream/rtl/AxiStreamScatterGather.vhd
+++ b/axi/axi-stream/rtl/AxiStreamScatterGather.vhd
@@ -29,8 +29,8 @@ entity AxiStreamScatterGather is
    generic (
       TPD_G                   : time                := 1 ns;
       AXIS_SLAVE_FRAME_SIZE_G : integer             := 129;
-      SLAVE_AXIS_CONFIG_G     : AxiStreamConfigType := ssiAxiStreamConfig(2);
-      MASTER_AXIS_CONFIG_G    : AxiStreamConfigType := ssiAxiStreamConfig(12));
+      SLAVE_AXIS_CONFIG_G     : AxiStreamConfigType;
+      MASTER_AXIS_CONFIG_G    : AxiStreamConfigType);
    port (
       -- Master system clock, 125Mhz
       axiClk : in sl;

--- a/axi/axi-stream/rtl/AxiStreamShift.vhd
+++ b/axi/axi-stream/rtl/AxiStreamShift.vhd
@@ -29,7 +29,7 @@ use surf.AxiStreamPkg.all;
 entity AxiStreamShift is
    generic (
       TPD_G          : time                  := 1 ns;
-      AXIS_CONFIG_G  : AxiStreamConfigType   := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G  : AxiStreamConfigType;
       PIPE_STAGES_G  : integer range 0 to 16 := 0;
       ADD_VALID_EN_G : boolean               := false;
       BYP_SHIFT_G    : boolean               := false);

--- a/axi/axi4/rtl/AxiMemTester.vhd
+++ b/axi/axi4/rtl/AxiMemTester.vhd
@@ -29,7 +29,7 @@ entity AxiMemTester is
       START_ADDR_G     : slv                      := X"00000000";
       STOP_ADDR_G      : slv                      := X"FFFFFFFF";
       BURST_LEN_G      : positive range 1 to 4096 := 4096;
-      AXI_CONFIG_G     : AxiConfigType            := AXI_CONFIG_INIT_C);
+      AXI_CONFIG_G     : AxiConfigType);
    port (
       -- AXI-Lite Interface
       axilClk         : in  sl;

--- a/axi/axi4/rtl/AxiRam.vhd
+++ b/axi/axi4/rtl/AxiRam.vhd
@@ -28,7 +28,7 @@ entity AxiRam is
       SYNTH_MODE_G   : string               := "inferred";
       MEMORY_TYPE_G  : string               := "block";
       READ_LATENCY_G : natural range 0 to 2 := 2;
-      AXI_CONFIG_G   : AxiConfigType        := axiConfig(16, 8, 4, 8));
+      AXI_CONFIG_G   : AxiConfigType);
    port (
       -- Clock and Reset
       axiClk          : in  sl;

--- a/axi/axi4/rtl/AxiReadEmulate.vhd
+++ b/axi/axi4/rtl/AxiReadEmulate.vhd
@@ -27,7 +27,7 @@ entity AxiReadEmulate is
    generic (
       TPD_G        : time          := 1 ns;
       LATENCY_G    : natural       := 31;
-      AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G : AxiConfigType;
       SIM_DEBUG_G  : boolean       := false);
    port (
       -- Clock/Reset

--- a/axi/axi4/rtl/AxiReadPathFifo.vhd
+++ b/axi/axi4/rtl/AxiReadPathFifo.vhd
@@ -52,8 +52,7 @@ entity AxiReadPathFifo is
       DATA_FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 9;
 
       -- BUS Config
-      AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C
-      );
+      AXI_CONFIG_G : AxiConfigType);
    port (
 
       -- Slave Port

--- a/axi/axi4/rtl/AxiResize.vhd
+++ b/axi/axi4/rtl/AxiResize.vhd
@@ -31,8 +31,8 @@ entity AxiResize is
       -- General Configurations
       TPD_G               : time          := 1 ns;
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G  : AxiConfigType := AXI_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C);
+      SLAVE_AXI_CONFIG_G  : AxiConfigType;
+      MASTER_AXI_CONFIG_G : AxiConfigType);
    port (
       -- Clock and reset
       axiClk          : in  sl;

--- a/axi/axi4/rtl/AxiWriteEmulate.vhd
+++ b/axi/axi4/rtl/AxiWriteEmulate.vhd
@@ -27,7 +27,7 @@ entity AxiWriteEmulate is
    generic (
       TPD_G        : time          := 1 ns;
       LATENCY_G    : natural       := 31;
-      AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G : AxiConfigType;
       SIM_DEBUG_G  : boolean       := false);
    port (
       -- Clock/Reset

--- a/axi/axi4/rtl/AxiWritePathFifo.vhd
+++ b/axi/axi4/rtl/AxiWritePathFifo.vhd
@@ -59,8 +59,7 @@ entity AxiWritePathFifo is
       RESP_FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 9;
 
       -- BUS Config
-      AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C
-      );
+      AXI_CONFIG_G : AxiConfigType);
    port (
 
       -- Slave Port

--- a/axi/dma/rtl/v1/AxiStreamDma.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDma.vhd
@@ -35,7 +35,7 @@ entity AxiStreamDma is
       AXI_READY_EN_G    : boolean              := false;
       AXIS_READY_EN_G   : boolean              := false;
       AXIS_CONFIG_G     : AxiStreamConfigType  := AXI_STREAM_CONFIG_INIT_C;
-      AXI_CONFIG_G      : AxiConfigType        := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G      : AxiConfigType;
       AXI_BURST_G       : slv(1 downto 0)      := "01";
       AXI_CACHE_G       : slv(3 downto 0)      := "1111";
       PEND_THRESH_G     : natural              := 0;

--- a/axi/dma/rtl/v1/AxiStreamDma.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDma.vhd
@@ -34,7 +34,7 @@ entity AxiStreamDma is
       AXIL_BASE_ADDR_G  : slv(31 downto 0)     := x"00000000";
       AXI_READY_EN_G    : boolean              := false;
       AXIS_READY_EN_G   : boolean              := false;
-      AXIS_CONFIG_G     : AxiStreamConfigType  := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G     : AxiStreamConfigType;
       AXI_CONFIG_G      : AxiConfigType;
       AXI_BURST_G       : slv(1 downto 0)      := "01";
       AXI_CACHE_G       : slv(3 downto 0)      := "1111";

--- a/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
@@ -42,7 +42,7 @@ entity AxiStreamDmaFifo is
       AXIS_CONFIG_G      : AxiStreamConfigType := AXIS_WRITE_DMA_CONFIG_C;
       -- AXI4 Configurations
       AXI_BASE_ADDR_G    : slv(63 downto 0)    := x"0000_0000_0000_0000";  -- Memory Base Address Offset
-      AXI_CONFIG_G       : AxiConfigType       := axiConfig(32, 8, 4, 4);
+      AXI_CONFIG_G       : AxiConfigType;
       AXI_BURST_G        : slv(1 downto 0)     := "01";
       AXI_CACHE_G        : slv(3 downto 0)     := "1111");
    port (

--- a/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
@@ -39,7 +39,7 @@ entity AxiStreamDmaFifo is
       MAX_FRAME_WIDTH_G  : positive            := 14;  -- Maximum AXI Stream frame size (units of address bits)
       AXI_BUFFER_WIDTH_G : positive            := 28;  -- Total AXI Memory for FIFO buffering (units of address bits)
       -- AXI Stream Configurations
-      AXIS_CONFIG_G      : AxiStreamConfigType := AXIS_WRITE_DMA_CONFIG_C;
+      AXIS_CONFIG_G      : AxiStreamConfigType;
       -- AXI4 Configurations
       AXI_BASE_ADDR_G    : slv(63 downto 0)    := x"0000_0000_0000_0000";  -- Memory Base Address Offset
       AXI_CONFIG_G       : AxiConfigType;

--- a/axi/dma/rtl/v1/AxiStreamDmaRead.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRead.vhd
@@ -30,7 +30,7 @@ entity AxiStreamDmaRead is
    generic (
       TPD_G           : time                := 1 ns;
       AXIS_READY_EN_G : boolean             := false;
-      AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G   : AxiStreamConfigType;
       AXI_CONFIG_G    : AxiConfigType;
       AXI_BURST_G     : slv(1 downto 0)     := "01";
       AXI_CACHE_G     : slv(3 downto 0)     := "1111";

--- a/axi/dma/rtl/v1/AxiStreamDmaRead.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRead.vhd
@@ -31,7 +31,7 @@ entity AxiStreamDmaRead is
       TPD_G           : time                := 1 ns;
       AXIS_READY_EN_G : boolean             := false;
       AXIS_CONFIG_G   : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      AXI_CONFIG_G    : AxiConfigType       := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G    : AxiConfigType;
       AXI_BURST_G     : slv(1 downto 0)     := "01";
       AXI_CACHE_G     : slv(3 downto 0)     := "1111";
       SW_CACHE_EN_G   : boolean             := false;

--- a/axi/dma/rtl/v1/AxiStreamDmaRingRead.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRingRead.vhd
@@ -39,7 +39,7 @@ entity AxiStreamDmaRingRead is
       AXI_CACHE_G           : slv(3 downto 0)          := "0011";  -- Cacheable
       AXI_STREAM_READY_EN_G : boolean                  := true;
       AXI_STREAM_CONFIG_G   : AxiStreamConfigType      := ssiAxiStreamConfig(8);
-      AXI_READ_CONFIG_G     : AxiConfigType            := axiConfig(32, 8, 1, 8));
+      AXI_READ_CONFIG_G     : AxiConfigType);
    port (
       -- AXI-Lite Interface for local registers
       axilClk         : in  sl;

--- a/axi/dma/rtl/v1/AxiStreamDmaRingRead.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRingRead.vhd
@@ -38,7 +38,7 @@ entity AxiStreamDmaRingRead is
       AXI_BURST_G           : slv(1 downto 0)          := "01";    -- INCR
       AXI_CACHE_G           : slv(3 downto 0)          := "0011";  -- Cacheable
       AXI_STREAM_READY_EN_G : boolean                  := true;
-      AXI_STREAM_CONFIG_G   : AxiStreamConfigType      := ssiAxiStreamConfig(8);
+      AXI_STREAM_CONFIG_G   : AxiStreamConfigType;
       AXI_READ_CONFIG_G     : AxiConfigType);
    port (
       -- AXI-Lite Interface for local registers

--- a/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
@@ -35,9 +35,9 @@ entity AxiStreamDmaRingWrite is
       ENABLE_UNALIGN_G     : boolean                  := false;
       TRIGGER_USER_BIT_G   : natural range 0 to 7     := 2;
       AXIL_BASE_ADDR_G     : slv(31 downto 0)         := (others => '0');
-      DATA_AXIS_CONFIG_G   : AxiStreamConfigType      := ssiAxiStreamConfig(8);
-      STATUS_AXIS_CONFIG_G : AxiStreamConfigType      := ssiAxiStreamConfig(1);
-      AXI_WRITE_CONFIG_G   : AxiConfigType            := axiConfig(32, 8, 1, 8);
+      DATA_AXIS_CONFIG_G   : AxiStreamConfigType;
+      STATUS_AXIS_CONFIG_G : AxiStreamConfigType;
+      AXI_WRITE_CONFIG_G   : AxiConfigType;
       BYP_SHIFT_G          : boolean                  := true;  -- Bypass both because we do not want them to back-pressure
       BYP_CACHE_G          : boolean                  := true); -- Bypass both because we do not want them to back-pressure
    port (

--- a/axi/dma/rtl/v1/AxiStreamDmaWrite.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaWrite.vhd
@@ -31,7 +31,7 @@ entity AxiStreamDmaWrite is
       TPD_G             : time                := 1 ns;
       AXI_READY_EN_G    : boolean             := false;
       AXIS_CONFIG_G     : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      AXI_CONFIG_G      : AxiConfigType       := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G      : AxiConfigType;
       AXI_BURST_G       : slv(1 downto 0)     := "01";
       AXI_CACHE_G       : slv(3 downto 0)     := "1111";
       BURST_BYTES_G     : positive range 1 to 4096 := 4096;

--- a/axi/dma/rtl/v1/AxiStreamDmaWrite.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaWrite.vhd
@@ -30,7 +30,7 @@ entity AxiStreamDmaWrite is
    generic (
       TPD_G             : time                := 1 ns;
       AXI_READY_EN_G    : boolean             := false;
-      AXIS_CONFIG_G     : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G     : AxiStreamConfigType;
       AXI_CONFIG_G      : AxiConfigType;
       AXI_BURST_G       : slv(1 downto 0)     := "01";
       AXI_CACHE_G       : slv(3 downto 0)     := "1111";

--- a/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
@@ -37,7 +37,7 @@ entity AxiStreamDmaV2 is
       AXIL_BASE_ADDR_G   : slv(31 downto 0)         := x"00000000";
       AXI_READY_EN_G     : boolean                  := false;
       AXIS_READY_EN_G    : boolean                  := false;
-      AXIS_CONFIG_G      : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G      : AxiStreamConfigType;
       AXI_DMA_CONFIG_G   : AxiConfigType;
       CHAN_COUNT_G       : positive range 1 to 16   := 1;
       BURST_BYTES_G      : positive range 1 to 4096 := 4096;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
@@ -38,7 +38,7 @@ entity AxiStreamDmaV2 is
       AXI_READY_EN_G     : boolean                  := false;
       AXIS_READY_EN_G    : boolean                  := false;
       AXIS_CONFIG_G      : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C;
-      AXI_DMA_CONFIG_G   : AxiConfigType            := AXI_CONFIG_INIT_C;
+      AXI_DMA_CONFIG_G   : AxiConfigType;
       CHAN_COUNT_G       : positive range 1 to 16   := 1;
       BURST_BYTES_G      : positive range 1 to 4096 := 4096;
       WR_PIPE_STAGES_G   : natural                  := 1;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -37,7 +37,7 @@ entity AxiStreamDmaV2Desc is
       AXIL_BASE_ADDR_G : slv(31 downto 0) := x"00000000";
 
       -- Configuration of AXI bus, must be 64 bits (or wider)
-      AXI_CONFIG_G : AxiConfigType := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G : AxiConfigType;
 
       -- Number of descriptor entries in write FIFO and return ring buffers
       DESC_AWIDTH_G : integer range 4 to 32 := 12;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Read.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Read.vhd
@@ -30,7 +30,7 @@ entity AxiStreamDmaV2Read is
    generic (
       TPD_G           : time                     := 1 ns;
       AXIS_READY_EN_G : boolean                  := false;
-      AXIS_CONFIG_G   : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G   : AxiStreamConfigType;
       AXI_CONFIG_G    : AxiConfigType;
       PIPE_STAGES_G   : natural                  := 1;
       BURST_BYTES_G   : positive range 1 to 4096 := 4096;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Read.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Read.vhd
@@ -31,7 +31,7 @@ entity AxiStreamDmaV2Read is
       TPD_G           : time                     := 1 ns;
       AXIS_READY_EN_G : boolean                  := false;
       AXIS_CONFIG_G   : AxiStreamConfigType      := AXI_STREAM_CONFIG_INIT_C;
-      AXI_CONFIG_G    : AxiConfigType            := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G    : AxiConfigType;
       PIPE_STAGES_G   : natural                  := 1;
       BURST_BYTES_G   : positive range 1 to 4096 := 4096;
       PEND_THRESH_G   : positive                 := 1);  -- In units of bytes

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -30,7 +30,7 @@ entity AxiStreamDmaV2Write is
    generic (
       TPD_G             : time                    := 1 ns;
       AXI_READY_EN_G    : boolean                 := false;
-      AXIS_CONFIG_G     : AxiStreamConfigType     := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G     : AxiStreamConfigType;
       AXI_CONFIG_G      : AxiConfigType
       PIPE_STAGES_G     : natural                 := 1;
       BURST_BYTES_G     : integer range 1 to 4096 := 4096;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -31,7 +31,7 @@ entity AxiStreamDmaV2Write is
       TPD_G             : time                    := 1 ns;
       AXI_READY_EN_G    : boolean                 := false;
       AXIS_CONFIG_G     : AxiStreamConfigType     := AXI_STREAM_CONFIG_INIT_C;
-      AXI_CONFIG_G      : AxiConfigType           := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G      : AxiConfigType
       PIPE_STAGES_G     : natural                 := 1;
       BURST_BYTES_G     : integer range 1 to 4096 := 4096;
       ACK_WAIT_BVALID_G : boolean                 := true);

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -31,7 +31,7 @@ entity AxiStreamDmaV2Write is
       TPD_G             : time                    := 1 ns;
       AXI_READY_EN_G    : boolean                 := false;
       AXIS_CONFIG_G     : AxiStreamConfigType;
-      AXI_CONFIG_G      : AxiConfigType
+      AXI_CONFIG_G      : AxiConfigType;
       PIPE_STAGES_G     : natural                 := 1;
       BURST_BYTES_G     : integer range 1 to 4096 := 4096;
       ACK_WAIT_BVALID_G : boolean                 := true);

--- a/axi/dma/rtl/v2/AxiStreamDmaV2WriteMux.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2WriteMux.vhd
@@ -27,7 +27,7 @@ use surf.AxiPkg.all;
 entity AxiStreamDmaV2WriteMux is
    generic (
       TPD_G          : time          := 1 ns;
-      AXI_CONFIG_G   : AxiConfigType := AXI_CONFIG_INIT_C;
+      AXI_CONFIG_G   : AxiConfigType;
       AXI_READY_EN_G : boolean       := false);
    port (
       -- Clock and reset

--- a/axi/simlink/sim/RogueTcpStreamWrap.vhd
+++ b/axi/simlink/sim/RogueTcpStreamWrap.vhd
@@ -27,7 +27,7 @@ entity RogueTcpStreamWrap is
       PORT_NUM_G    : natural range 1024 to 49151 := 9000;
       SSI_EN_G      : boolean                     := true;
       CHAN_COUNT_G  : positive range 1 to 256     := 1;
-      AXIS_CONFIG_G : AxiStreamConfigType         := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- Clock and Reset
       axisClk     : in  sl;

--- a/protocols/batcher/rtl/AxiStreamBatcher.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcher.vhd
@@ -31,7 +31,7 @@ entity AxiStreamBatcher is
       MAX_NUMBER_SUB_FRAMES_G      : positive            := 32;  -- Units of sub-frames
       SUPER_FRAME_BYTE_THRESHOLD_G : natural             := 8192;  -- Units of bytes
       MAX_CLK_GAP_G                : natural             := 256;  -- Units of clock cycles
-      AXIS_CONFIG_G                : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G                : AxiStreamConfigType;
       INPUT_PIPE_STAGES_G          : natural             := 0;
       OUTPUT_PIPE_STAGES_G         : natural             := 1);
    port (

--- a/protocols/batcher/rtl/AxiStreamBatcherAxil.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherAxil.vhd
@@ -32,7 +32,7 @@ entity AxiStreamBatcherAxil is
       MAX_NUMBER_SUB_FRAMES_G      : positive            := 32;
       SUPER_FRAME_BYTE_THRESHOLD_G : natural             := 8192;
       MAX_CLK_GAP_G                : natural             := 256;
-      AXIS_CONFIG_G                : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G                : AxiStreamConfigType;
       INPUT_PIPE_STAGES_G          : natural             := 0;
       OUTPUT_PIPE_STAGES_G         : natural             := 1);
 

--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -47,7 +47,7 @@ entity AxiStreamBatcherEventBuilder is
       -- Set the TDEST to detect for transition frame
       TRANS_TDEST_G : slv(7 downto 0) := x"FF";
 
-      AXIS_CONFIG_G        : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
+      AXIS_CONFIG_G        : AxiStreamConfigType;
       INPUT_PIPE_STAGES_G  : natural             := 0;
       OUTPUT_PIPE_STAGES_G : natural             := 0);
    port (

--- a/protocols/clink/rtl/ClinkCtrl.vhd
+++ b/protocols/clink/rtl/ClinkCtrl.vhd
@@ -30,7 +30,7 @@ entity ClinkCtrl is
       TPD_G              : time                := 1 ns;
       INV_34_G           : boolean             := false;
       UART_READY_EN_G    : boolean             := true;
-      UART_AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      UART_AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- Cable In/Out
       cblHalfP    : inout slv(4 downto 0); -- 15, 17,  5,  6, 3

--- a/protocols/clink/rtl/ClinkFraming.vhd
+++ b/protocols/clink/rtl/ClinkFraming.vhd
@@ -28,7 +28,7 @@ entity ClinkFraming is
    generic (
       TPD_G              : time                := 1 ns;
       COMMON_DATA_CLK_G  : boolean             := false;  -- true if dataClk=sysClk
-      DATA_AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      DATA_AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- System clock and reset
       sysClk     : in  sl;

--- a/protocols/clink/rtl/ClinkTop.vhd
+++ b/protocols/clink/rtl/ClinkTop.vhd
@@ -34,8 +34,8 @@ entity ClinkTop is
       UART_READY_EN_G    : boolean              := true;
       COMMON_AXIL_CLK_G  : boolean              := false;  -- true if axilClk=sysClk
       COMMON_DATA_CLK_G  : boolean              := false;  -- true if dataClk=sysClk
-      DATA_AXIS_CONFIG_G : AxiStreamConfigType  := AXI_STREAM_CONFIG_INIT_C;
-      UART_AXIS_CONFIG_G : AxiStreamConfigType  := AXI_STREAM_CONFIG_INIT_C;
+      DATA_AXIS_CONFIG_G : AxiStreamConfigType;
+      UART_AXIS_CONFIG_G : AxiStreamConfigType;
       AXIL_BASE_ADDR_G   : slv(31 downto 0));
    port (
       -- Connector 0, Half 0, Control for Base,Medium,Full,Deca

--- a/protocols/clink/rtl/ClinkUart.vhd
+++ b/protocols/clink/rtl/ClinkUart.vhd
@@ -27,7 +27,7 @@ entity ClinkUart is
    generic (
       TPD_G              : time                := 1 ns;
       UART_READY_EN_G    : boolean             := true;
-      UART_AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      UART_AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- Clock and reset, 200Mhz
       intClk      : in  sl;

--- a/protocols/packetizer/rtl/AxiStreamBytePacker.vhd
+++ b/protocols/packetizer/rtl/AxiStreamBytePacker.vhd
@@ -31,8 +31,8 @@ use surf.AxiStreamPkg.all;
 entity AxiStreamBytePacker is
    generic (
       TPD_G           : time                := 1 ns;
-      SLAVE_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      SLAVE_CONFIG_G  : AxiStreamConfigType;
+      MASTER_CONFIG_G : AxiStreamConfigType);
    port (
       -- System clock and reset
       axiClk       : in  sl;

--- a/protocols/packetizer/tb/AxiStreamBytePackerTbRx.vhd
+++ b/protocols/packetizer/tb/AxiStreamBytePackerTbRx.vhd
@@ -26,7 +26,7 @@ entity AxiStreamBytePackerTbRx is
    generic (
       TPD_G         : time                := 1 ns;
       BYTE_SIZE_C   : positive            := 1;
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- System clock and reset
       axiClk       : in  sl;

--- a/protocols/packetizer/tb/AxiStreamBytePackerTbTx.vhd
+++ b/protocols/packetizer/tb/AxiStreamBytePackerTbTx.vhd
@@ -26,7 +26,7 @@ entity AxiStreamBytePackerTbTx is
    generic (
       TPD_G         : time                := 1 ns;
       BYTE_SIZE_C   : positive            := 1;
-      AXIS_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- System clock and reset
       axiClk       : in  sl;

--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -61,8 +61,8 @@ entity RssiCore is
       SEGMENT_ADDR_SIZE_G : positive := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
 
       -- AXIS Configurations
-      APP_AXIS_CONFIG_G        : AxiStreamConfigType := ssiAxiStreamConfig(4, TKEEP_NORMAL_C);
-      TSP_AXIS_CONFIG_G        : AxiStreamConfigType := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      APP_AXIS_CONFIG_G        : AxiStreamConfigType;
+      TSP_AXIS_CONFIG_G        : AxiStreamConfigType;
 
       -- Generic RSSI parameters
       BYP_TX_BUFFER_G : boolean := false;

--- a/protocols/rssi/v1/rtl/RssiCoreWrapper.vhd
+++ b/protocols/rssi/v1/rtl/RssiCoreWrapper.vhd
@@ -47,8 +47,8 @@ entity RssiCoreWrapper is
       MEMORY_TYPE_G        : string               := "block";
       ILEAVE_ON_NOTVALID_G : boolean              := false;  -- Unused (legacy generic)
       -- AXIS Configurations
-      APP_AXIS_CONFIG_G    : AxiStreamConfigArray := (0 => ssiAxiStreamConfig(8, TKEEP_NORMAL_C));
-      TSP_AXIS_CONFIG_G    : AxiStreamConfigType  := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      APP_AXIS_CONFIG_G    : AxiStreamConfigArray;
+      TSP_AXIS_CONFIG_G    : AxiStreamConfigType;
       -- Version and connection ID
       INIT_SEQ_N_G         : natural              := 16#80#;
       CONN_ID_G            : positive             := 16#12345678#;

--- a/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
@@ -57,8 +57,8 @@ entity AxiRssiCore is
       MAX_SEG_SIZE_G      : positive            := 1024;  --! max. payload size (units of bytes)
       AXI_CONFIG_G        : AxiConfigType;  --! Defines the AXI configuration but ADDR_WIDTH_C should be defined as the space for RSSI and maybe not the entire memory address space
       -- AXIS Configurations
-      APP_AXIS_CONFIG_G   : AxiStreamConfigType := ssiAxiStreamConfig(8, TKEEP_NORMAL_C);
-      TSP_AXIS_CONFIG_G   : AxiStreamConfigType := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      APP_AXIS_CONFIG_G   : AxiStreamConfigType;
+      TSP_AXIS_CONFIG_G   : AxiStreamConfigType;
       -- RSSI Timeouts
       CLK_FREQUENCY_G     : real                := 156.25E+6;  --! In units of Hz
       TIMEOUT_UNIT_G      : real                := 1.0E-3;  --! In units of seconds

--- a/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiCore.vhd
@@ -55,7 +55,7 @@ entity AxiRssiCore is
       SERVER_G            : boolean             := true;  --! Module is server or client
       -- AXI Configurations
       MAX_SEG_SIZE_G      : positive            := 1024;  --! max. payload size (units of bytes)
-      AXI_CONFIG_G        : AxiConfigType       := RSSI_AXI_CONFIG_C;  --! Defines the AXI configuration but ADDR_WIDTH_C should be defined as the space for RSSI and maybe not the entire memory address space
+      AXI_CONFIG_G        : AxiConfigType;  --! Defines the AXI configuration but ADDR_WIDTH_C should be defined as the space for RSSI and maybe not the entire memory address space
       -- AXIS Configurations
       APP_AXIS_CONFIG_G   : AxiStreamConfigType := ssiAxiStreamConfig(8, TKEEP_NORMAL_C);
       TSP_AXIS_CONFIG_G   : AxiStreamConfigType := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);

--- a/protocols/rssi/v1b/rtl/AxiRssiCoreWrapper.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiCoreWrapper.vhd
@@ -34,7 +34,7 @@ entity AxiRssiCoreWrapper is
       TPD_G               : time                 := 1 ns;
       SERVER_G            : boolean              := true;  --! Module is server or client
       JUMBO_G             : boolean              := false;  --! true=8192 byte payload, false=1024 byte payload
-      AXI_CONFIG_G        : AxiConfigType        := RSSI_AXI_CONFIG_C;  --! Defines the AXI configuration but ADDR_WIDTH_C should be defined as the space for RSSI and "maybe" not the entire memory address space available
+      AXI_CONFIG_G        : AxiConfigType;  --! Defines the AXI configuration but ADDR_WIDTH_C should be defined as the space for RSSI and "maybe" not the entire memory address space available
       -- AXIS Configurations
       APP_STREAMS_G       : positive             := 1;
       APP_STREAM_ROUTES_G : Slv8Array            := (0 => "--------");

--- a/protocols/rssi/v1b/rtl/AxiRssiCoreWrapper.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiCoreWrapper.vhd
@@ -38,8 +38,8 @@ entity AxiRssiCoreWrapper is
       -- AXIS Configurations
       APP_STREAMS_G       : positive             := 1;
       APP_STREAM_ROUTES_G : Slv8Array            := (0 => "--------");
-      APP_AXIS_CONFIG_G   : AxiStreamConfigArray := (0 => ssiAxiStreamConfig(8, TKEEP_NORMAL_C));
-      TSP_AXIS_CONFIG_G   : AxiStreamConfigType  := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      APP_AXIS_CONFIG_G   : AxiStreamConfigArray;
+      TSP_AXIS_CONFIG_G   : AxiStreamConfigType;
       -- RSSI Timeouts
       CLK_FREQUENCY_G     : real                 := 156.25E+6;  -- In units of Hz
       TIMEOUT_UNIT_G      : real                 := 1.0E-3;  -- In units of seconds

--- a/protocols/rssi/v1b/rtl/AxiRssiRxFsm.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiRxFsm.vhd
@@ -57,7 +57,7 @@ use surf.SsiPkg.all;
 entity AxiRssiRxFsm is
    generic (
       TPD_G               : time          := 1 ns;
-      AXI_CONFIG_G        : AxiConfigType := RSSI_AXI_CONFIG_C;
+      AXI_CONFIG_G        : AxiConfigType;
       BURST_BYTES_G       : positive      := 1024;
       WINDOW_ADDR_SIZE_G  : positive      := 7;  -- 2^WINDOW_ADDR_SIZE_G  = Number of segments
       HEADER_CHKSUM_EN_G  : boolean       := true;

--- a/protocols/rssi/v1b/rtl/AxiRssiTxFsm.vhd
+++ b/protocols/rssi/v1b/rtl/AxiRssiTxFsm.vhd
@@ -55,7 +55,7 @@ use surf.SsiPkg.all;
 entity AxiRssiTxFsm is
    generic (
       TPD_G               : time          := 1 ns;
-      AXI_CONFIG_G        : AxiConfigType := RSSI_AXI_CONFIG_C;
+      AXI_CONFIG_G        : AxiConfigType;
       BURST_BYTES_G       : positive      := 1024;
       WINDOW_ADDR_SIZE_G  : positive      := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Number of segments
       SEGMENT_ADDR_SIZE_G : positive      := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words

--- a/protocols/salt/core/rtl/SaltRx.vhd
+++ b/protocols/salt/core/rtl/SaltRx.vhd
@@ -28,7 +28,7 @@ entity SaltRx is
    generic (
       TPD_G               : time                := 1 ns;
       COMMON_RX_CLK_G     : boolean             := false;  -- Set to true if mAxisClk and clk are the same clock
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := ssiAxiStreamConfig(4));
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- Master Port
       mAxisClk    : in  sl;

--- a/protocols/salt/core/rtl/SaltTx.vhd
+++ b/protocols/salt/core/rtl/SaltTx.vhd
@@ -28,7 +28,7 @@ entity SaltTx is
    generic (
       TPD_G              : time                := 1 ns;
       COMMON_TX_CLK_G    : boolean             := false;  -- Set to true if sAxisClk and clk are the same clock
-      SLAVE_AXI_CONFIG_G : AxiStreamConfigType := ssiAxiStreamConfig(4));
+      SLAVE_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- Slave Port
       sAxisClk    : in  sl;

--- a/protocols/salt/xilinx7/rtl/Salt7Series.vhd
+++ b/protocols/salt/xilinx7/rtl/Salt7Series.vhd
@@ -28,8 +28,8 @@ entity Salt7Series is
       RX_ENABLE_G         : boolean             := true;
       COMMON_TX_CLK_G     : boolean             := false;  -- Set to true if sAxisClk and clk are the same clock
       COMMON_RX_CLK_G     : boolean             := false;  -- Set to true if mAxisClk and clk are the same clock
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := ssiAxiStreamConfig(4);
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := ssiAxiStreamConfig(4));
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- TX Serial Stream
       txP         : out sl;

--- a/protocols/salt/xilinxUltraScale/rtl/SaltUltraScale.vhd
+++ b/protocols/salt/xilinxUltraScale/rtl/SaltUltraScale.vhd
@@ -32,8 +32,8 @@ entity SaltUltraScale is
       RX_ENABLE_G         : boolean             := true;
       COMMON_TX_CLK_G     : boolean             := false;  -- Set to true if sAxisClk and clk are the same clock
       COMMON_RX_CLK_G     : boolean             := false;  -- Set to true if mAxisClk and clk are the same clock
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := ssiAxiStreamConfig(4);
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := ssiAxiStreamConfig(4));
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- TX Serial Stream
       txP           : out sl;

--- a/protocols/srp/rtl/AxiLiteSrpV0.vhd
+++ b/protocols/srp/rtl/AxiLiteSrpV0.vhd
@@ -42,7 +42,7 @@ entity AxiLiteSrpV0 is
       FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 2**8;
 
       -- AXI Stream IO Config
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Streaming Master (Tx) Data Interface (mAxisClk domain)

--- a/protocols/srp/rtl/SrpV0AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV0AxiLite.vhd
@@ -43,7 +43,7 @@ entity SrpV0AxiLite is
       FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 2**8;
 
       -- AXI Stream IO Config
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Streaming Slave (Rx) Interface (sAxisClk domain)

--- a/protocols/srp/rtl/SrpV3Axi.vhd
+++ b/protocols/srp/rtl/SrpV3Axi.vhd
@@ -44,8 +44,8 @@ entity SrpV3Axi is
       AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       UNALIGNED_ACCESS_G  : boolean                 := false;
       BYTE_ACCESS_G       : boolean                 := false;
-      WRITE_EN_G          : boolean                 := true;       -- Write ops enabled
-      READ_EN_G           : boolean                 := true);      -- Read ops enabled
+      WRITE_EN_G          : boolean                 := true;  -- Write ops enabled
+      READ_EN_G           : boolean                 := true);  -- Read ops enabled
    port (
       -- AXIS Slave Interface (sAxisClk domain)
       sAxisClk       : in  sl;
@@ -71,7 +71,7 @@ architecture rtl of SrpV3Axi is
 
    constant DMA_AXIS_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
-      TDATA_BYTES_C => 4,
+      TDATA_BYTES_C => AXI_CONFIG_G.DATA_BYTES_C,  -- Matches the AXI4 DATA width
       TDEST_BITS_C  => 0,
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_NORMAL_C,
@@ -178,7 +178,7 @@ begin
          axiReadSlave  => axiReadSlave);             -- [in]
 
 
-   comb : process (r, axiRst, rdDmaAck, srpReq, wrDmaAck) is
+   comb : process (axiRst, r, rdDmaAck, srpReq, wrDmaAck) is
       variable v         : RegType;
       variable addrError : sl;
    begin
@@ -200,13 +200,13 @@ begin
       end if;
       v.wrDmaReq.maxSize := srpReq.reqSize + 1;
 
-      v.rdDmaReq.request   := srpReq.request and toSl(srpReq.opcode = SRP_READ_C) and not addrError;
-      v.rdDmaReq.address   := srpReq.addr;
-      v.rdDmaReq.prot      := srpReq.prot;
+      v.rdDmaReq.request := srpReq.request and toSl(srpReq.opcode = SRP_READ_C) and not addrError;
+      v.rdDmaReq.address := srpReq.addr;
+      v.rdDmaReq.prot    := srpReq.prot;
       if (UNALIGNED_ACCESS_G = false and BYTE_ACCESS_G = false) then
          v.rdDmaReq.address(1 downto 0) := (others => '0');
       end if;
-      v.rdDmaReq.size      := srpReq.reqSize + 1;
+      v.rdDmaReq.size := srpReq.reqSize + 1;
 
 
       v.srpAck.done := '0';

--- a/protocols/srp/rtl/SrpV3Axi.vhd
+++ b/protocols/srp/rtl/SrpV3Axi.vhd
@@ -37,11 +37,11 @@ entity SrpV3Axi is
       SLAVE_READY_EN_G    : boolean                 := true;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       AXI_CLK_FREQ_G      : real                    := 156.25E+6;  -- units of Hz
-      AXI_CONFIG_G        : AxiConfigType           := axiConfig(33, 4, 1, 8);
+      AXI_CONFIG_G        : AxiConfigType;
       AXI_BURST_G         : slv(1 downto 0)         := "01";
       AXI_CACHE_G         : slv(3 downto 0)         := "1111";
       ACK_WAIT_BVALID_G   : boolean                 := true;
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType     := ssiAxiStreamConfig(2);
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       UNALIGNED_ACCESS_G  : boolean                 := false;
       BYTE_ACCESS_G       : boolean                 := false;
       WRITE_EN_G          : boolean                 := true;       -- Write ops enabled

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -42,7 +42,7 @@ entity SrpV3AxiLite is
       SLAVE_READY_EN_G      : boolean                 := false;
       GEN_SYNC_FIFO_G       : boolean                 := false;
       AXIL_CLK_FREQ_G       : real                    := 156.25E+6;  -- units of Hz
-      AXI_STREAM_CONFIG_G   : AxiStreamConfigType     := ssiAxiStreamConfig(2));
+      AXI_STREAM_CONFIG_G   : AxiStreamConfigType);
    port (
       -- AXIS Slave Interface (sAxisClk domain)
       sAxisClk         : in  sl;

--- a/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLiteFull.vhd
@@ -36,7 +36,7 @@ entity SrpV3AxiLiteFull is
       SLAVE_READY_EN_G    : boolean                 := false;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       AXIL_CLK_FREQ_G     : real                    := 156.25E+6;  -- units of Hz
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType     := ssiAxiStreamConfig(2));
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
    port (
       -- AXIS Slave Interface (sAxisClk domain)
       sAxisClk         : in  sl;

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -3,11 +3,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: SLAC Register Protocol Version 3, AXI-Lite Interface
---
--- Note: This module only supports 32-bit aligned addresses and 32-bit transactions.
---       For non 32-bit aligned addresses or non 32-bit transactions, use
---       the SrpV3Axi.vhd module with the AxiToAxiLite.vhd bridge
+-- Description: SLAC Register Protocol Version 3, Core FSM Logic
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -40,7 +40,7 @@ entity SrpV3Core is
       SLAVE_READY_EN_G    : boolean                 := false;
       GEN_SYNC_FIFO_G     : boolean                 := false;
       SRP_CLK_FREQ_G      : real                    := 156.25E+6;  -- units of Hz
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType     := ssiAxiStreamConfig(2);
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       UNALIGNED_ACCESS_G  : boolean                 := false;
       BYTE_ACCESS_G       : boolean                 := false;
       WRITE_EN_G          : boolean                 := true;       -- Write ops enabled

--- a/protocols/ssi/rtl/SsiAxiLiteMaster.vhd
+++ b/protocols/ssi/rtl/SsiAxiLiteMaster.vhd
@@ -72,7 +72,7 @@ entity SsiAxiLiteMaster is
       FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 2**8;
 
       -- AXI Stream IO Config
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Streaming Slave (Rx) Interface (sAxisClk domain)

--- a/protocols/ssi/rtl/SsiCmdMaster.vhd
+++ b/protocols/ssi/rtl/SsiCmdMaster.vhd
@@ -49,8 +49,7 @@ entity SsiCmdMaster is
       FIFO_PAUSE_THRESH_G : integer range 1 to (2**24) := 8;
 
       -- AXI Stream Configuration
-      AXI_STREAM_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C
-      );
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
    port (
 
       -- Streaming Data Interface

--- a/protocols/ssi/rtl/SsiDbgTap.vhd
+++ b/protocols/ssi/rtl/SsiDbgTap.vhd
@@ -29,7 +29,7 @@ entity SsiDbgTap is
    generic (
       TPD_G        : time                := 1 ns;
       CNT_WIDTH_G  : positive            := 16;
-      AXI_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- Slave Port
       axisClk    : in sl;

--- a/protocols/ssi/rtl/SsiFifo.vhd
+++ b/protocols/ssi/rtl/SsiFifo.vhd
@@ -62,8 +62,8 @@ entity SsiFifo is
       CASCADE_PAUSE_SEL_G    : natural             := 0;
       CASCADE_SIZE_G         : positive            := 1;
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G     : AxiStreamConfigType := SSI_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G    : AxiStreamConfigType := SSI_CONFIG_INIT_C);
+      SLAVE_AXI_CONFIG_G     : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G    : AxiStreamConfigType);
    port (
       -- Slave Interface (sAxisClk domain)
       sAxisClk        : in  sl;

--- a/protocols/ssi/rtl/SsiFrameLimiter.vhd
+++ b/protocols/ssi/rtl/SsiFrameLimiter.vhd
@@ -36,8 +36,8 @@ entity SsiFrameLimiter is
       SLAVE_FIFO_G        : boolean             := false;
       MASTER_FIFO_G       : boolean             := false;
       SLAVE_READY_EN_G    : boolean             := true;
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := AXI_STREAM_CONFIG_INIT_C);
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- Slave Port
       sAxisClk    : in  sl;

--- a/protocols/ssi/rtl/SsiIbFrameFilter.vhd
+++ b/protocols/ssi/rtl/SsiIbFrameFilter.vhd
@@ -32,7 +32,7 @@ entity SsiIbFrameFilter is
    generic (
       TPD_G            : time                := 1 ns;
       SLAVE_READY_EN_G : boolean             := true;
-      AXIS_CONFIG_G    : AxiStreamConfigType := SSI_CONFIG_INIT_C);
+      AXIS_CONFIG_G    : AxiStreamConfigType);
    port (
       -- Slave Interface (User Application Interface)
       sAxisMaster    : in  AxiStreamMasterType;

--- a/protocols/ssi/rtl/SsiIncrementingTx.vhd
+++ b/protocols/ssi/rtl/SsiIncrementingTx.vhd
@@ -40,7 +40,7 @@ entity SsiIncrementingTx is
       PRBS_SEED_SIZE_G           : natural range 32 to 128    := 32;
       PRBS_TAPS_G                : NaturalArray               := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream IO Config
-      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType        := ssiAxiStreamConfig(16, TKEEP_NORMAL_C);
+      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       MASTER_AXI_PIPE_STAGES_G   : natural range 0 to 16      := 0);
    port (
       -- Master Port (mAxisClk)

--- a/protocols/ssi/rtl/SsiInsertSof.vhd
+++ b/protocols/ssi/rtl/SsiInsertSof.vhd
@@ -38,8 +38,8 @@ entity SsiInsertSof is
       SLAVE_FIFO_G        : boolean                                      := true;
       MASTER_FIFO_G       : boolean                                      := true;
       -- AXI Stream Port Configurations
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType                          := AXI_STREAM_CONFIG_INIT_C;
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType                          := AXI_STREAM_CONFIG_INIT_C);
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- Slave Port
       sAxisClk    : in  sl;

--- a/protocols/ssi/rtl/SsiObFrameFilter.vhd
+++ b/protocols/ssi/rtl/SsiObFrameFilter.vhd
@@ -32,7 +32,7 @@ entity SsiObFrameFilter is
       TPD_G         : time                := 1 ns;
       VALID_THOLD_G : natural             := 1;
       PIPE_STAGES_G : natural             := 1;
-      AXIS_CONFIG_G : AxiStreamConfigType := SSI_CONFIG_INIT_C);
+      AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- Slave Port (AXIS FIFO Read Interface)
       sAxisMaster    : in  AxiStreamMasterType;

--- a/protocols/ssi/rtl/SsiPrbsRateGen.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRateGen.vhd
@@ -38,7 +38,7 @@ entity SsiPrbsRateGen is
       FIFO_ADDR_WIDTH_G          : natural range 4 to 48      := 9;
       -- AXI Stream Configurations
       AXIS_CLK_FREQ_G            : real                       := 156.25E+6;  -- units of Hz
-      AXIS_CONFIG_G              : AxiStreamConfigType        := AXI_STREAM_CONFIG_INIT_C);
+      AXIS_CONFIG_G              : AxiStreamConfigType);
    port (
       -- Master Port (mAxisClk)
       mAxisClk        : in  sl;

--- a/protocols/ssi/rtl/SsiPrbsRx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRx.vhd
@@ -45,9 +45,7 @@ entity SsiPrbsRx is
       PRBS_TAPS_G                : NaturalArray             := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream IO Config
       SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType;
-      SLAVE_AXI_PIPE_STAGES_G    : natural                  := 0;
-      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType      := ssiAxiStreamConfig(16);
-      MASTER_AXI_PIPE_STAGES_G   : natural                  := 0);
+      SLAVE_AXI_PIPE_STAGES_G    : natural                  := 0);
    port (
       -- Streaming RX Data Interface (sAxisClk domain)
       sAxisClk        : in  sl;
@@ -247,10 +245,10 @@ begin
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
-         PIPE_STAGES_G       => MASTER_AXI_PIPE_STAGES_G,
+         PIPE_STAGES_G       => SLAVE_AXI_PIPE_STAGES_G,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => PRBS_SSI_CONFIG_C,
-         MASTER_AXI_CONFIG_G => MASTER_AXI_STREAM_CONFIG_G)
+         MASTER_AXI_CONFIG_G => SLAVE_AXI_STREAM_CONFIG_G)
       port map (
          -- Clock and reset
          axisClk     => sAxisClk,

--- a/protocols/ssi/rtl/SsiPrbsRx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRx.vhd
@@ -44,9 +44,9 @@ entity SsiPrbsRx is
       PRBS_SEED_SIZE_G           : positive range 32 to 512 := 32;
       PRBS_TAPS_G                : NaturalArray             := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream IO Config
-      SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType      := ssiAxiStreamConfig(4);
+      SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType
       SLAVE_AXI_PIPE_STAGES_G    : natural                  := 0;
-      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType      := ssiAxiStreamConfig(4);
+      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType      := ssiAxiStreamConfig(16);
       MASTER_AXI_PIPE_STAGES_G   : natural                  := 0);
    port (
       -- Streaming RX Data Interface (sAxisClk domain)

--- a/protocols/ssi/rtl/SsiPrbsRx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRx.vhd
@@ -44,7 +44,7 @@ entity SsiPrbsRx is
       PRBS_SEED_SIZE_G           : positive range 32 to 512 := 32;
       PRBS_TAPS_G                : NaturalArray             := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream IO Config
-      SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType
+      SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType;
       SLAVE_AXI_PIPE_STAGES_G    : natural                  := 0;
       MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType      := ssiAxiStreamConfig(16);
       MASTER_AXI_PIPE_STAGES_G   : natural                  := 0);

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -48,7 +48,7 @@ entity SsiPrbsTx is
       PRBS_TAPS_G                : NaturalArray            := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       PRBS_INCREMENT_G           : boolean                 := false;  -- Increment mode by default instead of PRBS
       -- AXI Stream Configurations
-      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType     := ssiAxiStreamConfig(16, TKEEP_COMP_C);
+      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       MASTER_AXI_PIPE_STAGES_G   : natural range 0 to 16   := 0);
    port (
       -- Master Port (mAxisClk)

--- a/protocols/ssi/rtl/SsiPrbsTxOld.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTxOld.vhd
@@ -40,7 +40,7 @@ entity SsiPrbsTxOld is
       PRBS_SEED_SIZE_G           : natural range 32 to 128    := 32;
       PRBS_TAPS_G                : NaturalArray               := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream Configurations
-      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType        := ssiAxiStreamConfig(16, TKEEP_COMP_C);
+      MASTER_AXI_STREAM_CONFIG_G : AxiStreamConfigType;
       MASTER_AXI_PIPE_STAGES_G   : natural range 0 to 16      := 0);
    port (
       -- Master Port (mAxisClk)

--- a/xilinx/7Series/sem/rtl/SsiSem.vhd
+++ b/xilinx/7Series/sem/rtl/SsiSem.vhd
@@ -31,8 +31,8 @@ entity SsiSem is
       TPD_G               : time                := 1 ns;
       COMMON_AXIL_CLK_G   : boolean             := false;
       COMMON_AXIS_CLK_G   : boolean             := false;
-      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType := ssiAxiStreamConfig(1);
-      MASTER_AXI_CONFIG_G : AxiStreamConfigType := ssiAxiStreamConfig(1));
+      SLAVE_AXI_CONFIG_G  : AxiStreamConfigType;
+      MASTER_AXI_CONFIG_G : AxiStreamConfigType);
    port (
       -- SEM clock and reset
       semClk          : in  sl;


### PR DESCRIPTION
### Description
- Force the user to define AXI_CONFIG_G and AXI_STREAM_CONFIG_G
  - Instead of accidentally building with defaults
- Bug fix for non-32b AXI4 transactions in SrpV3Axi
  - assumed a 4-byte AXI stream, which was mismatched to the AXI4 width