### PR TITLE
Make github actions script more generic for copying

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Gen Release
         env:
-          TRAVIS_REPO_SLUG: slaclab/surf
+          TRAVIS_REPO_SLUG: ${{ github.repository }}
           TRAVIS_TAG: ${{ steps.get_image_info.outputs.tag }}
           GH_REPO_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -171,7 +171,7 @@ jobs:
               echo ::set-output name=os::linux-64
           fi
 
-      - name: Build And Upload Surf
+      - name: Build And Upload
         run: |
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh

--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -171,7 +171,7 @@ jobs:
               echo ::set-output name=os::linux-64
           fi
 
-      - name: Build And Upload Rogue
+      - name: Build And Upload Surf
         run: |
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
Removing repo specific references later in the script to make copying easier.