### PR TITLE
AxiStreamDmaV2Desc.vhd Updates

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -565,9 +565,7 @@ begin
             end if;
          end if;
 
-         if r.enable = '0' then
-            v.wrReqMissed := (others => '0');
-         elsif wrReqList /= 0 and uAnd(wrFifoValid) = '0' then
+         if wrReqList /= 0 and uAnd(wrFifoValid) = '0' then
             v.wrReqMissed := r.wrReqMissed + 1;
          end if;
 
@@ -779,18 +777,10 @@ begin
          v.intReqEn    := '0';
       end if;
 
-      -- Engine disabled
-      if r.enable = '0' then
-         v.intReqEn    := '0';
-         v.intReqCount := (others => '0');
-         v.interrupt   := '0';
-         v.forceInt    := '0';
-      end if;
-
       if r.intSwAckReq = '1' then
          v.intHoldoffCount := (others => '0');
       elsif uAnd(r.intHoldoffCount) = '0' then
-         v.intHoldoffCount := r.intHoldoffCount+1;
+         v.intHoldoffCount := r.intHoldoffCount + 1;
       end if;
 
       ----------------------------------------------------------
@@ -826,16 +816,6 @@ begin
          v.rdFifoRd              := '1';
       end if;
 
-      -- Check if disabled
-      if r.enable = '0' then
-         v.wrIndex := (others => '0');
-         v.rdIndex := (others => '0');
-      end if;
-
-      if (r.enable = '0') and (v.enable = '1') and (r.enableCnt /= x"FF") then
-         v.enableCnt := r.enableCnt + 1;
-      end if;
-
       ----------------------------------------------------------
       -- Buffer Group Tracking
       ----------------------------------------------------------
@@ -856,6 +836,25 @@ begin
          end if;
 
       end loop;
+
+      ----------------------------------------------------------
+      -- Check if disabled
+      ----------------------------------------------------------
+      if r.enable = '0' then
+         v.wrIndex         := (others => '0');
+         v.rdIndex         := (others => '0');
+         v.wrReqMissed     := (others => '0');
+         v.idBuffCount     := (others => (others => '0'));
+         v.intHoldoffCount := (others => '0');
+         v.intReqEn        := '0';
+         v.intReqCount     := (others => '0');
+         v.interrupt       := '0';
+         v.forceInt        := '0';
+      end if;
+
+      if (r.enable = '0') and (v.enable = '1') and (r.enableCnt /= x"FF") then
+         v.enableCnt := r.enableCnt + 1;
+      end if;
 
       ----------------------------------------------------------
       -- Outputs
@@ -886,7 +885,9 @@ begin
          end if;
       end loop;
 
+      ----------------------------------------------------------
       -- Reset
+      ----------------------------------------------------------
       if (axiRst = '1') then
          v := REG_INIT_C;
       end if;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -371,10 +371,10 @@ begin
          TPD_G   => TPD_G,
          WIDTH_G => 16)
       port map (
-         clk => axiClk,
-         ain => r.intHoldoff,
-         bin => r.intHoldoffCount,
-         ls  => holdoffCompare);  --  (a <  b) <--> r.intHoldoffCount > r.intHoldoff
+         clk  => axiClk,
+         ain  => r.intHoldoffCount,
+         bin  => r.intHoldoff,
+         gtEq => holdoffCompare);  --  (a >= b) <--> r.intHoldoffCount >= r.intHoldoff
 
    U_Pause : for i in 0 to 7 generate
       U_DspComparator : entity surf.DspComparator
@@ -382,10 +382,10 @@ begin
             TPD_G   => TPD_G,
             WIDTH_G => 32)
          port map (
-            clk => axiClk,
-            ain => r.idBuffThold(i),
-            bin => r.idBuffCount(i),
-            ls  => idBuffCompare(i));  --  (a <  b) <--> r.idBuffCount(i) > r.idBuffThold(i)
+            clk  => axiClk,
+            ain  => r.idBuffCount(i),
+            bin  => r.idBuffThold(i),
+            gtEq => idBuffCompare(i));  --  (a >= b) <--> r.idBuffCount(i) >= r.idBuffThold(i)
    end generate;
 
    -----------------------------------------
@@ -777,9 +777,12 @@ begin
          v.intReqEn    := '0';
       end if;
 
+      -- Check if we need to reset IRQ holdoff counter
       if r.intSwAckReq = '1' then
          v.intHoldoffCount := (others => '0');
-      elsif uAnd(r.intHoldoffCount) = '0' then
+
+      -- Check if not max value
+      elsif r.intHoldoffCount /= x"FFFF" then
          v.intHoldoffCount := r.intHoldoffCount + 1;
       end if;
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -824,10 +824,10 @@ begin
       ----------------------------------------------------------
       for i in 0 to 7 loop
 
-         if r.idBuffInc(i) = '1' and r.idBuffDec(i) = '0' and r.idBuffCount(i) /= x"FFFFFFFF" then
+         if r.idBuffInc(i) = '1' and r.idBuffDec(i) = '0' then
             v.idBuffCount(i) := r.idBuffCount(i) + 1;
 
-         elsif r.idBuffInc(i) = '0' and r.idBuffDec(i) = '1' and r.idBuffCount(i) /= 0 then
+         elsif r.idBuffInc(i) = '0' and r.idBuffDec(i) = '1' then
             v.idBuffCount(i) := r.idBuffCount(i) - 1;
 
          end if;


### PR DESCRIPTION
### Description
- implementing intHoldoff and idBuff with DSP primatives
  - Helps with making timing
- reset idBuffCount if DMA disabled
  - Plus some code clean up on resetting counters/indexs when DMA disabled
- bug fixes for intHoldoffCount=intHoldoff and idBuffCount=idBuffThold 
  - Specifically fixes the issue where BG[X].Count = BG[X].Threshold + 1 when asserting pause
- Removing roll over or roll underconditions in idBuffCount
  - should NEVER happen and don't want to mask out or hide a potential problem
