### PR TITLE
Ip integrator Support

### DIFF
--- a/axi/axi-lite/ip_integrator/AxiDualPortRamIpIntegrator.vhd
+++ b/axi/axi-lite/ip_integrator/AxiDualPortRamIpIntegrator.vhd
@@ -1,0 +1,178 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: IP Integrator Wrapper for surf.AxiVersion
+-------------------------------------------------------------------------------
+-- TCL Command: create_bd_cell -type module -reference AxiDualPortRamIpIntegrator AxiDualPortRam_0
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity AxiDualPortRamIpIntegrator is
+   generic (
+      EN_ERROR_RESP     : boolean              := false;
+      SYNTH_MODE        : string               := "inferred";
+      MEMORY_TYPE       : string               := "block";
+      MEMORY_INIT_FILE  : string               := "none";  -- Used for MEMORY_TYPE="XPM only
+      MEMORY_INIT_PARAM : string               := "0";  -- Used for MEMORY_TYPE="XPM only
+      READ_LATENCY      : natural range 0 to 3 := 3;
+      AXI_WR_EN         : boolean              := true;
+      SYS_WR_EN         : boolean              := false;
+      SYS_BYTE_WR_EN    : boolean              := false;
+      COMMON_CLK        : boolean              := false;
+      ADDR_WIDTH        : positive             := 5;
+      DATA_WIDTH        : positive             := 32);
+   port (
+      -- AXI-Lite Interface
+      S_AXI_ACLK    : in  std_logic;
+      S_AXI_ARESETN : in  std_logic;
+      S_AXI_AWADDR  : in  std_logic_vector(ADDR_WIDTH+1 downto 0);
+      S_AXI_AWPROT  : in  std_logic_vector(2 downto 0);
+      S_AXI_AWVALID : in  std_logic;
+      S_AXI_AWREADY : out std_logic;
+      S_AXI_WDATA   : in  std_logic_vector(31 downto 0);
+      S_AXI_WSTRB   : in  std_logic_vector(3 downto 0);
+      S_AXI_WVALID  : in  std_logic;
+      S_AXI_WREADY  : out std_logic;
+      S_AXI_BRESP   : out std_logic_vector(1 downto 0);
+      S_AXI_BVALID  : out std_logic;
+      S_AXI_BREADY  : in  std_logic;
+      S_AXI_ARADDR  : in  std_logic_vector(ADDR_WIDTH+1 downto 0);
+      S_AXI_ARPROT  : in  std_logic_vector(2 downto 0);
+      S_AXI_ARVALID : in  std_logic;
+      S_AXI_ARREADY : out std_logic;
+      S_AXI_RDATA   : out std_logic_vector(31 downto 0);
+      S_AXI_RRESP   : out std_logic_vector(1 downto 0);
+      S_AXI_RVALID  : out std_logic;
+      S_AXI_RREADY  : in  std_logic;
+      -- SYS RAM Interface
+      CLK           : in  std_logic                                   := '0';
+      EN            : in  std_logic                                   := '1';
+      WE            : in  std_logic_vector((DATA_WIDTH/8)-1 downto 0) := (others => '0');
+      RST           : in  std_logic                                   := '0';
+      ADDR          : in  std_logic_vector(ADDR_WIDTH-1 downto 0)     := (others => '0');
+      DIN           : in  std_logic_vector(DATA_WIDTH-1 downto 0)     := (others => '0');
+      DOUT          : out std_logic_vector(DATA_WIDTH-1 downto 0));
+end AxiDualPortRamIpIntegrator;
+
+architecture mapping of AxiDualPortRamIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of CLK  : signal is "xilinx.com:interface:bram:1.0 RAM_PORT CLK";
+   attribute X_INTERFACE_INFO of EN   : signal is "xilinx.com:interface:bram:1.0 RAM_PORT EN";
+   attribute X_INTERFACE_INFO of WE   : signal is "xilinx.com:interface:bram:1.0 RAM_PORT WE";
+   attribute X_INTERFACE_INFO of RST  : signal is "xilinx.com:interface:bram:1.0 RAM_PORT RST";
+   attribute X_INTERFACE_INFO of ADDR : signal is "xilinx.com:interface:bram:1.0 RAM_PORT ADDR";
+   attribute X_INTERFACE_INFO of DIN  : signal is "xilinx.com:interface:bram:1.0 RAM_PORT DIN";
+   attribute X_INTERFACE_INFO of DOUT : signal is "xilinx.com:interface:bram:1.0 RAM_PORT DOUT";
+
+   attribute X_INTERFACE_PARAMETER of ADDR : signal is
+      "XIL_INTERFACENAME RAM_PORT, " &
+      "MEM_SIZE " & integer'image(2**ADDR_WIDTH) & ", " &
+      "MEM_WIDTH " & integer'image(DATA_WIDTH) & ", " &
+      "MEM_ECC NONE, " &
+      "MASTER_TYPE OTHER, " &
+      "READ_LATENCY " & integer'image(READ_LATENCY);
+
+   signal uOrWe     : sl;
+   signal intWe     : sl;
+   signal intWeByte : slv(wordCount(DATA_WIDTH, 8)-1 downto 0);
+
+   signal axilClk         : sl;
+   signal axilRst         : sl;
+   signal axilReadMaster  : AxiLiteReadMasterType;
+   signal axilReadSlave   : AxiLiteReadSlaveType;
+   signal axilWriteMaster : AxiLiteWriteMasterType;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType;
+
+begin
+
+   U_ShimLayer : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         EN_ERROR_RESP => EN_ERROR_RESP,
+         HAS_WSTRB     => 1,            -- Using write strobe
+         ADDR_WIDTH    => ADDR_WIDTH+2)
+      port map (
+         -- IP Integrator AXI-Lite Interface
+         S_AXI_ACLK      => S_AXI_ACLK,
+         S_AXI_ARESETN   => S_AXI_ARESETN,
+         S_AXI_AWADDR    => S_AXI_AWADDR,
+         S_AXI_AWPROT    => S_AXI_AWPROT,
+         S_AXI_AWVALID   => S_AXI_AWVALID,
+         S_AXI_AWREADY   => S_AXI_AWREADY,
+         S_AXI_WDATA     => S_AXI_WDATA,
+         S_AXI_WSTRB     => S_AXI_WSTRB,
+         S_AXI_WVALID    => S_AXI_WVALID,
+         S_AXI_WREADY    => S_AXI_WREADY,
+         S_AXI_BRESP     => S_AXI_BRESP,
+         S_AXI_BVALID    => S_AXI_BVALID,
+         S_AXI_BREADY    => S_AXI_BREADY,
+         S_AXI_ARADDR    => S_AXI_ARADDR,
+         S_AXI_ARPROT    => S_AXI_ARPROT,
+         S_AXI_ARVALID   => S_AXI_ARVALID,
+         S_AXI_ARREADY   => S_AXI_ARREADY,
+         S_AXI_RDATA     => S_AXI_RDATA,
+         S_AXI_RRESP     => S_AXI_RRESP,
+         S_AXI_RVALID    => S_AXI_RVALID,
+         S_AXI_RREADY    => S_AXI_RREADY,
+         -- SURF AXI-Lite Interface
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         axilReadMaster  => axilReadMaster,
+         axilReadSlave   => axilReadSlave,
+         axilWriteMaster => axilWriteMaster,
+         axilWriteSlave  => axilWriteSlave);
+
+   U_AxiDualPortRam : entity surf.AxiDualPortRam
+      generic map (
+         SYNTH_MODE_G        => SYNTH_MODE,
+         MEMORY_TYPE_G       => MEMORY_TYPE,
+         MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE,
+         MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM,
+         READ_LATENCY_G      => READ_LATENCY,
+         AXI_WR_EN_G         => AXI_WR_EN,
+         SYS_WR_EN_G         => SYS_WR_EN,
+         SYS_BYTE_WR_EN_G    => SYS_BYTE_WR_EN,
+         COMMON_CLK_G        => COMMON_CLK,
+         ADDR_WIDTH_G        => ADDR_WIDTH,
+         DATA_WIDTH_G        => DATA_WIDTH)
+      port map (
+         -- AXI-Lite Interface
+         axiClk         => axilClk,
+         axiRst         => axilRst,
+         axiReadMaster  => axilReadMaster,
+         axiReadSlave   => axilReadSlave,
+         axiWriteMaster => axilWriteMaster,
+         axiWriteSlave  => axilWriteSlave,
+         -- Standard Port
+         clk            => CLK,
+         en             => EN,
+         we             => intWe,
+         weByte         => intWeByte,
+         rst            => RST,
+         addr           => ADDR,
+         din            => DIN,
+         dout           => DOUT);
+
+   uOrWe     <= uOr(WE);
+   intWe     <= uOrWe;
+   intWeByte <= WE when(SYS_BYTE_WR_EN) else (others => uOrWe);
+
+end mapping;

--- a/axi/axi-lite/ip_integrator/AxiVersionIpIntegrator.vhd
+++ b/axi/axi-lite/ip_integrator/AxiVersionIpIntegrator.vhd
@@ -1,0 +1,180 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: IP Integrator Wrapper for surf.AxiVersion
+-------------------------------------------------------------------------------
+-- TCL Command: create_bd_cell -type module -reference AxiVersionIpIntegrator AxiVersion_0
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+library ruckus;
+use ruckus.BuildInfoPkg.all;
+
+entity AxiVersionIpIntegrator is
+   generic (
+      EN_ERROR_RESP    : boolean                       := false;
+      FREQ_HZ          : positive                      := 125000000;
+      EN_DEVICE_DNA    : boolean                       := false;
+      EN_ICAP          : boolean                       := false;
+      EN_DS2411        : boolean                       := false;
+      USE_SLOWCLK      : boolean                       := false;
+      BUFR_CLK_DIV     : positive                      := 8;
+      AUTO_RELOAD_EN   : boolean                       := false;
+      AUTO_RELOAD_TIME : positive                      := 10;  -- units of seconds
+      AUTO_RELOAD_ADDR : std_logic_vector(31 downto 0) := x"00000000");
+   port (
+      -- AXI-Lite Interface
+      S_AXI_ACLK     : in    std_logic;
+      S_AXI_ARESETN  : in    std_logic;
+      S_AXI_AWADDR   : in    std_logic_vector(11 downto 0);  -- Must match ADDR_WIDTH_C
+      S_AXI_AWPROT   : in    std_logic_vector(2 downto 0);
+      S_AXI_AWVALID  : in    std_logic;
+      S_AXI_AWREADY  : out   std_logic;
+      S_AXI_WDATA    : in    std_logic_vector(31 downto 0);
+      S_AXI_WSTRB    : in    std_logic_vector(3 downto 0);
+      S_AXI_WVALID   : in    std_logic;
+      S_AXI_WREADY   : out   std_logic;
+      S_AXI_BRESP    : out   std_logic_vector(1 downto 0);
+      S_AXI_BVALID   : out   std_logic;
+      S_AXI_BREADY   : in    std_logic;
+      S_AXI_ARADDR   : in    std_logic_vector(11 downto 0);  -- Must match ADDR_WIDTH_C
+      S_AXI_ARPROT   : in    std_logic_vector(2 downto 0);
+      S_AXI_ARVALID  : in    std_logic;
+      S_AXI_ARREADY  : out   std_logic;
+      S_AXI_RDATA    : out   std_logic_vector(31 downto 0);
+      S_AXI_RRESP    : out   std_logic_vector(1 downto 0);
+      S_AXI_RVALID   : out   std_logic;
+      S_AXI_RREADY   : in    std_logic;
+      -- Optional: User Reset
+      userReset      : out   std_logic;
+      -- Optional: FPGA Reloading Interface
+      fpgaEnReload   : in    std_logic                            := '1';
+      fpgaReload     : out   std_logic;
+      fpgaReloadAddr : out   std_logic_vector(31 downto 0);
+      upTimeCnt      : out   std_logic_vector(31 downto 0);
+      -- Optional: Serial Number outputs
+      slowClk        : in    std_logic                            := '0';
+      dnaValueOut    : out   std_logic_vector(127 downto 0);
+      fdValueOut     : out   std_logic_vector(63 downto 0);
+      -- Optional: user values
+      userValues     : in    std_logic_vector((64*32)-1 downto 0) := (others => '0');
+      -- Optional: DS2411 interface
+      fdSerSdio      : inout std_logic                            := 'Z');
+end AxiVersionIpIntegrator;
+
+architecture mapping of AxiVersionIpIntegrator is
+
+   constant ADDR_WIDTH_C : positive := 12;  -- Must match the entity's port width
+
+   constant CLK_PERIOD_C : real := (1.0/real(FREQ_HZ));  -- units of seconds
+
+   signal axilClk         : sl;
+   signal axilRst         : sl;
+   signal axilReadMaster  : AxiLiteReadMasterType;
+   signal axilReadSlave   : AxiLiteReadSlaveType;
+   signal axilWriteMaster : AxiLiteWriteMasterType;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType;
+
+   signal userValuesArray : Slv32Array(0 to 63);
+
+begin
+
+   U_ShimLayer : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         EN_ERROR_RESP => EN_ERROR_RESP,
+         FREQ_HZ       => FREQ_HZ,
+         ADDR_WIDTH    => ADDR_WIDTH_C)
+      port map (
+         -- IP Integrator AXI-Lite Interface
+         S_AXI_ACLK      => S_AXI_ACLK,
+         S_AXI_ARESETN   => S_AXI_ARESETN,
+         S_AXI_AWADDR    => S_AXI_AWADDR,
+         S_AXI_AWPROT    => S_AXI_AWPROT,
+         S_AXI_AWVALID   => S_AXI_AWVALID,
+         S_AXI_AWREADY   => S_AXI_AWREADY,
+         S_AXI_WDATA     => S_AXI_WDATA,
+         S_AXI_WSTRB     => S_AXI_WSTRB,
+         S_AXI_WVALID    => S_AXI_WVALID,
+         S_AXI_WREADY    => S_AXI_WREADY,
+         S_AXI_BRESP     => S_AXI_BRESP,
+         S_AXI_BVALID    => S_AXI_BVALID,
+         S_AXI_BREADY    => S_AXI_BREADY,
+         S_AXI_ARADDR    => S_AXI_ARADDR,
+         S_AXI_ARPROT    => S_AXI_ARPROT,
+         S_AXI_ARVALID   => S_AXI_ARVALID,
+         S_AXI_ARREADY   => S_AXI_ARREADY,
+         S_AXI_RDATA     => S_AXI_RDATA,
+         S_AXI_RRESP     => S_AXI_RRESP,
+         S_AXI_RVALID    => S_AXI_RVALID,
+         S_AXI_RREADY    => S_AXI_RREADY,
+         -- SURF AXI-Lite Interface
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         axilReadMaster  => axilReadMaster,
+         axilReadSlave   => axilReadSlave,
+         axilWriteMaster => axilWriteMaster,
+         axilWriteSlave  => axilWriteSlave);
+
+   process(userValues)
+      variable i      : natural;
+      variable retVar : Slv32Array(0 to 63);
+   begin
+      for i in 0 to 63 loop
+         retVar(i) := userValues((i*32)+31 downto i*32);
+      end loop;
+      userValuesArray <= retVar;
+   end process;
+
+   U_AxiVersion : entity surf.AxiVersion
+      generic map (
+         BUILD_INFO_G       => BUILD_INFO_C,
+         CLK_PERIOD_G       => CLK_PERIOD_C,
+         EN_DEVICE_DNA_G    => EN_DEVICE_DNA,
+         EN_DS2411_G        => EN_DS2411,
+         EN_ICAP_G          => EN_ICAP,
+         USE_SLOWCLK_G      => USE_SLOWCLK,
+         BUFR_CLK_DIV_G     => BUFR_CLK_DIV,
+         AUTO_RELOAD_EN_G   => AUTO_RELOAD_EN,
+         AUTO_RELOAD_TIME_G => AUTO_RELOAD_TIME,
+         AUTO_RELOAD_ADDR_G => AUTO_RELOAD_ADDR)
+      port map (
+         -- AXI-Lite Interface
+         axiClk         => axilClk,
+         axiRst         => axilRst,
+         axiReadMaster  => axilReadMaster,
+         axiReadSlave   => axilReadSlave,
+         axiWriteMaster => axilWriteMaster,
+         axiWriteSlave  => axilWriteSlave,
+         -- Optional: User Reset
+         userReset      => userReset,
+         -- Optional: FPGA Reloading Interface
+         fpgaEnReload   => fpgaEnReload,
+         fpgaReload     => fpgaReload,
+         fpgaReloadAddr => fpgaReloadAddr,
+         upTimeCnt      => upTimeCnt,
+         -- Optional: Serial Number outputs
+         slowClk        => slowClk,
+         dnaValueOut    => dnaValueOut,
+         fdValueOut     => fdValueOut,
+         -- Optional: user values
+         userValues     => userValuesArray,
+         -- Optional: DS2411 interface
+         fdSerSdio      => fdSerSdio);
+
+end mapping;

--- a/axi/axi-lite/ip_integrator/AxiVersionIpIntegrator.vhd
+++ b/axi/axi-lite/ip_integrator/AxiVersionIpIntegrator.vhd
@@ -28,16 +28,8 @@ use ruckus.BuildInfoPkg.all;
 
 entity AxiVersionIpIntegrator is
    generic (
-      EN_ERROR_RESP    : boolean                       := false;
-      FREQ_HZ          : positive                      := 125000000;
-      EN_DEVICE_DNA    : boolean                       := false;
-      EN_ICAP          : boolean                       := false;
-      EN_DS2411        : boolean                       := false;
-      USE_SLOWCLK      : boolean                       := false;
-      BUFR_CLK_DIV     : positive                      := 8;
-      AUTO_RELOAD_EN   : boolean                       := false;
-      AUTO_RELOAD_TIME : positive                      := 10;  -- units of seconds
-      AUTO_RELOAD_ADDR : std_logic_vector(31 downto 0) := x"00000000");
+      EN_ERROR_RESP : boolean  := false;
+      FREQ_HZ       : positive := 125000000);
    port (
       -- AXI-Lite Interface
       S_AXI_ACLK     : in    std_logic;
@@ -143,16 +135,8 @@ begin
 
    U_AxiVersion : entity surf.AxiVersion
       generic map (
-         BUILD_INFO_G       => BUILD_INFO_C,
-         CLK_PERIOD_G       => CLK_PERIOD_C,
-         EN_DEVICE_DNA_G    => EN_DEVICE_DNA,
-         EN_DS2411_G        => EN_DS2411,
-         EN_ICAP_G          => EN_ICAP,
-         USE_SLOWCLK_G      => USE_SLOWCLK,
-         BUFR_CLK_DIV_G     => BUFR_CLK_DIV,
-         AUTO_RELOAD_EN_G   => AUTO_RELOAD_EN,
-         AUTO_RELOAD_TIME_G => AUTO_RELOAD_TIME,
-         AUTO_RELOAD_ADDR_G => AUTO_RELOAD_ADDR)
+         BUILD_INFO_G => BUILD_INFO_C,
+         CLK_PERIOD_G => CLK_PERIOD_C)
       port map (
          -- AXI-Lite Interface
          axiClk         => axilClk,

--- a/axi/axi-lite/ip_integrator/MasterAxiLiteIpIntegrator.vhd
+++ b/axi/axi-lite/ip_integrator/MasterAxiLiteIpIntegrator.vhd
@@ -1,0 +1,157 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI-Lite interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity MasterAxiLiteIpIntegrator is
+   generic (
+      INTERFACENAME : string               := "M_AXI";
+      EN_ERROR_RESP : boolean              := false;
+      HAS_PROT      : natural range 0 to 1 := 0;
+      HAS_WSTRB     : natural range 0 to 1 := 0;
+      FREQ_HZ       : positive             := 100000000;
+      ADDR_WIDTH    : positive             := 12);
+   port (
+      -- IP Integrator AXI-Lite Interface
+      M_AXI_ACLK      : in  std_logic;
+      M_AXI_ARESETN   : in  std_logic;
+      M_AXI_AWADDR    : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      M_AXI_AWPROT    : out std_logic_vector(2 downto 0);
+      M_AXI_AWVALID   : out std_logic;
+      M_AXI_AWREADY   : in  std_logic;
+      M_AXI_WDATA     : out std_logic_vector(31 downto 0);
+      M_AXI_WSTRB     : out std_logic_vector(3 downto 0);
+      M_AXI_WVALID    : out std_logic;
+      M_AXI_WREADY    : in  std_logic;
+      M_AXI_BRESP     : in  std_logic_vector(1 downto 0);
+      M_AXI_BVALID    : in  std_logic;
+      M_AXI_BREADY    : out std_logic;
+      M_AXI_ARADDR    : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      M_AXI_ARPROT    : out std_logic_vector(2 downto 0);
+      M_AXI_ARVALID   : out std_logic;
+      M_AXI_ARREADY   : in  std_logic;
+      M_AXI_RDATA     : in  std_logic_vector(31 downto 0);
+      M_AXI_RRESP     : in  std_logic_vector(1 downto 0);
+      M_AXI_RVALID    : in  std_logic;
+      M_AXI_RREADY    : out std_logic;
+      -- SURF AXI-Lite Interface
+      axilClk         : out sl;
+      axilRst         : out sl;
+      axilReadMaster  : in  AxiLiteReadMasterType;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType;
+      axilWriteSlave  : out AxiLiteWriteSlaveType);
+end MasterAxiLiteIpIntegrator;
+
+architecture mapping of MasterAxiLiteIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of M_AXI_RREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RREADY";
+   attribute X_INTERFACE_INFO of M_AXI_RVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RVALID";
+   attribute X_INTERFACE_INFO of M_AXI_RRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RRESP";
+   attribute X_INTERFACE_INFO of M_AXI_RDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RDATA";
+   attribute X_INTERFACE_INFO of M_AXI_ARREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREADY";
+   attribute X_INTERFACE_INFO of M_AXI_ARVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARVALID";
+   attribute X_INTERFACE_INFO of M_AXI_ARADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARADDR";
+   attribute X_INTERFACE_INFO of M_AXI_ARPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARPROT";
+   attribute X_INTERFACE_INFO of M_AXI_BREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BREADY";
+   attribute X_INTERFACE_INFO of M_AXI_BVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BVALID";
+   attribute X_INTERFACE_INFO of M_AXI_BRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BRESP";
+   attribute X_INTERFACE_INFO of M_AXI_WREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WREADY";
+   attribute X_INTERFACE_INFO of M_AXI_WVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WVALID";
+   attribute X_INTERFACE_INFO of M_AXI_WDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WDATA";
+   attribute X_INTERFACE_INFO of M_AXI_WSTRB       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WSTRB";
+   attribute X_INTERFACE_INFO of M_AXI_AWREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREADY";
+   attribute X_INTERFACE_INFO of M_AXI_AWVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWVALID";
+   attribute X_INTERFACE_INFO of M_AXI_AWPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWPROT";
+   attribute X_INTERFACE_INFO of M_AXI_AWADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWADDR";
+   attribute X_INTERFACE_PARAMETER of M_AXI_AWADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "PROTOCOL AXI4LITE, " &
+      "DATA_WIDTH 32, " &
+      "HAS_PROT " & integer'image(HAS_PROT) & ", " &
+      "HAS_WSTRB " & integer'image(HAS_WSTRB) & ", " &
+      "MAX_BURST_LENGTH 1, " &
+      "ADDR_WIDTH " & integer'image(ADDR_WIDTH) & ", " &
+      "FREQ_HZ " & integer'image(FREQ_HZ);
+
+   attribute X_INTERFACE_INFO of M_AXI_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of M_AXI_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of M_AXI_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of M_AXI_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN, " &
+      "FREQ_HZ " & integer'image(FREQ_HZ);
+
+   signal M_AXI_ReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal M_AXI_ReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal M_AXI_WriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal M_AXI_WriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+
+begin
+
+   axilClk <= M_AXI_ACLK;
+
+   M_AXI_ReadMaster <= axilReadMaster;
+   axilReadSlave    <= M_AXI_ReadSlave;
+
+   M_AXI_WriteMaster <= axilWriteMaster;
+   axilWriteSlave    <= M_AXI_WriteSlave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => M_AXI_ACLK,
+         asyncRst => M_AXI_ARESETN,
+         syncRst  => axilRst);
+
+   M_AXI_ARADDR  <= M_AXI_ReadMaster.araddr(ADDR_WIDTH-1 downto 0);
+   M_AXI_ARPROT  <= M_AXI_ReadMaster.arprot;
+   M_AXI_ARVALID <= M_AXI_ReadMaster.arvalid;
+   M_AXI_RREADY  <= M_AXI_ReadMaster.rready;
+
+   M_AXI_ReadSlave.arready <= M_AXI_ARREADY;
+   M_AXI_ReadSlave.rdata   <= M_AXI_RDATA;
+   M_AXI_ReadSlave.rresp   <= M_AXI_RRESP when(EN_ERROR_RESP) else AXI_RESP_OK_C;
+   M_AXI_ReadSlave.rvalid  <= M_AXI_RVALID;
+
+   M_AXI_AWADDR  <= M_AXI_WriteMaster.awaddr(ADDR_WIDTH-1 downto 0);
+   M_AXI_AWPROT  <= M_AXI_WriteMaster.awprot;
+   M_AXI_AWVALID <= M_AXI_WriteMaster.awvalid;
+   M_AXI_WDATA   <= M_AXI_WriteMaster.wdata;
+   M_AXI_WSTRB   <= M_AXI_WriteMaster.wstrb when(HAS_WSTRB /= 0) else x"F";
+   M_AXI_WVALID  <= M_AXI_WriteMaster.wvalid;
+   M_AXI_BREADY  <= M_AXI_WriteMaster.bready;
+
+   M_AXI_WriteSlave.awready <= M_AXI_AWREADY;
+   M_AXI_WriteSlave.wready  <= M_AXI_WREADY;
+   M_AXI_WriteSlave.bresp   <= M_AXI_BRESP when(EN_ERROR_RESP) else AXI_RESP_OK_C;
+   M_AXI_WriteSlave.bvalid  <= M_AXI_BVALID;
+
+end mapping;

--- a/axi/axi-lite/ip_integrator/SlaveAxiLiteIpIntegrator.vhd
+++ b/axi/axi-lite/ip_integrator/SlaveAxiLiteIpIntegrator.vhd
@@ -1,0 +1,157 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI-Lite interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity SlaveAxiLiteIpIntegrator is
+   generic (
+      INTERFACENAME : string               := "S_AXI";
+      EN_ERROR_RESP : boolean              := false;
+      HAS_PROT      : natural range 0 to 1 := 0;
+      HAS_WSTRB     : natural range 0 to 1 := 0;
+      FREQ_HZ       : positive             := 100000000;
+      ADDR_WIDTH    : positive             := 12);
+   port (
+      -- IP Integrator AXI-Lite Interface
+      S_AXI_ACLK      : in  std_logic;
+      S_AXI_ARESETN   : in  std_logic;
+      S_AXI_AWADDR    : in  std_logic_vector(ADDR_WIDTH-1 downto 0);
+      S_AXI_AWPROT    : in  std_logic_vector(2 downto 0);
+      S_AXI_AWVALID   : in  std_logic;
+      S_AXI_AWREADY   : out std_logic;
+      S_AXI_WDATA     : in  std_logic_vector(31 downto 0);
+      S_AXI_WSTRB     : in  std_logic_vector(3 downto 0);
+      S_AXI_WVALID    : in  std_logic;
+      S_AXI_WREADY    : out std_logic;
+      S_AXI_BRESP     : out std_logic_vector(1 downto 0);
+      S_AXI_BVALID    : out std_logic;
+      S_AXI_BREADY    : in  std_logic;
+      S_AXI_ARADDR    : in  std_logic_vector(ADDR_WIDTH-1 downto 0);
+      S_AXI_ARPROT    : in  std_logic_vector(2 downto 0);
+      S_AXI_ARVALID   : in  std_logic;
+      S_AXI_ARREADY   : out std_logic;
+      S_AXI_RDATA     : out std_logic_vector(31 downto 0);
+      S_AXI_RRESP     : out std_logic_vector(1 downto 0);
+      S_AXI_RVALID    : out std_logic;
+      S_AXI_RREADY    : in  std_logic;
+      -- SURF AXI-Lite Interface
+      axilClk         : out sl;
+      axilRst         : out sl;
+      axilReadMaster  : out AxiLiteReadMasterType;
+      axilReadSlave   : in  AxiLiteReadSlaveType;
+      axilWriteMaster : out AxiLiteWriteMasterType;
+      axilWriteSlave  : in  AxiLiteWriteSlaveType);
+end SlaveAxiLiteIpIntegrator;
+
+architecture mapping of SlaveAxiLiteIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of S_AXI_RREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RREADY";
+   attribute X_INTERFACE_INFO of S_AXI_RVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RVALID";
+   attribute X_INTERFACE_INFO of S_AXI_RRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RRESP";
+   attribute X_INTERFACE_INFO of S_AXI_RDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RDATA";
+   attribute X_INTERFACE_INFO of S_AXI_ARREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREADY";
+   attribute X_INTERFACE_INFO of S_AXI_ARVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARVALID";
+   attribute X_INTERFACE_INFO of S_AXI_ARADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARADDR";
+   attribute X_INTERFACE_INFO of S_AXI_ARPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARPROT";
+   attribute X_INTERFACE_INFO of S_AXI_BREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BREADY";
+   attribute X_INTERFACE_INFO of S_AXI_BVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BVALID";
+   attribute X_INTERFACE_INFO of S_AXI_BRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BRESP";
+   attribute X_INTERFACE_INFO of S_AXI_WREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WREADY";
+   attribute X_INTERFACE_INFO of S_AXI_WVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WVALID";
+   attribute X_INTERFACE_INFO of S_AXI_WDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WDATA";
+   attribute X_INTERFACE_INFO of S_AXI_WSTRB       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WSTRB";
+   attribute X_INTERFACE_INFO of S_AXI_AWREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREADY";
+   attribute X_INTERFACE_INFO of S_AXI_AWVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWVALID";
+   attribute X_INTERFACE_INFO of S_AXI_AWPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWPROT";
+   attribute X_INTERFACE_INFO of S_AXI_AWADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWADDR";
+   attribute X_INTERFACE_PARAMETER of S_AXI_AWADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "PROTOCOL AXI4LITE, " &
+      "DATA_WIDTH 32, " &
+      "HAS_PROT " & integer'image(HAS_PROT) & ", " &
+      "HAS_WSTRB " & integer'image(HAS_WSTRB) & ", " &
+      "MAX_BURST_LENGTH 1, " &
+      "ADDR_WIDTH " & integer'image(ADDR_WIDTH) & ", " &
+      "FREQ_HZ " & integer'image(FREQ_HZ);
+
+   attribute X_INTERFACE_INFO of S_AXI_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of S_AXI_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of S_AXI_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of S_AXI_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN, " &
+      "FREQ_HZ " & integer'image(FREQ_HZ);
+
+   signal S_AXI_ReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal S_AXI_ReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal S_AXI_WriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal S_AXI_WriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+
+begin
+
+   axilClk <= S_AXI_ACLK;
+
+   axilReadMaster  <= S_AXI_ReadMaster;
+   S_AXI_ReadSlave <= axilReadSlave;
+
+   axilWriteMaster  <= S_AXI_WriteMaster;
+   S_AXI_WriteSlave <= axilWriteSlave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => S_AXI_ACLK,
+         asyncRst => S_AXI_ARESETN,
+         syncRst  => axilRst);
+
+   S_AXI_ReadMaster.araddr(ADDR_WIDTH-1 downto 0) <= S_AXI_ARADDR;
+   S_AXI_ReadMaster.arprot                        <= S_AXI_ARPROT;
+   S_AXI_ReadMaster.arvalid                       <= S_AXI_ARVALID;
+   S_AXI_ReadMaster.rready                        <= S_AXI_RREADY;
+
+   S_AXI_ARREADY <= S_AXI_ReadSlave.arready;
+   S_AXI_RDATA   <= S_AXI_ReadSlave.rdata;
+   S_AXI_RRESP   <= S_AXI_ReadSlave.rresp when(EN_ERROR_RESP) else AXI_RESP_OK_C;
+   S_AXI_RVALID  <= S_AXI_ReadSlave.rvalid;
+
+   S_AXI_WriteMaster.awaddr(ADDR_WIDTH-1 downto 0) <= S_AXI_AWADDR;
+   S_AXI_WriteMaster.awprot                        <= S_AXI_AWPROT;
+   S_AXI_WriteMaster.awvalid                       <= S_AXI_AWVALID;
+   S_AXI_WriteMaster.wdata                         <= S_AXI_WDATA;
+   S_AXI_WriteMaster.wstrb                         <= S_AXI_WSTRB when(HAS_WSTRB /= 0) else x"F";
+   S_AXI_WriteMaster.wvalid                        <= S_AXI_WVALID;
+   S_AXI_WriteMaster.bready                        <= S_AXI_BREADY;
+
+   S_AXI_AWREADY <= S_AXI_WriteSlave.awready;
+   S_AXI_WREADY  <= S_AXI_WriteSlave.wready;
+   S_AXI_BRESP   <= S_AXI_WriteSlave.bresp when(EN_ERROR_RESP) else AXI_RESP_OK_C;
+   S_AXI_BVALID  <= S_AXI_WriteSlave.bvalid;
+
+end mapping;

--- a/axi/axi-lite/ruckus.tcl
+++ b/axi/axi-lite/ruckus.tcl
@@ -3,6 +3,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
+loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/axi/axi-stream/ip_integrator/MasterAxiStreamIpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/MasterAxiStreamIpIntegrator.vhd
@@ -1,0 +1,118 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI Stream interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity MasterAxiStreamIpIntegrator is
+   generic (
+      INTERFACENAME   : string                 := "M_AXIS";
+      HAS_TLAST       : natural range 0 to 1   := 1;
+      HAS_TKEEP       : natural range 0 to 1   := 1;
+      HAS_TSTRB       : natural range 0 to 1   := 0;
+      HAS_TREADY      : natural range 0 to 1   := 1;
+      TUSER_WIDTH     : natural range 1 to 8   := 2;
+      TID_WIDTH       : natural range 1 to 8   := 1;
+      TDEST_WIDTH     : natural range 1 to 8   := 1;
+      TDATA_NUM_BYTES : natural range 1 to 128 := 1);
+   port (
+      -- IP Integrator AXI Stream Interface
+      M_AXIS_ACLK    : in  std_logic           := '0';
+      M_AXIS_ARESETN : in  std_logic           := '0';
+      M_AXIS_TVALID  : out std_logic;
+      M_AXIS_TDATA   : out std_logic_vector((8*TDATA_NUM_BYTES)-1 downto 0);
+      M_AXIS_TSTRB   : out std_logic_vector(TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TKEEP   : out std_logic_vector(TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TLAST   : out std_logic;
+      M_AXIS_TDEST   : out std_logic_vector(TDEST_WIDTH-1 downto 0);
+      M_AXIS_TID     : out std_logic_vector(TID_WIDTH-1 downto 0);
+      M_AXIS_TUSER   : out std_logic_vector(TUSER_WIDTH-1 downto 0);
+      M_AXIS_TREADY  : in  std_logic           := '1';
+      -- SURF AXI Stream Interface
+      axisClk        : out sl;
+      axisRst        : out sl;
+      axisMaster     : in  AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+      axisSlave      : out AxiStreamSlaveType);
+end MasterAxiStreamIpIntegrator;
+
+architecture mapping of MasterAxiStreamIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of M_AXIS_TVALID     : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TVALID";
+   attribute X_INTERFACE_INFO of M_AXIS_TLAST      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TLAST";
+   attribute X_INTERFACE_INFO of M_AXIS_TDATA      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TDATA";
+   attribute X_INTERFACE_INFO of M_AXIS_TKEEP      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TKEEP";
+   attribute X_INTERFACE_INFO of M_AXIS_TREADY     : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TREADY";
+   attribute X_INTERFACE_PARAMETER of M_AXIS_TDATA : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "LAYERED_METADATA undef, " &
+      "HAS_TLAST " & integer'image(HAS_TLAST) & ", " &
+      "HAS_TKEEP " & integer'image(HAS_TKEEP) & ", " &
+      "HAS_TSTRB " & integer'image(HAS_TSTRB) & ", " &
+      "HAS_TREADY " & integer'image(HAS_TREADY) & ", " &
+      "TUSER_WIDTH " & integer'image(TUSER_WIDTH) & ", " &
+      "TID_WIDTH " & integer'image(TID_WIDTH) & ", " &
+      "TDEST_WIDTH " & integer'image(TDEST_WIDTH) & ", " &
+      "TDATA_NUM_BYTES " & integer'image(TDATA_NUM_BYTES);
+
+   attribute X_INTERFACE_INFO of M_AXIS_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of M_AXIS_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of M_AXIS_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of M_AXIS_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN";
+
+   signal M_AXIS_Master : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal M_AXIS_Slave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+
+begin
+
+   axisClk <= M_AXIS_ACLK;
+
+   M_AXIS_Master <= axisMaster;
+   axisSlave     <= M_AXIS_Slave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => M_AXIS_ACLK,
+         asyncRst => M_AXIS_ARESETN,
+         syncRst  => axisRst);
+
+   M_AXIS_TVALID <= M_AXIS_Master.tValid;
+   M_AXIS_TDATA  <= M_AXIS_Master.tData((8*TDATA_NUM_BYTES)-1 downto 0);
+   M_AXIS_TSTRB  <= M_AXIS_Master.tStrb(TDATA_NUM_BYTES-1 downto 0) when(HAS_TSTRB /= 0) else (others => '1');
+   M_AXIS_TKEEP  <= M_AXIS_Master.tKeep(TDATA_NUM_BYTES-1 downto 0) when(HAS_TKEEP /= 0) else (others => '1');
+   M_AXIS_TLAST  <= M_AXIS_Master.tLast                             when(HAS_TLAST /= 0) else '0';
+   M_AXIS_TDEST  <= M_AXIS_Master.tDest(TDEST_WIDTH-1 downto 0);
+   M_AXIS_TID    <= M_AXIS_Master.tId(TID_WIDTH-1 downto 0);
+   M_AXIS_TUSER  <= M_AXIS_Master.tUser(TUSER_WIDTH-1 downto 0);
+
+   M_AXIS_Slave.tReady <= M_AXIS_TREADY when(HAS_TREADY /= 0) else '1';
+
+end mapping;

--- a/axi/axi-stream/ip_integrator/MasterAxiStreamTerminateIpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/MasterAxiStreamTerminateIpIntegrator.vhd
@@ -1,0 +1,85 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: IP Integrator Wrapper for terminating a MASTER AXI stream bus
+-------------------------------------------------------------------------------
+-- TCL Command: create_bd_cell -type module -reference MasterAxiStreamTerminateIpIntegrator MasterAxisTerm_0
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity MasterAxiStreamTerminateIpIntegrator is
+   generic (
+      INTERFACENAME   : string                 := "M_AXIS";
+      HAS_TLAST       : natural range 0 to 1   := 1;
+      HAS_TKEEP       : natural range 0 to 1   := 1;
+      HAS_TSTRB       : natural range 0 to 1   := 0;
+      HAS_TREADY      : natural range 0 to 1   := 1;
+      TUSER_WIDTH     : natural range 1 to 8   := 2;
+      TID_WIDTH       : natural range 1 to 8   := 1;
+      TDEST_WIDTH     : natural range 1 to 8   := 1;
+      TDATA_NUM_BYTES : natural range 1 to 128 := 1);
+   port (
+      -- IP Integrator AXI Stream Interface
+      M_AXIS_ACLK    : in  std_logic := '0';
+      M_AXIS_ARESETN : in  std_logic := '0';
+      M_AXIS_TVALID  : out std_logic;
+      M_AXIS_TDATA   : out std_logic_vector((8*TDATA_NUM_BYTES)-1 downto 0);
+      M_AXIS_TSTRB   : out std_logic_vector(TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TKEEP   : out std_logic_vector(TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TLAST   : out std_logic;
+      M_AXIS_TDEST   : out std_logic_vector(TDEST_WIDTH-1 downto 0);
+      M_AXIS_TID     : out std_logic_vector(TID_WIDTH-1 downto 0);
+      M_AXIS_TUSER   : out std_logic_vector(TUSER_WIDTH-1 downto 0);
+      M_AXIS_TREADY  : in  std_logic := '1');
+end MasterAxiStreamTerminateIpIntegrator;
+
+architecture mapping of MasterAxiStreamTerminateIpIntegrator is
+
+begin
+
+   U_ShimLayer : entity surf.MasterAxiStreamIpIntegrator
+      generic map (
+         HAS_TLAST       => HAS_TLAST,
+         HAS_TKEEP       => HAS_TKEEP,
+         HAS_TSTRB       => HAS_TSTRB,
+         HAS_TREADY      => HAS_TREADY,
+         TUSER_WIDTH     => TUSER_WIDTH,
+         TID_WIDTH       => TID_WIDTH,
+         TDEST_WIDTH     => TDEST_WIDTH,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         M_AXIS_ACLK    => M_AXIS_ACLK,
+         M_AXIS_ARESETN => M_AXIS_ARESETN,
+         M_AXIS_TVALID  => M_AXIS_TVALID,
+         M_AXIS_TDATA   => M_AXIS_TDATA,
+         M_AXIS_TSTRB   => M_AXIS_TSTRB,
+         M_AXIS_TKEEP   => M_AXIS_TKEEP,
+         M_AXIS_TLAST   => M_AXIS_TLAST,
+         M_AXIS_TDEST   => M_AXIS_TDEST,
+         M_AXIS_TID     => M_AXIS_TID,
+         M_AXIS_TUSER   => M_AXIS_TUSER,
+         M_AXIS_TREADY  => M_AXIS_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => open,
+         axisRst        => open,
+         axisMaster     => AXI_STREAM_MASTER_INIT_C,
+         axisSlave      => open);
+
+end mapping;

--- a/axi/axi-stream/ip_integrator/SlaveAxiStreamIpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/SlaveAxiStreamIpIntegrator.vhd
@@ -1,0 +1,118 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI Stream interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity SlaveAxiStreamIpIntegrator is
+   generic (
+      INTERFACENAME   : string                 := "S_AXIS";
+      HAS_TLAST       : natural range 0 to 1   := 1;
+      HAS_TKEEP       : natural range 0 to 1   := 1;
+      HAS_TSTRB       : natural range 0 to 1   := 0;
+      HAS_TREADY      : natural range 0 to 1   := 1;
+      TUSER_WIDTH     : natural range 1 to 8   := 2;
+      TID_WIDTH       : natural range 1 to 8   := 1;
+      TDEST_WIDTH     : natural range 1 to 8   := 1;
+      TDATA_NUM_BYTES : natural range 1 to 128 := 1);
+   port (
+      -- IP Integrator AXI Stream Interface
+      S_AXIS_ACLK    : in  std_logic                                        := '0';
+      S_AXIS_ARESETN : in  std_logic                                        := '0';
+      S_AXIS_TVALID  : in  std_logic                                        := '0';
+      S_AXIS_TDATA   : in  std_logic_vector((8*TDATA_NUM_BYTES)-1 downto 0) := (others => '0');
+      S_AXIS_TSTRB   : in  std_logic_vector(TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TKEEP   : in  std_logic_vector(TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TLAST   : in  std_logic                                        := '0';
+      S_AXIS_TDEST   : in  std_logic_vector(TDEST_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TID     : in  std_logic_vector(TID_WIDTH-1 downto 0)           := (others => '0');
+      S_AXIS_TUSER   : in  std_logic_vector(TUSER_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TREADY  : out std_logic;
+      -- SURF AXI Stream Interface
+      axisClk        : out sl;
+      axisRst        : out sl;
+      axisMaster     : out AxiStreamMasterType;
+      axisSlave      : in  AxiStreamSlaveType                               := AXI_STREAM_SLAVE_FORCE_C);
+end SlaveAxiStreamIpIntegrator;
+
+architecture mapping of SlaveAxiStreamIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of S_AXIS_TVALID     : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TVALID";
+   attribute X_INTERFACE_INFO of S_AXIS_TLAST      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TLAST";
+   attribute X_INTERFACE_INFO of S_AXIS_TDATA      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TDATA";
+   attribute X_INTERFACE_INFO of S_AXIS_TKEEP      : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TKEEP";
+   attribute X_INTERFACE_INFO of S_AXIS_TREADY     : signal is "xilinx.com:interface:axis:1.0 " & INTERFACENAME & " TREADY";
+   attribute X_INTERFACE_PARAMETER of S_AXIS_TDATA : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "LAYERED_METADATA undef, " &
+      "HAS_TLAST " & integer'image(HAS_TLAST) & ", " &
+      "HAS_TKEEP " & integer'image(HAS_TKEEP) & ", " &
+      "HAS_TSTRB " & integer'image(HAS_TSTRB) & ", " &
+      "HAS_TREADY " & integer'image(HAS_TREADY) & ", " &
+      "TUSER_WIDTH " & integer'image(TUSER_WIDTH) & ", " &
+      "TID_WIDTH " & integer'image(TID_WIDTH) & ", " &
+      "TDEST_WIDTH " & integer'image(TDEST_WIDTH) & ", " &
+      "TDATA_NUM_BYTES " & integer'image(TDATA_NUM_BYTES);
+
+   attribute X_INTERFACE_INFO of S_AXIS_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of S_AXIS_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of S_AXIS_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of S_AXIS_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN";
+
+   signal S_AXIS_Master : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal S_AXIS_Slave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+
+begin
+
+   axisClk <= S_AXIS_ACLK;
+
+   axisMaster   <= S_AXIS_Master;
+   S_AXIS_Slave <= axisSlave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => S_AXIS_ACLK,
+         asyncRst => S_AXIS_ARESETN,
+         syncRst  => axisRst);
+
+   S_AXIS_Master.tValid                                <= S_AXIS_TVALID;
+   S_AXIS_Master.tData((8*TDATA_NUM_BYTES)-1 downto 0) <= S_AXIS_TDATA;
+   S_AXIS_Master.tStrb(TDATA_NUM_BYTES-1 downto 0)     <= S_AXIS_TSTRB when(HAS_TSTRB /= 0) else (others => '1');
+   S_AXIS_Master.tKeep(TDATA_NUM_BYTES-1 downto 0)     <= S_AXIS_TKEEP when(HAS_TKEEP /= 0) else (others => '1');
+   S_AXIS_Master.tLast                                 <= S_AXIS_TLAST when(HAS_TLAST /= 0) else '0';
+   S_AXIS_Master.tDest(TDEST_WIDTH-1 downto 0)         <= S_AXIS_TDEST;
+   S_AXIS_Master.tId(TID_WIDTH-1 downto 0)             <= S_AXIS_TID;
+   S_AXIS_Master.tUser(TUSER_WIDTH-1 downto 0)         <= S_AXIS_TUSER;
+
+   S_AXIS_TREADY <= S_AXIS_Slave.tReady when(HAS_TREADY /= 0) else '1';
+
+end mapping;

--- a/axi/axi-stream/ip_integrator/SlaveAxiStreamTerminateIpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/SlaveAxiStreamTerminateIpIntegrator.vhd
@@ -1,0 +1,81 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: IP Integrator Wrapper for terminating a SLAVE AXI stream bus
+-------------------------------------------------------------------------------
+-- TCL Command: create_bd_cell -type module -reference SlaveAxiStreamTerminateIpIntegrator SlaveAxisTerm_0
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity SlaveAxiStreamTerminateIpIntegrator is
+   generic (
+      INTERFACENAME   : string                 := "S_AXIS";
+      HAS_TLAST       : natural range 0 to 1   := 1;
+      HAS_TKEEP       : natural range 0 to 1   := 1;
+      HAS_TSTRB       : natural range 0 to 1   := 0;
+      HAS_TREADY      : natural range 0 to 1   := 1;
+      TUSER_WIDTH     : natural range 1 to 8   := 2;
+      TID_WIDTH       : natural range 1 to 8   := 1;
+      TDEST_WIDTH     : natural range 1 to 8   := 1;
+      TDATA_NUM_BYTES : natural range 1 to 128 := 1);
+   port (
+      -- IP Integrator AXI Stream Interface
+      S_AXIS_TVALID  : in  std_logic                                        := '0';
+      S_AXIS_TDATA   : in  std_logic_vector((8*TDATA_NUM_BYTES)-1 downto 0) := (others => '0');
+      S_AXIS_TSTRB   : in  std_logic_vector(TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TKEEP   : in  std_logic_vector(TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TLAST   : in  std_logic                                        := '0';
+      S_AXIS_TDEST   : in  std_logic_vector(TDEST_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TID     : in  std_logic_vector(TID_WIDTH-1 downto 0)           := (others => '0');
+      S_AXIS_TUSER   : in  std_logic_vector(TUSER_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TREADY  : out std_logic);
+end SlaveAxiStreamTerminateIpIntegrator;
+
+architecture mapping of SlaveAxiStreamTerminateIpIntegrator is
+
+begin
+
+   U_ShimLayer : entity surf.SlaveAxiStreamIpIntegrator
+      generic map (
+         HAS_TLAST       => HAS_TLAST,
+         HAS_TKEEP       => HAS_TKEEP,
+         HAS_TSTRB       => HAS_TSTRB,
+         HAS_TREADY      => HAS_TREADY,
+         TUSER_WIDTH     => TUSER_WIDTH,
+         TID_WIDTH       => TID_WIDTH,
+         TDEST_WIDTH     => TDEST_WIDTH,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         S_AXIS_TVALID  => S_AXIS_TVALID,
+         S_AXIS_TDATA   => S_AXIS_TDATA,
+         S_AXIS_TSTRB   => S_AXIS_TSTRB,
+         S_AXIS_TKEEP   => S_AXIS_TKEEP,
+         S_AXIS_TLAST   => S_AXIS_TLAST,
+         S_AXIS_TDEST   => S_AXIS_TDEST,
+         S_AXIS_TID     => S_AXIS_TID,
+         S_AXIS_TUSER   => S_AXIS_TUSER,
+         S_AXIS_TREADY  => S_AXIS_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => open,
+         axisRst        => open,
+         axisMaster     => open,
+         axisSlave      => AXI_STREAM_SLAVE_FORCE_C);
+
+end mapping;

--- a/axi/axi-stream/ruckus.tcl
+++ b/axi/axi-stream/ruckus.tcl
@@ -3,6 +3,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
+loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/axi/axi4/ip_integrator/MasterAxiIpIntegrator.vhd
+++ b/axi/axi4/ip_integrator/MasterAxiIpIntegrator.vhd
@@ -1,0 +1,266 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiPkg.all;
+
+entity MasterAxiIpIntegrator is
+   generic (
+      INTERFACENAME         : string                    := "M_AXI";
+      EN_ERROR_RESP         : boolean                   := false;
+      MAX_BURST_LENGTH      : positive range 1 to 256   := 256;  -- [1, 256]
+      NUM_WRITE_OUTSTANDING : natural range 0 to 32     := 1;   -- [0, 32]
+      NUM_READ_OUTSTANDING  : natural range 0 to 32     := 1;   -- [0, 32]
+      SUPPORTS_NARROW_BURST : natural range 0 to 1      := 1;
+--      BUSER_WIDTH           : positive                  := 1;
+--      RUSER_WIDTH           : positive                  := 1;
+--      WUSER_WIDTH           : positive                  := 1;
+--      ARUSER_WIDTH          : positive                  := 1;
+--      AWUSER_WIDTH          : positive                  := 1;
+      ADDR_WIDTH            : positive range 1 to 64    := 32;  -- [1, 64]
+      ID_WIDTH              : positive                  := 1;
+      DATA_WIDTH            : positive range 32 to 1024 := 32;  -- [32,64,128,256,512,1024]
+      HAS_BURST             : natural range 0 to 1      := 1;
+      HAS_CACHE             : natural range 0 to 1      := 1;
+      HAS_LOCK              : natural range 0 to 1      := 1;
+      HAS_PROT              : natural range 0 to 1      := 1;
+      HAS_QOS               : natural range 0 to 1      := 1;
+      HAS_REGION            : natural range 0 to 1      := 1;
+      HAS_WSTRB             : natural range 0 to 1      := 1;
+      HAS_BRESP             : natural range 0 to 1      := 1;
+      HAS_RRESP             : natural range 0 to 1      := 1);
+   port (
+      -- IP Integrator AXI-Lite Interface
+      M_AXI_ACLK     : in  std_logic;
+      M_AXI_ARESETN  : in  std_logic;
+      M_AXI_AWID     : out std_logic_vector(ID_WIDTH-1 downto 0);
+      M_AXI_AWADDR   : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      M_AXI_AWLEN    : out std_logic_vector(7 downto 0);
+      M_AXI_AWSIZE   : out std_logic_vector(2 downto 0);
+      M_AXI_AWBURST  : out std_logic_vector(1 downto 0);
+      M_AXI_AWLOCK   : out std_logic_vector(1 downto 0);
+      M_AXI_AWCACHE  : out std_logic_vector(3 downto 0);
+      M_AXI_AWPROT   : out std_logic_vector(2 downto 0);
+      M_AXI_AWREGION : out std_logic_vector(3 downto 0);
+      M_AXI_AWQOS    : out std_logic_vector(3 downto 0);
+--      M_AXI_AWUSER   : out std_logic_vector(AWUSER_WIDTH-1 downto 0);
+      M_AXI_AWVALID  : out std_logic;
+      M_AXI_AWREADY  : in  std_logic;
+      M_AXI_WID      : out std_logic_vector(ID_WIDTH-1 downto 0);
+      M_AXI_WDATA    : out std_logic_vector(DATA_WIDTH-1 downto 0);
+      M_AXI_WSTRB    : out std_logic_vector((DATA_WIDTH/8)-1 downto 0);
+      M_AXI_WLAST    : out std_logic;
+--      M_AXI_WUSER    : out std_logic_vector(WUSER_WIDTH-1 downto 0);
+      M_AXI_WVALID   : out std_logic;
+      M_AXI_WREADY   : in  std_logic;
+      M_AXI_BID      : in  std_logic_vector(ID_WIDTH-1 downto 0);
+      M_AXI_BRESP    : in  std_logic_vector(1 downto 0);
+--      M_AXI_BUSER    : in  std_logic_vector(BUSER_WIDTH downto 0);
+      M_AXI_BVALID   : in  std_logic;
+      M_AXI_BREADY   : out std_logic;
+      M_AXI_ARID     : out std_logic_vector(ID_WIDTH-1 downto 0);
+      M_AXI_ARADDR   : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      M_AXI_ARLEN    : out std_logic_vector(7 downto 0);
+      M_AXI_ARSIZE   : out std_logic_vector(2 downto 0);
+      M_AXI_ARBURST  : out std_logic_vector(1 downto 0);
+      M_AXI_ARLOCK   : out std_logic_vector(1 downto 0);
+      M_AXI_ARCACHE  : out std_logic_vector(3 downto 0);
+      M_AXI_ARPROT   : out std_logic_vector(2 downto 0);
+      M_AXI_ARREGION : out std_logic_vector(3 downto 0);
+      M_AXI_ARQOS    : out std_logic_vector(3 downto 0);
+--      M_AXI_ARUSER   : out std_logic_vector(ARUSER_WIDTH-1 downto 0);
+      M_AXI_ARVALID  : out std_logic;
+      M_AXI_ARREADY  : in  std_logic;
+      M_AXI_RID      : in  std_logic_vector(ID_WIDTH-1 downto 0);
+      M_AXI_RDATA    : in  std_logic_vector(DATA_WIDTH-1 downto 0);
+      M_AXI_RRESP    : in  std_logic_vector(1 downto 0);
+      M_AXI_RLAST    : in  std_logic;
+--      M_AXI_RUSER    : in  std_logic_vector(RUSER_WIDTH-1 downto 0);
+      M_AXI_RVALID   : in  std_logic;
+      M_AXI_RREADY   : out std_logic;
+      -- SURF AXI Interface
+      axiClk         : out sl;
+      axiRst         : out sl;
+      axiReadMaster  : in  AxiReadMasterType;
+      axiReadSlave   : out AxiReadSlaveType;
+      axiWriteMaster : in  AxiWriteMasterType;
+      axiWriteSlave  : out AxiWriteSlaveType);
+end MasterAxiIpIntegrator;
+
+architecture mapping of MasterAxiIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of M_AXI_AWID        : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWID";
+   attribute X_INTERFACE_INFO of M_AXI_AWADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWADDR";
+   attribute X_INTERFACE_INFO of M_AXI_AWLEN       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWLEN";
+   attribute X_INTERFACE_INFO of M_AXI_AWSIZE      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWSIZE";
+   attribute X_INTERFACE_INFO of M_AXI_AWBURST     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWBURST";
+   attribute X_INTERFACE_INFO of M_AXI_AWLOCK      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWLOCK";
+   attribute X_INTERFACE_INFO of M_AXI_AWCACHE     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWCACHE";
+   attribute X_INTERFACE_INFO of M_AXI_AWPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWPROT";
+   attribute X_INTERFACE_INFO of M_AXI_AWREGION    : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREGION";
+   attribute X_INTERFACE_INFO of M_AXI_AWQOS       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWQOS";
+--   attribute X_INTERFACE_INFO of M_AXI_AWUSER      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWUSER";
+   attribute X_INTERFACE_INFO of M_AXI_AWVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWVALID";
+   attribute X_INTERFACE_INFO of M_AXI_AWREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREADY";
+   attribute X_INTERFACE_INFO of M_AXI_WID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WID";
+   attribute X_INTERFACE_INFO of M_AXI_WDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WDATA";
+   attribute X_INTERFACE_INFO of M_AXI_WSTRB       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WSTRB";
+   attribute X_INTERFACE_INFO of M_AXI_WLAST       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WLAST";
+--   attribute X_INTERFACE_INFO of M_AXI_WUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WUSER";
+   attribute X_INTERFACE_INFO of M_AXI_WVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WVALID";
+   attribute X_INTERFACE_INFO of M_AXI_WREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WREADY";
+   attribute X_INTERFACE_INFO of M_AXI_BID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BID";
+   attribute X_INTERFACE_INFO of M_AXI_BRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BRESP";
+--   attribute X_INTERFACE_INFO of M_AXI_BUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BUSER";
+   attribute X_INTERFACE_INFO of M_AXI_BVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BVALID";
+   attribute X_INTERFACE_INFO of M_AXI_BREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BREADY";
+   attribute X_INTERFACE_INFO of M_AXI_ARID        : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARID";
+   attribute X_INTERFACE_INFO of M_AXI_ARADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARADDR";
+   attribute X_INTERFACE_INFO of M_AXI_ARLEN       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARLEN";
+   attribute X_INTERFACE_INFO of M_AXI_ARSIZE      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARSIZE";
+   attribute X_INTERFACE_INFO of M_AXI_ARBURST     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARBURST";
+   attribute X_INTERFACE_INFO of M_AXI_ARLOCK      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARLOCK";
+   attribute X_INTERFACE_INFO of M_AXI_ARCACHE     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARCACHE";
+   attribute X_INTERFACE_INFO of M_AXI_ARPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARPROT";
+   attribute X_INTERFACE_INFO of M_AXI_ARREGION    : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREGION";
+   attribute X_INTERFACE_INFO of M_AXI_ARQOS       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARQOS";
+--   attribute X_INTERFACE_INFO of M_AXI_ARUSER      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARUSER";
+   attribute X_INTERFACE_INFO of M_AXI_ARVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARVALID";
+   attribute X_INTERFACE_INFO of M_AXI_ARREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREADY";
+   attribute X_INTERFACE_INFO of M_AXI_RID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RID";
+   attribute X_INTERFACE_INFO of M_AXI_RDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RDATA";
+   attribute X_INTERFACE_INFO of M_AXI_RRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RRESP";
+   attribute X_INTERFACE_INFO of M_AXI_RLAST       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RLAST";
+--   attribute X_INTERFACE_INFO of M_AXI_RUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RUSER";
+   attribute X_INTERFACE_INFO of M_AXI_RVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RVALID";
+   attribute X_INTERFACE_INFO of M_AXI_RREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RREADY";
+   attribute X_INTERFACE_PARAMETER of M_AXI_AWADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "PROTOCOL AXI4, " &
+      "MAX_BURST_LENGTH " & integer'image(MAX_BURST_LENGTH) & ", " &
+      "NUM_WRITE_OUTSTANDING " & integer'image(NUM_WRITE_OUTSTANDING) & ", " &
+      "NUM_READ_OUTSTANDING " & integer'image(NUM_READ_OUTSTANDING) & ", " &
+      "SUPPORTS_NARROW_BURST " & integer'image(SUPPORTS_NARROW_BURST) & ", " &
+--      "BUSER_WIDTH " & integer'image(BUSER_WIDTH) & ", " &
+--      "RUSER_WIDTH " & integer'image(RUSER_WIDTH) & ", " &
+--      "WUSER_WIDTH " & integer'image(WUSER_WIDTH) & ", " &
+--      "ARUSER_WIDTH " & integer'image(ARUSER_WIDTH) & ", " &
+--      "AWUSER_WIDTH " & integer'image(AWUSER_WIDTH) & ", " &    
+      "ADDR_WIDTH " & integer'image(ADDR_WIDTH) & ", " &
+      "ID_WIDTH " & integer'image(ID_WIDTH) & ", " &
+      "DATA_WIDTH " & integer'image(DATA_WIDTH) & ", " &
+      "HAS_BURST " & integer'image(HAS_BURST) & ", " &
+      "HAS_CACHE " & integer'image(HAS_CACHE) & ", " &
+      "HAS_LOCK " & integer'image(HAS_LOCK) & ", " &
+      "HAS_PROT " & integer'image(HAS_PROT) & ", " &
+      "HAS_QOS " & integer'image(HAS_QOS) & ", " &
+      "HAS_REGION " & integer'image(HAS_REGION) & ", " &
+      "HAS_WSTRB " & integer'image(HAS_WSTRB) & ", " &
+      "HAS_BRESP " & integer'image(HAS_BRESP) & ", " &
+      "HAS_RRESP " & integer'image(HAS_RRESP);
+
+   attribute X_INTERFACE_INFO of M_AXI_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of M_AXI_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of M_AXI_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of M_AXI_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN";
+
+   signal M_AXI_ReadMaster  : AxiReadMasterType  := AXI_READ_MASTER_INIT_C;
+   signal M_AXI_ReadSlave   : AxiReadSlaveType   := AXI_READ_SLAVE_INIT_C;
+   signal M_AXI_WriteMaster : AxiWriteMasterType := AXI_WRITE_MASTER_INIT_C;
+   signal M_AXI_WriteSlave  : AxiWriteSlaveType  := AXI_WRITE_SLAVE_INIT_C;
+
+begin
+
+   axiClk <= M_AXI_ACLK;
+
+   M_AXI_ReadMaster <= axiReadMaster;
+   axiReadSlave     <= M_AXI_ReadSlave;
+
+   M_AXI_WriteMaster <= axiWriteMaster;
+   axiWriteSlave     <= M_AXI_WriteSlave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => M_AXI_ACLK,
+         asyncRst => M_AXI_ARESETN,
+         syncRst  => axiRst);
+
+   M_AXI_AWID     <= M_AXI_WriteMaster.awid(ID_WIDTH-1 downto 0);
+   M_AXI_AWADDR   <= M_AXI_WriteMaster.awaddr(ADDR_WIDTH-1 downto 0);
+   M_AXI_AWLEN    <= M_AXI_WriteMaster.awlen(7 downto 0);
+   M_AXI_AWSIZE   <= M_AXI_WriteMaster.awsize(2 downto 0);
+   M_AXI_AWBURST  <= M_AXI_WriteMaster.awburst(1 downto 0);
+   M_AXI_AWLOCK   <= M_AXI_WriteMaster.awlock(1 downto 0);
+   M_AXI_AWCACHE  <= M_AXI_WriteMaster.awcache(3 downto 0);
+   M_AXI_AWPROT   <= M_AXI_WriteMaster.awprot;
+   M_AXI_AWREGION <= M_AXI_WriteMaster.awregion(3 downto 0);
+   M_AXI_AWQOS    <= M_AXI_WriteMaster.awqos(3 downto 0);
+--   M_AXI_AWUSER   <= M_AXI_WriteMaster.awuser(AWUSER_WIDTH-1 downto 0);
+   M_AXI_AWVALID  <= M_AXI_WriteMaster.awvalid;
+   M_AXI_WID      <= M_AXI_WriteMaster.wid(ID_WIDTH-1 downto 0);
+   M_AXI_WDATA    <= M_AXI_WriteMaster.wdata(DATA_WIDTH-1 downto 0);
+   M_AXI_WSTRB    <= M_AXI_WriteMaster.wstrb((DATA_WIDTH/8)-1 downto 0) when(HAS_WSTRB /= 0) else (others => '1');
+   M_AXI_WLAST    <= M_AXI_WriteMaster.wlast;
+--   M_AXI_WUSER    <= M_AXI_WriteMaster.wuser(WUSER_WIDTH-1 downto 0);
+   M_AXI_WVALID   <= M_AXI_WriteMaster.wvalid;
+   M_AXI_BREADY   <= M_AXI_WriteMaster.bready;
+
+   M_AXI_WriteSlave.awready                  <= M_AXI_AWREADY;
+   M_AXI_WriteSlave.wready                   <= M_AXI_WREADY;
+   M_AXI_WriteSlave.bid(ID_WIDTH-1 downto 0) <= M_AXI_BID;
+   M_AXI_WriteSlave.bresp                    <= M_AXI_BRESP when(EN_ERROR_RESP and (HAS_BRESP /= 0)) else "00";
+--   M_AXI_WriteSlave.buser(BUSER_WIDTH-1 downto 0) <= M_AXI_BUSER;
+   M_AXI_WriteSlave.bvalid                   <= M_AXI_BVALID;
+
+   M_AXI_ARID     <= M_AXI_ReadMaster.arid(ID_WIDTH-1 downto 0);
+   M_AXI_ARADDR   <= M_AXI_ReadMaster.araddr(ADDR_WIDTH-1 downto 0);
+   M_AXI_ARLEN    <= M_AXI_ReadMaster.arlen;
+   M_AXI_ARSIZE   <= M_AXI_ReadMaster.arsize;
+   M_AXI_ARBURST  <= M_AXI_ReadMaster.arburst;
+   M_AXI_ARLOCK   <= M_AXI_ReadMaster.arlock;
+   M_AXI_ARCACHE  <= M_AXI_ReadMaster.arcache;
+   M_AXI_ARPROT   <= M_AXI_ReadMaster.arprot;
+   M_AXI_ARREGION <= M_AXI_ReadMaster.arregion(3 downto 0);
+   M_AXI_ARQOS    <= M_AXI_ReadMaster.arqos(3 downto 0);
+--   M_AXI_ARUSER   <= M_AXI_ReadMaster.aruser(ARUSER_WIDTH-1 downto 0);
+   M_AXI_ARVALID  <= M_AXI_ReadMaster.arvalid;
+   M_AXI_RREADY   <= M_AXI_ReadMaster.rready;
+
+   M_AXI_ReadSlave.arready                      <= M_AXI_ARREADY;
+   M_AXI_ReadSlave.rid(ID_WIDTH-1 downto 0)     <= M_AXI_RID;
+   M_AXI_ReadSlave.rdata(DATA_WIDTH-1 downto 0) <= M_AXI_RDATA;
+   M_AXI_ReadSlave.rresp                        <= M_AXI_RRESP when(EN_ERROR_RESP and (HAS_RRESP /= 0)) else "00";
+   M_AXI_ReadSlave.rlast                        <= M_AXI_RLAST;
+--   M_AXI_ReadSlave.ruser(RUSER_WIDTH-1 downto 0) <= M_AXI_RUSER;
+   M_AXI_ReadSlave.rvalid                       <= M_AXI_RVALID;
+
+end mapping;

--- a/axi/axi4/ip_integrator/SlaveAxiIpIntegrator.vhd
+++ b/axi/axi4/ip_integrator/SlaveAxiIpIntegrator.vhd
@@ -1,0 +1,266 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf AXI interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiPkg.all;
+
+entity SlaveAxiIpIntegrator is
+   generic (
+      INTERFACENAME         : string                    := "S_AXI";
+      EN_ERROR_RESP         : boolean                   := false;
+      MAX_BURST_LENGTH      : positive range 1 to 256   := 256;  -- [1, 256]
+      NUM_WRITE_OUTSTANDING : natural range 0 to 32     := 1;   -- [0, 32]
+      NUM_READ_OUTSTANDING  : natural range 0 to 32     := 1;   -- [0, 32]
+      SUPPORTS_NARROW_BURST : natural range 0 to 1      := 1;
+--      BUSER_WIDTH           : positive                  := 1;
+--      RUSER_WIDTH           : positive                  := 1;
+--      WUSER_WIDTH           : positive                  := 1;
+--      ARUSER_WIDTH          : positive                  := 1;
+--      AWUSER_WIDTH          : positive                  := 1;
+      ADDR_WIDTH            : positive range 1 to 64    := 32;  -- [1, 64]
+      ID_WIDTH              : positive                  := 1;
+      DATA_WIDTH            : positive range 32 to 1024 := 32;  -- [32,64,128,256,512,1024]
+      HAS_BURST             : natural range 0 to 1      := 1;
+      HAS_CACHE             : natural range 0 to 1      := 1;
+      HAS_LOCK              : natural range 0 to 1      := 1;
+      HAS_PROT              : natural range 0 to 1      := 1;
+      HAS_QOS               : natural range 0 to 1      := 1;
+      HAS_REGION            : natural range 0 to 1      := 1;
+      HAS_WSTRB             : natural range 0 to 1      := 1;
+      HAS_BRESP             : natural range 0 to 1      := 1;
+      HAS_RRESP             : natural range 0 to 1      := 1);
+   port (
+      -- IP Integrator AXI-Lite Interface
+      S_AXI_ACLK     : in  std_logic;
+      S_AXI_ARESETN  : in  std_logic;
+      S_AXI_AWID     : in  std_logic_vector(ID_WIDTH-1 downto 0);
+      S_AXI_AWADDR   : in  std_logic_vector(ADDR_WIDTH-1 downto 0);
+      S_AXI_AWLEN    : in  std_logic_vector(7 downto 0);
+      S_AXI_AWSIZE   : in  std_logic_vector(2 downto 0);
+      S_AXI_AWBURST  : in  std_logic_vector(1 downto 0);
+      S_AXI_AWLOCK   : in  std_logic_vector(1 downto 0);
+      S_AXI_AWCACHE  : in  std_logic_vector(3 downto 0);
+      S_AXI_AWPROT   : in  std_logic_vector(2 downto 0);
+      S_AXI_AWREGION : in  std_logic_vector(3 downto 0);
+      S_AXI_AWQOS    : in  std_logic_vector(3 downto 0);
+--      S_AXI_AWUSER   : in  std_logic_vector(AWUSER_WIDTH-1 downto 0);
+      S_AXI_AWVALID  : in  std_logic;
+      S_AXI_AWREADY  : out std_logic;
+      S_AXI_WID      : in  std_logic_vector(ID_WIDTH-1 downto 0);
+      S_AXI_WDATA    : in  std_logic_vector(DATA_WIDTH-1 downto 0);
+      S_AXI_WSTRB    : in  std_logic_vector((DATA_WIDTH/8)-1 downto 0);
+      S_AXI_WLAST    : in  std_logic;
+--      S_AXI_WUSER    : in  std_logic_vector(WUSER_WIDTH-1 downto 0);
+      S_AXI_WVALID   : in  std_logic;
+      S_AXI_WREADY   : out std_logic;
+      S_AXI_BID      : out std_logic_vector(ID_WIDTH-1 downto 0);
+      S_AXI_BRESP    : out std_logic_vector(1 downto 0);
+--      S_AXI_BUSER    : out std_logic_vector(BUSER_WIDTH downto 0);
+      S_AXI_BVALID   : out std_logic;
+      S_AXI_BREADY   : in  std_logic;
+      S_AXI_ARID     : in  std_logic_vector(ID_WIDTH-1 downto 0);
+      S_AXI_ARADDR   : in  std_logic_vector(ADDR_WIDTH-1 downto 0);
+      S_AXI_ARLEN    : in  std_logic_vector(7 downto 0);
+      S_AXI_ARSIZE   : in  std_logic_vector(2 downto 0);
+      S_AXI_ARBURST  : in  std_logic_vector(1 downto 0);
+      S_AXI_ARLOCK   : in  std_logic_vector(1 downto 0);
+      S_AXI_ARCACHE  : in  std_logic_vector(3 downto 0);
+      S_AXI_ARPROT   : in  std_logic_vector(2 downto 0);
+      S_AXI_ARREGION : in  std_logic_vector(3 downto 0);
+      S_AXI_ARQOS    : in  std_logic_vector(3 downto 0);
+--      S_AXI_ARUSER   : in  std_logic_vector(ARUSER_WIDTH-1 downto 0);
+      S_AXI_ARVALID  : in  std_logic;
+      S_AXI_ARREADY  : out std_logic;
+      S_AXI_RID      : out std_logic_vector(ID_WIDTH-1 downto 0);
+      S_AXI_RDATA    : out std_logic_vector(DATA_WIDTH-1 downto 0);
+      S_AXI_RRESP    : out std_logic_vector(1 downto 0);
+      S_AXI_RLAST    : out std_logic;
+--      S_AXI_RUSER    : out std_logic_vector(RUSER_WIDTH-1 downto 0);
+      S_AXI_RVALID   : out std_logic;
+      S_AXI_RREADY   : in  std_logic;
+      -- SURF AXI Interface
+      axiClk         : out sl;
+      axiRst         : out sl;
+      axiReadMaster  : out AxiReadMasterType;
+      axiReadSlave   : in  AxiReadSlaveType;
+      axiWriteMaster : out AxiWriteMasterType;
+      axiWriteSlave  : in  AxiWriteSlaveType);
+end SlaveAxiIpIntegrator;
+
+architecture mapping of SlaveAxiIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of S_AXI_AWID        : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWID";
+   attribute X_INTERFACE_INFO of S_AXI_AWADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWADDR";
+   attribute X_INTERFACE_INFO of S_AXI_AWLEN       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWLEN";
+   attribute X_INTERFACE_INFO of S_AXI_AWSIZE      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWSIZE";
+   attribute X_INTERFACE_INFO of S_AXI_AWBURST     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWBURST";
+   attribute X_INTERFACE_INFO of S_AXI_AWLOCK      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWLOCK";
+   attribute X_INTERFACE_INFO of S_AXI_AWCACHE     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWCACHE";
+   attribute X_INTERFACE_INFO of S_AXI_AWPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWPROT";
+   attribute X_INTERFACE_INFO of S_AXI_AWREGION    : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREGION";
+   attribute X_INTERFACE_INFO of S_AXI_AWQOS       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWQOS";
+--   attribute X_INTERFACE_INFO of S_AXI_AWUSER      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWUSER";
+   attribute X_INTERFACE_INFO of S_AXI_AWVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWVALID";
+   attribute X_INTERFACE_INFO of S_AXI_AWREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " AWREADY";
+   attribute X_INTERFACE_INFO of S_AXI_WID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WID";
+   attribute X_INTERFACE_INFO of S_AXI_WDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WDATA";
+   attribute X_INTERFACE_INFO of S_AXI_WSTRB       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WSTRB";
+   attribute X_INTERFACE_INFO of S_AXI_WLAST       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WLAST";
+--   attribute X_INTERFACE_INFO of S_AXI_WUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WUSER";
+   attribute X_INTERFACE_INFO of S_AXI_WVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WVALID";
+   attribute X_INTERFACE_INFO of S_AXI_WREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " WREADY";
+   attribute X_INTERFACE_INFO of S_AXI_BID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BID";
+   attribute X_INTERFACE_INFO of S_AXI_BRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BRESP";
+--   attribute X_INTERFACE_INFO of S_AXI_BUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BUSER";
+   attribute X_INTERFACE_INFO of S_AXI_BVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BVALID";
+   attribute X_INTERFACE_INFO of S_AXI_BREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " BREADY";
+   attribute X_INTERFACE_INFO of S_AXI_ARID        : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARID";
+   attribute X_INTERFACE_INFO of S_AXI_ARADDR      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARADDR";
+   attribute X_INTERFACE_INFO of S_AXI_ARLEN       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARLEN";
+   attribute X_INTERFACE_INFO of S_AXI_ARSIZE      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARSIZE";
+   attribute X_INTERFACE_INFO of S_AXI_ARBURST     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARBURST";
+   attribute X_INTERFACE_INFO of S_AXI_ARLOCK      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARLOCK";
+   attribute X_INTERFACE_INFO of S_AXI_ARCACHE     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARCACHE";
+   attribute X_INTERFACE_INFO of S_AXI_ARPROT      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARPROT";
+   attribute X_INTERFACE_INFO of S_AXI_ARREGION    : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREGION";
+   attribute X_INTERFACE_INFO of S_AXI_ARQOS       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARQOS";
+--   attribute X_INTERFACE_INFO of S_AXI_ARUSER      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARUSER";
+   attribute X_INTERFACE_INFO of S_AXI_ARVALID     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARVALID";
+   attribute X_INTERFACE_INFO of S_AXI_ARREADY     : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " ARREADY";
+   attribute X_INTERFACE_INFO of S_AXI_RID         : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RID";
+   attribute X_INTERFACE_INFO of S_AXI_RDATA       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RDATA";
+   attribute X_INTERFACE_INFO of S_AXI_RRESP       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RRESP";
+   attribute X_INTERFACE_INFO of S_AXI_RLAST       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RLAST";
+--   attribute X_INTERFACE_INFO of S_AXI_RUSER       : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RUSER";
+   attribute X_INTERFACE_INFO of S_AXI_RVALID      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RVALID";
+   attribute X_INTERFACE_INFO of S_AXI_RREADY      : signal is "xilinx.com:interface:aximm:1.0 " & INTERFACENAME & " RREADY";
+   attribute X_INTERFACE_PARAMETER of S_AXI_AWADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "PROTOCOL AXI4, " &
+      "MAX_BURST_LENGTH " & integer'image(MAX_BURST_LENGTH) & ", " &
+      "NUM_WRITE_OUTSTANDING " & integer'image(NUM_WRITE_OUTSTANDING) & ", " &
+      "NUM_READ_OUTSTANDING " & integer'image(NUM_READ_OUTSTANDING) & ", " &
+      "SUPPORTS_NARROW_BURST " & integer'image(SUPPORTS_NARROW_BURST) & ", " &
+--      "BUSER_WIDTH " & integer'image(BUSER_WIDTH) & ", " &
+--      "RUSER_WIDTH " & integer'image(RUSER_WIDTH) & ", " &
+--      "WUSER_WIDTH " & integer'image(WUSER_WIDTH) & ", " &
+--      "ARUSER_WIDTH " & integer'image(ARUSER_WIDTH) & ", " &
+--      "AWUSER_WIDTH " & integer'image(AWUSER_WIDTH) & ", " &    
+      "ADDR_WIDTH " & integer'image(ADDR_WIDTH) & ", " &
+      "ID_WIDTH " & integer'image(ID_WIDTH) & ", " &
+      "DATA_WIDTH " & integer'image(DATA_WIDTH) & ", " &
+      "HAS_BURST " & integer'image(HAS_BURST) & ", " &
+      "HAS_CACHE " & integer'image(HAS_CACHE) & ", " &
+      "HAS_LOCK " & integer'image(HAS_LOCK) & ", " &
+      "HAS_PROT " & integer'image(HAS_PROT) & ", " &
+      "HAS_QOS " & integer'image(HAS_QOS) & ", " &
+      "HAS_REGION " & integer'image(HAS_REGION) & ", " &
+      "HAS_WSTRB " & integer'image(HAS_WSTRB) & ", " &
+      "HAS_BRESP " & integer'image(HAS_BRESP) & ", " &
+      "HAS_RRESP " & integer'image(HAS_RRESP);
+
+   attribute X_INTERFACE_INFO of S_AXI_ARESETN      : signal is "xilinx.com:signal:reset:1.0 RST." & INTERFACENAME & "_ARESETN RST";
+   attribute X_INTERFACE_PARAMETER of S_AXI_ARESETN : signal is
+      "XIL_INTERFACENAME RST." & INTERFACENAME & "_ARESETN, " &
+      "POLARITY ACTIVE_LOW";
+
+   attribute X_INTERFACE_INFO of S_AXI_ACLK      : signal is "xilinx.com:signal:clock:1.0 CLK." & INTERFACENAME & "_ACLK CLK";
+   attribute X_INTERFACE_PARAMETER of S_AXI_ACLK : signal is
+      "XIL_INTERFACENAME CLK." & INTERFACENAME & "_ACLK, " &
+      "ASSOCIATED_BUSIF " & INTERFACENAME & ", " &
+      "ASSOCIATED_RESET " & INTERFACENAME & "_ARESETN";
+
+   signal S_AXI_ReadMaster  : AxiReadMasterType  := AXI_READ_MASTER_INIT_C;
+   signal S_AXI_ReadSlave   : AxiReadSlaveType   := AXI_READ_SLAVE_INIT_C;
+   signal S_AXI_WriteMaster : AxiWriteMasterType := AXI_WRITE_MASTER_INIT_C;
+   signal S_AXI_WriteSlave  : AxiWriteSlaveType  := AXI_WRITE_SLAVE_INIT_C;
+
+begin
+
+   axiClk <= S_AXI_ACLK;
+
+   axiReadMaster   <= S_AXI_ReadMaster;
+   S_AXI_ReadSlave <= axiReadSlave;
+
+   axiWriteMaster   <= S_AXI_WriteMaster;
+   S_AXI_WriteSlave <= axiWriteSlave;
+
+   U_RstSync : entity surf.RstSync
+      generic map (
+         IN_POLARITY_G  => '0',
+         OUT_POLARITY_G => '1')
+      port map (
+         clk      => S_AXI_ACLK,
+         asyncRst => S_AXI_ARESETN,
+         syncRst  => axiRst);
+
+   S_AXI_WriteMaster.awid(ID_WIDTH-1 downto 0)        <= S_AXI_AWID;
+   S_AXI_WriteMaster.awaddr(ADDR_WIDTH-1 downto 0)    <= S_AXI_AWADDR;
+   S_AXI_WriteMaster.awlen(7 downto 0)                <= S_AXI_AWLEN;
+   S_AXI_WriteMaster.awsize(2 downto 0)               <= S_AXI_AWSIZE;
+   S_AXI_WriteMaster.awburst(1 downto 0)              <= S_AXI_AWBURST;
+   S_AXI_WriteMaster.awlock(1 downto 0)               <= S_AXI_AWLOCK;
+   S_AXI_WriteMaster.awcache(3 downto 0)              <= S_AXI_AWCACHE;
+   S_AXI_WriteMaster.awprot                           <= S_AXI_AWPROT;
+   S_AXI_WriteMaster.awregion(3 downto 0)             <= S_AXI_AWREGION;
+   S_AXI_WriteMaster.awqos(3 downto 0)                <= S_AXI_AWQOS;
+--   S_AXI_WriteMaster.awuser(AWUSER_WIDTH-1 downto 0)  <= S_AXI_AWUSER;
+   S_AXI_WriteMaster.awvalid                          <= S_AXI_AWVALID;
+   S_AXI_WriteMaster.wid(ID_WIDTH-1 downto 0)         <= S_AXI_WID;
+   S_AXI_WriteMaster.wdata(DATA_WIDTH-1 downto 0)     <= S_AXI_WDATA;
+   S_AXI_WriteMaster.wstrb((DATA_WIDTH/8)-1 downto 0) <= S_AXI_WSTRB when(HAS_WSTRB /= 0) else (others => '1');
+   S_AXI_WriteMaster.wlast                            <= S_AXI_WLAST;
+--   S_AXI_WriteMaster.wuser(WUSER_WIDTH-1 downto 0)    <= S_AXI_WUSER;
+   S_AXI_WriteMaster.wvalid                           <= S_AXI_WVALID;
+   S_AXI_WriteMaster.bready                           <= S_AXI_BREADY;
+
+   S_AXI_AWREADY <= S_AXI_WriteSlave.awready;
+   S_AXI_WREADY  <= S_AXI_WriteSlave.wready;
+   S_AXI_BID     <= S_AXI_WriteSlave.bid(ID_WIDTH-1 downto 0);
+   S_AXI_BRESP   <= S_AXI_WriteSlave.bresp when(EN_ERROR_RESP and (HAS_BRESP /= 0)) else "00";
+--   S_AXI_BUSER   <= S_AXI_WriteSlave.buser(BUSER_WIDTH-1 downto 0);
+   S_AXI_BVALID  <= S_AXI_WriteSlave.bvalid;
+
+   S_AXI_ReadMaster.arid(ID_WIDTH-1 downto 0)     <= S_AXI_ARID;
+   S_AXI_ReadMaster.araddr(ADDR_WIDTH-1 downto 0) <= S_AXI_ARADDR;
+   S_AXI_ReadMaster.arlen                         <= S_AXI_ARLEN;
+   S_AXI_ReadMaster.arsize                        <= S_AXI_ARSIZE;
+   S_AXI_ReadMaster.arburst                       <= S_AXI_ARBURST;
+   S_AXI_ReadMaster.arlock                        <= S_AXI_ARLOCK;
+   S_AXI_ReadMaster.arcache                       <= S_AXI_ARCACHE;
+   S_AXI_ReadMaster.arprot                        <= S_AXI_ARPROT;
+   S_AXI_ReadMaster.arregion(3 downto 0)          <= S_AXI_ARREGION;
+   S_AXI_ReadMaster.arqos(3 downto 0)             <= S_AXI_ARQOS;
+--   S_AXI_ReadMaster.aruser(ARUSER_WIDTH-1 downto 0) <= S_AXI_ARUSER;
+   S_AXI_ReadMaster.arvalid                       <= S_AXI_ARVALID;
+   S_AXI_ReadMaster.rready                        <= S_AXI_RREADY;
+
+   S_AXI_ARREADY <= S_AXI_ReadSlave.arready;
+   S_AXI_RID     <= S_AXI_ReadSlave.rid(ID_WIDTH-1 downto 0);
+   S_AXI_RDATA   <= S_AXI_ReadSlave.rdata(DATA_WIDTH-1 downto 0);
+   S_AXI_RRESP   <= S_AXI_ReadSlave.rresp when(EN_ERROR_RESP and (HAS_RRESP /= 0)) else "00";
+   S_AXI_RLAST   <= S_AXI_ReadSlave.rlast;
+--   S_AXI_RUSER   <= S_AXI_ReadSlave.ruser(RUSER_WIDTH-1 downto 0);
+   S_AXI_RVALID  <= S_AXI_ReadSlave.rvalid;
+
+end mapping;

--- a/axi/axi4/ruckus.tcl
+++ b/axi/axi4/ruckus.tcl
@@ -3,6 +3,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
+loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/base/general/ip_integrator/MasterRamIpIntegrator.vhd
+++ b/base/general/ip_integrator/MasterRamIpIntegrator.vhd
@@ -1,0 +1,78 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf RAM interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+entity MasterRamIpIntegrator is
+   generic (
+      INTERFACENAME : string               := "M_RAM";
+      READ_LATENCY  : natural range 0 to 3 := 1;
+      ADDR_WIDTH    : positive             := 5;
+      DATA_WIDTH    : positive             := 32);
+   port (
+      -- IP Integrator RAM Interface
+      M_RAM_CLK  : out std_logic;
+      M_RAM_EN   : out std_logic;
+      M_RAM_WE   : out std_logic_vector((DATA_WIDTH/8)-1 downto 0);
+      M_RAM_RST  : out std_logic;
+      M_RAM_ADDR : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      M_RAM_DIN  : out std_logic_vector(DATA_WIDTH-1 downto 0);
+      M_RAM_DOUT : in  std_logic_vector(DATA_WIDTH-1 downto 0)     := (others => '0');
+      -- SURF RAM Interface
+      clk        : in  std_logic                                   := '0';
+      en         : in  std_logic                                   := '1';
+      we         : in  std_logic_vector((DATA_WIDTH/8)-1 downto 0) := (others => '0');
+      rst        : in  std_logic                                   := '0';
+      addr       : in  std_logic_vector(ADDR_WIDTH-1 downto 0)     := (others => '0');
+      din        : in  std_logic_vector(DATA_WIDTH-1 downto 0)     := (others => '0');
+      dout       : out std_logic_vector(DATA_WIDTH-1 downto 0));
+end MasterRamIpIntegrator;
+
+architecture mapping of MasterRamIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of M_RAM_CLK  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " CLK";
+   attribute X_INTERFACE_INFO of M_RAM_EN   : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " EN";
+   attribute X_INTERFACE_INFO of M_RAM_WE   : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " WE";
+   attribute X_INTERFACE_INFO of M_RAM_RST  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " RST";
+   attribute X_INTERFACE_INFO of M_RAM_ADDR : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " ADDR";
+   attribute X_INTERFACE_INFO of M_RAM_DIN  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " DIN";
+   attribute X_INTERFACE_INFO of M_RAM_DOUT : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " DOUT";
+
+   attribute X_INTERFACE_PARAMETER of M_RAM_ADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "MEM_SIZE " & integer'image(2**ADDR_WIDTH) & ", " &
+      "MEM_WIDTH " & integer'image(DATA_WIDTH) & ", " &
+      "MEM_ECC NONE, " &
+      "MASTER_TYPE OTHER, " &
+      "READ_LATENCY " & integer'image(READ_LATENCY);
+
+begin
+
+   assert (DATA_WIDTH mod 8 = 0) report "DATA_WIDTH must be a multiple of 8" severity failure;
+
+   M_RAM_CLK  <= clk;
+   M_RAM_EN   <= en;
+   M_RAM_WE   <= we;
+   M_RAM_RST  <= rst;
+   M_RAM_ADDR <= addr;
+   M_RAM_DIN  <= din;
+   dout       <= M_RAM_DOUT;
+
+end mapping;

--- a/base/general/ip_integrator/SlaveRamIpIntegrator.vhd
+++ b/base/general/ip_integrator/SlaveRamIpIntegrator.vhd
@@ -1,0 +1,78 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Common shim layer between IP Integrator interface and surf RAM interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+entity SlaveRamIpIntegrator is
+   generic (
+      INTERFACENAME : string               := "S_RAM";
+      READ_LATENCY  : natural range 0 to 3 := 1;
+      ADDR_WIDTH    : positive             := 5;
+      DATA_WIDTH    : positive             := 32);
+   port (
+      -- IP Integrator RAM Interface
+      S_RAM_CLK  : in  std_logic                                   := '0';
+      S_RAM_EN   : in  std_logic                                   := '1';
+      S_RAM_WE   : in  std_logic_vector((DATA_WIDTH/8)-1 downto 0) := (others => '0');
+      S_RAM_RST  : in  std_logic                                   := '0';
+      S_RAM_ADDR : in  std_logic_vector(ADDR_WIDTH-1 downto 0)     := (others => '0');
+      S_RAM_DIN  : in  std_logic_vector(DATA_WIDTH-1 downto 0)     := (others => '0');
+      S_RAM_DOUT : out std_logic_vector(DATA_WIDTH-1 downto 0);
+      -- SURF RAM Interface
+      clk        : out std_logic;
+      en         : out std_logic;
+      we         : out std_logic_vector((DATA_WIDTH/8)-1 downto 0);
+      rst        : out std_logic;
+      addr       : out std_logic_vector(ADDR_WIDTH-1 downto 0);
+      din        : out std_logic_vector(DATA_WIDTH-1 downto 0);
+      dout       : in  std_logic_vector(DATA_WIDTH-1 downto 0)     := (others => '0'));
+end SlaveRamIpIntegrator;
+
+architecture mapping of SlaveRamIpIntegrator is
+
+   attribute X_INTERFACE_INFO      : string;
+   attribute X_INTERFACE_PARAMETER : string;
+
+   attribute X_INTERFACE_INFO of S_RAM_CLK  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " CLK";
+   attribute X_INTERFACE_INFO of S_RAM_EN   : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " EN";
+   attribute X_INTERFACE_INFO of S_RAM_WE   : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " WE";
+   attribute X_INTERFACE_INFO of S_RAM_RST  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " RST";
+   attribute X_INTERFACE_INFO of S_RAM_ADDR : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " ADDR";
+   attribute X_INTERFACE_INFO of S_RAM_DIN  : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " DIN";
+   attribute X_INTERFACE_INFO of S_RAM_DOUT : signal is "xilinx.com:interface:bram:1.0 " & INTERFACENAME & " DOUT";
+
+   attribute X_INTERFACE_PARAMETER of S_RAM_ADDR : signal is
+      "XIL_INTERFACENAME " & INTERFACENAME & ", " &
+      "MEM_SIZE " & integer'image(2**ADDR_WIDTH) & ", " &
+      "MEM_WIDTH " & integer'image(DATA_WIDTH) & ", " &
+      "MEM_ECC NONE, " &
+      "MASTER_TYPE OTHER, " &
+      "READ_LATENCY " & integer'image(READ_LATENCY);
+
+begin
+
+   assert (DATA_WIDTH mod 8 = 0) report "DATA_WIDTH must be a multiple of 8" severity failure;
+
+   clk        <= S_RAM_CLK;
+   en         <= S_RAM_EN;
+   we         <= S_RAM_WE;
+   rst        <= S_RAM_RST;
+   addr       <= S_RAM_ADDR;
+   din        <= S_RAM_DIN;
+   S_RAM_DOUT <= dout;
+
+end mapping;

--- a/base/general/ruckus.tcl
+++ b/base/general/ruckus.tcl
@@ -3,6 +3,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
+loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"


### PR DESCRIPTION
### Description
- Adding Ip integrator Support
  - axi/axi-lite/ip_integrator/AxiVersionIpIntegrator.vhd
  - axi/axi-lite/ip_integrator/AxiDualPortRamIpIntegrator.vhd
  - axi/axi-lite/ip_integrator/MasterAxiLiteIpIntegrator.vhd
  - AxiDualPortRamIpIntegrator.vhd: Wrapper on AxiDualPortRam
  - axi/axi-lite/ip_integrator/SlaveAxiLiteIpIntegrator.vhd
  - axi/axi-stream/ip_integrator/MasterAxiStreamTerminateIpIntegrator.vhd
  - axi/axi-stream/ip_integrator/SlaveAxiStreamTerminateIpIntegrator.vhd
  - axi/axi-stream/ip_integrator/MasterAxiStreamIpIntegrator.vhd
  - axi/axi-stream/ip_integrator/SlaveAxiStreamIpIntegrator.vhd
  - base/general/ip_integrator/MasterRamIpIntegrator.vhd
  - base/general/ip_integrator/SlaveRamIpIntegrator.vhd