### PR TITLE
Allow per destination buffer limits in DMA engine

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -29,8 +29,9 @@ entity AxiStreamMux is
       TPD_G                : time                   := 1 ns;
       PIPE_STAGES_G        : integer range 0 to 16  := 0;
       NUM_SLAVES_G         : integer range 1 to 256 := 4;
-      -- In INDEXED mode, the output TDEST is set based on the selected slave index
+      -- In INDEXED mode, the output TDEST is set based on the selected slave index (default)
       -- In ROUTED mode, TDEST is set according to the TDEST_ROUTES_G table
+      -- In PASSTHROUGH mode, TDEST is passed through from the slave untouched
       MODE_G               : string                 := "INDEXED";
       -- In ROUTED mode, an array mapping how TDEST should be assigned for each slave port
       -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -104,12 +104,16 @@ architecture rtl of AxiStreamMux is
 
 begin
 
-   assert (MODE_G /= "INDEXED" or (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G)))
+   assert ( (MODE_G = "PASSTHROUGH") or (MODE_G = "INDEXED") or (MODE_G = "ROUTED") )
+      report "MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
+      severity error;
+
+   assert ( (MODE_G = "INDEXED") and (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G)) )
       report "In INDEXED mode, TDest range 7 downto " & integer'image(TDEST_LOW_G) &
       " is too small for NUM_SLAVES_G=" & integer'image(NUM_SLAVES_G)
       severity error;
 
-   assert (MODE_G /= "ROUTED" or (TDEST_ROUTES_G'length = NUM_SLAVES_G))
+   assert ( (MODE_G = "ROUTED") and (TDEST_ROUTES_G'length = NUM_SLAVES_G) )
       report "In ROUTED mode, length of TDEST_ROUTES_G: " & integer'image(TDEST_ROUTES_G'length) &
       " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
       severity error;
@@ -118,6 +122,10 @@ begin
       report "TID_MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
       severity error;
 
+   assert ( (TID_MODE_G = "ROUTED") and (TID_ROUTES_G'length = NUM_SLAVES_G) )
+      report "In ROUTED mode, length of TID_ROUTES_G: " & integer'image(TID_ROUTES_G'length) &
+      " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
+      severity error;
 
    -- Override TDESTS and TIDs according to the routing tables
    ROUTE_TABLE_REMAP : process (sAxisMasters) is
@@ -154,7 +162,7 @@ begin
          end loop;
       end if;
 
-      
+
       sAxisMastersTmp <= tmp;
    end process;
 

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -120,7 +120,7 @@ begin
 
 
    -- Override TDESTS and TIDs according to the routing tables
-   TDEST_REMAP : process (sAxisMasters) is
+   ROUTE_TABLE_REMAP : process (sAxisMasters) is
       variable tmp : AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
       variable i   : natural;
       variable j   : natural;

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -64,8 +64,7 @@ entity AxiStreamMux is
 
       -- Master
       mAxisMaster : out AxiStreamMasterType;
-      mAxisSlave  : in  AxiStreamSlaveType;
-      mAxisCtrl   : in  AxiStreamCtrlType := AXI_STREAM_CTRL_INIT_C);
+      mAxisSlave  : in  AxiStreamSlaveType);
 end AxiStreamMux;
 
 architecture rtl of AxiStreamMux is
@@ -132,7 +131,7 @@ begin
       sAxisMastersTmp <= tmp;
    end process;
 
-   comb : process (axisRst, disableSel, ileaveRearb, pipeAxisSlave, r, rearbitrate, sAxisMastersTmp, mAxisCtrl) is
+   comb : process (axisRst, disableSel, ileaveRearb, pipeAxisSlave, r, rearbitrate, sAxisMastersTmp) is
       variable v        : RegType;
       variable requests : slv(ARB_BITS_C-1 downto 0);
       variable selData  : AxiStreamMasterType;
@@ -165,7 +164,7 @@ begin
       -- Format requests
       requests := (others => '0');
       for i in 0 to (NUM_SLAVES_G-1) loop
-         requests(i) := sAxisMastersTmp(i).tValid and not disableSel(i) and not mAxisCtrl.destPause(i);
+         requests(i) := sAxisMastersTmp(i).tValid and not disableSel(i);
       end loop;
 
 
@@ -174,7 +173,7 @@ begin
          -- Also allow disableSel and rearbitrate to work at any time
          if (ILEAVE_EN_G) then
             if ((ILEAVE_ON_NOTVALID_G and selData.tValid = '0') or
-                (rearbitrate = '1' or disableSel(conv_integer(r.ackNum)) = '1' or mAxisCtrl.destPause(conv_integer(r.ackNum)) = '1')) then
+                (rearbitrate = '1' or disableSel(conv_integer(r.ackNum)) = '1')) then
                v.valid := '0';
             end if;
          end if;

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -39,7 +39,7 @@ entity AxiStreamMux is
       -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.
       TDEST_ROUTES_G       : Slv8Array              := (0 => "--------");
       -- In TID_OVERRIDE_G=true and ROUTED mode, an array mapping how TID should be assigned for each slave port
-      TID_ROUTES_G         : Slv8Array              := (0 => x"00");
+      TID_ROUTES_G         : Slv8Array              := (0 => "--------");
       -- In INDEXED mode, assign slave index to TDEST at this bit offset
       TDEST_LOW_G          : integer range 0 to 7   := 0;
       -- Set to true if interleaving dests

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -201,9 +201,9 @@ begin
          selData.tId := resize(r.ackNum, 8);
       end if;
 
-      -- NOTE: TID_MODE_G = "PASSTHROUGH" is the degenerate case
-      -- In the absense of "ROUTED" or "INDEXED", it will default to
-      -- assigning the slave input TID to the output master.
+      -- NOTE: MODE_G = "PASSTHROUGH and TID_MODE_G = "PASSTHROUGH" are degenerate cases.
+      -- In the absense of "ROUTED" or "INDEXED", TDEST and TID are assigned
+      -- directly from the slave input to the output master.
 
       -- Format requests
       requests := (others => '0');

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -31,14 +31,14 @@ entity AxiStreamMux is
       PIPE_STAGES_G        : integer range 0 to 16  := 0;
       NUM_SLAVES_G         : integer range 1 to 256 := 4;
       -- Set to true if you want to override Slave's TID
-      TID_EN_G             : boolean                := false;
+      TID_OVERRIDE_G             : boolean                := false;
       -- In INDEXED mode, the output TDEST is set based on the selected slave index
       -- In ROUTED mode, TDEST is set accoring to the TDEST_ROUTES_G table
       MODE_G               : string                 := "INDEXED";
       -- In ROUTED mode, an array mapping how TDEST should be assigned for each slave port
       -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.
       TDEST_ROUTES_G       : Slv8Array              := (0 => "--------");
-      -- In TID_EN_G=true and ROUTED mode, an array mapping how TID should be assigned for each slave port
+      -- In TID_OVERRIDE_G=true and ROUTED mode, an array mapping how TID should be assigned for each slave port
       TID_ROUTES_G         : Slv8Array              := (0 => x"00");
       -- In INDEXED mode, assign slave index to TDEST at this bit offset
       TDEST_LOW_G          : integer range 0 to 7   := 0;
@@ -193,13 +193,29 @@ begin
             -- Assign data to output
             v.master := selData;
 
-            -- Assign the ID to output
-            if TID_EN_G then
+            -- Check if overriding the TID
+            if TID_OVERRIDE_G then
+
                if MODE_G = "ROUTED" then
-                  v.master.tId := TID_ROUTES_G(conv_integer(r.ackNum));
+
+                  for j in 7 downto 0 loop
+
+                     if (TID_ROUTES_G(conv_integer(r.ackNum))(j) = '1') then
+                        v.master.tId(j) := '1';
+
+                     elsif(TID_ROUTES_G(conv_integer(r.ackNum))(j) = '0') then
+                        v.master.tId(j) := '0';
+
+                     else
+                        v.master.tId(j) := selData.tId(j);
+                     end if;
+
+                  end loop;
+
                else
                   v.master.tId := toSlv(conv_integer(r.ackNum), 8);
                end if;
+
             end if;
 
             -- Increment the txn count

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -65,7 +65,7 @@ entity AxiStreamMux is
       -- Master
       mAxisMaster : out AxiStreamMasterType;
       mAxisSlave  : in  AxiStreamSlaveType;
-      mAxisCtrl   : in  AxiStreamCtrlType);
+      mAxisCtrl   : in  AxiStreamCtrlType := AXI_STREAM_CTRL_INIT_C);
 end AxiStreamMux;
 
 architecture rtl of AxiStreamMux is

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -32,7 +32,7 @@ entity AxiStreamMux is
       -- In INDEXED mode, the output TDEST is set based on the selected slave index (default)
       -- In ROUTED mode, TDEST is set according to the TDEST_ROUTES_G table
       -- In PASSTHROUGH mode, TDEST is passed through from the slave untouched
-      MODE_G               : string                 := "INDEXED";
+      MODE_G               : string                 := "INDEXED"; -- Note: Planning to rename "MODE_G" to "TDEST_MODE_G" in a future MAJOR release of SURF
       -- In ROUTED mode, an array mapping how TDEST should be assigned for each slave port
       -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.
       TDEST_ROUTES_G       : Slv8Array              := (0 => "--------");

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -108,12 +108,12 @@ begin
       report "MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
       severity error;
 
-   assert ( (MODE_G = "INDEXED") and (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G)) )
+   assert ( (MODE_G = "INDEXED") and (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G)) ) or (MODE_G /= "INDEXED")
       report "In INDEXED mode, TDest range 7 downto " & integer'image(TDEST_LOW_G) &
       " is too small for NUM_SLAVES_G=" & integer'image(NUM_SLAVES_G)
       severity error;
 
-   assert ( (MODE_G = "ROUTED") and (TDEST_ROUTES_G'length = NUM_SLAVES_G) )
+   assert ( (MODE_G = "ROUTED") and (TDEST_ROUTES_G'length = NUM_SLAVES_G) ) or (MODE_G /= "ROUTED")
       report "In ROUTED mode, length of TDEST_ROUTES_G: " & integer'image(TDEST_ROUTES_G'length) &
       " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
       severity error;
@@ -122,7 +122,7 @@ begin
       report "TID_MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
       severity error;
 
-   assert ( (TID_MODE_G = "ROUTED") and (TID_ROUTES_G'length = NUM_SLAVES_G) )
+   assert ( (TID_MODE_G = "ROUTED") and (TID_ROUTES_G'length = NUM_SLAVES_G) ) or (TID_MODE_G /= "ROUTED")
       report "In ROUTED mode, length of TID_ROUTES_G: " & integer'image(TID_ROUTES_G'length) &
       " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
       severity error;

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -174,7 +174,7 @@ begin
          -- Also allow disableSel and rearbitrate to work at any time
          if (ILEAVE_EN_G) then
             if ((ILEAVE_ON_NOTVALID_G and selData.tValid = '0') or
-                (rearbitrate = '1' or disableSel(conv_integer(r.ackNum)) = '1' or mAxisCtrl.destPause(i) = '1')) then
+                (rearbitrate = '1' or disableSel(conv_integer(r.ackNum)) = '1' or mAxisCtrl.destPause(conv_integer(r.ackNum)) = '1')) then
                v.valid := '0';
             end if;
          end if;

--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -113,20 +113,17 @@ package AxiStreamPkg is
    -- Special control backpressure interface for use with stream fifos
    -------------------------------------------------------------------------------------------------
    type AxiStreamCtrlType is record
-      bgPause  : slv(7 downto 0);
       pause    : sl;
       overflow : sl;
       idle     : sl;
    end record AxiStreamCtrlType;
 
    constant AXI_STREAM_CTRL_INIT_C : AxiStreamCtrlType := (
-      bgPause  => (others=>'0'),
       pause    => '1',
       overflow => '0',
       idle     => '0');
 
    constant AXI_STREAM_CTRL_UNUSED_C : AxiStreamCtrlType := (
-      bgPause  => (others=>'0'),
       pause    => '0',
       overflow => '0',
       idle     => '1');

--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -113,20 +113,23 @@ package AxiStreamPkg is
    -- Special control backpressure interface for use with stream fifos
    -------------------------------------------------------------------------------------------------
    type AxiStreamCtrlType is record
-      pause    : sl;
-      overflow : sl;
-      idle     : sl;
+      destPause : slv(255 downto 0);
+      pause     : sl;
+      overflow  : sl;
+      idle      : sl;
    end record AxiStreamCtrlType;
 
    constant AXI_STREAM_CTRL_INIT_C : AxiStreamCtrlType := (
-      pause    => '1',
-      overflow => '0',
-      idle     => '0');
+      destPause => (others=>'0'),
+      pause     => '1',
+      overflow  => '0',
+      idle      => '0');
 
    constant AXI_STREAM_CTRL_UNUSED_C : AxiStreamCtrlType := (
-      pause    => '0',
-      overflow => '0',
-      idle     => '1');
+      destPause => (others=>'0'),
+      pause     => '0',
+      overflow  => '0',
+      idle      => '1');
 
    type AxiStreamCtrlArray is array (natural range<>) of AxiStreamCtrlType;
    type AxiStreamCtrlVectorArray is array (natural range<>, natural range<>) of AxiStreamCtrlType;

--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -126,10 +126,10 @@ package AxiStreamPkg is
       idle     => '0');
 
    constant AXI_STREAM_CTRL_UNUSED_C : AxiStreamCtrlType := (
-      destPause => (others=>'0'),
-      pause     => '0',
-      overflow  => '0',
-      idle      => '1');
+      bgPause  => (others=>'0'),
+      pause    => '0',
+      overflow => '0',
+      idle     => '1');
 
    type AxiStreamCtrlArray is array (natural range<>) of AxiStreamCtrlType;
    type AxiStreamCtrlVectorArray is array (natural range<>, natural range<>) of AxiStreamCtrlType;

--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -113,17 +113,17 @@ package AxiStreamPkg is
    -- Special control backpressure interface for use with stream fifos
    -------------------------------------------------------------------------------------------------
    type AxiStreamCtrlType is record
-      destPause : slv(255 downto 0);
-      pause     : sl;
-      overflow  : sl;
-      idle      : sl;
+      bgPause  : slv(7 downto 0);
+      pause    : sl;
+      overflow : sl;
+      idle     : sl;
    end record AxiStreamCtrlType;
 
    constant AXI_STREAM_CTRL_INIT_C : AxiStreamCtrlType := (
-      destPause => (others=>'0'),
-      pause     => '1',
-      overflow  => '0',
-      idle      => '0');
+      bgPause  => (others=>'0'),
+      pause    => '1',
+      overflow => '0',
+      idle     => '0');
 
    constant AXI_STREAM_CTRL_UNUSED_C : AxiStreamCtrlType := (
       destPause => (others=>'0'),

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -161,17 +161,19 @@ package AxiDmaPkg is
 
    type AxiWriteDmaDescReqType is record
       valid      : sl;
+      id         : slv(7 downto 0);
       dest       : slv(7 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_DESC_REQ_INIT_C : AxiWriteDmaDescReqType := (
       valid      => '0',
+      id         => (others=>'0'),
       dest       => (others=>'0')
    );
 
    type AxiWriteDmaDescReqArray is array (natural range<>) of AxiWriteDmaDescReqType;
 
-   constant AXI_WRITE_DMA_DESC_REQ_SIZE_C : integer := 8;
+   constant AXI_WRITE_DMA_DESC_REQ_SIZE_C : integer := 16;
 
    function toSlv (r : AxiWriteDmaDescReqType ) return slv;
    function toAxiWriteDmaDescReq (din : slv; valid : sl) return AxiWriteDmaDescReqType;
@@ -390,6 +392,7 @@ package body AxiDmaPkg is
       variable i        : integer := 0;
    begin
       assignSlv(i, retValue, r.dest);
+      assignSlv(i, retValue, r.id);
       return(retValue);
    end function;
 
@@ -399,6 +402,7 @@ package body AxiDmaPkg is
    begin
       desc.valid := valid;
       assignRecord(i, din, desc.dest);
+      assignRecord(i, din, desc.id);
       return(desc);
    end function;
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2.vhd
@@ -56,6 +56,7 @@ entity AxiStreamDmaV2 is
       interrupt       : out sl;
       online          : out slv(CHAN_COUNT_G-1 downto 0);
       acknowledge     : out slv(CHAN_COUNT_G-1 downto 0);
+      buffGrpPause    : out slv(7 downto 0);
       -- AXI Stream Interface
       sAxisMasters    : in  AxiStreamMasterArray(CHAN_COUNT_G-1 downto 0);
       sAxisSlaves     : out AxiStreamSlaveArray(CHAN_COUNT_G-1 downto 0);
@@ -137,7 +138,8 @@ begin
          axiRdCache      => axiRdCache,
          axiWrCache      => axiWrCache,
          axiWriteMasters => descWriteMasters,
-         axiWriteSlaves  => descWriteSlaves);
+         axiWriteSlaves  => descWriteSlaves,
+         buffGrpPause    => buffGrpPause);
 
    -- Read/Write channel 0 unused.
    axiReadMasters(0)  <= AXI_READ_MASTER_INIT_C;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -78,7 +78,11 @@ entity AxiStreamDmaV2Desc is
       axiWrCache      : out slv(3 downto 0);
       -- AXI Interface
       axiWriteMasters : out AxiWriteMasterArray(CHAN_COUNT_G-1 downto 0);
-      axiWriteSlaves  : in  AxiWriteSlaveArray(CHAN_COUNT_G-1 downto 0));
+      axiWriteSlaves  : in  AxiWriteSlaveArray(CHAN_COUNT_G-1 downto 0);
+
+      -- Buffer Group Pause
+      buffGrpPause    : out slv(7 downto 0);
+
 end AxiStreamDmaV2Desc;
 
 architecture rtl of AxiStreamDmaV2Desc is
@@ -140,6 +144,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffRdCache : slv(3 downto 0);
       buffWrCache : slv(3 downto 0);
       enableCnt   : slv(7 downto 0);
+      idBuffThold : Slv32Array(7 downto 0);
 
       -- FIFOs
       fifoDin        : slv(31 downto 0);
@@ -177,6 +182,13 @@ architecture rtl of AxiStreamDmaV2Desc is
       intHoldoff      : slv(15 downto 0);
       intHoldoffCount : slv(15 downto 0);
 
+      idBuffCount : Slv32Array(7 downto 0);
+
+      idBuffInc   : slv(7 downto 0);
+      idBuffDec   : slv(7 downto 0);
+
+      buffGrpPause : slv(7 downto 0);
+
    end record RegType;
 
    constant REG_INIT_C : RegType := (
@@ -209,6 +221,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffRdCache     => (others => '0'),
       buffWrCache     => (others => '0'),
       enableCnt       => (others => '0'),
+      idBuffThold     => (others => (others => '0')),
       -- FIFOs
       fifoDin         => (others => '0'),
       wrFifoWr        => (others => '0'),
@@ -240,7 +253,11 @@ architecture rtl of AxiStreamDmaV2Desc is
       intReqCount     => (others => '0'),
       interrupt       => '0',
       intHoldoff      => toSlv(10000,16),  -- ~20 kHz
-      intHoldoffCount => (others => '0') );
+      intHoldoffCount => (others => '0'),
+      idBuffCount     => (others => (others => '0')),
+      idBuffInc       => (others => '0'),
+      idBuffDec       => (others => '0'),
+      buffGrpPause    => (others => '0'));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -361,6 +378,8 @@ begin
       variable dmaRdReq     : AxiReadDmaDescReqType;
       variable rdIndex      : natural;
       variable regCon       : AxiLiteEndPointType;
+      variable idIncrement  : slv(7 downto 0);
+      variable idDecrement  : slv(7 downto 0);
    begin
 
       -- Latch the current value
@@ -372,6 +391,8 @@ begin
       v.wrFifoWr    := (others => '0');
       v.wrFifoRd    := '0';
       v.acknowledge := (others => '0');
+      v.idBuffInc   := (others=>'0');
+      v.idBuffDec   := (others=>'0');
 
       ----------------------------------------------------------
       -- Register access
@@ -435,6 +456,12 @@ begin
       axiSlaveRegister(regCon, x"080", 0, v.forceInt);
 
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
+
+      for i in 0 to 7 loop
+         axiSlaveRegister(regCon, toSlv(144 + i,12), 0, v.idBuffThold);  -- 0x090 - 0xAC
+         axiSlaveRegisterR(regCon, toSlv(176 + i,12), 0, r.idBuffCount); -- 0x0B0 - 0xCC
+         axiWrDetect(regCon, toSlv(176 + i,12), v.idBuffDec(i));         -- 0x0B0 - 0xCC
+      end loop;
 
       -- End transaction block
       axiSlaveDefault(regCon, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
@@ -538,6 +565,8 @@ begin
          v.wrFifoRd                                     := '1';
          v.wrReqValid                                   := '0';
 
+         v.idBuffInc(conv_integer(dmaWrDescReq(conv_integer(r.wrReqNum)).id(2 downto 0))) := '1';
+
       end if;
 
       ----------------------------------------------------------
@@ -636,7 +665,8 @@ begin
             v.axiWriteMaster.wdata(63 downto 32)   := dmaWrDescRet(descIndex).buffId;
             v.axiWriteMaster.wdata(31 downto 24)   := dmaWrDescRet(descIndex).firstUser;
             v.axiWriteMaster.wdata(23 downto 16)   := dmaWrDescRet(descIndex).lastUser;
-            v.axiWriteMaster.wdata(15 downto 4)    := (others => '0');
+            v.axiWriteMaster.wdata(15 downto 8)    := dmaWrDescRet(descIndex).id;
+            v.axiWriteMaster.wdata(7  downto 4)    := (others => '0');
             v.axiWriteMaster.wdata(3)              := dmaWrDescRet(descIndex).continue;
             v.axiWriteMaster.wdata(2 downto 0)     := dmaWrDescRet(descIndex).result;
 
@@ -781,11 +811,33 @@ begin
       end if;
 
       ----------------------------------------------------------
+      -- Buffer Group Tracking
+      ----------------------------------------------------------
+      for i in 0 to 7 loop
+
+         if r.idBuffInc(i) = '1' and r.idBuffDec(i) = '0' and r.idBuffCount(i) /= x"FFFFFFFF" then
+            v.idBuffCount(i) := r.idBuffCount(i) + 1;
+
+         elsif r.idBuffInc(i) = '0' and r.idBuffDec(i) = '1' and r.idBuffCount(i) /= 0 then
+            v.idBuffCount(i) := r.idBuffCount(i) - 1;
+
+         end if;
+
+         if r.idBuffThold(i) /= 0 and r.idBuffCount(i) > r.idBuffThold(i) then
+            v.buffGrpPause(i) := '1';
+         else
+            v.buffGrpPause(i) := '0';
+         end if;
+      end loop;
+
+      ----------------------------------------------------------
       -- Outputs
       ----------------------------------------------------------
 
       axilReadSlave  <= r.axilReadSlave;
       axilWriteSlave <= r.axilWriteSlave;
+
+      buffGrpPause <= r.buffGrpPause;
 
       online          <= r.online;
       interrupt       <= r.interrupt;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -81,7 +81,7 @@ entity AxiStreamDmaV2Desc is
       axiWriteSlaves  : in  AxiWriteSlaveArray(CHAN_COUNT_G-1 downto 0);
 
       -- Buffer Group Pause
-      buffGrpPause    : out slv(7 downto 0);
+      buffGrpPause    : out slv(7 downto 0)
 
 end AxiStreamDmaV2Desc;
 
@@ -458,9 +458,9 @@ begin
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
 
       for i in 0 to 7 loop
-         axiSlaveRegister(regCon, toSlv(144 + i,12), 0, v.idBuffThold);  -- 0x090 - 0xAC
-         axiSlaveRegisterR(regCon, toSlv(176 + i,12), 0, r.idBuffCount); -- 0x0B0 - 0xCC
-         axiWrDetect(regCon, toSlv(176 + i,12), v.idBuffDec(i));         -- 0x0B0 - 0xCC
+         axiSlaveRegister(regCon, toSlv(144 + i*4,12), 0, v.idBuffThold);  -- 0x090 - 0xAC
+         axiSlaveRegisterR(regCon, toSlv(176 + i*4,12), 0, r.idBuffCount); -- 0x0B0 - 0xCC
+         axiWrDetect(regCon, toSlv(176 + i*4,12), v.idBuffDec(i));         -- 0x0B0 - 0xCC
       end loop;
 
       -- End transaction block

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -81,7 +81,7 @@ entity AxiStreamDmaV2Desc is
       axiWriteSlaves  : in  AxiWriteSlaveArray(CHAN_COUNT_G-1 downto 0);
 
       -- Buffer Group Pause
-      buffGrpPause    : out slv(7 downto 0)
+      buffGrpPause    : out slv(7 downto 0));
 
 end AxiStreamDmaV2Desc;
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -210,6 +210,10 @@ begin
             end if;
          ----------------------------------------------------------------------
          when IDLE_S =>
+            -- Set write dma request data
+            v.dmaWrDescReq.dest := intAxisMaster.tDest;
+            v.dmaWrDescReq.id   := intAxisMaster.tId;
+
             if intAxisMaster.tValid = '1' then
                -- Current destination matches incoming frame
                if r.dmaWrTrack.dest = intAxisMaster.tDest then
@@ -232,9 +236,8 @@ begin
 
                -- Wait for mem selection to match incoming frame
                elsif trackData.dest = intAxisMaster.tDest then
-                  -- Set tracking data and setup request
+                  -- Set tracking data
                   v.dmaWrTrack := trackData;
-                  v.dmaWrDescReq.dest := trackData.dest;
 
                   -- Is entry valid or do we need a new buffer
                   if trackData.inUse = '1' then

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -314,7 +314,7 @@ begin
             if intAxisMaster.tValid = '1' then
                v.stCount := (others=>'0');
                -- Destination has changed, complete current write
-               if intAxisMaster.tDest /= r.dmaWrDescReq.dest then
+               if intAxisMaster.tDest /= r.dmaWrTrack.dest then
                   v.state := PAD_S;
                -- Overflow detect
                elsif (r.dmaWrTrack.maxSize(31 downto 5) = 0) then -- Assumes max AXIS.TDATA width of 128-bits
@@ -492,7 +492,7 @@ begin
             -- Incoming valid data
             if intAxisMaster.tValid = '1' then
                -- Destination has changed, complete current write
-               if intAxisMaster.tDest /= r.dmaWrDescReq.dest then
+               if intAxisMaster.tDest /= r.dmaWrTrack.dest then
                   v.state := IDLE_S;
                else
                   -- Accept the data

--- a/protocols/ssi/rtl/SsiPkg.vhd
+++ b/protocols/ssi/rtl/SsiPkg.vhd
@@ -51,8 +51,9 @@ package SsiPkg is
       dataBytes : positive;
       tKeepMode : TKeepModeType         := TKEEP_COMP_C;
       tUserMode : TUserModeType         := TUSER_FIRST_LAST_C;
-      tDestBits : natural range 0 to 8  := 4;
-      tUserBits : positive range 2 to 8 := 2)
+      tDestBits : natural  range 0 to 8 := SSI_TDEST_BITS_C;
+      tUserBits : positive range 2 to 8 := SSI_TUSER_BITS_C;
+      tIdBits   : natural  range 0 to 8 := SSI_TID_BITS_C)
       return AxiStreamConfigType;
 
    -- A default SSI config is useful to have
@@ -149,15 +150,16 @@ package body SsiPkg is
       dataBytes : positive;
       tKeepMode : TKeepModeType         := TKEEP_COMP_C;
       tUserMode : TUserModeType         := TUSER_FIRST_LAST_C;
-      tDestBits : natural range 0 to 8  := 4;
-      tUserBits : positive range 2 to 8 := 2)
+      tDestBits : natural  range 0 to 8 := SSI_TDEST_BITS_C;
+      tUserBits : positive range 2 to 8 := SSI_TUSER_BITS_C;
+      tIdBits   : natural  range 0 to 8 := SSI_TID_BITS_C)
       return AxiStreamConfigType is
       variable ret : AxiStreamConfigType;
    begin
       ret.TDATA_BYTES_C := dataBytes;       -- Configurable data size
       ret.TUSER_BITS_C  := tUserBits;       -- 2 TUSER: EOFE, SOF
       ret.TDEST_BITS_C  := tDestBits;       -- 4 TDEST bits for VC
-      ret.TID_BITS_C    := SSI_TID_BITS_C;  -- TID not used
+      ret.TID_BITS_C    := tIdBits;         -- Optional TID
       ret.TKEEP_MODE_C  := tKeepMode;       --
       ret.TSTRB_EN_C    := SSI_TSTRB_EN_C;  -- No TSTRB support in SSI
       ret.TUSER_MODE_C  := tUserMode;       -- User field valid on last only


### PR DESCRIPTION
The goal of this PR is to allow a limit on the number of outstanding DMA buffers any single destination can be using. This will allow the client to set a max buffer count after opening a channel on the driver. The end result is a flow control signal which extends outside of the dma engine to the mux point for a set of streams.

In order to accomplish this we need to communicate this per dest pause to the mux stage. Here I propose adding a destPause vector to the AxiStreamCtrl record and using this record in the AxiStreamMux device.
