### PR TITLE
Fixed typo in ClinkChannel.py

### DIFF
--- a/python/surf/protocols/clink/_ClinkChannel.py
+++ b/python/surf/protocols/clink/_ClinkChannel.py
@@ -67,7 +67,7 @@ class ClinkChannel(pr.Device):
             description = """
                 None: Disables output
                 Line: 1D camera
-                Frame" 2D pixel array
+                Frame: 2D pixel array
                 """,
         ))
 


### PR DESCRIPTION
### Description
- Fixed typo in the FrameMode's description
