### PR TITLE
Fix SlvDelayFifo Syntax to Allow VCS Compilation

### DIFF
--- a/base/general/rtl/SlvDelayFifo.vhd
+++ b/base/general/rtl/SlvDelayFifo.vhd
@@ -94,7 +94,7 @@ begin
          GEN_SYNC_FIFO_G => true,
          MEMORY_TYPE_G   => FIFO_MEMORY_TYPE_G,
          FWFT_EN_G       => true,
-         DATA_WIDTH_G    => (DELAY_BITS_G+DATA_WIDTH_G),
+         DATA_WIDTH_G    => FIFO_WIDTH_C,
          ADDR_WIDTH_G    => FIFO_ADDR_WIDTH_G)
       port map (
          rst         => rst,


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Fix VHDL syntax so that SlvDelayFifo will compile in VCS.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

VCS is really pedantic and raised the following errors:
```
Parsing design file '/u/re/bareese/projects/lcls2-timetool/firmware/submodules/surf/base/general/rtl/SlvDelayFifo.vhd'
Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/u/re/bareese/projects/lcls2-timetool/firmware/submodules/surf/base/general/rtl/SlvDelayFifo.vhd, 102
RTL
           din(DATA_FIELD_C)   => inputData,
              ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.
Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/u/re/bareese/projects/lcls2-timetool/firmware/submodules/surf/base/general/rtl/SlvDelayFifo.vhd, 103
RTL
           din(DELAY_FIELD_C)  => r.readoutTime,
              ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.
Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/u/re/bareese/projects/lcls2-timetool/firmware/submodules/surf/base/general/rtl/SlvDelayFifo.vhd, 107
RTL
           dout(DATA_FIELD_C)  => fifoReadoutData,
               ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.
Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/u/re/bareese/projects/lcls2-timetool/firmware/submodules/surf/base/general/rtl/SlvDelayFifo.vhd, 108
RTL
           dout(DELAY_FIELD_C) => fifoReadoutTime,
               ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.
```

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
