### PR TITLE
Restoring AXI-Lite response for JESD module from v2.6.0 tag

### DIFF
--- a/protocols/jesd204b/rtl/JesdRxReg.vhd
+++ b/protocols/jesd204b/rtl/JesdRxReg.vhd
@@ -229,7 +229,7 @@ begin
             when others =>
                axilWriteResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveWriteResponse(v.axilWriteSlave);
+         axiSlaveWriteResponse(v.axilWriteSlave, axilWriteResp);
       end if;
 
       if (axilStatus.readEnable = '1') then
@@ -288,7 +288,7 @@ begin
             when others =>
                axilReadResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveReadResponse(v.axilReadSlave);
+         axiSlaveReadResponse(v.axilReadSlave, axilReadResp);
       end if;
 
       -- Reset

--- a/protocols/jesd204b/rtl/JesdTxReg.vhd
+++ b/protocols/jesd204b/rtl/JesdTxReg.vhd
@@ -259,7 +259,7 @@ begin
             when others =>
                axilWriteResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveWriteResponse(v.axilWriteSlave);
+         axiSlaveWriteResponse(v.axilWriteSlave, axilWriteResp);
       end if;
 
       if (axilStatus.readEnable = '1') then
@@ -321,7 +321,7 @@ begin
             when others =>
                axilReadResp := AXI_RESP_DECERR_C;
          end case;
-         axiSlaveReadResponse(v.axilReadSlave);
+         axiSlaveReadResponse(v.axilReadSlave, axilReadResp);
       end if;
 
       -- Reset


### PR DESCRIPTION
### Description
- Confirmed that these were not the cause of the issue
  - Related to PR#689