### PR TITLE
Adding TPD_G support to XPM RAMs

### DIFF
--- a/base/ram/xilinx/SimpleDualPortRamXpm.vhd
+++ b/base/ram/xilinx/SimpleDualPortRamXpm.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 
@@ -57,6 +56,8 @@ architecture rtl of SimpleDualPortRamXpm is
 
    signal resetB : sl;
 
+   signal doutb_xpm : slv(DATA_WIDTH_G-1 downto 0);
+
 begin
 
    U_RAM : xpm_memory_sdpram
@@ -91,7 +92,7 @@ begin
          enb            => enb,
          clkb           => clkb,
          addrb          => addrb,
-         doutb          => doutb,
+         doutb          => doutb_xpm,
          regceb         => regceb,
          -- Misc.Interface
          rstb           => resetB,
@@ -102,5 +103,7 @@ begin
          sleep          => '0');
 
    resetB <= rstb when(RST_POLARITY_G = '1') else not(rstb);
+
+   doutb <= doutb_xpm after TPD_G;
 
 end rtl;

--- a/base/ram/xilinx/TrueDualPortRamXpm.vhd
+++ b/base/ram/xilinx/TrueDualPortRamXpm.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 
@@ -63,6 +62,9 @@ architecture rtl of TrueDualPortRamXpm is
    signal resetA : sl;
    signal resetB : sl;
 
+   signal douta_xpm : slv(DATA_WIDTH_G-1 downto 0);
+   signal doutb_xpm : slv(DATA_WIDTH_G-1 downto 0);
+
 begin
 
    U_RAM : xpm_memory_tdpram
@@ -100,7 +102,7 @@ begin
          rsta           => resetA,
          addra          => addra,
          dina           => dina,
-         douta          => douta,
+         douta          => douta_xpm,
          -- Port B
          clkb           => clkb,
          enb            => enb,
@@ -109,7 +111,7 @@ begin
          rstb           => resetB,
          addrb          => addrb,
          dinb           => dinb,
-         doutb          => doutb,
+         doutb          => doutb_xpm,
          -- Misc.Interface
          dbiterra       => open,
          dbiterrb       => open,
@@ -123,5 +125,8 @@ begin
 
    resetA <= rsta when(RST_POLARITY_G = '1') else not(rsta);
    resetB <= rstb when(RST_POLARITY_G = '1') else not(rstb);
+
+   douta <= douta_xpm after TPD_G;
+   doutb <= doutb_xpm after TPD_G;
 
 end rtl;


### PR DESCRIPTION
### Description
- similar to the XPM FIFOs, adding TPD_G output delay to XPM RAMs
- TPD_G makes viewing the simulation behavior a lot easier