### PR TITLE
Updating SPI PROMs' addrMode default 32-bits mode

### DIFF
--- a/python/surf/devices/cypress/_CypressS25Fl.py
+++ b/python/surf/devices/cypress/_CypressS25Fl.py
@@ -29,6 +29,8 @@ class CypressS25Fl(surf.devices.micron.AxiMicronN25Q):
         ########################################
         # Overwrite with Cypress S25FL Constants
         ########################################
+        self.ERASE_4BYTE_CMD = (0xDC << 16)
+        self.WRITE_4BYTE_CMD = (0x12 << 16)
         self.FLAG_STATUS_REG = (0x05 << 16)
         self.FLAG_STATUS_RDY = (0x01)
         self.BRAC_CMD        = (0xB9 << 16)

--- a/python/surf/devices/cypress/_CypressS25Fl.py
+++ b/python/surf/devices/cypress/_CypressS25Fl.py
@@ -24,7 +24,7 @@ class CypressS25Fl(surf.devices.micron.AxiMicronN25Q):
                  addrMode    = True, # False = 24-bit Address mode, True = 32-bit Address Mode
                  **kwargs):
 
-        super().__init__(description = description, **kwargs)
+        super().__init__(description = description, addrMode = addrMode, **kwargs)
 
         ########################################
         # Overwrite with Cypress S25FL Constants

--- a/python/surf/devices/cypress/_CypressS25Fl.py
+++ b/python/surf/devices/cypress/_CypressS25Fl.py
@@ -21,7 +21,7 @@ import datetime
 class CypressS25Fl(surf.devices.micron.AxiMicronN25Q):
     def __init__(self,
                  description = "Container for Cypress S25FL PROM device",
-                 addrMode    = False, # False = 24-bit Address mode, True = 32-bit Address Mode
+                 addrMode    = True, # False = 24-bit Address mode, True = 32-bit Address Mode
                  **kwargs):
 
         super().__init__(description = description, **kwargs)

--- a/python/surf/devices/micron/_AxiMicronN25Q.py
+++ b/python/surf/devices/micron/_AxiMicronN25Q.py
@@ -23,7 +23,7 @@ import math
 class AxiMicronN25Q(pr.Device):
     def __init__(self,
             description = "AXI-Lite Micron N25Q and Micron MT25Q PROM",
-            addrMode    = False, # False = 24-bit Address mode, True = 32-bit Address Mode
+            addrMode    = True, # False = 24-bit Address mode, True = 32-bit Address Mode
             tryCount    = 5,
             **kwargs):
 

--- a/python/surf/devices/micron/_AxiMicronN25Q.py
+++ b/python/surf/devices/micron/_AxiMicronN25Q.py
@@ -53,8 +53,11 @@ class AxiMicronN25Q(pr.Device):
         self.ADDR_ENTER_CMD = (0xB7 << 16)
         self.ADDR_EXIT_CMD  = (0xE9 << 16)
 
-        self.ERASE_CMD  = (0xD8 << 16)
-        self.WRITE_CMD  = (0x02 << 16)
+        self.ERASE_3BYTE_CMD  = (0xD8 << 16)
+        self.ERASE_4BYTE_CMD  = self.ERASE_3BYTE_CMD
+
+        self.WRITE_3BYTE_CMD  = (0x02 << 16)
+        self.WRITE_4BYTE_CMD  = self.WRITE_3BYTE_CMD
 
         self.STATUS_REG_WR_CMD = (0x01 << 16)
         self.STATUS_REG_RD_CMD = (0x05 << 16)
@@ -265,16 +268,16 @@ class AxiMicronN25Q(pr.Device):
     def eraseCmd(self, address):
         self.setAddrReg(address)
         if (self._addrMode):
-            self.setCmd(self.WRITE_MASK|self.ERASE_CMD|0x4)
+            self.setCmd(self.WRITE_MASK|self.ERASE_4BYTE_CMD|0x4)
         else:
-            self.setCmd(self.WRITE_MASK|self.ERASE_CMD|0x3)
+            self.setCmd(self.WRITE_MASK|self.ERASE_3BYTE_CMD|0x3)
 
     def writeCmd(self, address):
         self.setAddrReg(address)
         if (self._addrMode):
-            self.setCmd(self.WRITE_MASK|self.WRITE_CMD|0x104)
+            self.setCmd(self.WRITE_MASK|self.WRITE_4BYTE_CMD|0x104)
         else:
-            self.setCmd(self.WRITE_MASK|self.WRITE_CMD|0x103)
+            self.setCmd(self.WRITE_MASK|self.WRITE_3BYTE_CMD|0x103)
 
     def readCmd(self, address):
         self.setAddrReg(address)


### PR DESCRIPTION
### Description
- This is a much better default since 99% of all our SPI PROMs > 24-bits of address
  - I (and others) have been burnt too many times having the default set to 24-bits
- Updating CypressS25Fl.py's addrMode default to true (32-bits mode)
  - Including bug fix for CypressS25Fl and 32-bit address mode
- Updating AxiMicronN25Q.py's addrMode default to true (32-bits mode)