### PR TITLE
Removing Accidental Commit of Python Debugger By User

### DIFF
--- a/python/surf/protocols/clink/_ClinkSerialTx.py
+++ b/python/surf/protocols/clink/_ClinkSerialTx.py
@@ -15,8 +15,6 @@
 
 import rogue.interfaces.stream
 
-import pdb
-
 class ClinkSerialTx(rogue.interfaces.stream.Master):
 
     def __init__(self):
@@ -32,8 +30,6 @@ class ClinkSerialTx(rogue.interfaces.stream.Master):
 
     def sendString(self,st):
         print( 'sendString: %s' % st )
-        if st.startswith( '@SN?' ):
-            pdb.set_trace()
         ba = bytearray((len(st)+1)*4)
         i = 0
         for c in st:


### PR DESCRIPTION
### Description
- ClinkSerialTx is the `general` class and should be sub-class if the user wants to add custom debugger break point with strings that start with '@SN?'