### PR TITLE
Updating SW Default for ClinkChannel.SerThrottle

### DIFF
--- a/python/surf/protocols/clink/_ClinkChannel.py
+++ b/python/surf/protocols/clink/_ClinkChannel.py
@@ -120,7 +120,7 @@ class ClinkChannel(pr.Device):
             disp         = '{}',
             mode         = "RW",
             units        = "microsec",
-            value        = 30000, # 30ms/byte
+            value        = 10000, # 10ms/byte
         ))
 
         self.add(pr.RemoteVariable(


### PR DESCRIPTION
### Description
- Should Match hardware default value
   - https://github.com/slaclab/surf/blob/v2.8.0/protocols/clink/rtl/ClinkPkg.vhd#L112
