### PR TITLE
Fixed bug where PGP RX TDEST alaways zero and not VC index for VCS simulation

### DIFF
--- a/axi/simlink/sim/RogueTcpStreamWrap.vhd
+++ b/axi/simlink/sim/RogueTcpStreamWrap.vhd
@@ -27,6 +27,7 @@ entity RogueTcpStreamWrap is
       PORT_NUM_G    : natural range 1024 to 49151 := 9000;
       SSI_EN_G      : boolean                     := true;
       CHAN_COUNT_G  : positive range 1 to 256     := 1;
+      TDEST_MASK_G  : slv(7 downto 0)             := x"00";  -- Sets output TDEST when CHAN_COUNT_G=1
       AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- Clock and Reset
@@ -142,7 +143,7 @@ begin
             ibLast     => ibMasters(i).tLast);
 
       obMasters(i).tStrb <= (others => '1');
-      obMasters(i).tDest <= (others => '0');
+      obMasters(i).tDest <= TDEST_MASK_G when(CHAN_COUNT_G = 1) else x"00";
       obMasters(i).tId   <= (others => '0');
 
       obMasters(i).tKeep(AXI_STREAM_MAX_TKEEP_WIDTH_C-1 downto 8)  <= (others => '0');

--- a/protocols/pgp/pgp2b/core/tb/RoguePgp2bSim.vhd
+++ b/protocols/pgp/pgp2b/core/tb/RoguePgp2bSim.vhd
@@ -87,6 +87,7 @@ begin
             PORT_NUM_G    => (PORT_NUM_G + i*2),
             SSI_EN_G      => true,
             CHAN_COUNT_G  => 1,
+            TDEST_MASK_G  => toSlv(i,8),
             AXIS_CONFIG_G => SSI_PGP2B_CONFIG_C)
          port map (
             axisClk     => pgpClk,              -- [in]

--- a/protocols/pgp/pgp3/core/tb/RoguePgp3Sim.vhd
+++ b/protocols/pgp/pgp3/core/tb/RoguePgp3Sim.vhd
@@ -98,6 +98,7 @@ begin
             PORT_NUM_G    => (PORT_NUM_G + i*2),
             SSI_EN_G      => true,
             CHAN_COUNT_G  => 1,
+            TDEST_MASK_G  => toSlv(i,8),
             AXIS_CONFIG_G => PGP3_AXIS_CONFIG_C)
          port map (
             axisClk     => clk,              -- [in]


### PR DESCRIPTION
### Description
- Added `TDEST_MASK_G` to `RogueTcpStreamWrap.vhd` to set the outbound AXI stream's DEST when CHAN_COUNT_G=1
- Then set `TDEST_MASK_G = VC index` in the PGP wrappers