### PR TITLE
More ESCRYODET-671 development Updates

### DIFF
--- a/python/surf/devices/ti/_Lmk048Base.py
+++ b/python/surf/devices/ti/_Lmk048Base.py
@@ -1057,6 +1057,15 @@ class Lmk048Base(pr.Device):
             mode         = 'RW',
         ))
 
+        self.add(pr.RemoteVariable(
+            name         = 'RESET',
+            description  = 'RESET',
+            offset       = (0x0000 << 2),
+            bitSize      = 1,
+            bitOffset    = 7,
+            mode         = 'WO',
+        ))
+
         ##############################
         # Commands
         ##############################

--- a/python/surf/protocols/jesd204b/_JesdRx.py
+++ b/python/surf/protocols/jesd204b/_JesdRx.py
@@ -315,6 +315,7 @@ class JesdRx(pr.Device):
                 mode         = "RO",
                 number       =  numRxLanes,
                 stride       =  4,
+                disp         = '{:d}',
                 pollInterval = 1,
             )
 


### PR DESCRIPTION
### Description
- Mapping the LMK RESET at address 0x0 in software
- Displaying the JESD RX elastic buffer in decimal (instead of HEX)