### PR TITLE
Jesd204bPkg.invData bug fix

### DIFF
--- a/protocols/jesd204b/rtl/Jesd204bPkg.vhd
+++ b/protocols/jesd204b/rtl/Jesd204bPkg.vhd
@@ -419,6 +419,7 @@ package body Jesd204bPkg is
 
       for i in (SAMPLES_IN_WORD_C-1) downto 0 loop
          vSlv(i*8*F_int+8*F_int-1 downto i*8*F_int) := invSigned(vSlv(i*8*F_int+8*F_int-1 downto i*8*F_int));
+         vSlv(i*8*F_int+8*F_int-1 downto i*8*F_int) :=  vSlv(i*8*F_int+8*F_int-1 downto i*8*F_int) - 1; -- +1 correction (https://jira.slac.stanford.edu/browse/ESLMPS-94)
       end loop;
 
       return vSlv;


### PR DESCRIPTION
### Description
- Correct for a +1 offset when using the `Jesd204bPkg.invData` function 

### JIRA
[ESLMPS-94](https://jira.slac.stanford.edu/browse/ESLMPS-94)