### PR TITLE
Resolving AXI-Lite Protocol Violations in the AxiLitePkg.vhd

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -203,7 +203,7 @@ begin
 
                -- Clear when acked by master
                if (r.sAxiWriteSlaves(s).bvalid = '1' and sAxiWriteMasters(s).bready = '1') then
-                  v.sAxiWriteSlaves(s).bvalid := '0';  
+                  v.sAxiWriteSlaves(s).bvalid := '0';
                   v.slave(s).wrState          := S_WAIT_AXI_TXN_S;
                end if;
 

--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -560,12 +560,6 @@ package body AxiLitePkg is
       ----------------------------------------------------------------------------------------------
       readEnable := '0';
 
-      -- Reset rvalid upon rready
-      if (axiReadMaster.rready = '1') then
-         axiReadSlave.rvalid := '0';
-         axiReadSlave.rdata  := (others => '0');
-      end if;
-
       -- Check if last cycle accepted read address
       if (axiReadSlave.arready = '1') then
 
@@ -573,6 +567,12 @@ package body AxiLitePkg is
          axiReadSlave.rvalid := '1';
 
       else
+
+         -- Reset rvalid upon rready
+         if (axiReadMaster.rready = '1') then
+            axiReadSlave.rvalid := '0';
+            axiReadSlave.rdata  := (others => '0');
+         end if;
 
          -- Incoming read txn and last txn has concluded
          if (axiReadMaster.arvalid = '1' and axiReadSlave.rvalid = '0') then

--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -537,7 +537,7 @@ package body AxiLitePkg is
       if (axiWriteMaster.bready = '1') then
          axiWriteSlave.bvalid := '0';
       end if;
-   end procedure;
+   end procedure axiSlaveWaitWriteTxn;
 
    procedure axiSlaveWaitReadTxn (
       signal axiReadMaster  : in    AxiLiteReadMasterType;

--- a/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaFifo.vhd
@@ -377,9 +377,6 @@ begin
 
       --------------------------------------------------------------------------------
 
-      -- Zero out the read data bus
-      v.axilReadSlave.rdata := (others => '0');
-
       -- Determine the transaction type
       axiSlaveWaitTxn(axilEp, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
 

--- a/devices/AnalogDevices/ad9249/7Series/rtl/Ad9249ConfigNoPullup.vhd
+++ b/devices/AnalogDevices/ad9249/7Series/rtl/Ad9249ConfigNoPullup.vhd
@@ -125,7 +125,6 @@ begin
    begin
       v := r;
 
-      v.axilReadSlave.rdata := (others => '0');
       axiSlaveWaitTxn(axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave, axilStatus);
 
       -- Any other address is forwarded to the chip via SPI

--- a/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
+++ b/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
@@ -235,10 +235,9 @@ begin
    begin
       v := axilR;
 
-      v.dataDelaySet        := (others => '0');
-      v.frameDelaySet       := '0';
-      v.axilReadSlave.rdata := (others => '0');
-      v.lockedCountRst      := '0';
+      v.dataDelaySet   := (others => '0');
+      v.frameDelaySet  := '0';
+      v.lockedCountRst := '0';
 
       -- Store last two samples read from ADC
       if (debugDataValid = '1' and axilR.freezeDebug = '0') then

--- a/protocols/saci/rtl/SaciMultiPixel.vhd
+++ b/protocols/saci/rtl/SaciMultiPixel.vhd
@@ -98,7 +98,6 @@ begin
    begin
       v := r;
 
-      v.sAxilReadSlave.rdata := (others => '0');
       axiSlaveWaitTxn(sAxilWriteMaster, sAxilReadMaster, v.sAxilWriteSlave, v.sAxilReadSlave, axiStatus);
 
       if (axiStatus.writeEnable = '1' and r.globalMultiPix.req = '0') then

--- a/protocols/saci/rtl/SaciPrepRdout.vhd
+++ b/protocols/saci/rtl/SaciPrepRdout.vhd
@@ -109,7 +109,6 @@ begin
    begin
       v := r;
 
-      v.sAxilReadSlave.rdata := (others => '0');
       axiSlaveWaitTxn(regCon, sAxilWriteMaster, sAxilReadMaster, v.sAxilWriteSlave, v.sAxilReadSlave);
 
       -- error counters


### PR DESCRIPTION
### Description
- resolved AXI-Lite protocol violation = AXI_ERRS_BRESP_AW for axiSlaveWriteResponse()
- resolved AXI-Lite protocol violation = AXI_AUXM_RCAM_UNDERFLOW for axiSlaveReadResponse()
- resolved AXI-Lite protocol violation = AXI_AUXM_RCAM_UNDERFLOW for axiSlaveDefault()
- Update to axiSlaveReadResponse() and axiSlaveWaitReadTxn() requires rdata not to be modified outside of axilStatus.readEnable=0x1
- whitespace removal on AxiLiteCrossbar.vhd

### Simulation Testbed
https://github.com/slaclab/surf-axi-protocol-checking/blob/master/firmware/simulations/SurfAxiLiteProtocolCheckerTb/tb/SurfAxiLiteProtocolCheckerTb.vhd