### PR TITLE
bring Pgp3AxiL's STATUS_CNT_WIDTH_G/ERROR_CNT_WIDTH_G to top-level

### DIFF
--- a/protocols/pgp/pgp3/core/rtl/Pgp3Core.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Core.vhd
@@ -38,6 +38,8 @@ entity Pgp3Core is
       TX_MUX_ILEAVE_EN_G          : boolean               := true;
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_PGP_MON_G                : boolean               := true;
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
    port (
       -- Tx User interface
@@ -163,8 +165,8 @@ begin
             COMMON_TX_CLK_G    => false,
             COMMON_RX_CLK_G    => false,
             WRITE_EN_G         => true,
-            STATUS_CNT_WIDTH_G => 16,
-            ERROR_CNT_WIDTH_G  => 8,
+            STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
+            ERROR_CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
             AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G)
          port map (
             pgpTxClk        => pgpTxClk,         -- [in]

--- a/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUs.vhd
+++ b/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUs.vhd
@@ -52,6 +52,8 @@ entity Pgp3GthUs is
       EN_PGP_MON_G                : boolean               := false;
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
       AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
    port (
@@ -205,6 +207,8 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
       port map (
          -- Tx User interface

--- a/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUsWrapper.vhd
@@ -57,6 +57,8 @@ entity Pgp3GthUsWrapper is
       EN_QPLL_DRP_G               : boolean                     := false;
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
       AXIL_CLK_FREQ_G             : real                        := 125.0E+6);
    port (
@@ -226,6 +228,8 @@ begin
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),
                AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
                AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
             port map (
                -- Stable Clock and Reset

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUs.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUs.vhd
@@ -51,6 +51,8 @@ entity Pgp3GthUs is
       EN_PGP_MON_G                : boolean               := false;
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
       AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
    port (
@@ -204,6 +206,8 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
       port map (
          -- Tx User interface

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
@@ -57,6 +57,8 @@ entity Pgp3GthUsWrapper is
       EN_QPLL_DRP_G               : boolean                     := false;
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
       AXIL_CLK_FREQ_G             : real                        := 125.0E+6);
    port (
@@ -227,6 +229,8 @@ begin
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),
                AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
                AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
             port map (
                -- Stable Clock and Reset

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7.vhd
@@ -56,6 +56,8 @@ entity Pgp3Gtp7 is
       EN_PGP_MON_G                : boolean               := false;
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
       AXIL_CLK_FREQ_G             : real                  := 156.25E+6);
    port (
@@ -229,6 +231,8 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
       port map (
          -- Tx User interface

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
@@ -57,6 +57,8 @@ entity Pgp3Gtp7Wrapper is
       EN_QPLL_DRP_G               : boolean                     := false;
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
       AXIL_CLK_FREQ_G             : real                        := 156.25E+6);
    port (
@@ -256,6 +258,8 @@ begin
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),
                AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
                AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
             port map (
                -- Stable Clock and Reset

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7.vhd
@@ -51,6 +51,8 @@ entity Pgp3Gtx7 is
       EN_PGP_MON_G                : boolean               := false;
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
       AXIL_CLK_FREQ_G             : real                  := 156.25E+6);
    port (
@@ -209,6 +211,8 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
       port map (
          -- Tx User interface

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
@@ -56,6 +56,8 @@ entity Pgp3Gtx7Wrapper is
       EN_QPLL_DRP_G               : boolean                     := false;
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
       AXIL_CLK_FREQ_G             : real                        := 156.25E+6);
    port (
@@ -231,6 +233,8 @@ begin
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),
                AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
                AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
             port map (
                -- Stable Clock and Reset


### PR DESCRIPTION
### Description
- Used to optimize LUT usage