### PR TITLE
Bring out SYNTH_MODE_G generic for internal RAMs

### DIFF
--- a/ethernet/EthMacCore/rtl/EthMacRx.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRx.vhd
@@ -38,7 +38,9 @@ entity EthMacRx is
       -- VLAN Configurations
       VLAN_EN_G      : boolean               := false;
       VLAN_SIZE_G    : positive range 1 to 8 := 1;
-      VLAN_VID_G     : Slv12Array            := (0 => x"001"));
+      VLAN_VID_G     : Slv12Array            := (0 => x"001");
+      -- Internal RAM sythesis mode
+      SYNTH_MODE_G   : string                := "inferred");
    port (
       -- Clock and Reset
       ethClkEn     : in  sl;
@@ -88,8 +90,9 @@ begin
    -------------------
    U_Import : entity surf.EthMacRxImport
       generic map (
-         TPD_G      => TPD_G,
-         PHY_TYPE_G => PHY_TYPE_G)
+         TPD_G        => TPD_G,
+         PHY_TYPE_G   => PHY_TYPE_G,
+         SYNTH_MODE_G => SYNTH_MODE_G)
       port map (
          -- Clock and reset
          ethClkEn    => ethClkEn,

--- a/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
@@ -25,8 +25,9 @@ use surf.EthMacPkg.all;
 
 entity EthMacRxImport is
    generic (
-      TPD_G      : time   := 1 ns;
-      PHY_TYPE_G : string := "XGMII");
+      TPD_G        : time   := 1 ns;
+      PHY_TYPE_G   : string := "XGMII";
+      SYNTH_MODE_G : string := "inferred");
    port (
       -- Clock and Reset
       ethClkEn    : in  sl;
@@ -97,7 +98,8 @@ begin
    U_1G : if (PHY_TYPE_G = "GMII") generate
       U_GMII : entity surf.EthMacRxImportGmii
          generic map (
-            TPD_G => TPD_G)
+            TPD_G        => TPD_G;
+            SYNTH_MODE_G => SYNTH_MODE_G)
          port map (
             -- Clock and Reset
             ethClkEn    => ethClkEn,

--- a/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImport.vhd
@@ -98,7 +98,7 @@ begin
    U_1G : if (PHY_TYPE_G = "GMII") generate
       U_GMII : entity surf.EthMacRxImportGmii
          generic map (
-            TPD_G        => TPD_G;
+            TPD_G        => TPD_G,
             SYNTH_MODE_G => SYNTH_MODE_G)
          port map (
             -- Clock and Reset

--- a/ethernet/EthMacCore/rtl/EthMacRxImportGmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacRxImportGmii.vhd
@@ -25,7 +25,8 @@ use surf.EthMacPkg.all;
 
 entity EthMacRxImportGmii is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SYNTH_MODE_G : string := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Clock and Reset
       ethClkEn    : in  sl;
@@ -111,23 +112,24 @@ begin
          SLAVE_READY_EN_G    => true,
          VALID_THOLD_G       => 1,
          -- FIFO configurations
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "distributed",
          GEN_SYNC_FIFO_G     => true,
          CASCADE_SIZE_G      => 1,
          FIFO_ADDR_WIDTH_G   => 4,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,  --  8-bit AXI stream interface
+         SLAVE_AXI_CONFIG_G  => AXI_CONFIG_C,            --  8-bit AXI stream interface
          MASTER_AXI_CONFIG_G => INT_EMAC_AXIS_CONFIG_C)  -- 128-bit AXI stream interface
       port map (
          -- Slave Port
          sAxisClk    => ethClk,
          sAxisRst    => ethRst,
-         sAxisMaster => macMaster,      -- 8-bit AXI stream interface
+         sAxisMaster => macMaster,                       -- 8-bit AXI stream interface
          sAxisSlave  => open,
          -- Master Port
          mAxisClk    => ethClk,
          mAxisRst    => ethRst,
-         mAxisMaster => macIbMaster,    -- 128-bit AXI stream interface
+         mAxisMaster => macIbMaster,                     -- 128-bit AXI stream interface
          mAxisSlave  => AXI_STREAM_SLAVE_FORCE_C);
 
    comb : process (crcIn, crcOut, ethClkEn, ethRst, gmiiRxDv, gmiiRxEr,

--- a/ethernet/EthMacCore/rtl/EthMacTop.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTop.vhd
@@ -147,7 +147,8 @@ begin
          VLAN_EN_G         => VLAN_EN_G,
          VLAN_SIZE_G       => VLAN_SIZE_G,
          VLAN_COMMON_CLK_G => VLAN_COMMON_CLK_G,
-         VLAN_CONFIG_G     => VLAN_CONFIG_G)
+         VLAN_CONFIG_G     => VLAN_CONFIG_G,
+         SYNTH_MODE_G      => SYNTH_MODE_G)
       port map (
          -- Master Clock and Reset
          mClk         => ethClk,
@@ -192,7 +193,9 @@ begin
          -- VLAN Configurations
          VLAN_EN_G       => VLAN_EN_G,
          VLAN_SIZE_G     => VLAN_SIZE_G,
-         VLAN_VID_G      => VLAN_VID_G)
+         VLAN_VID_G      => VLAN_VID_G,
+         -- RAM sythesis Mode
+         SYNTH_MODE_G    => SYNTH_MODE_G)
       port map (
          -- Clocks
          ethClkEn       => ethClkEn,
@@ -267,7 +270,9 @@ begin
          -- VLAN Configurations
          VLAN_EN_G      => VLAN_EN_G,
          VLAN_SIZE_G    => VLAN_SIZE_G,
-         VLAN_VID_G     => VLAN_VID_G)
+         VLAN_VID_G     => VLAN_VID_G,
+         -- RAM Synthesis mode
+         SYNTH_MODE_G   => SYNTH_MODE_G)
       port map (
          -- Clock and Reset
          ethClkEn     => ethClkEn,

--- a/ethernet/EthMacCore/rtl/EthMacTx.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTx.vhd
@@ -38,7 +38,9 @@ entity EthMacTx is
       -- VLAN Configurations
       VLAN_EN_G       : boolean                  := false;
       VLAN_SIZE_G     : positive range 1 to 8    := 1;
-      VLAN_VID_G      : Slv12Array               := (0 => x"001"));
+      VLAN_VID_G      : Slv12Array               := (0 => x"001");
+      -- RAM Synthesis mode
+      SYNTH_MODE_G    : string                   := "inferred");
    port (
       -- Clock and Reset
       ethClkEn       : in  sl;
@@ -208,8 +210,9 @@ begin
    -----------------------
    U_Export : entity surf.EthMacTxExport
       generic map (
-         TPD_G      => TPD_G,
-         PHY_TYPE_G => PHY_TYPE_G)
+         TPD_G        => TPD_G,
+         PHY_TYPE_G   => PHY_TYPE_G;
+         SYNTH_MODE_G => SYNTH_MODE_G)
       port map (
          -- Clock and reset
          ethClkEn       => ethClkEn,

--- a/ethernet/EthMacCore/rtl/EthMacTx.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTx.vhd
@@ -211,7 +211,7 @@ begin
    U_Export : entity surf.EthMacTxExport
       generic map (
          TPD_G        => TPD_G,
-         PHY_TYPE_G   => PHY_TYPE_G;
+         PHY_TYPE_G   => PHY_TYPE_G,
          SYNTH_MODE_G => SYNTH_MODE_G)
       port map (
          -- Clock and reset

--- a/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
@@ -31,7 +31,7 @@ entity EthMacTxCsum is
       JUMBO_G        : boolean          := true;
       VLAN_G         : boolean          := false;
       VID_G          : slv(11 downto 0) := x"001";
-      SYNTH_MODE_G   : string           := "inferred");  -- Synthesis mode for internal RAMs      
+      SYNTH_MODE_G   : string           := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Clock and Reset
       ethClk      : in  sl;

--- a/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxCsum.vhd
@@ -30,7 +30,8 @@ entity EthMacTxCsum is
       DROP_ERR_PKT_G : boolean          := true;
       JUMBO_G        : boolean          := true;
       VLAN_G         : boolean          := false;
-      VID_G          : slv(11 downto 0) := x"001");
+      VID_G          : slv(11 downto 0) := x"001";
+      SYNTH_MODE_G   : string           := "inferred");  -- Synthesis mode for internal RAMs      
    port (
       -- Clock and Reset
       ethClk      : in  sl;
@@ -302,7 +303,7 @@ begin
                      v.ipv4Hdr(9)         := rxMaster.tData(63 downto 56);  -- Protocol
                      v.ipv4Hdr(12)        := rxMaster.tData(87 downto 80);  -- Source IP Address
                      v.ipv4Hdr(13)        := rxMaster.tData(95 downto 88);  -- Source IP Address
-                     v.ipv4Hdr(14)        := rxMaster.tData(103 downto 96);  -- Source IP Address
+                     v.ipv4Hdr(14)        := rxMaster.tData(103 downto 96);   -- Source IP Address
                      v.ipv4Hdr(15)        := rxMaster.tData(111 downto 104);  -- Source IP Address
                      v.ipv4Hdr(16)        := rxMaster.tData(119 downto 112);  -- Destination IP Address
                      v.ipv4Hdr(17)        := rxMaster.tData(127 downto 120);  -- Destination IP Address
@@ -356,32 +357,32 @@ begin
                -- Check if NON-VLAN
                if (VLAN_G = false) then
                   -- Fill in the IPv4 header checksum
-                  v.ipv4Hdr(18) := rxMaster.tData(7 downto 0);  -- Destination IP Address
-                  v.ipv4Hdr(19) := rxMaster.tData(15 downto 8);  -- Destination IP Address
+                  v.ipv4Hdr(18) := rxMaster.tData(7 downto 0);        -- Destination IP Address
+                  v.ipv4Hdr(19) := rxMaster.tData(15 downto 8);       -- Destination IP Address
                   -- Check for UDP data with inbound length/checksum
                   if (r.ipv4Det(0) = '1') and (r.udpDet(0) = '1') then
                      -- Mask off inbound UDP length/checksum
                      v.tData := rxMaster.tData(127 downto 80) & x"00000000" & rxMaster.tData(47 downto 0);
                   end if;
                   -- Track the number of bytes
-                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 2;
-                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 2;
+                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) - 2;
+                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) - 2;
                else
                   -- Fill in the IPv4 header checksum
-                  v.ipv4Hdr(14) := rxMaster.tData(7 downto 0);  -- Source IP Address
-                  v.ipv4Hdr(15) := rxMaster.tData(15 downto 8);  -- Source IP Address
-                  v.ipv4Hdr(16) := rxMaster.tData(23 downto 16);  -- Destination IP Address
-                  v.ipv4Hdr(17) := rxMaster.tData(31 downto 24);  -- Destination IP Address
-                  v.ipv4Hdr(18) := rxMaster.tData(39 downto 32);  -- Destination IP Address
-                  v.ipv4Hdr(19) := rxMaster.tData(47 downto 40);  -- Destination IP Address
+                  v.ipv4Hdr(14) := rxMaster.tData(7 downto 0);        -- Source IP Address
+                  v.ipv4Hdr(15) := rxMaster.tData(15 downto 8);       -- Source IP Address
+                  v.ipv4Hdr(16) := rxMaster.tData(23 downto 16);      -- Destination IP Address
+                  v.ipv4Hdr(17) := rxMaster.tData(31 downto 24);      -- Destination IP Address
+                  v.ipv4Hdr(18) := rxMaster.tData(39 downto 32);      -- Destination IP Address
+                  v.ipv4Hdr(19) := rxMaster.tData(47 downto 40);      -- Destination IP Address
                   -- Check for UDP data with inbound length/checksum
                   if (r.ipv4Det(0) = '1') and (r.udpDet(0) = '1') then
                      -- Mask off inbound UDP length/checksum
                      v.tData := rxMaster.tData(127 downto 112) & x"00000000" & rxMaster.tData(79 downto 0);
                   end if;
                   -- Track the number of bytes
-                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 6;
-                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C) - 6;
+                  v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) - 6;
+                  v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C) - 6;
                end if;
                -- Check for EOF
                if (rxMaster.tLast = '1') then
@@ -421,8 +422,8 @@ begin
                   end if;
                end if;
                -- Track the number of bytes
-               v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C);
-               v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep,INT_EMAC_AXIS_CONFIG_C);
+               v.ipv4Len(0) := r.ipv4Len(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C);
+               v.protLen(0) := r.protLen(0) + getTKeep(rxMaster.tKeep, INT_EMAC_AXIS_CONFIG_C);
                -- Check for EOF
                if (rxMaster.tLast = '1') or (v.ipv4Len(0) > MAX_FRAME_SIZE_C) then
                   -- Save the EOFE value
@@ -460,7 +461,7 @@ begin
 
       -- Fill in the IPv4 header
       v.ipv4Hdr(2) := v.ipv4Len(0)(15 downto 8);  -- IPV4_Length(15 downto 8)
-      v.ipv4Hdr(3) := v.ipv4Len(0)(7 downto 0);  -- IPV4_Length(7 downto 0)
+      v.ipv4Hdr(3) := v.ipv4Len(0)(7 downto 0);   -- IPV4_Length(7 downto 0)
 
       -- Wait for the transaction data
       if (tranValid = '1') and (r.tranRd = '0') then
@@ -642,6 +643,7 @@ begin
          SLAVE_READY_EN_G    => true,
          VALID_THOLD_G       => 1,
          -- FIFO configurations
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
          GEN_SYNC_FIFO_G     => true,
          CASCADE_SIZE_G      => ite(JUMBO_G, 2, 1),
@@ -661,17 +663,19 @@ begin
          mAxisMaster => mMaster,
          mAxisSlave  => mSlave);
 
-   Fifo_Trans : entity surf.FifoSync
+   Fifo_Trans : entity surf.Fifo
       generic map (
-         TPD_G         => TPD_G,
-         MEMORY_TYPE_G => "distributed",
-         FWFT_EN_G     => true,
-         DATA_WIDTH_G  => 69,
-         ADDR_WIDTH_G  => 4,
-         FULL_THRES_G  => 8)
+         TPD_G           => TPD_G,
+         GEN_SYNC_FIFO_G => true,
+         SYNTH_MODE_G    => SYNTH_MODE_G,
+         MEMORY_TYPE_G   => "distributed",
+         FWFT_EN_G       => true,
+         DATA_WIDTH_G    => 69,
+         ADDR_WIDTH_G    => 4,
+         FULL_THRES_G    => 8)
       port map (
-         clk                => ethClk,
          rst                => ethRst,
+         wr_clk             => ethClk,
          --Write Ports (wr_clk domain)
          wr_en              => r.calc(0).step(EMAC_CSUM_PIPELINE_C),
          din(68)            => r.fragDet(EMAC_CSUM_PIPELINE_C+1),
@@ -685,6 +689,7 @@ begin
          din(15 downto 0)   => r.protCsum,
          prog_full          => tranPause,
          --Read Ports (rd_clk domain)
+         rd_clk             => ethClk,
          rd_en              => r.tranRd,
          dout(68)           => fragDet,
          dout(67)           => eofeDet,

--- a/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
@@ -88,7 +88,7 @@ begin
    U_10G : if (PHY_TYPE_G = "XGMII") generate
       U_XGMII : entity surf.EthMacTxExportXgmii
          generic map (
-            TPD_G        => TPD_G;
+            TPD_G        => TPD_G,
             SYNTH_MODE_G => SYNTH_MODE_G)
          port map (
             -- Clock and Reset

--- a/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExport.vhd
@@ -24,8 +24,9 @@ use surf.StdRtlPkg.all;
 
 entity EthMacTxExport is
    generic (
-      TPD_G      : time   := 1 ns;
-      PHY_TYPE_G : string := "XGMII");
+      TPD_G        : time   := 1 ns;
+      PHY_TYPE_G   : string := "XGMII";
+      SYNTH_MODE_G : string := "inferred");
    port (
       -- Clock and Reset
       ethClkEn       : in  sl;
@@ -87,7 +88,8 @@ begin
    U_10G : if (PHY_TYPE_G = "XGMII") generate
       U_XGMII : entity surf.EthMacTxExportXgmii
          generic map (
-            TPD_G => TPD_G)
+            TPD_G        => TPD_G;
+            SYNTH_MODE_G => SYNTH_MODE_G)
          port map (
             -- Clock and Reset
             ethClk         => ethClk,

--- a/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxExportXgmii.vhd
@@ -25,7 +25,8 @@ use surf.EthMacPkg.all;
 
 entity EthMacTxExportXgmii is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SYNTH_MODE_G : string := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Clock and Reset
       ethClk         : in  sl;
@@ -146,23 +147,24 @@ begin
          SLAVE_READY_EN_G    => true,
          VALID_THOLD_G       => 1,
          -- FIFO configurations
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "distributed",
          GEN_SYNC_FIFO_G     => true,
          CASCADE_SIZE_G      => 1,
          FIFO_ADDR_WIDTH_G   => 4,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => INT_EMAC_AXIS_CONFIG_C,  -- 128-bit AXI stream interface
-         MASTER_AXI_CONFIG_G => AXI_CONFIG_C)        -- 64-bit AXI stream interface
+         MASTER_AXI_CONFIG_G => AXI_CONFIG_C)            -- 64-bit AXI stream interface
       port map (
          -- Slave Port
          sAxisClk    => ethClk,
          sAxisRst    => ethRst,
-         sAxisMaster => macObMaster,                 -- 128-bit AXI stream interface
+         sAxisMaster => macObMaster,                     -- 128-bit AXI stream interface
          sAxisSlave  => macObSlave,
          -- Master Port
          mAxisClk    => ethClk,
          mAxisRst    => ethRst,
-         mAxisMaster => macMaster,                   -- 64-bit AXI stream interface
+         mAxisMaster => macMaster,                       -- 64-bit AXI stream interface
          mAxisSlave  => macSlave);
 
    -- Generate read
@@ -340,9 +342,9 @@ begin
 
             -- Wait for gap, min 3 clocks
             if stateCount >= INTERGAP_C and stateCount >= 3 then
-               nxtState     <= ST_IDLE_C;
+               nxtState <= ST_IDLE_C;
             else
-               nxtState     <= curState;
+               nxtState <= curState;
             end if;
 
          -- Padding frame
@@ -414,7 +416,7 @@ begin
 
             -- CRC Valid
             crcDataValid <= intAdvance after TPD_G;
-            crcIn        <= intData after TPD_G;
+            crcIn        <= intData    after TPD_G;
 
             -- Last line
             if intLastLine = '1' then

--- a/ethernet/EthMacCore/rtl/EthMacTxFifo.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacTxFifo.vhd
@@ -32,7 +32,8 @@ entity EthMacTxFifo is
       VLAN_EN_G         : boolean             := false;
       VLAN_SIZE_G       : positive            := 1;
       VLAN_COMMON_CLK_G : boolean             := false;
-      VLAN_CONFIG_G     : AxiStreamConfigType := INT_EMAC_AXIS_CONFIG_C);
+      VLAN_CONFIG_G     : AxiStreamConfigType := INT_EMAC_AXIS_CONFIG_C;
+      SYNTH_MODE_G      : string              := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Master Clock and Reset
       mClk         : in  sl;
@@ -79,6 +80,7 @@ begin
             SLAVE_READY_EN_G    => true,
             VALID_THOLD_G       => 1,
             -- FIFO configurations
+            SYNTH_MODE_G        => SYNTH_MODE_G,
             MEMORY_TYPE_G       => "distributed",
             GEN_SYNC_FIFO_G     => PRIM_COMMON_CLK_G,
             CASCADE_SIZE_G      => 1,
@@ -119,6 +121,7 @@ begin
                SLAVE_READY_EN_G    => true,
                VALID_THOLD_G       => 1,
                -- FIFO configurations
+               SYNTH_MODE_G        => SYNTH_MODE_G,
                MEMORY_TYPE_G       => "distributed",
                GEN_SYNC_FIFO_G     => BYP_COMMON_CLK_G,
                CASCADE_SIZE_G      => 1,
@@ -161,6 +164,7 @@ begin
                   SLAVE_READY_EN_G    => true,
                   VALID_THOLD_G       => 1,
                   -- FIFO configurations
+                  SYNTH_MODE_G        => SYNTH_MODE_G,
                   MEMORY_TYPE_G       => "distributed",
                   GEN_SYNC_FIFO_G     => VLAN_COMMON_CLK_G,
                   CASCADE_SIZE_G      => 1,

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
@@ -28,6 +28,7 @@ entity GigEthGtx7 is
    generic (
       TPD_G                   : time                := 1 ns;
       PAUSE_EN_G              : boolean             := true;
+      SYNTH_MODE_G            : string              := "inferred";
       -- AXI-Lite Configurations
       EN_AXI_REG_G            : boolean             := false;
       AXIL_BASE_ADDR_G        : slv(31 downto 0)    := X"00000000";
@@ -237,6 +238,7 @@ begin
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",
+         SYNTH_MODE_G    => SYNTH_MODE_G,
          PRIM_CONFIG_G   => AXIS_CONFIG_G)
       port map (
          -- Primary Interface

--- a/ethernet/UdpEngine/rtl/UdpEngine.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngine.vhd
@@ -33,16 +33,17 @@ entity UdpEngine is
       CLIENT_SIZE_G  : positive      := 1;
       CLIENT_PORTS_G : PositiveArray := (0 => 8193);
       -- General UDP/ARP/DHCP Generics
-      TX_FLOW_CTRL_G : boolean       := true; -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
+      TX_FLOW_CTRL_G : boolean       := true;  -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
       DHCP_G         : boolean       := false;
-      CLK_FREQ_G     : real          := 156.25E+06;  -- In units of Hz
-      COMM_TIMEOUT_G : positive      := 30);  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
+      CLK_FREQ_G     : real          := 156.25E+06;   -- In units of Hz
+      COMM_TIMEOUT_G : positive      := 30;  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
+      SYNTH_MODE_G   : string        := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Local Configurations
-      localMac         : in  slv(47 downto 0);  --  big-Endian configuration
-      broadcastIp      : in  slv(31 downto 0);  --  big-Endian configuration
-      localIpIn        : in  slv(31 downto 0);  --  big-Endian configuration
-      dhcpIpOut        : out slv(31 downto 0);  --  big-Endian configuration
+      localMac         : in  slv(47 downto 0);        --  big-Endian configuration
+      broadcastIp      : in  slv(31 downto 0);        --  big-Endian configuration
+      localIpIn        : in  slv(31 downto 0);        --  big-Endian configuration
+      dhcpIpOut        : out slv(31 downto 0);        --  big-Endian configuration
       -- Interface to IPV4 Engine
       obUdpMaster      : out AxiStreamMasterType;
       obUdpSlave       : in  AxiStreamSlaveType;
@@ -143,7 +144,8 @@ begin
             TPD_G          => TPD_G,
             -- UDP ARP/DHCP Generics
             CLK_FREQ_G     => CLK_FREQ_G,
-            COMM_TIMEOUT_G => COMM_TIMEOUT_G)
+            COMM_TIMEOUT_G => COMM_TIMEOUT_G;
+            SYNTH_MODE_G   => SYNTH_MODE_G)
          port map (
             -- Local Configurations
             localMac     => localMac,

--- a/ethernet/UdpEngine/rtl/UdpEngine.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngine.vhd
@@ -144,7 +144,7 @@ begin
             TPD_G          => TPD_G,
             -- UDP ARP/DHCP Generics
             CLK_FREQ_G     => CLK_FREQ_G,
-            COMM_TIMEOUT_G => COMM_TIMEOUT_G;
+            COMM_TIMEOUT_G => COMM_TIMEOUT_G,
             SYNTH_MODE_G   => SYNTH_MODE_G)
          port map (
             -- Local Configurations

--- a/ethernet/UdpEngine/rtl/UdpEngineWrapper.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineWrapper.vhd
@@ -38,18 +38,19 @@ entity UdpEngineWrapper is
       CLIENT_PORTS_G      : PositiveArray   := (0 => 8193);
       CLIENT_EXT_CONFIG_G : boolean         := false;
       -- General IPv4/ICMP/ARP/DHCP Generics
-      TX_FLOW_CTRL_G      : boolean         := true; -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
+      TX_FLOW_CTRL_G      : boolean         := true;  -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
       DHCP_G              : boolean         := false;
       ICMP_G              : boolean         := true;
       ARP_G               : boolean         := true;
-      CLK_FREQ_G          : real            := 156.25E+06;  -- In units of Hz
+      CLK_FREQ_G          : real            := 156.25E+06;   -- In units of Hz
       COMM_TIMEOUT_G      : positive        := 30;  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
-      TTL_G               : slv(7 downto 0) := x"20";  -- IPv4's Time-To-Live (TTL)
-      VLAN_G              : boolean         := false);  -- true = VLAN support
+      TTL_G               : slv(7 downto 0) := x"20";        -- IPv4's Time-To-Live (TTL)
+      VLAN_G              : boolean         := false;        -- true = VLAN support
+      SYNTH_MODE_G        : string          := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Local Configurations
-      localMac         : in  slv(47 downto 0);  --  big-Endian configuration
-      localIp          : in  slv(31 downto 0);  --  big-Endian configuration
+      localMac         : in  slv(47 downto 0);      --  big-Endian configuration
+      localIp          : in  slv(31 downto 0);      --  big-Endian configuration
       -- Remote Configurations
       clientRemotePort : in  Slv16Array(CLIENT_SIZE_G-1 downto 0)           := (others => x"0000");
       clientRemoteIp   : in  Slv32Array(CLIENT_SIZE_G-1 downto 0)           := (others => x"00000000");
@@ -169,7 +170,8 @@ begin
          TX_FLOW_CTRL_G => TX_FLOW_CTRL_G,
          DHCP_G         => DHCP_G,
          CLK_FREQ_G     => CLK_FREQ_G,
-         COMM_TIMEOUT_G => COMM_TIMEOUT_G)
+         COMM_TIMEOUT_G => COMM_TIMEOUT_G,
+         SYNTH_MODE_G   => SYNTH_MODE_G)
       port map (
          -- Local Configurations
          localMac         => localMac,

--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -58,18 +58,18 @@ entity RssiCore is
       RETRANSMIT_ENABLE_G : boolean := true;  -- Enable/Disable retransmissions in tx module
 
       WINDOW_ADDR_SIZE_G  : positive range 1 to 10 := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Max number of segments in buffer
-      SEGMENT_ADDR_SIZE_G : positive := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
+      SEGMENT_ADDR_SIZE_G : positive               := 7;  -- 2^SEGMENT_ADDR_SIZE_G = Number of 64 bit wide data words
 
       -- AXIS Configurations
-      APP_AXIS_CONFIG_G        : AxiStreamConfigType;
-      TSP_AXIS_CONFIG_G        : AxiStreamConfigType;
+      APP_AXIS_CONFIG_G : AxiStreamConfigType;
+      TSP_AXIS_CONFIG_G : AxiStreamConfigType;
 
       -- Generic RSSI parameters
       BYP_TX_BUFFER_G : boolean := false;
       BYP_RX_BUFFER_G : boolean := false;
 
-      SYNTH_MODE_G   : string := "inferred";
-      MEMORY_TYPE_G  : string := "block";
+      SYNTH_MODE_G  : string := "inferred";
+      MEMORY_TYPE_G : string := "block";
 
       -- Version and connection ID
       INIT_SEQ_N_G       : natural  := 16#80#;
@@ -78,17 +78,17 @@ entity RssiCore is
       HEADER_CHKSUM_EN_G : boolean  := true;
 
       -- Window parameters of receiver module
-      MAX_NUM_OUTS_SEG_G : positive range 2 to 1024 := 8; -- <=(2**WINDOW_ADDR_SIZE_G)
-      MAX_SEG_SIZE_G     : positive := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
+      MAX_NUM_OUTS_SEG_G : positive range 2 to 1024 := 8;     -- <=(2**WINDOW_ADDR_SIZE_G)
+      MAX_SEG_SIZE_G     : positive                 := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
 
       -- RSSI Timeouts
-      ACK_TOUT_G     : positive := 25;   -- unit depends on TIMEOUT_UNIT_G
-      RETRANS_TOUT_G : positive := 50;   -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
+      ACK_TOUT_G     : positive := 25;  -- unit depends on TIMEOUT_UNIT_G
+      RETRANS_TOUT_G : positive := 50;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
       NULL_TOUT_G    : positive := 200;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= 4*RETRANS_TOUT_G)
 
       -- Counters
-      MAX_RETRANS_CNT_G     : positive := 2;
-      MAX_CUM_ACK_CNT_G     : positive := 3
+      MAX_RETRANS_CNT_G : positive := 2;
+      MAX_CUM_ACK_CNT_G : positive := 3
       );
    port (
       clk_i : in sl;
@@ -120,9 +120,9 @@ entity RssiCore is
       axilWriteSlave  : out AxiLiteWriteSlaveType;
 
       -- Internal statuses
-      statusReg_o     : out slv(6 downto 0);
+      statusReg_o : out slv(6 downto 0);
 
-      maxSegSize_o    : out slv(15 downto 0));
+      maxSegSize_o : out slv(15 downto 0));
 end entity RssiCore;
 
 architecture rtl of RssiCore is
@@ -266,9 +266,9 @@ architecture rtl of RssiCore is
    signal s_initSeqNReg     : slv(7 downto 0);
    signal s_appRssiParamReg : RssiParamType;
 
-   signal s_statusReg   : slv(statusReg_o'range);
-   signal s_dropCntReg  : slv(31 downto 0);
-   signal s_validCntReg : slv(31 downto 0);
+   signal s_statusReg    : slv(statusReg_o'range);
+   signal s_dropCntReg   : slv(31 downto 0);
+   signal s_validCntReg  : slv(31 downto 0);
    signal s_reconCntReg  : slv(31 downto 0);
    signal s_resendCntReg : slv(31 downto 0);
 
@@ -285,8 +285,8 @@ architecture rtl of RssiCore is
 ----------------------------------------------------------------------
 begin
    -- Assertions to check generics
-   assert (1 <= MAX_NUM_OUTS_SEG_G and MAX_NUM_OUTS_SEG_G <=(2**WINDOW_ADDR_SIZE_G)) report "MAX_NUM_OUTS_SEG_G should be less or equal to 2**WINDOW_ADDR_SIZE_G" severity failure;
-   assert (8 <= MAX_SEG_SIZE_G and  MAX_SEG_SIZE_G <=(2**SEGMENT_ADDR_SIZE_G)*8) report "MAX_SEG_SIZE_G should be less or equal to (2**SEGMENT_ADDR_SIZE_G)*8" severity failure;
+   assert (1 <= MAX_NUM_OUTS_SEG_G and MAX_NUM_OUTS_SEG_G <= (2**WINDOW_ADDR_SIZE_G)) report "MAX_NUM_OUTS_SEG_G should be less or equal to 2**WINDOW_ADDR_SIZE_G" severity failure;
+   assert (8 <= MAX_SEG_SIZE_G and MAX_SEG_SIZE_G <= (2**SEGMENT_ADDR_SIZE_G)*8) report "MAX_SEG_SIZE_G should be less or equal to (2**SEGMENT_ADDR_SIZE_G)*8" severity failure;
 
 
    -- /////////////////////////////////////////////////////////
@@ -340,7 +340,7 @@ begin
          validCnt_i  => s_validCntReg,
          resendCnt_i => s_resendCntReg,
          reconCnt_i  => s_reconCntReg
-      );
+         );
 
    s_injectFault <= s_injectFaultReg or inject_i;
 
@@ -528,7 +528,7 @@ begin
          validCnt_o      => s_validCntReg,
          resendCnt_o     => s_resendCntReg,
          reconCnt_o      => s_reconCntReg
-      );
+         );
 
    -- /////////////////////////////////////////////////////////
    ------------------------------------------------------------
@@ -877,12 +877,13 @@ begin
    AppFifoOut_INST : entity surf.AxiStreamFifoV2
       generic map (
          TPD_G               => TPD_G,
-         SLAVE_READY_EN_G    => false, -- Using pause
+         SLAVE_READY_EN_G    => false,  -- Using pause
          GEN_SYNC_FIFO_G     => true,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
-         FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1, -- Enough to store 2 segments
+         FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1,          -- Enough to store 2 segments
          FIFO_FIXED_THRESH_G => true,
-         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16, -- Threshold at 1 segment minus padding
+         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16,  -- Threshold at 1 segment minus padding
          INT_WIDTH_SELECT_G  => "CUSTOM",
          INT_DATA_WIDTH_G    => RSSI_WORD_WIDTH_C,
          SLAVE_AXI_CONFIG_G  => RSSI_AXIS_CONFIG_C,
@@ -907,12 +908,13 @@ begin
    TspFifoOut_INST : entity surf.AxiStreamFifoV2
       generic map (
          TPD_G               => TPD_G,
-         SLAVE_READY_EN_G    => false, -- Using pause
+         SLAVE_READY_EN_G    => false,  -- Using pause
          GEN_SYNC_FIFO_G     => true,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
-         FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1, -- Enough to store 2 segments
+         FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1,          -- Enough to store 2 segments
          FIFO_FIXED_THRESH_G => true,
-         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16, -- Threshold at 1 segment minus padding
+         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16,  -- Threshold at 1 segment minus padding
          INT_WIDTH_SELECT_G  => "CUSTOM",
          INT_DATA_WIDTH_G    => RSSI_WORD_WIDTH_C,
          SLAVE_AXI_CONFIG_G  => RSSI_AXIS_CONFIG_C,
@@ -937,7 +939,7 @@ begin
    for i in 1 downto 0 generate
       U_AxiStreamMon : entity surf.AxiStreamMon
          generic map (
-            TPD_G            => TPD_G,
+            TPD_G           => TPD_G,
             AXIS_CLK_FREQ_G => CLK_FREQUENCY_G,
             AXIS_CONFIG_G   => APP_AXIS_CONFIG_G)
          port map (

--- a/protocols/srp/rtl/AxiLiteSrpV0.vhd
+++ b/protocols/srp/rtl/AxiLiteSrpV0.vhd
@@ -34,8 +34,9 @@ entity AxiLiteSrpV0 is
       TPD_G : time := 1 ns;
 
       -- FIFO Config
-      RESP_THOLD_G        : integer range 0 to (2**24) := 1;      -- =1 = normal operation
+      RESP_THOLD_G        : integer range 0 to (2**24) := 1;  -- =1 = normal operation
       SLAVE_READY_EN_G    : boolean                    := false;
+      SYNTH_MODE_G        : string                     := "inferred";
       MEMORY_TYPE_G       : string                     := "block";
       GEN_SYNC_FIFO_G     : boolean                    := false;
       FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 9;
@@ -124,6 +125,7 @@ begin
          PIPE_STAGES_G       => 1,
          INT_PIPE_STAGES_G   => 0,
          VALID_THOLD_G       => RESP_THOLD_G,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => MEMORY_TYPE_G,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          CASCADE_SIZE_G      => 1,
@@ -152,6 +154,7 @@ begin
          PIPE_STAGES_G       => 1,
          INT_PIPE_STAGES_G   => 0,
          SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => MEMORY_TYPE_G,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          CASCADE_SIZE_G      => 1,
@@ -176,7 +179,7 @@ begin
    -------------------------------------
 
    comb : process (axilRst, r, rxFifoAxisMaster, sAxilReadMaster, sAxilWriteMaster, txFifoAxisSlave) is
-      variable v  : RegType;
+      variable v          : RegType;
       variable axilStatus : AxiLiteStatusType;
    begin
       v := r;
@@ -256,15 +259,15 @@ begin
                   then
                      v.sAxilReadSlave.rdata := rxFifoAxisMaster.tdata(95 downto 64);
                      axiSlaveReadResponse(v.sAxilReadSlave, AXI_RESP_OK_C);
-                     v.state               := WAIT_AXIL_REQ_S;
+                     v.state                := WAIT_AXIL_REQ_S;
                   elsif (rxFifoAxisMaster.tLast = '0') then
                      v.sAxilReadSlave.rdata := (others => '1');
                      axiSlaveReadResponse(v.sAxilReadSlave, AXI_RESP_SLVERR_C);
-                     v.state := BLEED_S;
+                     v.state                := BLEED_S;
                   else
                      v.sAxilReadSlave.rdata := (others => '1');
                      axiSlaveReadResponse(v.sAxilReadSlave, AXI_RESP_SLVERR_C);
-                     v.state               := WAIT_AXIL_REQ_S;
+                     v.state                := WAIT_AXIL_REQ_S;
                   end if;
                end if;
 

--- a/protocols/srp/rtl/SrpV0AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV0AxiLite.vhd
@@ -37,6 +37,7 @@ entity SrpV0AxiLite is
       RESP_THOLD_G        : integer range 0 to (2**24) := 1;  -- =1 = normal operation
       SLAVE_READY_EN_G    : boolean                    := false;
       EN_32BIT_ADDR_G     : boolean                    := false;
+      SYNTH_MODE_G        : string                     := "inferred";
       MEMORY_TYPE_G       : string                     := "block";
       GEN_SYNC_FIFO_G     : boolean                    := false;
       FIFO_ADDR_WIDTH_G   : integer range 4 to 48      := 9;
@@ -431,6 +432,7 @@ begin
          INT_PIPE_STAGES_G   => 0,
          PIPE_STAGES_G       => 1,
          VALID_THOLD_G       => RESP_THOLD_G,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => MEMORY_TYPE_G,
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          CASCADE_SIZE_G      => 1,

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -37,8 +37,9 @@ entity SrpV3AxiLite is
       INT_PIPE_STAGES_G     : natural range 0 to 16   := 1;
       PIPE_STAGES_G         : natural range 0 to 16   := 1;
       FIFO_PAUSE_THRESH_G   : positive range 1 to 511 := 256;
-      TX_VALID_THOLD_G      : positive range 1 to 511 := 500;   -- >1 = only when frame ready or # entries
-      TX_VALID_BURST_MODE_G : boolean                 := true;  -- only used in VALID_THOLD_G>1
+      FIFO_SYNTH_MODE_G     : string                  := "inferred";
+      TX_VALID_THOLD_G      : positive range 1 to 511 := 500;  -- >1 = only when frame ready or # entries
+      TX_VALID_BURST_MODE_G : boolean                 := true;       -- only used in VALID_THOLD_G>1
       SLAVE_READY_EN_G      : boolean                 := false;
       GEN_SYNC_FIFO_G       : boolean                 := false;
       AXIL_CLK_FREQ_G       : real                    := 156.25E+6;  -- units of Hz
@@ -214,8 +215,9 @@ begin
          INT_PIPE_STAGES_G   => INT_PIPE_STAGES_G,
          PIPE_STAGES_G       => PIPE_STAGES_G,
          SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
-         VALID_THOLD_G       => 0,  -- = 0 = only when frame ready
+         VALID_THOLD_G       => 0,      -- = 0 = only when frame ready
          -- FIFO configurations
+         SYNTH_MODE_G        => FIFO_SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          INT_WIDTH_SELECT_G  => "CUSTOM",
@@ -789,6 +791,7 @@ begin
          VALID_THOLD_G       => TX_VALID_THOLD_G,
          VALID_BURST_MODE_G  => TX_VALID_BURST_MODE_G,
          -- FIFO configurations
+         SYNTH_MODE_G        => FIFO_SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          INT_WIDTH_SELECT_G  => "CUSTOM",

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -152,21 +152,21 @@ begin
    RX_FIFO : entity surf.SsiFifo
       generic map (
          -- General Configurations
-         TPD_G                  => TPD_G,
-         PIPE_STAGES_G          => PIPE_STAGES_G,
-         SLAVE_READY_EN_G       => SLAVE_READY_EN_G,
-         VALID_THOLD_G          => 0,  -- = 0 = only when frame ready
+         TPD_G               => TPD_G,
+         PIPE_STAGES_G       => PIPE_STAGES_G,
+         SLAVE_READY_EN_G    => SLAVE_READY_EN_G,
+         VALID_THOLD_G       => 0,      -- = 0 = only when frame ready
          -- FIFO configurations
-         MEMORY_TYPE_G          => "block",
-         GEN_SYNC_FIFO_G        => GEN_SYNC_FIFO_G,
-         FIFO_ADDR_WIDTH_G      => 9,   -- 2kB/FIFO = 32-bits x 512 entries
-         CASCADE_SIZE_G         => 3,   -- 6kB = 3 FIFOs x 2 kB/FIFO
-         CASCADE_PAUSE_SEL_G    => 2,   -- Set pause select on top FIFO
-         FIFO_FIXED_THRESH_G    => true,
-         FIFO_PAUSE_THRESH_G    => FIFO_PAUSE_THRESH_G,
+         MEMORY_TYPE_G       => "block",
+         GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
+         FIFO_ADDR_WIDTH_G   => 9,      -- 2kB/FIFO = 32-bits x 512 entries
+         CASCADE_SIZE_G      => 3,      -- 6kB = 3 FIFOs x 2 kB/FIFO
+         CASCADE_PAUSE_SEL_G => 2,      -- Set pause select on top FIFO
+         FIFO_FIXED_THRESH_G => true,
+         FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
          -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G     => AXI_STREAM_CONFIG_G,
-         MASTER_AXI_CONFIG_G    => SRP_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXI_STREAM_CONFIG_G,
+         MASTER_AXI_CONFIG_G => SRP_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => sAxisClk,
@@ -675,6 +675,7 @@ begin
          SLAVE_READY_EN_G    => true,
          VALID_THOLD_G       => TX_VALID_THOLD_G,
          -- FIFO configurations
+         SYNTH_MODE_G        => SYNTH_MODE_G,
          MEMORY_TYPE_G       => "block",
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          CASCADE_SIZE_G      => 1,

--- a/protocols/srp/rtl/SrpV3Core.vhd
+++ b/protocols/srp/rtl/SrpV3Core.vhd
@@ -31,6 +31,7 @@ entity SrpV3Core is
    generic (
       TPD_G               : time                    := 1 ns;
       PIPE_STAGES_G       : natural range 0 to 16   := 1;
+      SYNTH_MODE_G        : string                  := "inferred";
       FIFO_PAUSE_THRESH_G : positive range 1 to 511 := 256;
       TX_VALID_THOLD_G    : positive                := 1;
       SLAVE_READY_EN_G    : boolean                 := false;


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

This PR exposes the SYNTH_MOD_G generic from internal RAMs in modules where it makes sense to have this configurable. 

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

For Xilinx builds, the `SYNTH_MOD_G => "xpm"` option seems to provide much better timing closure for very large RAMs compared to `"inferred"`. It is useful to therefore to make the option available when possible.

