### PR TITLE
OutputBufferReg.vhd Update

### DIFF
--- a/xilinx/7Series/general/rtl/OutputBufferReg.vhd
+++ b/xilinx/7Series/general/rtl/OutputBufferReg.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 
@@ -28,7 +27,7 @@ entity OutputBufferReg is
    generic (
       TPD_G          : time    := 1 ns;
       DIFF_PAIR_G    : boolean := false;
-      DDR_CLK_EDGE_G : string  := "OPPOSITE_EDGE";
+      DDR_CLK_EDGE_G : string  := "SAME_EDGE";
       INIT_G         : bit     := '0';
       SRTYPE_G       : string  := "SYNC");
    port (


### PR DESCRIPTION
### Description
- updating the defautl to same edge because 99% of the time only rising edge 
  - Helps making timing because not using falling edge
- ... And because ODDR.D1 and ODDR.D2 tied together