### PR TITLE
protocols/xvc-udp/ruckus.tcl update

### DIFF
--- a/protocols/xvc-udp/ruckus.tcl
+++ b/protocols/xvc-udp/ruckus.tcl
@@ -29,7 +29,6 @@ if { $::env(VIVADO_VERSION) >= 2018.3 } {
 
    if { [info exists ::env(USE_XVC_DEBUG)] != 1 || $::env(USE_XVC_DEBUG) == 0 } {
       loadSource -lib surf -path "$::DIR_PATH/dcp/${dirType}/Stub/images/UdpDebugBridge.dcp"
-      set_property IS_GLOBAL_INCLUDE {1} [get_files UdpDebugBridge.dcp]
 
    } elseif { $::env(USE_XVC_DEBUG) == -1 } {
       puts "Note: USE_XVC_DEBUG = -1"
@@ -39,7 +38,6 @@ if { $::env(VIVADO_VERSION) >= 2018.3 } {
 
    } else {
       loadSource -lib surf -path "$::DIR_PATH/dcp/${dirType}/Impl/images/UdpDebugBridge.dcp"
-       set_property IS_GLOBAL_INCLUDE {1} [get_files UdpDebugBridge.dcp]
    }
 
 } else {


### PR DESCRIPTION
### Description
- cannot add .DCP as global with Vivado 2020.1 DFX or with use IP Integrator + custom RTL modules