### PR TITLE
AxiStreamCombiner & AxiStreamSplitter Updates

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamCombiner.vhd
+++ b/axi/axi-stream/rtl/AxiStreamCombiner.vhd
@@ -72,8 +72,8 @@ architecture rtl of AxiStreamCombiner is
 
 begin
 
-   assert (MASTER_AXI_CONFIG_G.TDATA_BYTES_C = LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C)
-      report "MASTER_AXI_CONFIG_G.TDATA_BYTES_C must be LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C" severity failure;
+   assert (LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C = SLAVE_AXI_CONFIG_G.TDATA_BYTES_C)
+      report "MASTER_AXI_CONFIG_G.TDATA_BYTES_C must be SLAVE_AXI_CONFIG_G.TDATA_BYTES_C/LANES_G*" severity failure;
 
    comb : process (axisRst, mAxisSlave, r, sAxisMasters) is
       variable v      : RegType;

--- a/axi/axi-stream/rtl/AxiStreamCombiner.vhd
+++ b/axi/axi-stream/rtl/AxiStreamCombiner.vhd
@@ -74,8 +74,8 @@ architecture rtl of AxiStreamCombiner is
 
 begin
 
-   assert (LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C = SLAVE_AXI_CONFIG_G.TDATA_BYTES_C)
-      report "MASTER_AXI_CONFIG_G.TDATA_BYTES_C must be SLAVE_AXI_CONFIG_G.TDATA_BYTES_C/LANES_G*" severity failure;
+   assert (MASTER_AXI_CONFIG_G.TDATA_BYTES_C = LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C)
+      report "MASTER_AXI_CONFIG_G.TDATA_BYTES_C must be LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C" severity failure;
 
    comb : process (axisRst, mAxisSlave, r, sAxisMasters) is
       variable v      : RegType;

--- a/axi/axi-stream/rtl/AxiStreamCombiner.vhd
+++ b/axi/axi-stream/rtl/AxiStreamCombiner.vhd
@@ -3,6 +3,8 @@
 -------------------------------------------------------------------------------
 -- Description: Combines multiple "narrower" buses into a "wide" AXI stream bus
 -------------------------------------------------------------------------------
+-- Note: This module does NOT support interleaving of TDEST
+-------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
 -- top-level directory of this distribution and at:

--- a/axi/axi-stream/rtl/AxiStreamCombiner.vhd
+++ b/axi/axi-stream/rtl/AxiStreamCombiner.vhd
@@ -161,7 +161,7 @@ begin
                v.master := sAxisMasters(0);
                -- assemble the data
                for i in 0 to LANES_G-1 loop
-                  for j in 0 to MASTER_AXI_CONFIG_G.TDATA_BYTES_C-1 loop
+                  for j in 0 to SLAVE_AXI_CONFIG_G.TDATA_BYTES_C-1 loop
                      m                            := 8*j;
                      n                            := 8*(LANES_G*j+i);
                      v.master.tData(n+7 downto n) := sAxisMasters(i).tData(m+7 downto m);

--- a/axi/axi-stream/rtl/AxiStreamSplitter.vhd
+++ b/axi/axi-stream/rtl/AxiStreamSplitter.vhd
@@ -67,8 +67,8 @@ architecture rtl of AxiStreamSplitter is
 
 begin
 
-   assert (LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C = MASTER_AXI_CONFIG_G.TDATA_BYTES_C)
-      report "SLAVE_AXI_CONFIG_G.TDATA_BYTES_C must be MASTER_AXI_CONFIG_G.TDATA_BYTES_C/LANES_G" severity failure;
+   assert (SLAVE_AXI_CONFIG_G.TDATA_BYTES_C = LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C)
+      report "SLAVE_AXI_CONFIG_G.TDATA_BYTES_C must be LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C" severity failure;
 
    comb : process (axisRst, mAxisSlaves, r, sAxisMaster) is
       variable v    : RegType;

--- a/axi/axi-stream/rtl/AxiStreamSplitter.vhd
+++ b/axi/axi-stream/rtl/AxiStreamSplitter.vhd
@@ -65,8 +65,8 @@ architecture rtl of AxiStreamSplitter is
 
 begin
 
-   assert (SLAVE_AXI_CONFIG_G.TDATA_BYTES_C = LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C)
-      report "SLAVE_AXI_CONFIG_G.TDATA_BYTES_C must be LANES_G*MASTER_AXI_CONFIG_G.TDATA_BYTES_C" severity failure;
+   assert (LANES_G*SLAVE_AXI_CONFIG_G.TDATA_BYTES_C = MASTER_AXI_CONFIG_G.TDATA_BYTES_C)
+      report "SLAVE_AXI_CONFIG_G.TDATA_BYTES_C must be MASTER_AXI_CONFIG_G.TDATA_BYTES_C/LANES_G" severity failure;
 
    comb : process (axisRst, mAxisSlaves, r, sAxisMaster) is
       variable v    : RegType;

--- a/axi/axi-stream/rtl/AxiStreamSplitter.vhd
+++ b/axi/axi-stream/rtl/AxiStreamSplitter.vhd
@@ -3,6 +3,8 @@
 -------------------------------------------------------------------------------
 -- Description: splits a "wide" AXI stream bus into multiple "narrower" buses
 -------------------------------------------------------------------------------
+-- Note: This module does NOT support interleaving of TDEST
+-------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
 -- top-level directory of this distribution and at:
@@ -101,6 +103,7 @@ begin
                   v.masters(i).tData(SEQ_C'range)  := SEQ_C;
                   v.masters(i).tData(r.tSeq'range) := r.tSeq;
                   v.masters(i).tKeep               := genTKeep(MASTER_AXI_CONFIG_G.TDATA_BYTES_C);
+                  v.masters(i).tDest               := sAxisMaster.tDest;
                   v.tSeq                           := r.tSeq+1;
                end loop;
 


### PR DESCRIPTION
### Description
- adding tDest support to AxiStreamSplitter
- fixed out of bounds bug in AxiStreamCombiner
  - Example: slaves is 8-bytes and master is 24-bytes will have tData > 512-bit tData in the `for loop`