### PR TITLE
_Ad9249.py: resolve special characters and non numeric key errors

### DIFF
--- a/python/surf/devices/analog_devices/_Ad9249.py
+++ b/python/surf/devices/analog_devices/_Ad9249.py
@@ -96,23 +96,39 @@ class Ad9249ConfigGroup(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name        = 'DevIndexMask[7:0]',
-            offset      = [0x10, 0x14],
+            name        = 'DevIndexMask_DataCh[0]',
+            offset      = 0x10,
             bitSize     = 4,
             bitOffset   = 0,
             mode        = 'RW',
             disp        = '{:#b}',
-            base        = pr.UInt,
         ))
 
         self.add(pr.RemoteVariable(
-            name        = 'DevIndexMask[DCO:FCO]',
+            name        = 'DevIndexMask_DataCh[1]',
             offset      = 0x14,
-            bitSize     = 2,
-            bitOffset   = 0x4,
+            bitSize     = 4,
+            bitOffset   = 0,
             mode        = 'RW',
             disp        = '{:#b}',
-            base        = pr.UInt,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'DevIndexMask_FCO',
+            offset      = 0x14,
+            bitSize     = 1,
+            bitOffset   = 4,
+            mode        = 'RW',
+            disp        = '{:#b}',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'DevIndexMask_DCO',
+            offset      = 0x14,
+            bitSize     = 1,
+            bitOffset   = 5,
+            mode        = 'RW',
+            disp        = '{:#b}',
         ))
 
         self.add(pr.RemoteVariable(
@@ -256,8 +272,8 @@ class Ad9249Config(pr.Device):
                     base        = pr.Bool,
                     mode        = 'RW',
                 ))
-                self.add(Ad9249ConfigGroup(name=f'Ad9249Chip[{i}].BankConfig[0]', offset=i*0x1000))
-                self.add(Ad9249ConfigGroup(name=f'Ad9249Chip[{i}].BankConfig[1]', offset=i*0x1000+0x0800))
+                self.add(Ad9249ConfigGroup(name=f'Ad9249ChipBankConfig0[{i}]', offset=i*0x1000))
+                self.add(Ad9249ConfigGroup(name=f'Ad9249ChipBankConfig1[{i}]', offset=i*0x1000+0x0800))
 
 class Ad9249ReadoutGroup(pr.Device):
     def __init__(self,


### PR DESCRIPTION
### Description
- Changed `DevIndexMask[7:0]` to `DevIndexMask_DataCh[0]` and `DevIndexMask_DataCh[1]`
- Changed `DevIndexMask[DCO:FCO]` to `DevIndexMask_DCO` and  `DevIndexMask_FCO`
- Changed `Ad9249Chip[{i}].BankConfig[0]` to `Ad9249ChipBankConfig0[{i}]`
- Changed `Ad9249Chip[{i}].BankConfig[1]` to `Ad9249ChipBankConfig1[{i}]`
- Resolves these warning messages ...
```python
$ ipython -- scripts/EpixDaqGen2Gui.py --dev=sim
Rogue/pyrogue version v5.4.0-27-gfafb7a44. https://github.com/slaclab/rogue
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[0]:Node DevIndexMask[7:0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[0]:Array node DevIndexMask[7:0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[0]:Node DevIndexMask[DCO:FCO] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[0]:Array node DevIndexMask[DCO:FCO] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Node Ad9249Chip[0].BankConfig[0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Array node Ad9249Chip[0].BankConfig[0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[1]:Node DevIndexMask[7:0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[1]:Array node DevIndexMask[7:0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[1]:Node DevIndexMask[DCO:FCO] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[0].BankConfig[1]:Array node DevIndexMask[DCO:FCO] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Node Ad9249Chip[0].BankConfig[1] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Array node Ad9249Chip[0].BankConfig[1] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[0]:Node DevIndexMask[7:0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[0]:Array node DevIndexMask[7:0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[0]:Node DevIndexMask[DCO:FCO] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[0]:Array node DevIndexMask[DCO:FCO] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Node Ad9249Chip[1].BankConfig[0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Array node Ad9249Chip[1].BankConfig[0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[1]:Node DevIndexMask[7:0] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[1]:Array node DevIndexMask[7:0] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[1]:Node DevIndexMask[DCO:FCO] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249ConfigGroup.Ad9249Chip[1].BankConfig[1]:Array node DevIndexMask[DCO:FCO] with non numeric key will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Node Ad9249Chip[1].BankConfig[1] with one or more special characters will cause lookup errors.
WARNING:pyrogue.Device.Ad9249Config.Ad9249Config:Array node Ad9249Chip[1].BankConfig[1] with non numeric key will cause lookup errors.
```