### PR TITLE
pr.Device verify cleanup

### DIFF
--- a/python/surf/devices/ti/_Adc16Dx370.py
+++ b/python/surf/devices/ti/_Adc16Dx370.py
@@ -17,7 +17,7 @@ import pyrogue as pr
 import time
 
 class Adc16Dx370(pr.Device):
-    def __init__( self, verify=False, **kwargs):
+    def __init__( self, **kwargs):
 
         super().__init__(**kwargs)
 

--- a/python/surf/devices/ti/_Ads54J60.py
+++ b/python/surf/devices/ti/_Ads54J60.py
@@ -16,7 +16,7 @@ import time
 import surf.devices.ti
 
 class Ads54J60(pr.Device):
-    def __init__(self, verify=False, **kwargs):
+    def __init__(self, verify=True, **kwargs):
         super().__init__(
             size        = (0x1 << 18),
             **kwargs)

--- a/python/surf/devices/ti/_Ads54J60.py
+++ b/python/surf/devices/ti/_Ads54J60.py
@@ -16,7 +16,7 @@ import time
 import surf.devices.ti
 
 class Ads54J60(pr.Device):
-    def __init__(self, verify=True, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(
             size        = (0x1 << 18),
             **kwargs)
@@ -37,8 +37,8 @@ class Ads54J60(pr.Device):
         #####################
         # Add Device Channels
         #####################
-        self.add(surf.devices.ti.Ads54J60Channel(name='CH[0]',description='Channel A',offset=chA,expand=False,verify=verify,))
-        self.add(surf.devices.ti.Ads54J60Channel(name='CH[1]',description='Channel B',offset=chB,expand=False,verify=verify,))
+        self.add(surf.devices.ti.Ads54J60Channel(name='CH[0]',description='Channel A',offset=chA,expand=False))
+        self.add(surf.devices.ti.Ads54J60Channel(name='CH[1]',description='Channel B',offset=chB,expand=False))
 
         ##################
         # General Register
@@ -79,7 +79,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -90,7 +89,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -101,7 +99,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -112,7 +109,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -123,7 +119,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -134,7 +129,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -145,7 +139,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -156,7 +149,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -167,7 +159,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -178,7 +169,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -189,7 +179,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 5,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -200,7 +189,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -211,7 +199,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -222,7 +209,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 1,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -233,7 +219,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -244,7 +229,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -255,7 +239,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -266,7 +249,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -295,7 +277,6 @@ class Ads54J60(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         ##############################

--- a/python/surf/devices/ti/_Ads54J60Channel.py
+++ b/python/surf/devices/ti/_Ads54J60Channel.py
@@ -14,7 +14,7 @@
 import pyrogue as pr
 
 class Ads54J60Channel(pr.Device):
-    def __init__(self, verify=False, **kwargs):
+    def __init__(self, verify=True, **kwargs):
         super().__init__(**kwargs)
 
         #######################

--- a/python/surf/devices/ti/_Ads54J60Channel.py
+++ b/python/surf/devices/ti/_Ads54J60Channel.py
@@ -14,7 +14,7 @@
 import pyrogue as pr
 
 class Ads54J60Channel(pr.Device):
-    def __init__(self, verify=True, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         #######################
@@ -36,7 +36,6 @@ class Ads54J60Channel(pr.Device):
             # bitOffset    = 0,
             # base         = pr.UInt,
             # mode         = "RW",
-            # verify       = verify,
         # ))
 
         self.add(pr.RemoteVariable(
@@ -47,7 +46,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 5,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -58,7 +56,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -69,7 +66,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -80,7 +76,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -91,7 +86,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -102,7 +96,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -113,7 +106,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 5,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -124,7 +116,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -135,7 +126,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -146,7 +136,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -157,7 +146,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -168,7 +156,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -179,7 +166,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -190,7 +176,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         # self.add(pr.RemoteVariable(
@@ -201,7 +186,6 @@ class Ads54J60Channel(pr.Device):
             # bitOffset    = 0,
             # base         = pr.UInt,
             # mode         = "RW",
-            # verify       = verify,
         # ))
 
         ###################
@@ -216,7 +200,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -227,7 +210,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -238,7 +220,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -249,7 +230,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -260,7 +240,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 1,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -271,7 +250,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -282,7 +260,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -293,7 +270,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -304,7 +280,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -315,7 +290,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -326,7 +300,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 5,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -337,7 +310,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -348,7 +320,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -359,7 +330,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -370,7 +340,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -381,7 +350,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -392,7 +360,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 7,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -403,7 +370,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -414,7 +380,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -438,7 +403,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 4,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -449,7 +413,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -460,7 +423,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         ##################
@@ -475,7 +437,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -499,7 +460,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -510,7 +470,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -521,7 +480,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -532,7 +490,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 0,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -543,7 +500,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 6,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -554,7 +510,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 1,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -565,7 +520,6 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 5,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))
 
         self.add(pr.RemoteVariable(
@@ -576,5 +530,4 @@ class Ads54J60Channel(pr.Device):
             bitOffset    = 3,
             base         = pr.UInt,
             mode         = "RW",
-            verify       = verify,
         ))


### PR DESCRIPTION
### Description
- python/surf/devices/ti/_Adc16Dx370.py: removed unused `verify` arg
- python/surf/devices/ti/_Ads54J60.py: removed `verify` arg
- python/surf/devices/ti/_Ads54J60Channel.py: removed `verify` arg