### PR TITLE
Fix SspFramer

### DIFF
--- a/protocols/ssp/rtl/SspFramer.vhd
+++ b/protocols/ssp/rtl/SspFramer.vhd
@@ -20,8 +20,8 @@ use IEEE.STD_LOGIC_UNSIGNED.all;
 use IEEE.STD_LOGIC_ARITH.all;
 
 
-library surf;
-use surf.StdRtlPkg.all;
+library work;
+use work.StdRtlPkg.all;
 
 entity SspFramer is
 
@@ -125,6 +125,7 @@ begin
                   v.dataOut  := SSP_EOF_CODE_G;
                   v.dataKOut := SSP_EOF_K_G;
                   v.mode     := IDLE_MODE_C;
+                  v.readyIn  := '0';
                else
                   -- if not auto framing and valid drops, insert idle char
                   v.dataOut  := SSP_IDLE_CODE_G;

--- a/protocols/ssp/rtl/SspFramer.vhd
+++ b/protocols/ssp/rtl/SspFramer.vhd
@@ -20,8 +20,8 @@ use IEEE.STD_LOGIC_UNSIGNED.all;
 use IEEE.STD_LOGIC_ARITH.all;
 
 
-library work;
-use work.StdRtlPkg.all;
+library surf;
+use surf.StdRtlPkg.all;
 
 entity SspFramer is
 


### PR DESCRIPTION
### Description
-  if only 1 WORD was sent in a frame, data is lost. Back-pressure on EOF fixes that. 