### PR TITLE
RssiAxiLiteRegItf.vhd & Code10b12bPkg.vhd Update

### DIFF
--- a/protocols/line-codes/rtl/Code10b12bPkg.vhd
+++ b/protocols/line-codes/rtl/Code10b12bPkg.vhd
@@ -31,7 +31,7 @@ package Code10b12bPkg is
    -- These symbols are commas, sequences that can be used for word alignment
    constant K_28_3_C  : slv(9 downto 0) := b"00011_11100";  -- 0x07C -> 0x8FC, 0x703
    constant K_28_11_C : slv(9 downto 0) := b"01011_11100";  -- 0x17C -> 0x2FC, 0xD03
-   constant K_28_19_C : slv(9 downto 0) := b"10011_11100";  -- 0x27C -> 0x4FC, 0xB03   
+   constant K_28_19_C : slv(9 downto 0) := b"10011_11100";  -- 0x27C -> 0x4FC, 0xB03
 
    -- These symbols are not commas but can be used for control sequences
    -- Technically any K.28.x character is a valid k-char but these are preffered

--- a/protocols/rssi/v1/rtl/RssiAxiLiteRegItf.vhd
+++ b/protocols/rssi/v1/rtl/RssiAxiLiteRegItf.vhd
@@ -190,6 +190,17 @@ architecture rtl of RssiAxiLiteRegItf is
    signal dummyBit     : sl;
    signal negRssiParam : RssiParamType;
 
+   -- attribute dont_touch                 : string;
+   -- attribute dont_touch of r            : signal is "TRUE";
+   -- attribute dont_touch of s_RdAddr     : signal is "TRUE";
+   -- attribute dont_touch of s_WrAddr     : signal is "TRUE";
+   -- attribute dont_touch of s_status     : signal is "TRUE";
+   -- attribute dont_touch of s_dropCnt    : signal is "TRUE";
+   -- attribute dont_touch of s_reconCnt   : signal is "TRUE";
+   -- attribute dont_touch of s_resendCnt  : signal is "TRUE";
+   -- attribute dont_touch of dummyBit     : signal is "TRUE";
+   -- attribute dont_touch of negRssiParam : signal is "TRUE";
+
 begin
 
    -- Convert address to integer (lower two bits of address are always '0')
@@ -247,7 +258,7 @@ begin
             when others =>
                axilWriteResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveWriteResponse(v.axilWriteSlave);
+         axiSlaveWriteResponse(v.axilWriteSlave, axilWriteResp);
       end if;
 
       if (axilStatus.readEnable = '1') then
@@ -309,12 +320,12 @@ begin
                v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(0)(63 downto 32);
             when 16#19# =>
                v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(31 downto 0);
-            when 16#20# =>
+            when 16#1A# =>
                v.axilReadSlave.rdata(31 downto 0) := bandwidth_i(1)(63 downto 32);
             when others =>
                axilReadResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveReadResponse(v.axilReadSlave);
+         axiSlaveReadResponse(v.axilReadSlave, axilReadResp);
       end if;
 
       -- Map to chksumEn


### PR DESCRIPTION
### Description
- Removed Code10b12bPkg.vhd whitespace
- Register mapping bug fix to RssiAxiLiteRegItf.vhd
  - bandwidth_i(1)(63 downto 32) should be mapped to `16#1A# `(not `16#20#`)