### PR TITLE
RogueTcpStreamWrap.vhd Update

### DIFF
--- a/axi/simlink/sim/RogueTcpStreamWrap.vhd
+++ b/axi/simlink/sim/RogueTcpStreamWrap.vhd
@@ -71,18 +71,25 @@ begin
    ----------------
    -- Inbound DEMUX
    ----------------
-   U_DeMux : entity surf.AxiStreamDeMux
-      generic map (
-         TPD_G         => 1 ns,
-         NUM_MASTERS_G => CHAN_COUNT_G)
-      port map (
-         -- Clock and reset
-         axisClk      => axisClk,
-         axisRst      => axisRst,
-         sAxisMaster  => sAxisMaster,
-         sAxisSlave   => sAxisSlave,
-         mAxisMasters => dmMasters,
-         mAxisSlaves  => dmSlaves);
+   GEN_DEMUX : if (CHAN_COUNT_G /= 1) generate
+      U_DeMux : entity surf.AxiStreamDeMux
+         generic map (
+            TPD_G         => TPD_G,
+            NUM_MASTERS_G => CHAN_COUNT_G)
+         port map (
+            -- Clock and reset
+            axisClk      => axisClk,
+            axisRst      => axisRst,
+            sAxisMaster  => sAxisMaster,
+            sAxisSlave   => sAxisSlave,
+            mAxisMasters => dmMasters,
+            mAxisSlaves  => dmSlaves);
+   end generate;
+
+   BYP_DEMUX : if (CHAN_COUNT_G = 1) generate
+      dmMasters(0) <= sAxisMaster;
+      sAxisSlave   <= dmSlaves(0);
+   end generate;
 
    -- Channels
    U_ChanGen : for i in 0 to CHAN_COUNT_G-1 generate
@@ -168,16 +175,23 @@ begin
    ---------------
    -- Outbound MUX
    ---------------
-   U_Mux : entity surf.AxiStreamMux
-      generic map (
-         TPD_G        => 1 ns,
-         NUM_SLAVES_G => CHAN_COUNT_G)
-      port map (
-         axisClk      => axisClk,
-         axisRst      => axisRst,
-         sAxisMasters => mxMasters,
-         sAxisSlaves  => mxSlaves,
-         mAxisMaster  => mAxisMaster,
-         mAxisSlave   => mAxisSlave);
+   GEN_MUX : if (CHAN_COUNT_G /= 1) generate
+      U_Mux : entity surf.AxiStreamMux
+         generic map (
+            TPD_G        => TPD_G,
+            NUM_SLAVES_G => CHAN_COUNT_G)
+         port map (
+            axisClk      => axisClk,
+            axisRst      => axisRst,
+            sAxisMasters => mxMasters,
+            sAxisSlaves  => mxSlaves,
+            mAxisMaster  => mAxisMaster,
+            mAxisSlave   => mAxisSlave);
+   end generate;
+
+   BYP_MUX : if (CHAN_COUNT_G = 1) generate
+      mAxisMaster <= mxMasters(0);
+      mxSlaves(0) <= mAxisSlave;
+   end generate;
 
 end RogueTcpStreamWrap;


### PR DESCRIPTION
### Description
- Prevent dropping non-zero TDEST frames at the RogueTcpStreamWrap.AxiStreamDemux for interleave applications that use multiple RogueTcpStreamWrap modules with CHAN_COUNT_G=1
