### PR TITLE
Fix anaconda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
 
       script:
         # Build conda package
-        - travis_wait 60 conda build --debug conda-recipe --output-folder bld-dir -c tidair-tag -c conda-forge
+        - travis_wait 60 conda build --debug conda-recipe --output-folder bld-dir -c tidair-tag -c tidair-packages -c conda-forge
 
       after_success:
         # Upload conda package

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 requirements:
    build:
-     - python
+     - python<3.8
      - rogue
      - git
      - gitpython


### PR DESCRIPTION
Attempt to fix anaconda build by limiting build python version to less than 3.8. I have left the run limitation open to see if this works. 