### PR TITLE
fixed bug where SerThrottle SW init value would overwrite DataEn

### DIFF
--- a/python/surf/protocols/clink/_ClinkChannel.py
+++ b/python/surf/protocols/clink/_ClinkChannel.py
@@ -120,7 +120,6 @@ class ClinkChannel(pr.Device):
             disp         = '{}',
             mode         = "RW",
             units        = "microsec",
-            value        = 10000, # 10ms/byte
         ))
 
         self.add(pr.RemoteVariable(


### PR DESCRIPTION
### Description
- Fixes in the issue in the short term 
- In the long term, we should redo the register mapping to be 1 R/W (or WO) per 32-bit boundary