### PR TITLE
Fixing broken AXI Lite register access in AD9249

### DIFF
--- a/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
+++ b/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
@@ -246,7 +246,6 @@ begin
 
       v.dataDelaySet        := (others => '0');
       v.frameDelaySet       := '0';
-      v.axilReadSlave.rdata := (others => '0');
       v.lockedCountRst      := '0';
 
       -- Store last two samples read from ADC


### PR DESCRIPTION
Clearing v.axilReadSlave.rdata variable breaks the axil protocol. Must be removed.