### PR TITLE
Adding PGPv4 (PGPv3 with CRC in all k-codes)

### DIFF
--- a/protocols/pgp/pgp3/.gitignore
+++ b/protocols/pgp/pgp3/.gitignore
@@ -1,2 +1,0 @@
-gthUs/ip/Pgp3GthUsIp/*
-

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -213,14 +213,6 @@ package Pgp3Pkg is
       ebOverflow     => '0',
       ebStatus       => (others => '0'));
 
-   type Pgp3RefClkType is (
-      REFCLK_125_C,                -- Used in 6.25Gbps only
-      REFCLK_156_C,                -- Used in 10.3125Gbps & 6.25Gbps
-      REFCLK_186_C,                -- Used in 10.3125Gbps
-      REFCLK_250_C,                -- Used in 6.25Gbps only
-      REFCLK_312_C,                -- Used in 10.3125Gbps & 6.25Gbps
-      REFCLK_371_C);               -- Used in 10.3125Gbps
-
 end package Pgp3Pkg;
 
 package body Pgp3Pkg is

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Pkg.vhd
@@ -214,12 +214,12 @@ package Pgp3Pkg is
       ebStatus       => (others => '0'));
 
    type Pgp3RefClkType is (
-      PGP3_REFCLK_125_C,                -- Used in 6.25Gbps only
-      PGP3_REFCLK_156_C,                -- Used in 10.3125Gbps & 6.25Gbps
-      PGP3_REFCLK_186_C,                -- Used in 10.3125Gbps
-      PGP3_REFCLK_250_C,                -- Used in 6.25Gbps only
-      PGP3_REFCLK_312_C,                -- Used in 10.3125Gbps & 6.25Gbps
-      PGP3_REFCLK_371_C);               -- Used in 10.3125Gbps
+      REFCLK_125_C,                -- Used in 6.25Gbps only
+      REFCLK_156_C,                -- Used in 10.3125Gbps & 6.25Gbps
+      REFCLK_186_C,                -- Used in 10.3125Gbps
+      REFCLK_250_C,                -- Used in 6.25Gbps only
+      REFCLK_312_C,                -- Used in 10.3125Gbps & 6.25Gbps
+      REFCLK_371_C);               -- Used in 10.3125Gbps
 
 end package Pgp3Pkg;
 

--- a/protocols/pgp/pgp3/core/tb/Pgp3Tb.vhd
+++ b/protocols/pgp/pgp3/core/tb/Pgp3Tb.vhd
@@ -80,7 +80,7 @@ architecture tb of Pgp3Tb is
    signal pgpTxOut       : Pgp3TxOutType;
    signal pgpTxMasters   : AxiStreamMasterArray(NUM_VC_G-1 downto 0);  -- [in]
    signal pgpTxSlaves    : AxiStreamSlaveArray(NUM_VC_G-1 downto 0);   -- [out]
-   signal pgpTxCtrl      : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
    -- status from rx to tx
    signal locRxLinkReady : sl;
    signal remRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
@@ -147,16 +147,14 @@ begin
    -------------------------------------------------------------------------------------------------
    U_Pgp3Tx_1 : entity surf.Pgp3Tx
       generic map (
-         TPD_G                        => TPD_G,
-         NUM_VC_G                     => NUM_VC_G,
-         TX_CELL_WORDS_MAX_G          => TX_CELL_WORDS_MAX_G,
-         SKP_INTERVAL_G               => SKP_INTERVAL_G,
-         SKP_BURST_SIZE_G             => SKP_BURST_SIZE_G,
-         MUX_MODE_G                   => MUX_MODE_G,
-         MUX_TDEST_ROUTES_G           => MUX_TDEST_ROUTES_G,
-         MUX_TDEST_LOW_G              => MUX_TDEST_LOW_G,
-         MUX_INTERLEAVE_EN_G          => MUX_INTERLEAVE_EN_G,
-         MUX_INTERLEAVE_ON_NOTVALID_G => MUX_INTERLEAVE_ON_NOTVALID_G)
+         TPD_G                    => TPD_G,
+         NUM_VC_G                 => NUM_VC_G,
+         CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         MUX_MODE_G               => MUX_MODE_G,
+         MUX_TDEST_ROUTES_G       => MUX_TDEST_ROUTES_G,
+         MUX_TDEST_LOW_G          => MUX_TDEST_LOW_G,
+         MUX_ILEAVE_EN_G          => MUX_INTERLEAVE_EN_G,
+         MUX_ILEAVE_ON_NOTVALID_G => MUX_INTERLEAVE_ON_NOTVALID_G)
       port map (
          pgpTxClk       => axisClk,         -- [in]
          pgpTxRst       => axisRst,         -- [in]
@@ -164,11 +162,11 @@ begin
          pgpTxOut       => pgpTxOut,        -- [out]
          pgpTxMasters   => pgpTxMasters,    -- [in]
          pgpTxSlaves    => pgpTxSlaves,     -- [out]
-         pgpTxCtrl      => pgpTxCtrl,       -- [out]
          locRxFifoCtrl  => pgpRxCtrl,       -- [in]
          locRxLinkReady => locRxLinkReady,  -- [in]
          remRxFifoCtrl  => remRxFifoCtrl,   -- [in]
          remRxLinkReady => remRxLinkReady,  -- [in]
+         phyTxActive    => '1',             -- [in]
          phyTxReady     => '1',             -- [in]
          phyTxData      => phyTxData,       -- [out]
          phyTxHeader    => phyTxHeader);    -- [out]
@@ -191,11 +189,11 @@ begin
          remRxLinkReady   => remRxLinkReady,  -- [out]
          locRxLinkReady   => locRxLinkReady,  -- [out]
          phyRxClk         => '0',             -- [in]
-         phyRxReady       => '1',             -- [in]
+         phyRxRst         => axisRst,         -- [in]
+         phyRxActive      => '1',             -- [in]
          phyRxInit        => open,            -- [out]
-         phyRxHeaderValid => '1',             -- [in]
          phyRxHeader      => phyRxHeader,     -- [in]
-         phyRxDataValid   => "11",            -- [in]
+         phyRxValid       => '1',             -- [in]
          phyRxData        => phyRxData,       -- [in]
          phyRxStartSeq    => '0',             -- [in]
          phyRxSlip        => open);           -- [out]

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
@@ -30,7 +30,7 @@ use unisim.vcomponents.all;
 entity Pgp3GthUsQpll is
    generic (
       TPD_G             : time            := 1 ns;
-      REFCLK_TYPE_G     : Pgp3RefClkType  := PGP3_REFCLK_156_C;
+      REFCLK_TYPE_G     : Pgp3RefClkType  := REFCLK_156_C;
       RATE_G            : string          := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
       QPLL_REFCLK_SEL_G : slv(2 downto 0) := "001";
       EN_DRP_G          : boolean         := true);
@@ -103,7 +103,7 @@ architecture mapping of Pgp3GthUsQpll is
       ----------------------------------------
       -- Check for 156.25 MHz or 312.5 MHz OSC
       ----------------------------------------
-      if (refClkType = PGP3_REFCLK_156_C) or (refClkType = PGP3_REFCLK_312_C) then
+      if (refClkType = REFCLK_156_C) or (refClkType = REFCLK_312_C) then
 
          -- Check for non-10Gb/s rate
          if (rate /= "10.3125Gbps") then
@@ -112,7 +112,7 @@ architecture mapping of Pgp3GthUsQpll is
          end if;
 
          -- Check for double rate OSC
-         if (refClkType = PGP3_REFCLK_312_C) then
+         if (refClkType = REFCLK_312_C) then
             retVar.QPLL_REFCLK_DIV := 2;
          end if;
 
@@ -131,7 +131,7 @@ architecture mapping of Pgp3GthUsQpll is
          retVar.QPLL_FBDIV := 111;
 
          -- Check for OSC Frequency
-         if (refClkType = PGP3_REFCLK_186_C) then
+         if (refClkType = REFCLK_186_C) then
             retVar.QPLL_REFCLK_DIV := 2;
          else
             retVar.QPLL_REFCLK_DIV := 4;
@@ -163,8 +163,8 @@ begin
       report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
       severity error;
 
-   assert ((REFCLK_TYPE_G = PGP3_REFCLK_156_C) or (REFCLK_TYPE_G = PGP3_REFCLK_186_C) or (REFCLK_TYPE_G = PGP3_REFCLK_312_C) or (REFCLK_TYPE_G = PGP3_REFCLK_371_C))
-      report "REFCLK_TYPE_G: Must be either PGP3_REFCLK_156_C, PGP3_REFCLK_186_C, PGP3_REFCLK_312_C or PGP3_REFCLK_371_C"
+   assert ((REFCLK_TYPE_G = REFCLK_156_C) or (REFCLK_TYPE_G = REFCLK_186_C) or (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_371_C))
+      report "REFCLK_TYPE_G: Must be either REFCLK_156_C, REFCLK_186_C, REFCLK_312_C or REFCLK_371_C"
       severity error;
 
    GEN_VEC :

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsQpll.vhd
@@ -30,7 +30,7 @@ use unisim.vcomponents.all;
 entity Pgp3GthUsQpll is
    generic (
       TPD_G             : time            := 1 ns;
-      REFCLK_TYPE_G     : Pgp3RefClkType  := REFCLK_156_C;
+      REFCLK_FREQ_G     : real            := 156.25E+6;
       RATE_G            : string          := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
       QPLL_REFCLK_SEL_G : slv(2 downto 0) := "001";
       EN_DRP_G          : boolean         := true);
@@ -39,7 +39,7 @@ entity Pgp3GthUsQpll is
       stableClk       : in  sl;         -- GT needs a stable clock to "boot up"
       stableRst       : in  sl;
       -- QPLL Clocking
-      pgpRefClk       : in  sl;         -- REFCLK_TYPE_G
+      pgpRefClk       : in  sl;         -- REFCLK_FREQ_G
       qpllLock        : out Slv2Array(3 downto 0);
       qpllClk         : out Slv2Array(3 downto 0);
       qpllRefclk      : out Slv2Array(3 downto 0);
@@ -94,7 +94,7 @@ architecture mapping of Pgp3GthUsQpll is
       QPLL_LPF         => "1111111100",
       QPLL_LPF_G3      => "0000010101",
       QPLL_REFCLK_DIV  => 1);
-   function getQpllConfig (refClkType : Pgp3RefClkType; rate : string) return QpllConfig is
+   function getQpllConfig (refClkFreq : real; rate : string) return QpllConfig is
       variable retVar : QpllConfig;
    begin
       -- Init
@@ -103,7 +103,7 @@ architecture mapping of Pgp3GthUsQpll is
       ----------------------------------------
       -- Check for 156.25 MHz or 312.5 MHz OSC
       ----------------------------------------
-      if (refClkType = REFCLK_156_C) or (refClkType = REFCLK_312_C) then
+      if (refClkFreq = 156.25E+6) or (refClkFreq = 312.5E+6) then
 
          -- Check for non-10Gb/s rate
          if (rate /= "10.3125Gbps") then
@@ -112,7 +112,7 @@ architecture mapping of Pgp3GthUsQpll is
          end if;
 
          -- Check for double rate OSC
-         if (refClkType = REFCLK_312_C) then
+         if (refClkFreq = 312.5E+6) then
             retVar.QPLL_REFCLK_DIV := 2;
          end if;
 
@@ -131,7 +131,7 @@ architecture mapping of Pgp3GthUsQpll is
          retVar.QPLL_FBDIV := 111;
 
          -- Check for OSC Frequency
-         if (refClkType = REFCLK_186_C) then
+         if (refClkFreq = 185.7142855E+6) then
             retVar.QPLL_REFCLK_DIV := 2;
          else
             retVar.QPLL_REFCLK_DIV := 4;
@@ -143,7 +143,7 @@ architecture mapping of Pgp3GthUsQpll is
       return(retVar);
    end function;
 
-   constant QPLL_CONFIG_C : QpllConfig := getQpllConfig(REFCLK_TYPE_G, RATE_G);
+   constant QPLL_CONFIG_C : QpllConfig := getQpllConfig(REFCLK_FREQ_G, RATE_G);
 
    signal pllRefClk     : slv(1 downto 0);
    signal pllOutClk     : slv(1 downto 0);
@@ -163,8 +163,8 @@ begin
       report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
       severity error;
 
-   assert ((REFCLK_TYPE_G = REFCLK_156_C) or (REFCLK_TYPE_G = REFCLK_186_C) or (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_371_C))
-      report "REFCLK_TYPE_G: Must be either REFCLK_156_C, REFCLK_186_C, REFCLK_312_C or REFCLK_371_C"
+   assert ((REFCLK_FREQ_G = 156.25E+6) or (REFCLK_FREQ_G = 185.7142855E+6) or (REFCLK_FREQ_G = 312.5E+6) or (REFCLK_FREQ_G = 371.428571E+6))
+      report "REFCLK_FREQ_G: Must be either 156.25E+6, 185.7142855E+6, 312.5E+6 or 371.428571E+6"
       severity error;
 
    GEN_VEC :

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
@@ -38,7 +38,7 @@ entity Pgp3GthUsWrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := PGP3_REFCLK_156_C;
+      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_156_C;
       QPLL_REFCLK_SEL_G           : slv(2 downto 0)             := "001";
       ----------------------------------------------------------------------------------------------
       -- PGP Settings

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
@@ -38,7 +38,7 @@ entity Pgp3GthUsWrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_156_C;
+      REFCLK_FREQ_G               : real                        := 156.25E+6;
       QPLL_REFCLK_SEL_G           : slv(2 downto 0)             := "001";
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -71,9 +71,9 @@ entity Pgp3GthUsWrapper is
       pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
       pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
       -- GT Clocking
-      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_TYPE_G
-      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_TYPE_G
-      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_TYPE_G
+      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_FREQ_G
+      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_FREQ_G
+      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_FREQ_G
       pgpRefClkOut      : out sl;
       pgpRefClkDiv2Bufg : out sl;
       -- Clocking
@@ -183,7 +183,7 @@ begin
          generic map (
             TPD_G             => TPD_G,
             RATE_G            => RATE_G,
-            REFCLK_TYPE_G     => REFCLK_TYPE_G,
+            REFCLK_FREQ_G     => REFCLK_FREQ_G,
             QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G,
             EN_DRP_G          => EN_QPLL_DRP_G)
          port map (

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Qpll.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Qpll.vhd
@@ -32,7 +32,7 @@ entity Pgp3Gtp7Qpll is
    generic (
       TPD_G         : time           := 1 ns;
       EN_DRP_G      : boolean        := true;
-      REFCLK_TYPE_G : Pgp3RefClkType := REFCLK_250_C;
+      REFCLK_FREQ_G : real           := 250.0E+6;
       RATE_G        : string         := "6.25Gbps");  -- or "3.125Gbps"
    port (
       -- Stable Clock and Reset
@@ -67,9 +67,9 @@ architecture mapping of Pgp3Gtp7Qpll is
 
    impure function GenQpllFbDiv return integer is
    begin
-      if (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_156_C) then
+      if (REFCLK_FREQ_G = 312.5E+6) or (REFCLK_FREQ_G = 156.25E+6) then
          return 4;
-      elsif (REFCLK_TYPE_G = REFCLK_250_C) or (REFCLK_TYPE_G = REFCLK_125_C) then
+      elsif (REFCLK_FREQ_G = 250.0E+6) or (REFCLK_FREQ_G = 125.0E+6) then
          return 5;
       else
          return -1;
@@ -81,9 +81,9 @@ architecture mapping of Pgp3Gtp7Qpll is
 
    impure function GenQpllRefDiv return integer is
    begin
-      if (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_250_C) then
+      if (REFCLK_FREQ_G = 312.5E+6) or (REFCLK_FREQ_G = 250.0E+6) then
          return 2;
-      elsif (REFCLK_TYPE_G = REFCLK_156_C) or (REFCLK_TYPE_G = REFCLK_125_C) then
+      elsif (REFCLK_FREQ_G = 156.25E+6) or (REFCLK_FREQ_G = 125.0E+6) then
          return 1;
       else
          return -1;

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Qpll.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Qpll.vhd
@@ -32,7 +32,7 @@ entity Pgp3Gtp7Qpll is
    generic (
       TPD_G         : time           := 1 ns;
       EN_DRP_G      : boolean        := true;
-      REFCLK_TYPE_G : Pgp3RefClkType := PGP3_REFCLK_250_C;
+      REFCLK_TYPE_G : Pgp3RefClkType := REFCLK_250_C;
       RATE_G        : string         := "6.25Gbps");  -- or "3.125Gbps"
    port (
       -- Stable Clock and Reset
@@ -67,9 +67,9 @@ architecture mapping of Pgp3Gtp7Qpll is
 
    impure function GenQpllFbDiv return integer is
    begin
-      if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) or (REFCLK_TYPE_G = PGP3_REFCLK_156_C) then
+      if (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_156_C) then
          return 4;
-      elsif (REFCLK_TYPE_G = PGP3_REFCLK_250_C) or (REFCLK_TYPE_G = PGP3_REFCLK_125_C) then
+      elsif (REFCLK_TYPE_G = REFCLK_250_C) or (REFCLK_TYPE_G = REFCLK_125_C) then
          return 5;
       else
          return -1;
@@ -81,9 +81,9 @@ architecture mapping of Pgp3Gtp7Qpll is
 
    impure function GenQpllRefDiv return integer is
    begin
-      if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) or (REFCLK_TYPE_G = PGP3_REFCLK_250_C) then
+      if (REFCLK_TYPE_G = REFCLK_312_C) or (REFCLK_TYPE_G = REFCLK_250_C) then
          return 2;
-      elsif (REFCLK_TYPE_G = PGP3_REFCLK_156_C) or (REFCLK_TYPE_G = PGP3_REFCLK_125_C) then
+      elsif (REFCLK_TYPE_G = REFCLK_156_C) or (REFCLK_TYPE_G = REFCLK_125_C) then
          return 1;
       else
          return -1;

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
@@ -38,7 +38,7 @@ entity Pgp3Gtp7Wrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       SPEED_GRADE_G               : positive range 1 to 3       := 3;
       RATE_G                      : string                      := "6.25Gbps";  -- or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := PGP3_REFCLK_250_C;
+      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_250_C;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
@@ -38,7 +38,7 @@ entity Pgp3Gtp7Wrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       SPEED_GRADE_G               : positive range 1 to 3       := 3;
       RATE_G                      : string                      := "6.25Gbps";  -- or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_250_C;
+      REFCLK_FREQ_G               : real                        := 250.0E+6;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -202,7 +202,7 @@ begin
          generic map (
             TPD_G         => TPD_G,
             EN_DRP_G      => EN_QPLL_DRP_G,
-            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            REFCLK_FREQ_G => REFCLK_FREQ_G,
             RATE_G        => RATE_G)
          port map (
             -- Stable Clock and Reset

--- a/protocols/pgp/pgp3/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp3/gtp7/ruckus.tcl
@@ -36,6 +36,28 @@ if { $::env(VIVADO_VERSION) >= 2018.2 } {
 
    }
 
+   if { [info exists ::env(INCLUDE_PGP4_6G)] != 1 || $::env(INCLUDE_PGP4_6G) == 0 } {
+      set nop 0
+   } else {
+
+      loadConstraints -path "$::DIR_PATH/xdc/Pgp3Gtp7Ip6G.xdc"
+      set_property PROCESSING_ORDER {EARLY}        [get_files {Pgp3Gtp7Ip6G.xdc}]
+      set_property SCOPED_TO_REF    {Pgp3Gtp7Ip6G} [get_files {Pgp3Gtp7Ip6G.xdc}]
+      set_property SCOPED_TO_CELLS  {U0}           [get_files {Pgp3Gtp7Ip6G.xdc}]
+
+   }
+
+   if { [info exists ::env(INCLUDE_PGP4_3G)] != 1 || $::env(INCLUDE_PGP4_3G) == 0 } {
+      set nop 0
+   } else {
+
+      loadConstraints -path "$::DIR_PATH/xdc/Pgp3Gtp7Ip3G.xdc"
+      set_property PROCESSING_ORDER {EARLY}        [get_files {Pgp3Gtp7Ip3G.xdc}]
+      set_property SCOPED_TO_REF    {Pgp3Gtp7Ip3G} [get_files {Pgp3Gtp7Ip3G.xdc}]
+      set_property SCOPED_TO_CELLS  {U0}           [get_files {Pgp3Gtp7Ip3G.xdc}]
+
+   }
+
 } else {
    puts "\n\nWARNING: $::DIR_PATH requires Vivado 2018.2 (or later)\n\n"
 }

--- a/protocols/pgp/pgp3/gtp7/tb/Pgp3Gtp7Tb.vhd
+++ b/protocols/pgp/pgp3/gtp7/tb/Pgp3Gtp7Tb.vhd
@@ -81,7 +81,7 @@ begin
          NUM_LANES_G         => 1,
          NUM_VC_G            => 4,
          RATE_G              => "6.25Gbps",
-         REFCLK_TYPE_G       => PGP3_REFCLK_250_C)
+         REFCLK_TYPE_G       => REFCLK_250_C)
       port map (
          -- Stable Clock and Reset
          stableClk         => stableClk,

--- a/protocols/pgp/pgp3/gtp7/tb/Pgp3Gtp7Tb.vhd
+++ b/protocols/pgp/pgp3/gtp7/tb/Pgp3Gtp7Tb.vhd
@@ -81,7 +81,7 @@ begin
          NUM_LANES_G         => 1,
          NUM_VC_G            => 4,
          RATE_G              => "6.25Gbps",
-         REFCLK_TYPE_G       => REFCLK_250_C)
+         REFCLK_FREQ_G       => 250.0E+6)
       port map (
          -- Stable Clock and Reset
          stableClk         => stableClk,

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Qpll.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Qpll.vhd
@@ -32,7 +32,7 @@ entity Pgp3Gtx7Qpll is
    generic (
       TPD_G         : time           := 1 ns;
       EN_DRP_G      : boolean        := true;
-      REFCLK_TYPE_G : Pgp3RefClkType := REFCLK_312_C;
+      REFCLK_FREQ_G : real           := 312.5E+6;
       RATE_G        : string         := "10.3125Gbps");  -- or "6.25Gbps" or "3.125Gbps"
    port (
       -- Stable Clock and Reset
@@ -62,9 +62,9 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 10.3125Gbps
       -------------------------------
       if ((RATE_G = "10.3125Gbps")) then
-         if (REFCLK_TYPE_G = REFCLK_312_C) then
+         if (REFCLK_FREQ_G = 312.5E+6) then
             return 66;
-         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
+         elsif (REFCLK_FREQ_G = 156.25E+6) then
             return 66;
          else
             return -1;
@@ -73,13 +73,13 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 6.25Gbps or 3.125Gbps
       -----------------------------
       else
-         if (REFCLK_TYPE_G = REFCLK_312_C) then
+         if (REFCLK_FREQ_G = 312.5E+6) then
             return 40;
-         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
+         elsif (REFCLK_FREQ_G = 156.25E+6) then
             return 40;
-         elsif (REFCLK_TYPE_G = REFCLK_250_C) then
+         elsif (REFCLK_FREQ_G = 250.0E+6) then
             return 100;
-         elsif (REFCLK_TYPE_G = REFCLK_125_C) then
+         elsif (REFCLK_FREQ_G = 125.0E+6) then
             return 100;
          else
             return -1;
@@ -139,9 +139,9 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 10.3125Gbps
       -------------------------------
       if (RATE_G = "10.3125Gbps") then
-         if (REFCLK_TYPE_G = REFCLK_312_C) then
+         if (REFCLK_FREQ_G = 312.5E+6) then
             return 2;
-         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
+         elsif (REFCLK_FREQ_G = 156.25E+6) then
             return 1;
          else
             return -1;
@@ -150,13 +150,13 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 6.25Gbps or 3.125Gbps
       -----------------------------
       else
-         if (REFCLK_TYPE_G = REFCLK_312_C) then
+         if (REFCLK_FREQ_G = 312.5E+6) then
             return 2;
-         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
+         elsif (REFCLK_FREQ_G = 156.25E+6) then
             return 1;
-         elsif (REFCLK_TYPE_G = REFCLK_250_C) then
+         elsif (REFCLK_FREQ_G = 250.0E+6) then
             return 4;
-         elsif (REFCLK_TYPE_G = REFCLK_125_C) then
+         elsif (REFCLK_FREQ_G = 125.0E+6) then
             return 2;
          else
             return -1;

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Qpll.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Qpll.vhd
@@ -32,7 +32,7 @@ entity Pgp3Gtx7Qpll is
    generic (
       TPD_G         : time           := 1 ns;
       EN_DRP_G      : boolean        := true;
-      REFCLK_TYPE_G : Pgp3RefClkType := PGP3_REFCLK_312_C;
+      REFCLK_TYPE_G : Pgp3RefClkType := REFCLK_312_C;
       RATE_G        : string         := "10.3125Gbps");  -- or "6.25Gbps" or "3.125Gbps"
    port (
       -- Stable Clock and Reset
@@ -62,9 +62,9 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 10.3125Gbps
       -------------------------------
       if ((RATE_G = "10.3125Gbps")) then
-         if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) then
+         if (REFCLK_TYPE_G = REFCLK_312_C) then
             return 66;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_156_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
             return 66;
          else
             return -1;
@@ -73,13 +73,13 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 6.25Gbps or 3.125Gbps
       -----------------------------
       else
-         if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) then
+         if (REFCLK_TYPE_G = REFCLK_312_C) then
             return 40;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_156_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
             return 40;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_250_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_250_C) then
             return 100;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_125_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_125_C) then
             return 100;
          else
             return -1;
@@ -139,9 +139,9 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 10.3125Gbps
       -------------------------------
       if (RATE_G = "10.3125Gbps") then
-         if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) then
+         if (REFCLK_TYPE_G = REFCLK_312_C) then
             return 2;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_156_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
             return 1;
          else
             return -1;
@@ -150,13 +150,13 @@ architecture mapping of Pgp3Gtx7Qpll is
       -- RATE_G = 6.25Gbps or 3.125Gbps
       -----------------------------
       else
-         if (REFCLK_TYPE_G = PGP3_REFCLK_312_C) then
+         if (REFCLK_TYPE_G = REFCLK_312_C) then
             return 2;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_156_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_156_C) then
             return 1;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_250_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_250_C) then
             return 4;
-         elsif (REFCLK_TYPE_G = PGP3_REFCLK_125_C) then
+         elsif (REFCLK_TYPE_G = REFCLK_125_C) then
             return 2;
          else
             return -1;

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
@@ -37,7 +37,7 @@ entity Pgp3Gtx7Wrapper is
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_312_C;
+      REFCLK_FREQ_G               : real                        := 312.5E+6;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -183,7 +183,7 @@ begin
          generic map (
             TPD_G         => TPD_G,
             EN_DRP_G      => EN_QPLL_DRP_G,
-            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            REFCLK_FREQ_G => REFCLK_FREQ_G,
             RATE_G        => RATE_G)
          port map (
             -- Stable Clock and Reset

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
@@ -37,7 +37,7 @@ entity Pgp3Gtx7Wrapper is
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp3RefClkType              := PGP3_REFCLK_312_C;
+      REFCLK_TYPE_G               : Pgp3RefClkType              := REFCLK_312_C;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings

--- a/protocols/pgp/pgp3/gtx7/ruckus.tcl
+++ b/protocols/pgp/pgp3/gtx7/ruckus.tcl
@@ -49,6 +49,39 @@ if { $::env(VIVADO_VERSION) >= 2018.1 } {
 
    }
 
+   if { [info exists ::env(INCLUDE_PGP4_10G)] != 1 || $::env(INCLUDE_PGP4_10G) == 0 } {
+      set nop 0
+   } else {
+
+      loadConstraints -path "$::DIR_PATH/xdc/Pgp3Gtx7Ip10G.xdc"
+      set_property PROCESSING_ORDER {EARLY}         [get_files {Pgp3Gtx7Ip10G.xdc}]
+      set_property SCOPED_TO_REF    {Pgp3Gtx7Ip10G} [get_files {Pgp3Gtx7Ip10G.xdc}]
+      set_property SCOPED_TO_CELLS  {U0}            [get_files {Pgp3Gtx7Ip10G.xdc}]
+
+   }
+
+   if { [info exists ::env(INCLUDE_PGP4_6G)] != 1 || $::env(INCLUDE_PGP4_6G) == 0 } {
+      set nop 0
+   } else {
+
+      loadConstraints -path "$::DIR_PATH/xdc/Pgp3Gtx7Ip6G.xdc"
+      set_property PROCESSING_ORDER {EARLY}        [get_files {Pgp3Gtx7Ip6G.xdc}]
+      set_property SCOPED_TO_REF    {Pgp3Gtx7Ip6G} [get_files {Pgp3Gtx7Ip6G.xdc}]
+      set_property SCOPED_TO_CELLS  {U0}           [get_files {Pgp3Gtx7Ip6G.xdc}]
+
+   }
+
+   if { [info exists ::env(INCLUDE_PGP4_3G)] != 1 || $::env(INCLUDE_PGP4_3G) == 0 } {
+      set nop 0
+   } else {
+
+      loadConstraints -path "$::DIR_PATH/xdc/Pgp3Gtx7Ip3G.xdc"
+      set_property PROCESSING_ORDER {EARLY}        [get_files {Pgp3Gtx7Ip3G.xdc}]
+      set_property SCOPED_TO_REF    {Pgp3Gtx7Ip3G} [get_files {Pgp3Gtx7Ip3G.xdc}]
+      set_property SCOPED_TO_CELLS  {U0}           [get_files {Pgp3Gtx7Ip3G.xdc}]
+
+   }
+
 } else {
    puts "\n\nWARNING: $::DIR_PATH requires Vivado 2018.1 (or later)\n\n"
 }

--- a/protocols/pgp/pgp4/.gitignore
+++ b/protocols/pgp/pgp4/.gitignore
@@ -1,0 +1,2 @@
+gthUs/ip/Pgp3GthUsIp/*
+

--- a/protocols/pgp/pgp4/.gitignore
+++ b/protocols/pgp/pgp4/.gitignore
@@ -1,2 +1,0 @@
-gthUs/ip/Pgp3GthUsIp/*
-

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Core.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Core.vhd
@@ -1,0 +1,209 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Core
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+library ieee;
+use ieee.std_logic_1164.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4Core is
+
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0 => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_PGP_MON_G                : boolean               := true;
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
+      AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
+   port (
+      -- Tx User interface
+      pgpTxClk     : in  sl;
+      pgpTxRst     : in  sl;
+      pgpTxIn      : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
+      pgpTxOut     : out Pgp4TxOutType;
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+
+      -- Tx PHY interface
+      phyTxActive   : in  sl;
+      phyTxReady    : in  sl;
+      phyTxValid    : out sl;
+      phyTxStart    : out sl;
+      phyTxData     : out slv(63 downto 0);
+      phyTxHeader   : out slv(1 downto 0);
+
+      -- Rx User interface
+      pgpRxClk     : in  sl;
+      pgpRxRst     : in  sl;
+      pgpRxIn      : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
+      pgpRxOut     : out Pgp4RxOutType;
+      pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
+      -- Rx PHY interface
+      phyRxClk      : in  sl;
+      phyRxRst      : in  sl;
+      phyRxInit     : out sl;
+      phyRxActive   : in  sl;
+      phyRxValid    : in  sl;
+      phyRxHeader   : in  slv(1 downto 0);
+      phyRxData     : in  slv(63 downto 0);
+      phyRxStartSeq : in  sl;
+      phyRxSlip     : out sl;
+
+      -- Debug Interface
+      loopback     : out slv(2 downto 0);
+      txDiffCtrl   : out slv(4 downto 0);
+      txPreCursor  : out slv(4 downto 0);
+      txPostCursor : out slv(4 downto 0);
+
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end entity Pgp4Core;
+
+architecture rtl of Pgp4Core is
+
+   signal locRxLinkReady : sl;
+   signal remRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+   signal remRxLinkReady : sl;
+
+   signal pgpTxInInt  : Pgp4TxInType;
+   signal pgpTxOutInt : Pgp4TxOutType;
+   signal pgpRxInInt  : Pgp4RxInType;
+   signal pgpRxOutInt : Pgp4RxOutType;
+
+begin
+
+   pgpRxOut <= pgpRxOutInt;
+   pgpTxOut <= pgpTxOutInt;
+
+   U_Pgp4Tx_1 : entity surf.Pgp4Tx
+      generic map (
+         TPD_G                    => TPD_G,
+         NUM_VC_G                 => NUM_VC_G,
+         CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         MUX_MODE_G               => TX_MUX_MODE_G,
+         MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G)
+      port map (
+         pgpTxClk       => pgpTxClk,        -- [in]
+         pgpTxRst       => pgpTxRst,        -- [in]
+         pgpTxIn        => pgpTxInInt,      -- [in]
+         pgpTxOut       => pgpTxOutInt,     -- [out]
+         pgpTxMasters   => pgpTxMasters,    -- [in]
+         pgpTxSlaves    => pgpTxSlaves,     -- [out]
+         locRxFifoCtrl  => pgpRxCtrl,       -- [in]
+         locRxLinkReady => locRxLinkReady,  -- [in]
+         remRxFifoCtrl  => remRxFifoCtrl,   -- [in]
+         remRxLinkReady => remRxLinkReady,  -- [in]
+         phyTxActive    => phyTxActive,     --[in]
+         phyTxReady     => phyTxReady,      -- [in]
+         phyTxValid     => phyTxValid,      -- [out]
+         phyTxStart     => phyTxStart,      -- [out]
+         phyTxData      => phyTxData,       -- [out]
+         phyTxHeader    => phyTxHeader);    -- [out]
+
+   U_Pgp4Rx_1 : entity surf.Pgp4Rx
+      generic map (
+         TPD_G              => TPD_G,
+         NUM_VC_G           => NUM_VC_G,
+         ALIGN_SLIP_WAIT_G  => RX_ALIGN_SLIP_WAIT_G)
+      port map (
+         pgpRxClk       => pgpRxClk,        -- [in]
+         pgpRxRst       => pgpRxRst,        -- [in]
+         pgpRxIn        => pgpRxInInt,      -- [in]
+         pgpRxOut       => pgpRxOutInt,     -- [out]
+         pgpRxMasters   => pgpRxMasters,    -- [out]
+         pgpRxCtrl      => pgpRxCtrl,       -- [in]
+         remRxFifoCtrl  => remRxFifoCtrl,   -- [out]
+         remRxLinkReady => remRxLinkReady,  -- [out]
+         locRxLinkReady => locRxLinkReady,  -- [out]
+         phyRxClk       => phyRxClk,        -- [in]
+         phyRxRst       => phyRxRst,        -- [in]
+         phyRxInit      => phyRxInit,       -- [out]
+         phyRxActive    => phyRxActive,     -- [in]
+         phyRxValid     => phyRxValid,      -- [in]
+         phyRxHeader    => phyRxHeader,     -- [in]
+         phyRxData      => phyRxData,       -- [in]
+         phyRxStartSeq  => phyRxStartSeq,   -- [in]
+         phyRxSlip      => phyRxSlip);      -- [out]
+
+   GEN_PGP_MON : if (EN_PGP_MON_G) generate
+      U_Pgp3Axi_1 : entity surf.Pgp3AxiL  -- Same AXI-Lite module as PGPv3
+         generic map (
+            TPD_G              => TPD_G,
+            COMMON_TX_CLK_G    => false,
+            COMMON_RX_CLK_G    => false,
+            WRITE_EN_G         => true,
+            STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
+            ERROR_CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
+            AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G)
+         port map (
+            pgpTxClk        => pgpTxClk,         -- [in]
+            pgpTxRst        => pgpTxRst,         -- [in]
+            pgpTxIn         => pgpTxInInt,       -- [out]
+            pgpTxOut        => pgpTxOutInt,      -- [in]
+            locTxIn         => pgpTxIn,          -- [in]
+            pgpRxClk        => pgpRxClk,         -- [in]
+            pgpRxRst        => pgpRxRst,         -- [in]
+            pgpRxIn         => pgpRxInInt,       -- [out]
+            pgpRxOut        => pgpRxOutInt,      -- [in]
+            locRxIn         => pgpRxIn,          -- [in]
+            statusWord      => open,             -- [out]
+            statusSend      => open,             -- [out]
+            phyRxClk        => phyRxClk,         -- [in]
+            txDiffCtrl      => txDiffCtrl,       -- [out]
+            txPreCursor     => txPreCursor,      -- [out]
+            txPostCursor    => txPostCursor,     -- [out]
+            axilClk         => axilClk,          -- [in]
+            axilRst         => axilRst,          -- [in]
+            axilReadMaster  => axilReadMaster,   -- [in]
+            axilReadSlave   => axilReadSlave,    -- [out]
+            axilWriteMaster => axilWriteMaster,  -- [in]
+            axilWriteSlave  => axilWriteSlave);  -- [out]
+   end generate GEN_PGP_MON;
+
+   NO_PGP_MON : if (not EN_PGP_MON_G) generate
+      pgpTxInInt   <= pgpTxIn;
+      pgpRxInInt   <= pgpRxIn;
+      txDiffCtrl   <= (others => '1');
+      txPreCursor  <= "00111";
+      txPostCursor <= "00111";
+   end generate NO_PGP_MON;
+
+   loopback <= pgpRxInInt.loopback;
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -27,7 +27,7 @@ use surf.Pgp3Pkg.all;
 
 package Pgp4Pkg is
 
-   constant PGP4_VERSION_C : slv(7 downto 0) := toSlv(4,8); -- Version = 0x04
+   constant PGP4_VERSION_C : slv(7 downto 0) := toSlv(4, 8);  -- Version = 0x04
 
    constant PGP4_DEFAULT_TX_CELL_WORDS_MAX_C : positive := PGP3_DEFAULT_TX_CELL_WORDS_MAX_C;
 
@@ -40,9 +40,16 @@ package Pgp4Pkg is
    constant PGP4_SOC_C  : slv(7 downto 0)   := PGP3_SOC_C;
    constant PGP4_EOC_C  : slv(7 downto 0)   := PGP3_EOC_C;
    constant PGP4_SKP_C  : slv(7 downto 0)   := PGP3_SKP_C;
-   constant PGP4_USER_C : Slv8Array(0 to 7) := PGP3_USER_C;
+   constant PGP4_USER_C : Slv8Array(0 to 0) := (0 => PGP3_USER_C(0));
 
-   constant PGP4_VALID_BTF_ARRAY_C : Slv8Array := PGP3_VALID_BTF_ARRAY_C;
+   constant PGP4_VALID_BTF_ARRAY_C : Slv8Array := (
+      0 => PGP3_IDLE_C,
+      1 => PGP3_SOF_C,
+      2 => PGP3_EOF_C,
+      3 => PGP3_SOC_C,
+      4 => PGP3_EOC_C,
+      5 => PGP3_SKP_C,
+      6 => PGP3_USER_C(0));
 
    constant PGP4_D_HEADER_C : slv(1 downto 0) := PGP3_D_HEADER_C;
    constant PGP4_K_HEADER_C : slv(1 downto 0) := PGP3_K_HEADER_C;
@@ -108,10 +115,10 @@ package body Pgp4Pkg is
    is
       variable ret : slv(PGP4_LINKINFO_FIELD_C) := (others => '0');
    begin
-      ret(7 downto 0)  := PGP4_VERSION_C;
-      ret(8)           := locRxLinkReady;
+      ret(7 downto 0) := PGP4_VERSION_C;
+      ret(8)          := locRxLinkReady;
       for i in locRxFifoCtrl'range loop
-         ret(i+16)    := locRxFifoCtrl(i).pause;
+         ret(i+16) := locRxFifoCtrl(i).pause;
       end loop;
       return ret;
    end function;
@@ -125,7 +132,7 @@ package body Pgp4Pkg is
       version        := linkInfo(7 downto 0);
       remRxLinkReady := linkInfo(8);
       for i in remRxFifoCtrl'range loop
-         remRxFifoCtrl(i).pause    := linkInfo(i+16);
+         remRxFifoCtrl(i).pause := linkInfo(i+16);
       end loop;
    end procedure;
 

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -102,8 +102,6 @@ package Pgp4Pkg is
    subtype Pgp4RxOutArray is Pgp3RxOutArray;
    constant PGP4_RX_OUT_INIT_C : Pgp4RxOutType := PGP3_RX_OUT_INIT_C;
 
-   subtype Pgp4RefClkType is Pgp3RefClkType;
-
 end package Pgp4Pkg;
 
 package body Pgp4Pkg is

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -40,7 +40,7 @@ package Pgp4Pkg is
    constant PGP4_SOC_C  : slv(7 downto 0) := PGP3_SOC_C;
    constant PGP4_EOC_C  : slv(7 downto 0) := PGP3_EOC_C;
    constant PGP4_SKP_C  : slv(7 downto 0) := PGP3_SKP_C;
-   constant PGP4_USER_C : slv(7 downto 0) := (0 => PGP3_USER_C(0));
+   constant PGP4_USER_C : slv(7 downto 0) := PGP3_USER_C(0);
 
    constant PGP4_VALID_BTF_ARRAY_C : Slv8Array := (
       0 => PGP4_IDLE_C,

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -1,0 +1,148 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Support Package
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp3Pkg.all;
+
+package Pgp4Pkg is
+
+   constant PGP4_VERSION_C : slv(7 downto 0) := toSlv(4,8); -- Version = 0x04
+
+   constant PGP4_DEFAULT_TX_CELL_WORDS_MAX_C : positive := PGP3_DEFAULT_TX_CELL_WORDS_MAX_C;
+
+   constant PGP4_AXIS_CONFIG_C : AxiStreamConfigType := PGP3_AXIS_CONFIG_C;
+
+   -- Define K code BTFs
+   constant PGP4_IDLE_C : slv(7 downto 0)   := PGP3_IDLE_C;
+   constant PGP4_SOF_C  : slv(7 downto 0)   := PGP3_SOF_C;
+   constant PGP4_EOF_C  : slv(7 downto 0)   := PGP3_EOF_C;
+   constant PGP4_SOC_C  : slv(7 downto 0)   := PGP3_SOC_C;
+   constant PGP4_EOC_C  : slv(7 downto 0)   := PGP3_EOC_C;
+   constant PGP4_SKP_C  : slv(7 downto 0)   := PGP3_SKP_C;
+   constant PGP4_USER_C : Slv8Array(0 to 7) := PGP3_USER_C;
+
+   constant PGP4_VALID_BTF_ARRAY_C : Slv8Array := PGP3_VALID_BTF_ARRAY_C;
+
+   constant PGP4_D_HEADER_C : slv(1 downto 0) := PGP3_D_HEADER_C;
+   constant PGP4_K_HEADER_C : slv(1 downto 0) := PGP3_K_HEADER_C;
+
+   constant PGP4_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := PGP3_SCRAMBLER_TAPS_C;
+
+   subtype PGP4_BTF_FIELD_C is natural range 63 downto 56;
+   subtype PGP4_CHECKSUM_FIELD_C is natural range 55 downto 48;
+   subtype PGP4_SKIP_DATA_FIELD_C is natural range 47 downto 0;
+   subtype PGP4_USER_OPCODE_FIELD_C is natural range 47 downto 0;
+
+   subtype PGP4_LINKINFO_FIELD_C is natural range 31 downto 0;
+   subtype PGP4_SOFC_VC_FIELD_C is natural range 35 downto 32;
+   subtype PGP4_SOFC_SEQ_FIELD_C is natural range 47 downto 36;
+
+   subtype PGP4_EOFC_TUSER_FIELD_C is natural range 7 downto 0;
+   subtype PGP4_EOFC_BYTES_LAST_FIELD_C is natural range 15 downto 12;
+   subtype PGP4_EOFC_CRC_FIELD_C is natural range 47 downto 16;
+
+   constant PGP4_CRC_POLY_C : slv(31 downto 0) := PGP3_CRC_POLY_C;
+
+   function pgp4MakeLinkInfo (
+      locRxFifoCtrl  : AxiStreamCtrlArray;
+      locRxLinkReady : sl)
+      return slv;
+
+   procedure pgp4ExtractLinkInfo (
+      linkInfo       : in    slv(PGP4_LINKINFO_FIELD_C);
+      remRxFifoCtrl  : inout AxiStreamCtrlArray;
+      remRxLinkReady : inout sl;
+      version        : inout slv(7 downto 0));
+
+   function pgp4Checksum (
+      kCodeWord : slv(63 downto 0))
+      return slv;
+
+   subtype Pgp4TxInType is Pgp3TxInType;
+   subtype Pgp4TxInArray is Pgp3TxInArray;
+   constant PGP4_TX_IN_INIT_C : Pgp4TxInType := PGP3_TX_IN_INIT_C;
+
+   subtype Pgp4TxOutType is Pgp3TxOutType;
+   subtype Pgp4TxOutArray is Pgp3TxOutArray;
+   constant PGP4_TX_OUT_INIT_C : Pgp4TxOutType := PGP3_TX_OUT_INIT_C;
+
+   subtype Pgp4RxInType is Pgp3RxInType;
+   subtype Pgp4RxInArray is Pgp3RxInArray;
+   constant PGP4_RX_IN_INIT_C : Pgp4RxInType := PGP3_RX_IN_INIT_C;
+
+   subtype Pgp4RxOutType is Pgp3RxOutType;
+   subtype Pgp4RxOutArray is Pgp3RxOutArray;
+   constant PGP4_RX_OUT_INIT_C : Pgp4RxOutType := PGP3_RX_OUT_INIT_C;
+
+   subtype Pgp4RefClkType is Pgp3RefClkType;
+
+end package Pgp4Pkg;
+
+package body Pgp4Pkg is
+
+   function pgp4MakeLinkInfo (
+      locRxFifoCtrl  : AxiStreamCtrlArray;
+      locRxLinkReady : sl)
+      return slv
+   is
+      variable ret : slv(PGP4_LINKINFO_FIELD_C) := (others => '0');
+   begin
+      ret(7 downto 0)  := PGP4_VERSION_C;
+      ret(8)           := locRxLinkReady;
+      for i in locRxFifoCtrl'range loop
+         ret(i+16)    := locRxFifoCtrl(i).pause;
+      end loop;
+      return ret;
+   end function;
+
+   procedure pgp4ExtractLinkInfo (
+      linkInfo       : in    slv(PGP4_LINKINFO_FIELD_C);
+      remRxFifoCtrl  : inout AxiStreamCtrlArray;
+      remRxLinkReady : inout sl;
+      version        : inout slv(7 downto 0)) is
+   begin
+      version        := linkInfo(7 downto 0);
+      remRxLinkReady := linkInfo(8);
+      for i in remRxFifoCtrl'range loop
+         remRxFifoCtrl(i).pause    := linkInfo(i+16);
+      end loop;
+   end procedure;
+
+   function pgp4Checksum (
+      kCodeWord : slv(63 downto 0))
+      return slv
+   is
+      variable ret : slv(7 downto 0);
+   begin
+      ret := not (kCodeWord(7 downto 0) +
+                  kCodeWord(15 downto 8) +
+                  kCodeWord(23 downto 16) +
+                  kCodeWord(31 downto 24) +
+                  kCodeWord(39 downto 32) +
+                  kCodeWord(47 downto 47) +
+                  kCodeWord(63 downto 56));
+      return ret;
+   end function;
+
+end package body Pgp4Pkg;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -57,7 +57,7 @@ package Pgp4Pkg is
    constant PGP4_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := PGP3_SCRAMBLER_TAPS_C;
 
    subtype PGP4_BTF_FIELD_C is natural range 63 downto 56;
-   subtype PGP4_CHECKSUM_FIELD_C is natural range 55 downto 48;
+   subtype PGP4_K_CODE_CRC_FIELD_C is natural range 55 downto 48;
    subtype PGP4_SKIP_DATA_FIELD_C is natural range 47 downto 0;
    subtype PGP4_USER_OPCODE_FIELD_C is natural range 47 downto 0;
 
@@ -82,7 +82,7 @@ package Pgp4Pkg is
       remRxLinkReady : inout sl;
       version        : inout slv(7 downto 0));
 
-   function pgp4Checksum (
+   function pgp4KCodeCrc (
       kCodeWord : slv(63 downto 0))
       return slv;
 
@@ -136,7 +136,7 @@ package body Pgp4Pkg is
       end loop;
    end procedure;
 
-   function pgp4Checksum (
+   function pgp4KCodeCrc (
       kCodeWord : slv(63 downto 0))
       return slv
    is
@@ -154,27 +154,18 @@ package body Pgp4Pkg is
       -- Reverse the input
       data := bitReverse(data);
 
-      -- Apply the CRC algorithmm
+      -- Apply the CRC algorithm
       for d in 0 to 55 loop
          fb  := (others => (ret(7) xor data(d)));
          ret := ret(6 downto 0) & fb(0);
-         ret := (fb and CRC_POLY_G) xor ret;
+         ret := (fb and CRC_POLY_C) xor ret;
       end loop;
 
       -- Transpose and invert the output
       ret := bitReverse(ret);
       ret := not ret;
 
---       ret := not (kCodeWord(7 downto 0) +
---                   kCodeWord(15 downto 8) +
---                   kCodeWord(23 downto 16) +
---                   kCodeWord(31 downto 24) +
---                   kCodeWord(39 downto 32) +
---                   kCodeWord(47 downto 47) +
---                   kCodeWord(63 downto 56));
       return ret;
    end function;
-
-
 
 end package body Pgp4Pkg;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -1,0 +1,247 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Receive Block
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+use surf.AxiStreamPacketizer2Pkg.all;
+
+entity Pgp4Rx is
+
+   generic (
+      TPD_G              : time                  := 1 ns;
+      NUM_VC_G           : integer range 1 to 16 := 4;
+      ALIGN_SLIP_WAIT_G  : integer               := 32);
+   port (
+      -- User Transmit interface
+      pgpRxClk     : in  sl;
+      pgpRxRst     : in  sl;
+      pgpRxIn      : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
+      pgpRxOut     : out Pgp4RxOutType;
+      pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0); -- Unused
+
+      -- Status of local receive fifos
+      remRxFifoCtrl  : out AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      remRxLinkReady : out sl;
+      locRxLinkReady : out sl;
+
+      -- Phy interface
+      phyRxClk      : in  sl;
+      phyRxRst      : in  sl;
+      phyRxInit     : out sl;
+      phyRxActive   : in  sl;
+      phyRxValid    : in  sl;
+      phyRxHeader   : in  slv(1 downto 0);
+      phyRxData     : in  slv(63 downto 0);
+      phyRxStartSeq : in  sl;
+      phyRxSlip     : out sl);
+
+
+
+end entity Pgp4Rx;
+
+architecture rtl of Pgp4Rx is
+
+   constant SCRAMBLER_TAPS_C : IntegerArray := (0 => 39, 1 => 58);
+
+   signal gearboxAligned         : sl := '1';
+   signal unscramblerValid       : sl;
+   signal unscrambledValid       : sl;
+   signal unscrambledData        : slv(63 downto 0);
+   signal unscrambledHeader      : slv(1 downto 0);
+   signal remLinkData            : slv(47 downto 0);
+   signal ebValid                : sl;
+   signal ebData                 : slv(63 downto 0);
+   signal ebHeader               : slv(1 downto 0);
+   signal ebOverflow             : sl;
+   signal linkError              : sl;
+   signal ebStatus               : slv(8 downto 0);
+   signal phyRxInitInt           : sl;
+   signal pgpRawRxMaster         : AxiStreamMasterType;
+   signal pgpRawRxSlave          : AxiStreamSlaveType;
+   signal depacketizedAxisMaster : AxiStreamMasterType;
+   signal depacketizedAxisSlave  : AxiStreamSlaveType;
+
+   signal pgpRxOutProtocol  : Pgp4RxOutType;
+   signal depacketizerDebug : Packetizer2DebugType;
+
+   signal locRxLinkReadyInt : sl;
+   signal remRxLinkReadyInt : sl;
+   signal remRxFifoCtrlInt  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
+begin
+   phyRxInit      <= phyRxInitInt;
+   locRxLinkReady <= locRxLinkReadyInt;
+   remRxLinkReady <= remRxLinkReadyInt;
+   remRxFifoCtrl  <= remRxFifoCtrlInt;
+
+   -- Gearbox aligner
+   U_Pgp3RxGearboxAligner_1 : entity surf.Pgp3RxGearboxAligner -- Same RX gearbox aligner as PGPv3
+      generic map (
+         TPD_G        => TPD_G,
+         SLIP_WAIT_G  => ALIGN_SLIP_WAIT_G)
+      port map (
+         clk           => phyRxClk,         -- [in]
+         rst           => phyRxRst,         -- [in]
+         rxHeader      => phyRxHeader,      -- [in]
+         rxHeaderValid => phyRxValid,       -- [in]
+         slip          => phyRxSlip,        -- [out]
+         locked        => gearboxAligned);  -- [out]
+
+   -- Unscramble the data for 64b66b
+   unscramblerValid <= gearboxAligned and phyRxValid;
+   U_Scrambler_1 : entity surf.Scrambler
+      generic map (
+         TPD_G            => TPD_G,
+         DIRECTION_G      => "DESCRAMBLER",
+         DATA_WIDTH_G     => 64,
+         SIDEBAND_WIDTH_G => 2,
+         TAPS_G           => SCRAMBLER_TAPS_C)
+      port map (
+         clk            => phyRxClk,            -- [in]
+         rst            => phyRxRst,            -- [in]
+         inputValid     => unscramblerValid,    -- [in]
+         inputData      => phyRxData,           -- [in]
+         inputSideband  => phyRxHeader,         -- [in]
+         outputValid    => unscrambledValid,    -- [out]
+         outputData     => unscrambledData,     -- [out]
+         outputSideband => unscrambledHeader);  -- [out]
+
+   -- Elastic Buffer
+   U_Pgp4RxEb_1 : entity surf.Pgp4RxEb
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         phyRxClk    => phyRxClk,           -- [in]
+         phyRxRst    => phyRxRst,           -- [in]
+         phyRxValid  => unscrambledValid,   -- [in]
+         phyRxData   => unscrambledData,    -- [in]
+         phyRxHeader => unscrambledHeader,  -- [in]
+         pgpRxClk    => pgpRxClk,           -- [in]
+         pgpRxRst    => pgpRxRst,           -- [in]
+         pgpRxValid  => ebValid,            -- [out]
+         pgpRxData   => ebData,             -- [out]
+         pgpRxHeader => ebHeader,           -- [out]
+         remLinkData => remLinkData,        -- [out]
+         overflow    => ebOverflow,         -- [out]
+         linkError   => linkError,          -- [out]
+         status      => ebStatus);          -- [out]
+
+   -- Main RX protocol logic
+   U_Pgp4RxProtocol_1 : entity surf.Pgp4RxProtocol
+      generic map (
+         TPD_G    => TPD_G,
+         NUM_VC_G => NUM_VC_G)
+      port map (
+         pgpRxClk       => pgpRxClk,           -- [in]
+         pgpRxRst       => pgpRxRst,           -- [in]
+         pgpRxIn        => pgpRxIn,            -- [in]
+         pgpRxOut       => pgpRxOutProtocol,   -- [out]
+         pgpRxMaster    => pgpRawRxMaster,     -- [out]
+         pgpRxSlave     => pgpRawRxSlave,      -- [in]
+         remRxFifoCtrl  => remRxFifoCtrlInt,   -- [out]
+         remRxLinkReady => remRxLinkReadyInt,  -- [out]
+         locRxLinkReady => locRxLinkReadyInt,  -- [out]
+         linkError      => linkError,          -- [in]
+         phyRxActive    => phyRxActive,        -- [in]
+         protRxValid    => ebValid,            -- [in]
+         protRxPhyInit  => phyRxInitInt,       -- [out]
+         protRxData     => ebData,             -- [in]
+         protRxHeader   => ebHeader);          -- [in]
+
+   -- Depacketize the RX data frames
+   U_AxiStreamDepacketizer2_1 : entity surf.AxiStreamDepacketizer2
+      generic map (
+         TPD_G               => TPD_G,
+         MEMORY_TYPE_G       => "distributed",
+         CRC_MODE_G          => "DATA",
+         CRC_POLY_G          => PGP4_CRC_POLY_C,
+         TDEST_BITS_G        => 4,
+         INPUT_PIPE_STAGES_G => 1)
+      port map (
+         axisClk     => pgpRxClk,                -- [in]
+         axisRst     => pgpRxRst,                -- [in]
+         linkGood    => locRxLinkReadyInt,       -- [in]
+         debug       => depacketizerDebug,       -- [out]
+         sAxisMaster => pgpRawRxMaster,          -- [in]
+         sAxisSlave  => pgpRawRxSlave,           -- [out]
+         mAxisMaster => depacketizedAxisMaster,  -- [out]
+         mAxisSlave  => depacketizedAxisSlave);  -- [in]
+
+   -- Demultiplex the depacketized streams
+   U_AxiStreamDeMux_1 : entity surf.AxiStreamDeMux
+      generic map (
+         TPD_G         => TPD_G,
+         NUM_MASTERS_G => NUM_VC_G,
+         MODE_G        => "INDEXED",
+--       TDEST_ROUTES_G => DEMUX_ROUTES_G,
+         PIPE_STAGES_G => 0,
+         TDEST_HIGH_G  => 7,                                     -- Maybe 3?
+         TDEST_LOW_G   => 0)
+      port map (
+         axisClk      => pgpRxClk,                               -- [in]
+         axisRst      => pgpRxRst,                               -- [in]
+         sAxisMaster  => depacketizedAxisMaster,                 -- [in]
+         sAxisSlave   => depacketizedAxisSlave,                  -- [out]
+         mAxisMasters => pgpRxMasters,                           -- [out]
+         mAxisSlaves  => (others => AXI_STREAM_SLAVE_FORCE_C));  -- [in]
+
+   pgpRxOut.phyRxActive    <= phyRxActive;
+   pgpRxOut.linkReady      <= pgpRxOutProtocol.linkReady;
+   pgpRxOut.frameRx        <= depacketizerDebug.eof;
+   pgpRxOut.frameRxErr     <= depacketizerDebug.eofe;
+   pgpRxOut.cellError      <= depacketizerDebug.packetError;
+   pgpRxOut.opCodeEn       <= pgpRxOutProtocol.opCodeEn;
+   pgpRxOut.opCodeNumber   <= pgpRxOutProtocol.opCodeNumber;
+   pgpRxOut.opCodeData     <= pgpRxOutProtocol.opCodeData;
+   pgpRxOut.remLinkData    <= x"00" & remLinkData; -- PAD MSB with zeros to maintain PGPv3 interface compatibility
+   pgpRxOut.remRxLinkReady <= remRxLinkReadyInt;
+
+   pgpRxOut.phyRxData   <= phyRxData;
+   pgpRxOut.phyRxHeader <= phyRxHeader;
+   pgpRxOut.phyRxValid  <= phyRxValid;
+   pgpRxOut.phyRxInit   <= phyRxInitInt;
+
+   pgpRxOut.gearboxAligned <= gearboxAligned;
+
+   pgpRxOut.ebData     <= ebData;
+   pgpRxOut.ebHeader   <= ebHeader;
+   pgpRxOut.ebValid    <= ebValid;
+   pgpRxOut.ebOverflow <= ebOverflow;
+   pgpRxOut.ebStatus   <= ebStatus;
+
+   CTRL_OUT : for i in 15 downto 0 generate
+      USED : if (i < NUM_VC_G) generate
+         pgpRxOut.remRxOverflow(i) <= remRxFifoCtrlInt(i).overflow;
+         pgpRxOut.remRxPause(i)    <= remRxFifoCtrlInt(i).pause;
+      end generate;
+      UNUSED : if (i >= NUM_VC_G) generate
+         pgpRxOut.remRxOverflow(i) <= '0';
+         pgpRxOut.remRxPause(i)    <= '0';
+      end generate;
+   end generate;
+
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -88,8 +88,8 @@ begin
       -- Check for k-code
       if (phyRxHeader = PGP4_K_HEADER_C) then
 
-         -- Check for invalid checksum
-         if (phyRxData(PGP4_CHECKSUM_FIELD_C) /= pgp4Checksum(phyRxData)) then
+         -- Check for invalid K-code CRC
+         if (phyRxData(PGP4_K_CODE_CRC_FIELD_C) /= pgp4KCodeCrc(phyRxData)) then
 
             -- Don't write words into the FIFO
             v.fifoWrEn  := '0';

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -1,0 +1,184 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Rx Elastic Buffer
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4RxEb is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      phyRxClk    : in sl;
+      phyRxRst    : in sl;
+      phyRxValid  : in sl;
+      phyRxData   : in slv(63 downto 0);  -- Unscrambled data from the PHY
+      phyRxHeader : in slv(1 downto 0);
+      -- User Transmit interface
+      pgpRxClk    : in  sl;
+      pgpRxRst    : in  sl;
+      pgpRxValid  : out sl;
+      pgpRxData   : out slv(63 downto 0);
+      pgpRxHeader : out slv(1 downto 0);
+      remLinkData : out slv(47 downto 0);
+      overflow    : out sl;
+      linkError   : out sl;
+      status      : out slv(8 downto 0));
+end entity Pgp4RxEb;
+
+architecture rtl of Pgp4RxEb is
+
+   type RegType is record
+      linkError   : sl;
+      dataValid   : sl;
+      remLinkData : slv(47 downto 0);
+      fifoIn      : slv(65 downto 0);
+      fifoWrEn    : sl;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      linkError   => '0',
+      dataValid   => '0',
+      remLinkData => (others => '0'),
+      fifoIn      => (others => '0'),
+      fifoWrEn    => '0');
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal valid : sl;
+
+   signal overflowInt : sl;
+
+begin
+
+   comb : process (phyRxData, phyRxHeader, phyRxRst, phyRxValid, r) is
+      variable v        : RegType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Reset strobes
+      v.linkError := '0';
+      v.dataValid := '0';
+
+      -- Map to FIFO write
+      v.fifoIn(63 downto 0)  := phyRxData;
+      v.fifoIn(65 downto 64) := phyRxHeader;
+      v.fifoWrEn             := phyRxValid;
+
+      -- Check for k-code
+      if (phyRxHeader = PGP4_K_HEADER_C) then
+
+         -- Check for invalid checksum
+         if (phyRxData(PGP4_CHECKSUM_FIELD_C) /= pgp4Checksum(phyRxData)) then
+
+            -- Don't write words into the FIFO
+            v.fifoWrEn  := '0';
+
+            -- Set the error flag
+            v.linkError := '1';
+
+         elsif (phyRxData(PGP4_BTF_FIELD_C) = PGP4_SKP_C) then
+
+            -- Don't write SKP words into the FIFO
+            v.fifoWrEn    := '0';
+
+            -- Save the remote data bus
+            v.dataValid   := '1';
+            v.remLinkData := phyRxData(PGP4_SKIP_DATA_FIELD_C);
+
+         end if;
+
+      end if;
+
+      -- Reset
+      if (phyRxRst = '1') then
+         -- Maintain save behavior before the remLinkData update (not reseting fifoIn or fifoWrEn)
+         v.remLinkData := (others => '0');
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (phyRxClk) is
+   begin
+      if (rising_edge(phyRxClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   U_remLinkData : entity surf.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         DATA_WIDTH_G => 48)
+      port map (
+         rst    => phyRxRst,
+         wr_clk => phyRxClk,
+         wr_en  => r.dataValid,
+         din    => r.remLinkData,
+         rd_clk => pgpRxClk,
+         dout   => remLinkData);
+
+   U_FifoAsync_1 : entity surf.FifoAsync
+      generic map (
+         TPD_G         => TPD_G,
+         MEMORY_TYPE_G => "block",
+         FWFT_EN_G     => true,
+         PIPE_STAGES_G => 0,
+         DATA_WIDTH_G  => 66,
+         ADDR_WIDTH_G  => 9)
+      port map (
+         rst                => phyRxRst,
+         -- Write Interface
+         wr_clk             => phyRxClk,
+         wr_en              => r.fifoWrEn,
+         din                => r.fifoIn,
+         overflow           => overflowInt,
+         -- Read Interface
+         rd_clk             => pgpRxClk,
+         rd_en              => valid,
+         dout(63 downto 0)  => pgpRxData,
+         dout(65 downto 64) => pgpRxHeader,
+         rd_data_count      => status,
+         valid              => valid);
+
+   pgpRxValid <= valid;
+
+   U_overflow : entity surf.SynchronizerOneShot
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk      => pgpRxClk,
+         dataIn   => overflowInt,
+         dataOut  => overflow);
+
+   U_linkError : entity surf.SynchronizerOneShot
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk      => pgpRxClk,
+         dataIn   => r.linkError,
+         dataOut  => linkError);
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -144,8 +144,11 @@ begin
             -- Check for k-code
             if (protRxHeader = PGP4_K_HEADER_C) then
 
+               if pgp4KCodeCrc(protRxData) /= protRxData(PGP4_K_CODE_CRC_FIELD_C) then
+                  v.pgpRxOut.linkError := '1';
+
                -- Check for IDLE k-code
-               if (btf = PGP4_IDLE_C) then
+               elsif (btf = PGP4_IDLE_C) then
 
                   -- Extract the LinkInfo
                   pgp4ExtractLinkInfo(

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -1,0 +1,298 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Receive Protocol
+-- Takes pre-packetized AxiStream frames and creates a PGPv4 66/64 protocol
+-- stream (pre-scrambler). Inserts IDLE and SKP codes as needed. Inserts
+-- user K codes on request.
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiStreamPacketizer2Pkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4RxProtocol is
+   generic (
+      TPD_G    : time                  := 1 ns;
+      NUM_VC_G : integer range 1 to 16 := 4);
+   port (
+      -- User Transmit interface
+      pgpRxClk       : in  sl;
+      pgpRxRst       : in  sl;
+      pgpRxIn        : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
+      pgpRxOut       : out Pgp4RxOutType;
+      pgpRxMaster    : out AxiStreamMasterType;
+      pgpRxSlave     : in  AxiStreamSlaveType;
+      -- Status of local receive fifos
+      remRxFifoCtrl  : out AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      remRxLinkReady : out sl;
+      locRxLinkReady : out sl;
+      -- Received data from descrambler/CC FIFO
+      linkError      : in  sl;          -- Checksum error flag
+      phyRxActive    : in  sl;
+      protRxValid    : in  sl;
+      protRxPhyInit  : out sl;
+      protRxData     : in  slv(63 downto 0);
+      protRxHeader   : in  slv(1 downto 0));
+end entity Pgp4RxProtocol;
+
+architecture rtl of Pgp4RxProtocol is
+
+   type RegType is record
+      notValidCnt    : slv(31 downto 0);
+      count          : slv(15 downto 0);
+      pgpRxMaster    : AxiStreamMasterType;
+      pgpRxOut       : Pgp4RxOutType;
+      protRxPhyInit  : sl;
+      remRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      remRxLinkReady : sl;
+      locRxLinkReady : sl;  -- This might come from aligner instead?
+      version        : slv(7 downto 0);
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      notValidCnt    => (others => '0'),
+      count          => (others => '0'),
+      pgpRxMaster    => axiStreamMasterInit(PGP4_AXIS_CONFIG_C),
+      pgpRxOut       => PGP4_RX_OUT_INIT_C,
+      protRxPhyInit  => '1',
+      remRxFifoCtrl  => (others => AXI_STREAM_CTRL_INIT_C),  -- init paused
+      remRxLinkReady => '0',
+      locRxLinkReady => '0',
+      version        => (others => '0'));
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal phyRxActiveSyncFall : sl;
+   signal phyRxActiveSync     : sl;
+
+begin
+
+   U_phyRxActiveSync : entity surf.SynchronizerEdge
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk         => pgpRxClk,
+         rst         => pgpRxRst,
+         dataIn      => phyRxActive,
+         dataOut     => phyRxActiveSync,
+         fallingEdge => phyRxActiveSyncFall);
+
+   comb : process (linkError, pgpRxIn, pgpRxRst, phyRxActiveSync,
+                   phyRxActiveSyncFall, protRxData, protRxHeader, protRxValid,
+                   r) is
+      variable v        : RegType;
+      variable linkInfo : slv(31 downto 0);
+      variable btf      : slv(7 downto 0);
+   begin
+      -- Latch the current value
+      v := r;
+
+      btf := protRxData(PGP4_BTF_FIELD_C);
+
+      v.pgpRxMaster        := REG_INIT_C.pgpRxMaster;
+      v.pgpRxOut.opCodeEn  := '0';
+      v.pgpRxOut.linkDown  := '0';
+      v.pgpRxOut.linkError := linkError;
+      v.protRxPhyInit      := '0';
+
+      -- Just translate straight to AXI-Stream packetizer2 format and let the depacketizer handle any errors?
+      if (protRxValid = '1') then
+
+         -- Check if Unlinked
+         if (r.pgpRxOut.linkReady = '0') then
+            -- Need N valid headers in a row. Data is ignored.
+            v.count := (others => '0');
+            if (protRxHeader = PGP4_K_HEADER_C) then
+               for i in PGP4_VALID_BTF_ARRAY_C'range loop
+                  if (btf = PGP4_VALID_BTF_ARRAY_C(i)) then
+                     -- Valid header, increment count
+                     v.count := r.count + 1;
+                  end if;
+               end loop;
+            elsif (protRxHeader = PGP4_D_HEADER_C) then
+               -- Ignore data
+               v.count := r.count;
+            end if;
+
+         -- Else Linked
+         else
+
+            -- Increment count on every incoming word
+            -- reset when IDLE or SOF or SOC seen
+            v.count := r.count + 1;
+
+            -- Check for k-code
+            if (protRxHeader = PGP4_K_HEADER_C) then
+
+               -- Check for IDLE k-code
+               if (btf = PGP4_IDLE_C) then
+
+                  -- Extract the LinkInfo
+                  pgp4ExtractLinkInfo(
+                     protRxData(PGP4_LINKINFO_FIELD_C),
+                     v.remRxFifoCtrl,
+                     v.remRxLinkReady,
+                     v.version);
+
+                  -- Check for correct Version
+                  if (v.version = PGP4_VERSION_C) then
+                     v.count := (others => '0');
+                  else
+                     v.pgpRxOut.linkError := '1';
+                  end if;
+
+                  -- Update the remote overflow field
+                  for i in v.remRxFifoCtrl'range loop
+                     v.remRxFifoCtrl(i).overflow := protRxData(i+32);
+                  end loop;
+
+               -- Check for SOF/SOC k-code
+               elsif (btf = PGP4_SOF_C or btf = PGP4_SOC_C) then
+
+                  -- Extract the LinkInfo
+                  pgp4ExtractLinkInfo(
+                     protRxData(PGP4_LINKINFO_FIELD_C),
+                     v.remRxFifoCtrl,
+                     v.pgpRxOut.remRxLinkReady,
+                     v.version);
+
+                  -- Check for correct Version
+                  if (v.version = PGP4_VERSION_C) then
+                     v.count := (others => '0');
+                  else
+                     v.pgpRxOut.linkError := '1';
+                  end if;
+
+                  -- Convert to Packetizer header format
+                  v.pgpRxMaster :=
+                     makePacketizer2Header(
+                        CRC_MODE_C => "DATA",
+                        valid      => r.pgpRxOut.linkReady,  -- Hold Everything until linkready
+                        sof        => ite(btf = PGP4_SOF_C, '1', '0'),
+                        tdest      => resize(protRxData(PGP4_SOFC_VC_FIELD_C), 8),
+                        seq        => resize(protRxData(PGP4_SOFC_SEQ_FIELD_C), 16));
+
+               -- Check for EOF/EOC k-code
+               elsif (btf = PGP4_EOF_C or btf = PGP4_EOC_C) then
+
+                  -- Convert to Packetizer tail format
+                  v.pgpRxMaster :=
+                     makePacketizer2Tail(
+                        CRC_MODE_C => "DATA",
+                        valid      => r.pgpRxOut.linkReady,
+                        eof        => toSl(btf = PGP4_EOF_C),
+                        tuser      => protRxData(PGP4_EOFC_TUSER_FIELD_C),
+                        bytes      => protRxData(PGP4_EOFC_BYTES_LAST_FIELD_C),
+                        crc        => protRxData(PGP4_EOFC_CRC_FIELD_C));
+
+               -- Else find the match to user OP-code k-code
+               else
+                  for i in PGP4_USER_C'range loop
+                     if (btf = PGP4_USER_C(i)) then
+                        v.pgpRxOut.opCodeEn     := '1';
+                        v.pgpRxOut.opCodeNumber := toSlv(i, 3);
+                        v.pgpRxOut.opCodeData   := protRxData(PGP4_USER_OPCODE_FIELD_C);
+                     end if;
+                  end loop;
+               end if;
+
+            -- Check for data code
+            elsif (protRxHeader = PGP4_D_HEADER_C) then
+               -- Normal Data
+               v.pgpRxMaster.tValid             := r.pgpRxOut.linkReady;
+               v.pgpRxMaster.tData(63 downto 0) := protRxData;
+
+            -- Undefined protRxHeader
+            else
+               v.pgpRxOut.linkError := '1';
+            end if;
+
+         end if;
+      end if;
+
+      v.notValidCnt := (others => '0');
+      if (protRxValid = '0' and phyRxActiveSync = '1') then
+         v.notValidCnt := r.notValidCnt + 1;
+      end if;
+
+      -- Count reaching max indicates that link state needs to toggle
+      -- When not linked, r.count counts consecutive valid k-chars
+      -- When linked, r.count counts consecutive chars without a valid k-char
+      if (r.count = 1000) then
+         v.pgpRxOut.linkReady := not r.pgpRxOut.linkReady;
+         v.count              := (others => '0');
+      end if;
+
+      -- Check for RX Active Fail or LinkError
+      if (phyRxActiveSyncFall = '1') or (r.pgpRxOut.linkError = '1') then
+         v.pgpRxOut.linkReady := '0';
+      end if;
+
+      -- Reset phy if active but no valid data for 100 cycles
+      -- Indicates aligner unable to get lock
+      if (r.notValidCnt = 10000) then
+         v.pgpRxOut.linkReady := '0';
+         v.protRxPhyInit      := '1';
+      end if;
+
+      if (pgpRxIn.resetRx = '1') then
+         v.pgpRxOut.linkReady := '0';
+         v.protRxPhyInit      := '1';   -- Always init the phy on resetRx
+      end if;
+
+      if (r.pgpRxOut.linkReady = '1') and (v.pgpRxOut.linkReady = '0') then
+         v.pgpRxOut.linkDown := '1';
+         v.protRxPhyInit     := '1';
+         v.count             := (others => '0');
+      end if;
+
+      if (v.pgpRxOut.linkReady = '0') then
+         v.remRxLinkReady := '0';
+      end if;
+
+      -- Outputs
+      pgpRxOut       <= r.pgpRxOut;
+      protRxPhyInit  <= r.protRxPhyInit;
+      pgpRxMaster    <= r.pgpRxMaster;
+      remRxFifoCtrl  <= r.remRxFifoCtrl;
+      remRxLinkReady <= r.remRxLinkReady;
+      locRxLinkReady <= r.pgpRxOut.linkReady;
+
+      -- Reset
+      if (pgpRxRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (pgpRxClk) is
+   begin
+      if (rising_edge(pgpRxClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -46,7 +46,7 @@ entity Pgp4RxProtocol is
       remRxLinkReady : out sl;
       locRxLinkReady : out sl;
       -- Received data from descrambler/CC FIFO
-      linkError      : in  sl;          -- Checksum error flag
+      linkError      : in  sl;          -- K-code CRC error flag
       phyRxActive    : in  sl;
       protRxValid    : in  sl;
       protRxPhyInit  : out sl;
@@ -207,13 +207,10 @@ begin
 
                -- Else find the match to user OP-code k-code
                else
-                  for i in PGP4_USER_C'range loop
-                     if (btf = PGP4_USER_C(i)) then
-                        v.pgpRxOut.opCodeEn     := '1';
-                        v.pgpRxOut.opCodeNumber := toSlv(i, 3);
-                        v.pgpRxOut.opCodeData   := protRxData(PGP4_USER_OPCODE_FIELD_C);
-                     end if;
-                  end loop;
+                  if (btf = PGP4_USER_C) then
+                     v.pgpRxOut.opCodeEn   := '1';
+                     v.pgpRxOut.opCodeData := protRxData(PGP4_USER_OPCODE_FIELD_C);
+                  end if;
                end if;
 
             -- Check for data code

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -144,11 +144,8 @@ begin
             -- Check for k-code
             if (protRxHeader = PGP4_K_HEADER_C) then
 
-               if pgp4KCodeCrc(protRxData) /= protRxData(PGP4_K_CODE_CRC_FIELD_C) then
-                  v.pgpRxOut.linkError := '1';
-
                -- Check for IDLE k-code
-               elsif (btf = PGP4_IDLE_C) then
+               if (btf = PGP4_IDLE_C) then
 
                   -- Extract the LinkInfo
                   pgp4ExtractLinkInfo(

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Tx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Tx.vhd
@@ -1,0 +1,249 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Pgpv4 Transmit
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4Tx is
+
+   generic (
+      TPD_G                    : time                  := 1 ns;
+      -- PGP configuration
+      NUM_VC_G                 : integer range 1 to 16 := 1;
+      CELL_WORDS_MAX_G         : integer               := 256;  -- Number of 64-bit words per cell
+      -- Mux configuration
+      MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      MUX_TDEST_ROUTES_G       : Slv8Array             := (0 => "--------");  -- Only used in ROUTED mode
+      MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      MUX_ILEAVE_EN_G          : boolean               := true;
+      MUX_ILEAVE_ON_NOTVALID_G : boolean               := true);
+   port (
+      -- Transmit interface
+      pgpTxClk     : in  sl;
+      pgpTxRst     : in  sl;
+      pgpTxIn      : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
+      pgpTxOut     : out Pgp4TxOutType;
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+
+      -- Status of receive and remote FIFOs (Asynchronous)
+      locRxFifoCtrl  : in AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      locRxLinkReady : in sl;
+      remRxFifoCtrl  : in AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      remRxLinkReady : in sl;
+
+      -- PHY interface
+      phyTxActive   : in  sl;
+      phyTxReady    : in  sl;
+      phyTxValid    : out sl;
+      phyTxStart    : out sl;
+      phyTxData     : out slv(63 downto 0);
+      phyTxHeader   : out slv(1 downto 0));
+
+end entity Pgp4Tx;
+
+architecture rtl of Pgp4Tx is
+
+   -- Synchronized statuses
+   signal syncLocRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+   signal syncLocRxLinkReady : sl;
+   signal syncRemRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+   signal syncRemRxLinkReady : sl;
+
+   -- Pipeline signals
+   signal disableSel         : slv(NUM_VC_G-1 downto 0);
+   signal rearbitrate        : sl := '0';
+   signal muxedTxMaster      : AxiStreamMasterType;
+   signal muxedTxSlave       : AxiStreamSlaveType;
+   signal packetizedTxMaster : AxiStreamMasterType;
+   signal packetizedTxSlave  : AxiStreamSlaveType;
+
+   signal phyTxActiveL   : sl;
+   signal protTxValid    : sl;
+   signal protTxReady    : sl;
+   signal protTxStart    : sl;
+   signal protTxData     : slv(63 downto 0);
+   signal protTxHeader   : slv(1 downto 0);
+
+begin
+
+   -- Synchronize remote link and fifo status to tx clock
+   U_Synchronizer_REM : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => pgpTxClk,                              -- [in]
+         rst     => pgpTxRst,                              -- [in]
+         dataIn  => remRxLinkReady,                        -- [in]
+         dataOut => syncRemRxLinkReady);                   -- [out]
+   REM_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
+      U_SynchronizerVector_1 : entity surf.SynchronizerVector
+         generic map (
+            TPD_G   => TPD_G,
+            WIDTH_G => 2)
+         port map (
+            clk        => pgpTxClk,                        -- [in]
+            rst        => pgpTxRst,                        -- [in]
+            dataIn(0)  => remRxFifoCtrl(i).pause,          -- [in]
+            dataIn(1)  => remRxFifoCtrl(i).overflow,       -- [in]
+            dataOut(0) => syncRemRxFifoCtrl(i).pause,      -- [out]
+            dataOut(1) => syncRemRxFifoCtrl(i).overflow);  -- [out]
+   end generate;
+
+   -- Synchronize local rx status
+   U_Synchronizer_LOC : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => pgpTxClk,                              -- [in]
+         rst     => pgpTxRst,                              -- [in]
+         dataIn  => locRxLinkReady,                        -- [in]
+         dataOut => syncLocRxLinkReady);                   -- [out]
+   LOC_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
+      U_Synchronizer_pause : entity surf.Synchronizer
+         generic map (
+            TPD_G => TPD_G)
+         port map (
+            clk     => pgpTxClk,                              -- [in]
+            rst     => pgpTxRst,                              -- [in]
+            dataIn  => locRxFifoCtrl(i).pause,                -- [in]
+            dataOut => syncLocRxFifoCtrl(i).pause);           -- [out]
+      U_Synchronizer_overflow : entity surf.SynchronizerOneShot
+         generic map (
+            TPD_G => TPD_G)
+         port map (
+            clk     => pgpTxClk,                              -- [in]
+            rst     => pgpTxRst,                              -- [in]
+            dataIn  => locRxFifoCtrl(i).overflow,             -- [in]
+            dataOut => syncLocRxFifoCtrl(i).overflow);        -- [out]
+   end generate;
+
+   -- Use synchronized remote status to disable channels from mux selection
+   -- All flow control overriden by pgpTxIn 'disable' and 'flowCntlDis'
+   DISABLE_SEL : process (pgpTxIn, syncRemRxFifoCtrl) is
+   begin
+      for i in NUM_VC_G-1 downto 0 loop
+         if (pgpTxIn.disable = '1') then
+            disableSel(i) <= '1';
+         elsif (pgpTxIn.flowCntlDis = '1') then
+            disableSel(i) <= '0';
+         else
+            disableSel(i) <= syncRemRxFifoCtrl(i).pause;
+         end if;
+      end loop;
+   end process;
+
+   -- Multiplex the incomming tx streams with interleaving
+   U_AxiStreamMux_1 : entity surf.AxiStreamMux
+      generic map (
+         TPD_G                => TPD_G,
+         NUM_SLAVES_G         => NUM_VC_G,
+         MODE_G               => MUX_MODE_G,
+         PIPE_STAGES_G        => 0,
+         TDEST_LOW_G          => MUX_TDEST_LOW_G,
+         ILEAVE_EN_G          => MUX_ILEAVE_EN_G,
+         ILEAVE_ON_NOTVALID_G => MUX_ILEAVE_ON_NOTVALID_G,
+         ILEAVE_REARB_G       => CELL_WORDS_MAX_G)
+      port map (
+         axisClk      => pgpTxClk,       -- [in]
+         axisRst      => pgpTxRst,       -- [in]
+         disableSel   => disableSel,     -- [in]
+         rearbitrate  => rearbitrate,    -- [in]
+         sAxisMasters => pgpTxMasters,   -- [in]
+         sAxisSlaves  => pgpTxSlaves,    -- [out]
+         mAxisMaster  => muxedTxMaster,  -- [out]
+         mAxisSlave   => muxedTxSlave);  -- [in]
+
+   -- Feed muxed stream to packetizer
+   -- Note that the mux is doing the work of chunking
+   -- Packetizer applies packet formatting and CRC
+   -- rearbitrate signal doesn't really do anything (yet)
+   U_AxiStreamPacketizer2_1 : entity surf.AxiStreamPacketizer2
+      generic map (
+         TPD_G                => TPD_G,
+         CRC_MODE_G           => "DATA",
+         CRC_POLY_G           => PGP4_CRC_POLY_C,
+         MAX_PACKET_BYTES_G   => CELL_WORDS_MAX_G*8*2,
+         INPUT_PIPE_STAGES_G  => 1,
+         OUTPUT_PIPE_STAGES_G => 1)
+      port map (
+         axisClk     => pgpTxClk,            -- [in]
+         axisRst     => pgpTxRst,            -- [in]
+         rearbitrate => rearbitrate,         -- [out]
+         sAxisMaster => muxedTxMaster,       -- [in]
+         sAxisSlave  => muxedTxSlave,        -- [out]
+         mAxisMaster => packetizedTxMaster,  -- [out]
+         mAxisSlave  => packetizedTxSlave);  -- [in]
+
+   -- Feed packets into PGP TX Protocol engine
+   -- Translates Packetizer2 frames, status, and opcodes into unscrambled 64b66b charachters
+   U_Pgp4TxProtocol_1 : entity surf.Pgp4TxProtocol
+      generic map (
+         TPD_G            => TPD_G,
+         NUM_VC_G         => NUM_VC_G)
+      port map (
+         pgpTxClk       => pgpTxClk,            -- [in]
+         pgpTxRst       => pgpTxRst,            -- [in]
+         pgpTxIn        => pgpTxIn,             -- [in]
+         pgpTxOut       => pgpTxOut,            -- [out]
+         pgpTxMaster    => packetizedTxMaster,  -- [in]
+         pgpTxSlave     => packetizedTxSlave,   -- [out]
+         locRxFifoCtrl  => syncLocRxFifoCtrl,   -- [in]
+         locRxLinkReady => syncLocRxLinkReady,  -- [in]
+         remRxLinkReady => syncRemRxLinkReady,  -- [in]
+         phyTxActive    => phyTxActive,         -- [in]
+         protTxReady    => protTxReady,         -- [in]
+         protTxValid    => protTxValid,         -- [out]
+         protTxStart    => protTxStart,         -- [out]
+         protTxData     => protTxData,          -- [out]
+         protTxHeader   => protTxHeader);       -- [out]
+
+   -- Scramble the data for 64b66b
+   U_Scrambler_1 : entity surf.Scrambler
+      generic map (
+         TPD_G            => TPD_G,
+         DIRECTION_G      => "SCRAMBLER",
+         DATA_WIDTH_G     => 64,
+         SIDEBAND_WIDTH_G => 3,
+         TAPS_G           => PGP4_SCRAMBLER_TAPS_C)
+      port map (
+         clk                        => pgpTxClk,        -- [in]
+         rst                        => phyTxActiveL,    -- [in]
+         -- Input Interface
+         inputValid                 => protTxValid,     -- [in]
+         inputReady                 => protTxReady,     -- [out]
+         inputData                  => protTxData,      -- [in]
+         inputSideband(1 downto 0)  => protTxHeader,    -- [in]
+         inputSideband(2)           => protTxStart,     -- [in]
+         -- Output Interface
+         outputValid                => phyTxValid,      -- [out]
+         outputReady                => phyTxReady,      -- [in]
+         outputData                 => phyTxData,       -- [out]
+         outputSideband(1 downto 0) => phyTxHeader,     -- [out]
+         outputSideband(2)          => phyTxStart);     -- [out]
+
+   phyTxActiveL <= not(phyTxActive);
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
@@ -261,7 +261,7 @@ begin
             v.opCodeReady := '1';
 
             -- Update the TX data bus
-            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C(0);
+            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C;
             v.protTxData(PGP4_USER_OPCODE_FIELD_C) := pgpTxIn.opCodeData;
             v.protTxHeader                         := PGP4_K_HEADER_C;
             resetEventMetaData                     := false;
@@ -308,8 +308,8 @@ begin
 
          -- Check if k-code word
          if (v.protTxHeader = PGP4_K_HEADER_C) then
-            -- Insert the checksum
-            v.protTxData(PGP4_CHECKSUM_FIELD_C) := pgp4Checksum(v.protTxData);
+            -- Insert the CSC
+            v.protTxData(PGP4_K_CODE_CRC_FIELD_C) := pgp4KCodeCrc(v.protTxData);
          end if;
 
          -- Check if TX is disabled

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
@@ -261,7 +261,7 @@ begin
             v.opCodeReady := '1';
 
             -- Update the TX data bus
-            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C(conv_integer(pgpTxIn.opCodeNumber));
+            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C(0);
             v.protTxData(PGP4_USER_OPCODE_FIELD_C) := pgpTxIn.opCodeData;
             v.protTxHeader                         := PGP4_K_HEADER_C;
             resetEventMetaData                     := false;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxProtocol.vhd
@@ -1,0 +1,382 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Transmit Protocol
+-- Takes pre-packetized AxiStream frames and creates a PGPv4 66/64 protocol
+-- stream (pre-scrambler). Inserts IDLE and SKP codes as needed. Inserts
+-- user K codes on request.
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiStreamPacketizer2Pkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4TxProtocol is
+   generic (
+      TPD_G          : time                  := 1 ns;
+      NUM_VC_G       : integer range 1 to 16 := 4;
+      STARTUP_HOLD_G : integer               := 1000);
+   port (
+      -- User Transmit interface
+      pgpTxClk       : in  sl;
+      pgpTxRst       : in  sl;
+      pgpTxIn        : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
+      pgpTxOut       : out Pgp4TxOutType;
+      pgpTxMaster    : in  AxiStreamMasterType;
+      pgpTxSlave     : out AxiStreamSlaveType;
+      -- Status of local receive fifos
+      -- These get synchronized by the Pgp4Tx parent
+      locRxFifoCtrl  : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      locRxLinkReady : in  sl;
+      remRxLinkReady : in  sl;
+      -- Output Interface
+      phyTxActive    : in  sl;
+      protTxReady    : in  sl;
+      protTxValid    : out sl;
+      protTxStart    : out sl;
+      protTxData     : out slv(63 downto 0);
+      protTxHeader   : out slv(1 downto 0));
+end entity Pgp4TxProtocol;
+
+architecture rtl of Pgp4TxProtocol is
+
+   type RegType is record
+      pauseDly          : slv(NUM_VC_G-1 downto 0);
+      pauseEvent        : slv(NUM_VC_G-1 downto 0);
+      pauseEventSent    : slv(NUM_VC_G-1 downto 0);
+      overflowDly       : slv(NUM_VC_G-1 downto 0);
+      overflowEvent     : slv(NUM_VC_G-1 downto 0);
+      overflowEventSent : slv(NUM_VC_G-1 downto 0);
+      skpInterval       : slv(31 downto 0);
+      skpCount          : slv(31 downto 0);
+      startupCount      : integer;
+      pgpTxSlave        : AxiStreamSlaveType;
+      opCodeReady       : sl;
+      linkReady         : sl;
+      frameTx           : sl;
+      frameTxErr        : sl;
+      protTxValid       : sl;
+      protTxStart       : sl;
+      protTxData        : slv(63 downto 0);
+      protTxHeader      : slv(1 downto 0);
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      pauseDly          => (others => '0'),
+      pauseEvent        => (others => '0'),
+      pauseEventSent    => (others => '0'),
+      overflowDly       => (others => '0'),
+      overflowEvent     => (others => '0'),
+      overflowEventSent => (others => '0'),
+      skpInterval       => PGP4_TX_IN_INIT_C.skpInterval,
+      skpCount          => (others => '0'),
+      startupCount      => 0,
+      pgpTxSlave        => AXI_STREAM_SLAVE_INIT_C,
+      opCodeReady       => '0',
+      linkReady         => '0',
+      frameTx           => '0',
+      frameTxErr        => '0',
+      protTxValid       => '0',
+      protTxStart       => '0',
+      protTxData        => (others => '0'),
+      protTxHeader      => (others => '0'));
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+begin
+
+   comb : process (locRxFifoCtrl, locRxLinkReady, pgpTxIn, pgpTxMaster,
+                   pgpTxRst, phyTxActive, protTxReady, r, remRxLinkReady) is
+      variable v                  : RegType;
+      variable linkInfo           : slv(31 downto 0);
+      variable idleWord           : slv(63 downto 0);
+      variable dataEn             : sl;
+      variable rxFifoCtrl         : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      variable resetEventMetaData : boolean;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Update the variables default values
+      resetEventMetaData := false;
+      rxFifoCtrl         := locRxFifoCtrl;
+
+      -- Detect 0->1 edges on locRxFifoCtrl(i).pause and locRxFifoCtrl(i).overflow
+      for i in NUM_VC_G-1 downto 0 loop
+         -- Save last value for edge detection
+         v.pauseDly(i)    := locRxFifoCtrl(i).pause;
+         v.overflowDly(i) := locRxFifoCtrl(i).overflow;
+
+         -- Check for rising edge on pause
+         if (locRxFifoCtrl(i).pause = '1') and (r.pauseDly(i) = '0') then
+            v.pauseEvent(i) := '1';
+         end if;
+
+         -- Check for rising edge on overflow
+         if (locRxFifoCtrl(i).overflow = '1') and (r.overflowDly(i) = '0') then
+            v.overflowEvent(i) := '1';
+         end if;
+
+         -- Include the pauseEvent or overflowEvent in the linkInfo message
+         rxFifoCtrl(i).pause    := r.pauseEvent(i) or locRxFifoCtrl(i).pause;
+         rxFifoCtrl(i).overflow := r.overflowEvent(i) or locRxFifoCtrl(i).overflow;
+      end loop;
+
+      -- Generate the link information message
+      linkInfo := pgp4MakeLinkInfo(rxFifoCtrl, locRxLinkReady);
+
+      -- Generate the IDLE word
+      idleWord                        := (others => '0');
+      idleWord(PGP4_LINKINFO_FIELD_C) := linkInfo;
+      for i in NUM_VC_G-1 downto 0 loop
+         idleWord(i+32) := rxFifoCtrl(i).overflow;
+      end loop;
+      idleWord(PGP4_BTF_FIELD_C) := PGP4_IDLE_C;
+
+      -- Keep delay copy of skip interval configuration
+      v.skpInterval := pgpTxIn.skpInterval;
+
+      -- Check for change in configuration
+      if (r.skpInterval /= v.skpInterval) then
+         -- Force a skip
+         v.skpCount := v.skpInterval;
+      -- Check for counter roll over
+      elsif (r.skpCount /= r.skpInterval) then
+         -- Increment the counter
+         v.skpCount := r.skpCount + 1;
+      end if;
+
+      -- Don't accept new frame data by default
+      v.pgpTxSlave.tReady := '0';
+      v.opCodeReady       := '0';
+
+      v.frameTx    := '0';
+      v.frameTxErr := '0';
+
+      -- Check the handshaking
+      if (protTxReady = '1') then
+         v.protTxValid := '0';
+      end if;
+
+      dataEn := ite(pgpTxIn.flowCntlDis = '1', r.linkReady, remRxLinkReady);
+
+      if (v.protTxValid = '0' and phyTxActive = '1') then
+
+         -- Send only IDLE and SKP for STARTUP_HOLD_G cycles after reset
+         if (r.startupCount = STARTUP_HOLD_G) then
+            -- Set the flags
+            v.linkReady   := '1';
+            v.protTxStart := '1';
+            v.protTxValid := '1';
+         else
+            -- Increment the counter
+            v.startupCount := r.startupCount + 1;
+         end if;
+
+         --------------------------------------------------------
+         -- Decide whether to send IDLE, SKP, USER or data frames
+         -- Coded in reverse order of priority
+         --------------------------------------------------------
+
+         -- Send IDLE k-code by default
+         resetEventMetaData := true;
+         v.protTxData       := idleWord;
+         v.protTxHeader     := PGP4_K_HEADER_C;
+
+         --------------------------------------------------------------------
+         --                   Header and Data and Footer                   --
+         --------------------------------------------------------------------
+
+         -- Send data if there is data to send
+         if (pgpTxMaster.tValid = '1' and dataEn = '1') then
+
+            -- Accept the data
+            v.pgpTxSlave.tReady := '1';
+
+            -- Update the flag
+            resetEventMetaData := false;
+
+            if (ssiGetUserSof(PGP4_AXIS_CONFIG_C, pgpTxMaster) = '1') then
+
+               -- SOF/SOC, format SOF/SOC char from data
+               v.protTxData                        := (others => '0');
+               v.protTxData(PGP4_BTF_FIELD_C)      := ite(pgpTxMaster.tData(PACKETIZER2_HDR_SOF_BIT_C) = '1', PGP4_SOF_C, PGP4_SOC_C);
+               v.protTxData(PGP4_LINKINFO_FIELD_C) := linkInfo;
+               v.protTxData(PGP4_SOFC_VC_FIELD_C)  := resize(pgpTxMaster.tData(PACKETIZER2_HDR_TDEST_FIELD_C), 4);  -- Virtual Channel
+               v.protTxData(PGP4_SOFC_SEQ_FIELD_C) := resize(pgpTxMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C), 12);  -- Packet number
+               v.protTxHeader                      := PGP4_K_HEADER_C;
+
+            elsif (pgpTxMaster.tLast = '1') then
+
+               -- EOF/EOC
+               v.protTxData                               := (others => '0');
+               v.protTxData(PGP4_BTF_FIELD_C)             := ite(pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C) = '1', PGP4_EOF_C, PGP4_EOC_C);
+               v.protTxData(PGP4_EOFC_TUSER_FIELD_C)      := pgpTxMaster.tData(PACKETIZER2_TAIL_TUSER_FIELD_C);  -- TUSER LAST
+               v.protTxData(PGP4_EOFC_BYTES_LAST_FIELD_C) := pgpTxMaster.tData(PACKETIZER2_TAIL_BYTES_FIELD_C);  -- Last byte count
+               v.protTxData(PGP4_EOFC_CRC_FIELD_C)        := pgpTxMaster.tData(PACKETIZER2_TAIL_CRC_FIELD_C);  -- CRC
+               v.protTxHeader                             := PGP4_K_HEADER_C;
+
+               -- Debug output
+               v.frameTx    := pgpTxMaster.tData(PACKETIZER2_TAIL_EOF_BIT_C);
+               v.frameTxErr := v.frameTx and ssiGetUserEofe(PGP4_AXIS_CONFIG_C, pgpTxMaster);
+
+            else
+               -- Normal data
+               v.protTxData(63 downto 0) := pgpTxMaster.tData(63 downto 0);
+               v.protTxHeader            := PGP4_D_HEADER_C;
+
+            end if;
+         end if;
+
+         --------------------------------------------------------------------
+         --                   Commands and Metadata                        --
+         --------------------------------------------------------------------
+
+         -- USER codes override data and delay SKP if they happen to coincide
+         if (pgpTxIn.opCodeEn = '1' and dataEn = '1') then
+
+            -- Override any data acceptance.
+            v.pgpTxSlave.tReady := '0';
+
+            -- Accept the op-code
+            v.opCodeReady := '1';
+
+            -- Update the TX data bus
+            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C(conv_integer(pgpTxIn.opCodeNumber));
+            v.protTxData(PGP4_USER_OPCODE_FIELD_C) := pgpTxIn.opCodeData;
+            v.protTxHeader                         := PGP4_K_HEADER_C;
+            resetEventMetaData                     := false;
+
+         -- SKIP codes override data
+         elsif (r.skpCount = r.skpInterval) then
+
+            -- Reset the counter
+            v.skpCount := (others => '0');
+
+            -- Update the TX data bus
+            v.pgpTxSlave.tReady                  := '0';  -- Override any data acceptance.
+            v.protTxData(PGP4_SKIP_DATA_FIELD_C) := pgpTxIn.locData(PGP4_SKIP_DATA_FIELD_C);
+            v.protTxData(PGP4_BTF_FIELD_C)       := PGP4_SKP_C;
+            v.protTxHeader                       := PGP4_K_HEADER_C;
+            resetEventMetaData                   := false;
+
+         else
+
+            -- A local rx pause going high causes an IDLE char to be sent mid frame
+            -- So that the sending end is notified with minimum latency
+            for i in NUM_VC_G-1 downto 0 loop
+
+               -- Check for Pause event
+               if (r.pauseEvent(i) = '1') and (r.pauseEventSent(i) = '0') then
+                  v.pauseEventSent(i) := '1';
+                  v.pgpTxSlave.tReady := '0';
+                  v.protTxData        := idleWord;
+                  v.protTxHeader      := PGP4_K_HEADER_C;
+                  resetEventMetaData  := true;
+               end if;
+
+               -- Check for overflow event
+               if (r.overflowEvent(i) = '1') and (r.overflowEventSent(i) = '0') then
+                  v.overflowEventSent(i) := '1';
+                  v.pgpTxSlave.tReady    := '0';
+                  v.protTxData           := idleWord;
+                  v.protTxHeader         := PGP4_K_HEADER_C;
+                  resetEventMetaData     := true;
+               end if;
+
+            end loop;
+         end if;
+
+         -- Check if k-code word
+         if (v.protTxHeader = PGP4_K_HEADER_C) then
+            -- Insert the checksum
+            v.protTxData(PGP4_CHECKSUM_FIELD_C) := pgp4Checksum(v.protTxData);
+         end if;
+
+         -- Check if TX is disabled
+         if (pgpTxIn.disable = '1') then
+            v.linkReady    := '0';
+            v.protTxStart  := '0';
+            v.startupCount := 0;
+            v.protTxData   := (others => '0');
+            v.protTxHeader := (others => '0');
+         end if;
+
+      end if;
+
+      -- Check if link down
+      if (phyTxActive = '0') then
+         v.linkReady    := '0';
+         v.protTxStart  := '0';
+         v.startupCount := 0;
+      end if;
+
+      -- Check if need to reset event meta data
+      if (resetEventMetaData) then
+         v.pauseEvent        := (others => '0');
+         v.pauseEventSent    := (others => '0');
+         v.overflowEvent     := (others => '0');
+         v.overflowEventSent := (others => '0');
+      end if;
+
+      -- Outputs
+      pgpTxSlave <= v.pgpTxSlave;
+
+      protTxData   <= r.protTxData;
+      protTxHeader <= r.protTxHeader;
+      protTxValid  <= r.protTxValid;
+      protTxStart  <= r.protTxStart;
+
+      pgpTxOut.phyTxActive <= phyTxActive;
+      pgpTxOut.linkReady   <= r.linkReady;
+      pgpTxOut.frameTx     <= r.frameTx;
+      pgpTxOut.frameTxErr  <= r.frameTxErr;
+      pgpTxOut.opCodeReady <= v.opCodeReady;
+
+      for i in 15 downto 0 loop
+         if (i < NUM_VC_G) then
+            pgpTxOut.locOverflow(i) <= locRxFifoCtrl(i).overflow;
+            pgpTxOut.locPause(i)    <= locRxFifoCtrl(i).pause;
+         else
+            pgpTxOut.locOverflow(i) <= '0';
+            pgpTxOut.locPause(i)    <= '0';
+         end if;
+      end loop;
+
+      -- Reset
+      if (pgpTxRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (pgpTxClk) is
+   begin
+      if (rising_edge(pgpTxClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/ruckus.tcl
+++ b/protocols/pgp/pgp4/core/ruckus.tcl
@@ -1,0 +1,8 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"
+
+# Load Simulation
+loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
@@ -1,0 +1,315 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTH Ultrscale Core Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library UNISIM;
+use UNISIM.VCOMPONENTS.all;
+
+entity Pgp4GthUs is
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      RATE_G                      : string                := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      SYNTH_MODE_G                : string                := "inferred";
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_DRP_G                    : boolean               := false;
+      EN_PGP_MON_G                : boolean               := false;
+      TX_POLARITY_G               : sl                    := '0';
+      RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
+      AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk    : in  sl;            -- GT needs a stable clock to "boot up"
+      stableRst    : in  sl;
+      -- QPLL Interface
+      qpllLock     : in  slv(1 downto 0);
+      qpllclk      : in  slv(1 downto 0);
+      qpllrefclk   : in  slv(1 downto 0);
+      qpllRst      : out slv(1 downto 0);
+      -- Gt Serial IO
+      pgpGtTxP     : out sl;
+      pgpGtTxN     : out sl;
+      pgpGtRxP     : in  sl;
+      pgpGtRxN     : in  sl;
+      -- Clocking
+      pgpClk       : out sl;
+      pgpClkRst    : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn      : in  Pgp4RxInType;
+      pgpRxOut     : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn      : in  Pgp4TxInType;
+      pgpTxOut     : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GthUs;
+
+architecture rtl of Pgp4GthUs is
+
+   -- clocks
+   signal pgpRxClkInt : sl;
+   signal pgpRxRstInt : sl;
+   signal pgpTxClkInt : sl;
+   signal pgpTxRstInt : sl;
+
+   -- PgpRx Signals
+--   signal gtRxUserReset : sl;
+   signal phyRxClk      : sl;
+   signal phyRxRst      : sl;
+   signal phyRxInit     : sl;
+   signal phyRxActive   : sl;
+   signal phyRxValid    : sl;
+   signal phyRxHeader   : slv(1 downto 0);
+   signal phyRxData     : slv(63 downto 0);
+   signal phyRxStartSeq : sl;
+   signal phyRxSlip     : sl;
+
+
+   -- PgpTx Signals
+--   signal gtTxUserReset : sl;
+   signal phyTxActive   : sl;
+   signal phyTxStart    : sl;
+   signal phyTxData     : slv(63 downto 0);
+   signal phyTxHeader   : slv(1 downto 0);
+
+   constant NUM_AXIL_MASTERS_C : integer := 2;
+   constant PGP_AXIL_INDEX_C   : integer := 0;
+   constant DRP_AXIL_INDEX_C   : integer := 1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
+      PGP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G,
+         addrBits      => 12,
+         connectivity  => X"FFFF"),
+      DRP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G + X"1000",
+         addrBits      => 11,
+         connectivity  => X"FFFF"));
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+   signal loopback     : slv(2 downto 0);
+   signal txDiffCtrl   : slv(4 downto 0);
+   signal txPreCursor  : slv(4 downto 0);
+   signal txPostCursor : slv(4 downto 0);
+
+begin
+
+   assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps") or (RATE_G = "10.3125Gbps"))
+      report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
+      severity error;
+
+   pgpClk    <= pgpTxClkInt;
+   pgpClkRst <= pgpTxRstInt;
+
+   --gtRxUserReset <= phyRxInit or pgpRxIn.resetRx;
+   --gtTxUserReset <= pgpTxRst;
+
+   GEN_XBAR : if (EN_DRP_G and EN_PGP_MON_G) generate
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+   end generate GEN_XBAR;
+
+   -- If DRP or PGP_MON not enabled, no crossbar needed
+   -- If neither enabled, default values will auto-terminate the bus
+   GEN_DRP_ONLY : if (EN_DRP_G and not EN_PGP_MON_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(DRP_AXIL_INDEX_C);
+      axilWriteMasters(DRP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(DRP_AXIL_INDEX_C);
+      axilReadMasters(DRP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_DRP_ONLY;
+
+   GEN_PGP_MON_ONLY : if (EN_PGP_MON_G and not EN_DRP_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(PGP_AXIL_INDEX_C);
+      axilWriteMasters(PGP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(PGP_AXIL_INDEX_C);
+      axilReadMasters(PGP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_PGP_MON_ONLY;
+
+
+   U_Pgp4Core_1 : entity surf.Pgp4Core
+      generic map (
+         TPD_G                       => TPD_G,
+         NUM_VC_G                    => NUM_VC_G,
+         PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+         RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+         PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+         TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         TX_MUX_MODE_G               => TX_MUX_MODE_G,
+         TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+         EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+         AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+      port map (
+         -- Tx User interface
+         pgpTxClk        => pgpTxClkInt,                         -- [in]
+         pgpTxRst        => pgpTxRstInt,                         -- [in]
+         pgpTxIn         => pgpTxIn,                             -- [in]
+         pgpTxOut        => pgpTxOut,                            -- [out]
+         pgpTxMasters    => pgpTxMasters,                        -- [in]
+         pgpTxSlaves     => pgpTxSlaves,                         -- [out]
+         -- Tx PHY interface
+         phyTxActive     => phyTxActive,                         -- [in]
+         phyTxReady      => '1',                                 -- [in]
+         phyTxStart      => phyTxStart,                          -- [out]
+         phyTxData       => phyTxData,                           -- [out]
+         phyTxHeader     => phyTxHeader,                         -- [out]
+         -- Rx User interface
+         pgpRxClk        => pgpTxClkInt,                         -- [in]
+         pgpRxRst        => pgpTxRstInt,                         -- [in]
+         pgpRxIn         => pgpRxIn,                             -- [in]
+         pgpRxOut        => pgpRxOut,                            -- [out]
+         pgpRxMasters    => pgpRxMasters,                        -- [out]
+         pgpRxCtrl       => pgpRxCtrl,                           -- [in]
+         -- Rx PHY interface
+         phyRxClk        => phyRxClk,                            -- [in]
+         phyRxRst        => phyRxRst,                            -- [in]
+         phyRxInit       => phyRxInit,                           -- [out]
+         phyRxActive     => phyRxActive,                         -- [in]
+         phyRxValid      => phyRxValid,                          -- [in]
+         phyRxHeader     => phyRxHeader,                         -- [in]
+         phyRxData       => phyRxData,                           -- [in]
+         phyRxStartSeq   => phyRxStartSeq,                       -- [in]
+         phyRxSlip       => phyRxSlip,                           -- [out]
+         -- Debug Interface
+         loopback        => loopback,                            -- [out]
+         txDiffCtrl      => txDiffCtrl,                          -- [out]
+         txPreCursor     => txPreCursor,                         -- [out]
+         txPostCursor    => txPostCursor,                        -- [out]
+         -- AXI-Lite Register Interface (axilClk domain)
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(PGP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(PGP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(PGP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(PGP_AXIL_INDEX_C));  -- [out]
+
+   --------------------------
+   -- Wrapper for GTH IP core
+   --------------------------
+   U_Pgp3GthUsIpWrapper_1 : entity surf.Pgp3GthUsIpWrapper -- Same IP core for both PGPv3 and PGPv4
+      generic map (
+         TPD_G         => TPD_G,
+         TX_POLARITY_G => TX_POLARITY_G,
+         RX_POLARITY_G => RX_POLARITY_G,
+         RATE_G        => RATE_G,
+         EN_DRP_G      => EN_DRP_G)
+      port map (
+         stableClk       => stableClk,                           -- [in]
+         stableRst       => stableRst,                           -- [in]
+         qpllLock        => qpllLock,                            -- [in]
+         qpllclk         => qpllclk,                             -- [in]
+         qpllrefclk      => qpllrefclk,                          -- [in]
+         qpllRst         => qpllRst,                             -- [out]
+         gtRxP           => pgpGtRxP,                            -- [in]
+         gtRxN           => pgpGtRxN,                            -- [in]
+         gtTxP           => pgpGtTxP,                            -- [out]
+         gtTxN           => pgpGtTxN,                            -- [out]
+         rxReset         => phyRxInit,                           -- [in]
+         rxUsrClkActive  => open,                                -- [out]
+         rxResetDone     => phyRxActive,                         -- [out]
+         rxUsrClk        => open,                                -- [out]
+         rxUsrClk2       => phyRxClk,                            -- [out]
+         rxUsrClkRst     => phyRxRst,                            -- [out]
+         rxData          => phyRxData,                           -- [out]
+         rxDataValid     => phyRxValid,                          -- [out]
+         rxHeader        => phyRxHeader,                         -- [out]
+         rxHeaderValid   => open,                                -- [out]
+         rxStartOfSeq    => phyRxStartSeq,                       -- [out]
+         rxGearboxSlip   => phyRxSlip,                           -- [in]
+         rxOutClk        => open,                                -- [out]
+         txReset         => '0',                                 -- [in]
+         txUsrClkActive  => open,                                -- [out]
+         txResetDone     => phyTxActive,                         -- [out]
+         txUsrClk        => open,                                -- [out]
+         txUsrClk2       => pgpTxClkInt,                         -- [out]
+         txUsrClkRst     => pgpTxRstInt,                         -- [out]
+         txData          => phyTxData,                           -- [in]
+         txHeader        => phyTxHeader,                         -- [in]
+         txOutClk        => open,                                -- [out]
+         loopback        => loopback,                            -- [in]
+         txDiffCtrl      => txDiffCtrl,                          -- [in]
+         txPreCursor     => txPreCursor,                         -- [in]
+         txPostCursor    => txPostCursor,                        -- [in]
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C));  -- [out]
+
+
+end rtl;

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
@@ -1,0 +1,316 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTH Ultrascale Wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity Pgp4GthUsWrapper is
+   generic (
+      TPD_G                       : time                        := 1 ns;
+      ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
+      SYNTH_MODE_G                : string                      := "inferred";
+      MEMORY_TYPE_G               : string                      := "block";
+      NUM_LANES_G                 : positive range 1 to 4       := 1;
+      NUM_VC_G                    : positive range 1 to 16      := 4;
+      REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
+      RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean                     := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
+      PGP_TX_ENABLE_G             : boolean                     := true;
+      TX_CELL_WORDS_MAX_G         : integer                     := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                      := "INDEXED";      -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean                     := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean                     := true;
+      EN_PGP_MON_G                : boolean                     := false;
+      EN_GTH_DRP_G                : boolean                     := false;
+      EN_QPLL_DRP_G               : boolean                     := false;
+      TX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
+      AXIL_CLK_FREQ_G             : real                        := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk         : in  sl;       -- GT needs a stable clock to "boot up"
+      stableRst         : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtTxN          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
+      -- GT Clocking
+      pgpRefClkP        : in  sl                                                     := '0';  -- 156.25 MHz
+      pgpRefClkN        : in  sl                                                     := '1';  -- 156.25 MHz
+      pgpRefClkIn       : in  sl                                                     := '0';  -- 156.25 MHz
+      pgpRefClkOut      : out sl;
+      pgpRefClkDiv2Bufg : out sl;
+      -- Clocking
+      pgpClk            : out slv(NUM_LANES_G-1 downto 0);
+      pgpClkRst         : out slv(NUM_LANES_G-1 downto 0);
+      -- Non VC Rx Signals
+      pgpRxIn           : in  Pgp4RxInArray(NUM_LANES_G-1 downto 0);
+      pgpRxOut          : out Pgp4RxOutArray(NUM_LANES_G-1 downto 0);
+      -- Non VC Tx Signals
+      pgpTxIn           : in  Pgp4TxInArray(NUM_LANES_G-1 downto 0);
+      pgpTxOut          : out Pgp4TxOutArray(NUM_LANES_G-1 downto 0);
+      -- Frame Transmit Interface
+      pgpTxMasters      : in  AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpTxSlaves       : out AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters      : out AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpRxCtrl         : in  AxiStreamCtrlArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);  -- Used in implementation only
+      pgpRxSlaves       : in  AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0) := (others => AXI_STREAM_SLAVE_FORCE_C);  -- Used in simulation only
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk           : in  sl                                                     := '0';  -- Stable Clock
+      axilRst           : in  sl                                                     := '0';
+      axilReadMaster    : in  AxiLiteReadMasterType                                  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave     : out AxiLiteReadSlaveType                                   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster   : in  AxiLiteWriteMasterType                                 := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave    : out AxiLiteWriteSlaveType                                  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GthUsWrapper;
+
+architecture rtl of Pgp4GthUsWrapper is
+
+   signal qpllLock   : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllClk    : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRefclk : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRst    : Slv2Array(3 downto 0) := (others => "00");
+
+   signal pgpRefClkDiv2 : sl;
+   signal pgpRefClk     : sl;
+
+   constant NUM_AXIL_MASTERS_C : integer := NUM_LANES_G+1;
+   constant QPLL_AXIL_INDEX_C  : integer := NUM_AXIL_MASTERS_C-1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) :=
+      genAxiLiteConfig(NUM_AXIL_MASTERS_C, AXIL_BASE_ADDR_G, 16, 13);
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+begin
+
+   pgpRefClkOut <= pgpRefClk;
+
+   INT_REFCLK : if (REFCLK_G = false) generate
+
+      U_BUFG_GT : BUFG_GT
+         port map (
+            I       => pgpRefClkDiv2,
+            CE      => '1',
+            CLR     => '0',
+            CEMASK  => '1',
+            CLRMASK => '1',
+            DIV     => "000",           -- Divide by 1
+            O       => pgpRefClkDiv2Bufg);
+
+      U_pgpRefClk : IBUFDS_GTE4
+         generic map (
+            REFCLK_EN_TX_PATH  => '0',
+            REFCLK_HROW_CK_SEL => "00",  -- 2'b00: ODIV2 = O
+            REFCLK_ICNTL_RX    => "00")
+         port map (
+            I     => pgpRefClkP,
+            IB    => pgpRefClkN,
+            CEB   => '0',
+            ODIV2 => pgpRefClkDiv2,
+            O     => pgpRefClk);
+
+   end generate;
+
+   EXT_REFCLK : if (REFCLK_G = true) generate
+
+      pgpRefClkDiv2Bufg <= '0';
+      pgpRefClk         <= pgpRefClkIn;
+
+   end generate;
+
+   REAL_PGP : if (not ROGUE_SIM_EN_G) generate
+
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+
+      U_QPLL : entity surf.Pgp3GthUsQpll -- Same IP core for both PGPv3 and PGPv4
+         generic map (
+            TPD_G    => TPD_G,
+            RATE_G   => RATE_G,
+            EN_DRP_G => EN_QPLL_DRP_G)
+         port map (
+            -- Stable Clock and Reset
+            stableClk       => stableClk,                            -- [in]
+            stableRst       => stableRst,                            -- [in]
+            -- QPLL Clocking
+            pgpRefClk       => pgpRefClk,                            -- [in]
+            qpllLock        => qpllLock,                             -- [out]
+            qpllClk         => qpllClk,                              -- [out]
+            qpllRefclk      => qpllRefclk,                           -- [out]
+            qpllRst         => qpllRst,                              -- [in]
+            axilClk         => axilClk,                              -- [in]
+            axilRst         => axilRst,                              -- [in]
+            axilReadMaster  => axilReadMasters(QPLL_AXIL_INDEX_C),   -- [in]
+            axilReadSlave   => axilReadSlaves(QPLL_AXIL_INDEX_C),    -- [out]
+            axilWriteMaster => axilWriteMasters(QPLL_AXIL_INDEX_C),  -- [in]
+            axilWriteSlave  => axilWriteSlaves(QPLL_AXIL_INDEX_C));  -- [out]
+
+      -----------
+      -- PGP Core
+      -----------
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Pgp : entity surf.Pgp4GthUs
+            generic map (
+               TPD_G                       => TPD_G,
+               RATE_G                      => RATE_G,
+               SYNTH_MODE_G                => SYNTH_MODE_G,
+               ----------------------------------------------------------------------------------------------
+               -- PGP Settings
+               ----------------------------------------------------------------------------------------------
+               PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+               RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+               PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+               NUM_VC_G                    => NUM_VC_G,
+               TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+               TX_MUX_MODE_G               => TX_MUX_MODE_G,
+               TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+               TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+               TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+               TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+               EN_PGP_MON_G                => EN_PGP_MON_G,
+               EN_DRP_G                    => EN_GTH_DRP_G,
+               TX_POLARITY_G               => TX_POLARITY_G(i),
+               RX_POLARITY_G               => RX_POLARITY_G(i),
+               AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+               AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+            port map (
+               -- Stable Clock and Reset
+               stableClk       => stableClk,
+               stableRst       => stableRst,
+               -- QPLL Interface
+               qpllLock        => qpllLock(i),
+               qpllClk         => qpllClk(i),
+               qpllRefclk      => qpllRefclk(i),
+               qpllRst         => qpllRst(i),
+               -- Gt Serial IO
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- Clocking
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxCtrl       => pgpRxCtrl(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+
+      end generate GEN_LANE;
+
+   end generate REAL_PGP;
+
+   SIM_PGP : if (ROGUE_SIM_EN_G) generate
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+            generic map(
+               TPD_G      => TPD_G,
+               SYNTH_MODE_G  => SYNTH_MODE_G,
+               MEMORY_TYPE_G => MEMORY_TYPE_G,
+               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               NUM_VC_G   => NUM_VC_G)
+            port map(
+               -- GT Ports
+               pgpRefClk       => pgpRefClk,
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- PGP Clock and Reset
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxSlaves     => pgpRxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+      end generate GEN_LANE;
+   end generate SIM_PGP;
+
+end rtl;

--- a/protocols/pgp/pgp4/gthUs+/ruckus.tcl
+++ b/protocols/pgp/pgp4/gthUs+/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
@@ -1,0 +1,314 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTH Ultrascale Core Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library UNISIM;
+use UNISIM.VCOMPONENTS.all;
+
+entity Pgp4GthUs is
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      RATE_G                      : string                := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_DRP_G                    : boolean               := false;
+      EN_PGP_MON_G                : boolean               := false;
+      TX_POLARITY_G               : sl                    := '0';
+      RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
+      AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk    : in  sl;            -- GT needs a stable clock to "boot up"
+      stableRst    : in  sl;
+      -- QPLL Interface
+      qpllLock     : in  slv(1 downto 0);
+      qpllclk      : in  slv(1 downto 0);
+      qpllrefclk   : in  slv(1 downto 0);
+      qpllRst      : out slv(1 downto 0);
+      -- Gt Serial IO
+      pgpGtTxP     : out sl;
+      pgpGtTxN     : out sl;
+      pgpGtRxP     : in  sl;
+      pgpGtRxN     : in  sl;
+      -- Clocking
+      pgpClk       : out sl;
+      pgpClkRst    : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn      : in  Pgp4RxInType;
+      pgpRxOut     : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn      : in  Pgp4TxInType;
+      pgpTxOut     : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GthUs;
+
+architecture rtl of Pgp4GthUs is
+
+   -- clocks
+   signal pgpRxClkInt : sl;
+   signal pgpRxRstInt : sl;
+   signal pgpTxClkInt : sl;
+   signal pgpTxRstInt : sl;
+
+   -- PgpRx Signals
+   signal gtRxUserReset : sl;
+   signal phyRxClk      : sl;
+   signal phyRxRst      : sl;
+   signal phyRxInit     : sl;
+   signal phyRxActive   : sl;
+   signal phyRxValid    : sl;
+   signal phyRxHeader   : slv(1 downto 0);
+   signal phyRxData     : slv(63 downto 0);
+   signal phyRxStartSeq : sl;
+   signal phyRxSlip     : sl;
+
+
+   -- PgpTx Signals
+   signal gtTxUserReset : sl;
+   signal phyTxActive   : sl;
+   signal phyTxStart    : sl;
+   signal phyTxData     : slv(63 downto 0);
+   signal phyTxHeader   : slv(1 downto 0);
+
+   constant NUM_AXIL_MASTERS_C : integer := 2;
+   constant PGP_AXIL_INDEX_C   : integer := 0;
+   constant DRP_AXIL_INDEX_C   : integer := 1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
+      PGP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G,
+         addrBits      => 12,
+         connectivity  => X"FFFF"),
+      DRP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G + X"1000",
+         addrBits      => 11,
+         connectivity  => X"FFFF"));
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+   signal loopback     : slv(2 downto 0);
+   signal txDiffCtrl   : slv(4 downto 0);
+   signal txPreCursor  : slv(4 downto 0);
+   signal txPostCursor : slv(4 downto 0);
+
+begin
+
+   assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps") or (RATE_G = "10.3125Gbps"))
+      report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
+      severity error;
+
+   pgpClk    <= pgpTxClkInt;
+   pgpClkRst <= pgpTxRstInt;
+
+   gtRxUserReset <= phyRxInit or pgpRxIn.resetRx;
+   gtTxUserReset <= pgpTxIn.resetTx;
+
+   GEN_XBAR : if (EN_DRP_G and EN_PGP_MON_G) generate
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+   end generate GEN_XBAR;
+
+   -- If DRP or PGP_MON not enabled, no crossbar needed
+   -- If neither enabled, default values will auto-terminate the bus
+   GEN_DRP_ONLY : if (EN_DRP_G and not EN_PGP_MON_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(DRP_AXIL_INDEX_C);
+      axilWriteMasters(DRP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(DRP_AXIL_INDEX_C);
+      axilReadMasters(DRP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_DRP_ONLY;
+
+   GEN_PGP_MON_ONLY : if (EN_PGP_MON_G and not EN_DRP_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(PGP_AXIL_INDEX_C);
+      axilWriteMasters(PGP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(PGP_AXIL_INDEX_C);
+      axilReadMasters(PGP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_PGP_MON_ONLY;
+
+
+   U_Pgp4Core_1 : entity surf.Pgp4Core
+      generic map (
+         TPD_G                       => TPD_G,
+         NUM_VC_G                    => NUM_VC_G,
+         PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+         RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+         PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+         TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         TX_MUX_MODE_G               => TX_MUX_MODE_G,
+         TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+         EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+         AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+      port map (
+         -- Tx User interface
+         pgpTxClk        => pgpTxClkInt,                         -- [in]
+         pgpTxRst        => pgpTxRstInt,                         -- [in]
+         pgpTxIn         => pgpTxIn,                             -- [in]
+         pgpTxOut        => pgpTxOut,                            -- [out]
+         pgpTxMasters    => pgpTxMasters,                        -- [in]
+         pgpTxSlaves     => pgpTxSlaves,                         -- [out]
+         -- Tx PHY interface
+         phyTxActive     => phyTxActive,                         -- [in]
+         phyTxReady      => '1',                                 -- [in]
+         phyTxStart      => phyTxStart,                          -- [out]
+         phyTxData       => phyTxData,                           -- [out]
+         phyTxHeader     => phyTxHeader,                         -- [out]
+         -- Rx User interface
+         pgpRxClk        => pgpTxClkInt,                         -- [in]
+         pgpRxRst        => pgpTxRstInt,                         -- [in]
+         pgpRxIn         => pgpRxIn,                             -- [in]
+         pgpRxOut        => pgpRxOut,                            -- [out]
+         pgpRxMasters    => pgpRxMasters,                        -- [out]
+         pgpRxCtrl       => pgpRxCtrl,                           -- [in]
+         -- Rx PHY interface
+         phyRxClk        => phyRxClk,                            -- [in]
+         phyRxRst        => phyRxRst,                            -- [in]
+         phyRxInit       => phyRxInit,                           -- [out]
+         phyRxActive     => phyRxActive,                         -- [in]
+         phyRxValid      => phyRxValid,                          -- [in]
+         phyRxHeader     => phyRxHeader,                         -- [in]
+         phyRxData       => phyRxData,                           -- [in]
+         phyRxStartSeq   => phyRxStartSeq,                       -- [in]
+         phyRxSlip       => phyRxSlip,                           -- [out]
+         -- Debug Interface
+         loopback        => loopback,                            -- [out]
+         txDiffCtrl      => txDiffCtrl,                          -- [out]
+         txPreCursor     => txPreCursor,                         -- [out]
+         txPostCursor    => txPostCursor,                        -- [out]
+         -- AXI-Lite Register Interface (axilClk domain)
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(PGP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(PGP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(PGP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(PGP_AXIL_INDEX_C));  -- [out]
+
+   --------------------------
+   -- Wrapper for GTH IP core
+   --------------------------
+   U_Pgp3GthUsIpWrapper_1 : entity surf.Pgp3GthUsIpWrapper -- Same IP core for both PGPv3 and PGPv4
+      generic map (
+         TPD_G         => TPD_G,
+         TX_POLARITY_G => TX_POLARITY_G,
+         RX_POLARITY_G => RX_POLARITY_G,
+         RATE_G        => RATE_G,
+         EN_DRP_G      => EN_DRP_G)
+      port map (
+         stableClk       => stableClk,                           -- [in]
+         stableRst       => stableRst,                           -- [in]
+         qpllLock        => qpllLock,                            -- [in]
+         qpllclk         => qpllclk,                             -- [in]
+         qpllrefclk      => qpllrefclk,                          -- [in]
+         qpllRst         => qpllRst,                             -- [out]
+         gtRxP           => pgpGtRxP,                            -- [in]
+         gtRxN           => pgpGtRxN,                            -- [in]
+         gtTxP           => pgpGtTxP,                            -- [out]
+         gtTxN           => pgpGtTxN,                            -- [out]
+         rxReset         => gtRxUserReset,                       -- [in]
+         rxUsrClkActive  => open,                                -- [out]
+         rxResetDone     => phyRxActive,                         -- [out]
+         rxUsrClk        => open,                                -- [out]
+         rxUsrClk2       => phyRxClk,                            -- [out]
+         rxUsrClkRst     => phyRxRst,                            -- [out]
+         rxData          => phyRxData,                           -- [out]
+         rxDataValid     => phyRxValid,                          -- [out]
+         rxHeader        => phyRxHeader,                         -- [out]
+         rxHeaderValid   => open,                                -- [out]
+         rxStartOfSeq    => phyRxStartSeq,                       -- [out]
+         rxGearboxSlip   => phyRxSlip,                           -- [in]
+         rxOutClk        => open,                                -- [out]
+         txReset         => gtTxUserReset,                       -- [in]
+         txUsrClkActive  => open,                                -- [out]
+         txResetDone     => phyTxActive,                         -- [out]
+         txUsrClk        => open,                                -- [out]
+         txUsrClk2       => pgpTxClkInt,                         -- [out]
+         txUsrClkRst     => pgpTxRstInt,                         -- [out]
+         txData          => phyTxData,                           -- [in]
+         txHeader        => phyTxHeader,                         -- [in]
+         txOutClk        => open,                                -- [out]
+         loopback        => loopback,                            -- [in]
+         txDiffCtrl      => txDiffCtrl,                          -- [in]
+         txPreCursor     => txPreCursor,                         -- [in]
+         txPostCursor    => txPostCursor,                        -- [in]
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C));  -- [out]
+
+
+end rtl;

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -24,7 +24,6 @@ library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
 use surf.AxiLitePkg.all;
-use surf.Pgp3Pkg.all;
 use surf.Pgp4Pkg.all;
 
 library unisim;
@@ -39,7 +38,7 @@ entity Pgp4GthUsWrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_156_C;
+      REFCLK_FREQ_G               : real                        := 156.25E+6;
       QPLL_REFCLK_SEL_G           : slv(2 downto 0)             := "001";
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -72,9 +71,9 @@ entity Pgp4GthUsWrapper is
       pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
       pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
       -- GT Clocking
-      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_TYPE_G
-      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_TYPE_G
-      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_TYPE_G
+      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_FREQ_G
+      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_FREQ_G
+      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_FREQ_G
       pgpRefClkOut      : out sl;
       pgpRefClkDiv2Bufg : out sl;
       -- Clocking
@@ -184,7 +183,7 @@ begin
          generic map (
             TPD_G             => TPD_G,
             RATE_G            => RATE_G,
-            REFCLK_TYPE_G     => REFCLK_TYPE_G,
+            REFCLK_FREQ_G     => REFCLK_FREQ_G,
             QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G,
             EN_DRP_G          => EN_QPLL_DRP_G)
          port map (

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -24,6 +24,7 @@ library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
 use surf.AxiLitePkg.all;
+use surf.Pgp3Pkg.all;
 use surf.Pgp4Pkg.all;
 
 library unisim;

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -1,0 +1,315 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTH Ultrascale Wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity Pgp4GthUsWrapper is
+   generic (
+      TPD_G                       : time                        := 1 ns;
+      ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
+      NUM_LANES_G                 : positive range 1 to 4       := 1;
+      NUM_VC_G                    : positive range 1 to 16      := 4;
+      REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
+      RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_156_C;
+      QPLL_REFCLK_SEL_G           : slv(2 downto 0)             := "001";
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean                     := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
+      PGP_TX_ENABLE_G             : boolean                     := true;
+      TX_CELL_WORDS_MAX_G         : integer                     := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                      := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean                     := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean                     := true;
+      EN_PGP_MON_G                : boolean                     := false;
+      EN_GTH_DRP_G                : boolean                     := false;
+      EN_QPLL_DRP_G               : boolean                     := false;
+      TX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
+      AXIL_CLK_FREQ_G             : real                        := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk         : in  sl;       -- GT needs a stable clock to "boot up"
+      stableRst         : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtTxN          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
+      -- GT Clocking
+      pgpRefClkP        : in  sl                                                     := '0';  -- REFCLK_TYPE_G
+      pgpRefClkN        : in  sl                                                     := '1';  -- REFCLK_TYPE_G
+      pgpRefClkIn       : in  sl                                                     := '0';  -- REFCLK_TYPE_G
+      pgpRefClkOut      : out sl;
+      pgpRefClkDiv2Bufg : out sl;
+      -- Clocking
+      pgpClk            : out slv(NUM_LANES_G-1 downto 0);
+      pgpClkRst         : out slv(NUM_LANES_G-1 downto 0);
+      -- Non VC Rx Signals
+      pgpRxIn           : in  Pgp4RxInArray(NUM_LANES_G-1 downto 0);
+      pgpRxOut          : out Pgp4RxOutArray(NUM_LANES_G-1 downto 0);
+      -- Non VC Tx Signals
+      pgpTxIn           : in  Pgp4TxInArray(NUM_LANES_G-1 downto 0);
+      pgpTxOut          : out Pgp4TxOutArray(NUM_LANES_G-1 downto 0);
+      -- Frame Transmit Interface
+      pgpTxMasters      : in  AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpTxSlaves       : out AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters      : out AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpRxCtrl         : in  AxiStreamCtrlArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);  -- Used in implementation only
+      pgpRxSlaves       : in  AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0) := (others => AXI_STREAM_SLAVE_FORCE_C);  -- Used in simulation only
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk           : in  sl                                                     := '0';  -- Stable Clock
+      axilRst           : in  sl                                                     := '0';
+      axilReadMaster    : in  AxiLiteReadMasterType                                  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave     : out AxiLiteReadSlaveType                                   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster   : in  AxiLiteWriteMasterType                                 := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave    : out AxiLiteWriteSlaveType                                  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GthUsWrapper;
+
+architecture rtl of Pgp4GthUsWrapper is
+
+   signal qpllLock   : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllClk    : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRefclk : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRst    : Slv2Array(3 downto 0) := (others => "00");
+
+   signal pgpRefClkDiv2 : sl;
+   signal pgpRefClk     : sl;
+
+   constant NUM_AXIL_MASTERS_C : integer := NUM_LANES_G+1;
+   constant QPLL_AXIL_INDEX_C  : integer := NUM_AXIL_MASTERS_C-1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) :=
+      genAxiLiteConfig(NUM_AXIL_MASTERS_C, AXIL_BASE_ADDR_G, 16, 13);
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+begin
+
+   pgpRefClkOut <= pgpRefClk;
+
+   INT_REFCLK : if (REFCLK_G = false) generate
+
+      U_BUFG_GT : BUFG_GT
+         port map (
+            I       => pgpRefClkDiv2,
+            CE      => '1',
+            CLR     => '0',
+            CEMASK  => '1',
+            CLRMASK => '1',
+            DIV     => "000",           -- Divide by 1
+            O       => pgpRefClkDiv2Bufg);
+
+      U_pgpRefClk : IBUFDS_GTE3
+         generic map (
+            REFCLK_EN_TX_PATH  => '0',
+            REFCLK_HROW_CK_SEL => "00",  -- 2'b00: ODIV2 = O
+            REFCLK_ICNTL_RX    => "00")
+         port map (
+            I     => pgpRefClkP,
+            IB    => pgpRefClkN,
+            CEB   => '0',
+            ODIV2 => pgpRefClkDiv2,
+            O     => pgpRefClk);
+
+   end generate;
+
+   EXT_REFCLK : if (REFCLK_G = true) generate
+
+      pgpRefClkDiv2Bufg <= '0';
+      pgpRefClk         <= pgpRefClkIn;
+
+   end generate;
+
+   REAL_PGP : if (not ROGUE_SIM_EN_G) generate
+
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+
+      U_QPLL : entity surf.Pgp3GthUsQpll -- Same IP core for both PGPv3 and PGPv4
+         generic map (
+            TPD_G             => TPD_G,
+            RATE_G            => RATE_G,
+            REFCLK_TYPE_G     => REFCLK_TYPE_G,
+            QPLL_REFCLK_SEL_G => QPLL_REFCLK_SEL_G,
+            EN_DRP_G          => EN_QPLL_DRP_G)
+         port map (
+            -- Stable Clock and Reset
+            stableClk       => stableClk,                            -- [in]
+            stableRst       => stableRst,                            -- [in]
+            -- QPLL Clocking
+            pgpRefClk       => pgpRefClk,                            -- [in]
+            qpllLock        => qpllLock,                             -- [out]
+            qpllClk         => qpllClk,                              -- [out]
+            qpllRefclk      => qpllRefclk,                           -- [out]
+            qpllRst         => qpllRst,                              -- [in]
+            axilClk         => axilClk,                              -- [in]
+            axilRst         => axilRst,                              -- [in]
+            axilReadMaster  => axilReadMasters(QPLL_AXIL_INDEX_C),   -- [in]
+            axilReadSlave   => axilReadSlaves(QPLL_AXIL_INDEX_C),    -- [out]
+            axilWriteMaster => axilWriteMasters(QPLL_AXIL_INDEX_C),  -- [in]
+            axilWriteSlave  => axilWriteSlaves(QPLL_AXIL_INDEX_C));  -- [out]
+
+      -----------
+      -- PGP Core
+      -----------
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Pgp : entity surf.Pgp4GthUs
+            generic map (
+               TPD_G                       => TPD_G,
+               RATE_G                      => RATE_G,
+               ----------------------------------------------------------------------------------------------
+               -- PGP Settings
+               ----------------------------------------------------------------------------------------------
+               PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+               RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+               PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+               NUM_VC_G                    => NUM_VC_G,
+               TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+               TX_MUX_MODE_G               => TX_MUX_MODE_G,
+               TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+               TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+               TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+               TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+               EN_PGP_MON_G                => EN_PGP_MON_G,
+               EN_DRP_G                    => EN_GTH_DRP_G,
+               TX_POLARITY_G               => TX_POLARITY_G(i),
+               RX_POLARITY_G               => RX_POLARITY_G(i),
+               AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+               AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+            port map (
+               -- Stable Clock and Reset
+               stableClk       => stableClk,
+               stableRst       => stableRst,
+               -- QPLL Interface
+               qpllLock        => qpllLock(i),
+               qpllClk         => qpllClk(i),
+               qpllRefclk      => qpllRefclk(i),
+               qpllRst         => qpllRst(i),
+               -- Gt Serial IO
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- Clocking
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxCtrl       => pgpRxCtrl(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+
+      end generate GEN_LANE;
+
+   end generate REAL_PGP;
+
+   SIM_PGP : if (ROGUE_SIM_EN_G) generate
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+            generic map(
+               TPD_G      => TPD_G,
+               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               NUM_VC_G   => NUM_VC_G)
+            port map(
+               -- GT Ports
+               pgpRefClk       => pgpRefClk,
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- PGP Clock and Reset
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxSlaves     => pgpRxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+      end generate GEN_LANE;
+   end generate SIM_PGP;
+
+end rtl;

--- a/protocols/pgp/pgp4/gthUs/ruckus.tcl
+++ b/protocols/pgp/pgp4/gthUs/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
@@ -1,0 +1,348 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTP7 Core Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library UNISIM;
+use UNISIM.VCOMPONENTS.all;
+
+entity Pgp4Gtp7 is
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      RATE_G                      : string                := "6.25Gbps";  -- or "3.125Gbps"
+      CLKIN_PERIOD_G              : real;
+      BANDWIDTH_G                 : string;
+      CLKFBOUT_MULT_G             : positive;
+      CLKOUT0_DIVIDE_G            : positive;
+      CLKOUT1_DIVIDE_G            : positive;
+      CLKOUT2_DIVIDE_G            : positive;
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_DRP_G                    : boolean               := false;
+      EN_PGP_MON_G                : boolean               := false;
+      TX_POLARITY_G               : sl                    := '0';
+      RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
+      AXIL_CLK_FREQ_G             : real                  := 156.25E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk       : in  sl;         -- GT needs a stable clock to "boot up"
+      stableRst       : in  sl;
+      -- QPLL Interface
+      qPllOutClk      : in  slv(1 downto 0);
+      qPllOutRefClk   : in  slv(1 downto 0);
+      qPllLock        : in  slv(1 downto 0);
+      qPllRefClkLost  : in  slv(1 downto 0);
+      qpllRst         : out slv(1 downto 0);
+      -- TX PLL Interface
+      gtTxOutClk      : out sl;
+      gtTxPllRst      : out sl;
+      txPllClk        : in  slv(2 downto 0);
+      txPllRst        : in  slv(2 downto 0);
+      gtTxPllLock     : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP        : out sl;
+      pgpGtTxN        : out sl;
+      pgpGtRxP        : in  sl;
+      pgpGtRxN        : in  sl;
+      -- Clocking
+      pgpClk          : out sl;
+      pgpClkRst       : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn         : in  Pgp4RxInType;
+      pgpRxOut        : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn         : in  Pgp4TxInType;
+      pgpTxOut        : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters    : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves     : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters    : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl       : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4Gtp7;
+
+architecture rtl of Pgp4Gtp7 is
+
+   -- Clocks and Resets
+   signal phyRxClk : sl := '0';
+   signal phyRxRst : sl := '1';
+   signal phyTxClk : sl := '0';
+   signal phyTxRst : sl := '1';
+
+   -- PgpRx Signals
+   signal phyRxInit   : sl               := '0';
+   signal phyRxActive : sl               := '0';
+   signal phyRxValid  : sl               := '0';
+   signal phyRxHeader : slv(1 downto 0)  := (others => '0');
+   signal phyRxData   : slv(63 downto 0) := (others => '0');
+   signal phyRxSlip   : sl               := '0';
+   signal locRxOut    : Pgp4RxOutType;
+
+   -- PgpTx Signals
+   signal phyTxActive  : sl               := '0';
+   signal phyTxHeader  : slv(1 downto 0)  := (others => '0');
+   signal phyTxData    : slv(63 downto 0) := (others => '0');
+   signal phyTxValid   : sl               := '0';
+   signal phyTxDataRdy : sl               := '0';
+
+   constant NUM_AXIL_MASTERS_C : integer := 2;
+   constant PGP_AXIL_INDEX_C   : integer := 0;
+   constant DRP_AXIL_INDEX_C   : integer := 1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
+      PGP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G,
+         addrBits      => 12,
+         connectivity  => X"FFFF"),
+      DRP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G + X"1000",
+         addrBits      => 11,
+         connectivity  => X"FFFF"));
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+   signal loopback     : slv(2 downto 0) := (others => '0');
+   signal txDiffCtrl   : slv(4 downto 0);
+   signal txPreCursor  : slv(4 downto 0);
+   signal txPostCursor : slv(4 downto 0);
+
+   -- attribute dont_touch                 : string;
+   -- attribute dont_touch of phyRxClk     : signal is "TRUE";
+   -- attribute dont_touch of phyRxRst     : signal is "TRUE";
+   -- attribute dont_touch of phyTxClk     : signal is "TRUE";
+   -- attribute dont_touch of phyTxRst     : signal is "TRUE";
+   -- attribute dont_touch of phyRxInit    : signal is "TRUE";
+   -- attribute dont_touch of phyRxActive  : signal is "TRUE";
+   -- attribute dont_touch of phyRxValid   : signal is "TRUE";
+   -- attribute dont_touch of phyRxHeader  : signal is "TRUE";
+   -- attribute dont_touch of phyRxData    : signal is "TRUE";
+   -- attribute dont_touch of phyRxSlip    : signal is "TRUE";
+   -- attribute dont_touch of phyTxActive  : signal is "TRUE";
+   -- attribute dont_touch of phyTxHeader  : signal is "TRUE";
+   -- attribute dont_touch of phyTxData    : signal is "TRUE";
+   -- attribute dont_touch of phyTxValid   : signal is "TRUE";
+   -- attribute dont_touch of phyTxDataRdy : signal is "TRUE";
+
+begin
+
+   assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps"))
+      report "RATE_G: Must be either 3.125Gbps, 6.25Gbps"
+      severity error;
+
+   pgpClk    <= phyTxClk;
+   pgpClkRst <= phyTxRst;
+   pgpRxOut  <= locRxOut;
+
+   GEN_XBAR : if (EN_DRP_G and EN_PGP_MON_G) generate
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+   end generate GEN_XBAR;
+
+   -- If DRP or PGP_MON not enabled, no crossbar needed
+   -- If neither enabled, default values will auto-terminate the bus
+   GEN_DRP_ONLY : if (EN_DRP_G and not EN_PGP_MON_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(DRP_AXIL_INDEX_C);
+      axilWriteMasters(DRP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(DRP_AXIL_INDEX_C);
+      axilReadMasters(DRP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_DRP_ONLY;
+
+   GEN_PGP_MON_ONLY : if (EN_PGP_MON_G and not EN_DRP_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(PGP_AXIL_INDEX_C);
+      axilWriteMasters(PGP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(PGP_AXIL_INDEX_C);
+      axilReadMasters(PGP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_PGP_MON_ONLY;
+
+   U_Pgp4Core : entity surf.Pgp4Core
+      generic map (
+         TPD_G                       => TPD_G,
+         NUM_VC_G                    => NUM_VC_G,
+         PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+         RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+         PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+         TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         TX_MUX_MODE_G               => TX_MUX_MODE_G,
+         TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+         EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+         AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+      port map (
+         -- Tx User interface
+         pgpTxClk        => phyTxClk,                            -- [in]
+         pgpTxRst        => phyTxRst,                            -- [in]
+         pgpTxIn         => pgpTxIn,                             -- [in]
+         pgpTxOut        => pgpTxOut,                            -- [out]
+         pgpTxMasters    => pgpTxMasters,                        -- [in]
+         pgpTxSlaves     => pgpTxSlaves,                         -- [out]
+         -- Tx PHY interface
+         phyTxActive     => phyTxActive,                         -- [in]
+         phyTxHeader     => phyTxHeader,                         -- [out]
+         phyTxData       => phyTxData,                           -- [out]
+         phyTxValid      => phyTxValid,                          -- [out]
+         phyTxReady      => phyTxDataRdy,                        -- [in]
+         -- Rx User interface
+         pgpRxClk        => phyTxClk,                            -- [in]
+         pgpRxRst        => phyTxRst,                            -- [in]
+         pgpRxIn         => pgpRxIn,                             -- [in]
+         pgpRxOut        => locRxOut,                            -- [out]
+         pgpRxMasters    => pgpRxMasters,                        -- [out]
+         pgpRxCtrl       => pgpRxCtrl,                           -- [in]
+         -- Rx PHY interface
+         phyRxClk        => phyRxClk,                            -- [in]
+         phyRxRst        => phyRxRst,                            -- [in]
+         phyRxInit       => phyRxInit,                           -- [out]
+         phyRxActive     => phyRxActive,                         -- [in]
+         phyRxValid      => phyRxValid,                          -- [in]
+         phyRxHeader     => phyRxHeader,                         -- [in]
+         phyRxData       => phyRxData,                           -- [in]
+         phyRxStartSeq   => '0',                                 -- [in]
+         phyRxSlip       => phyRxSlip,                           -- [out]
+         -- Debug Interface
+         loopback        => loopback,                            -- [out]
+         txDiffCtrl      => txDiffCtrl,                          -- [out]
+         txPreCursor     => txPreCursor,                         -- [out]
+         txPostCursor    => txPostCursor,                        -- [out]
+         -- AXI-Lite Register Interface (axilClk domain)
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(PGP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(PGP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(PGP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(PGP_AXIL_INDEX_C));  -- [out]
+
+   --------------------------
+   -- Wrapper for GTH IP core
+   --------------------------
+   U_Pgp3Gtp7IpWrapper : entity surf.Pgp3Gtp7IpWrapper -- Same IP core for both PGPv3 and PGPv4
+      generic map (
+         TPD_G            => TPD_G,
+         CLKIN_PERIOD_G   => CLKIN_PERIOD_G,
+         BANDWIDTH_G      => BANDWIDTH_G,
+         CLKFBOUT_MULT_G  => CLKFBOUT_MULT_G,
+         CLKOUT0_DIVIDE_G => CLKOUT0_DIVIDE_G,
+         CLKOUT1_DIVIDE_G => CLKOUT1_DIVIDE_G,
+         CLKOUT2_DIVIDE_G => CLKOUT2_DIVIDE_G,
+         TX_POLARITY_G    => TX_POLARITY_G,
+         RX_POLARITY_G    => RX_POLARITY_G,
+         EN_DRP_G         => EN_DRP_G,
+         RATE_G           => RATE_G)
+      port map (
+         stableClk       => stableClk,
+         stableRst       => stableRst,
+         -- QPLL Interface
+         qPllOutClk      => qPllOutClk,
+         qPllOutRefClk   => qPllOutRefClk,
+         qPllLock        => qPllLock,
+         qpllRefClkLost  => qpllRefClkLost,
+         qpllRst         => qpllRst,
+         -- TX PLL Interface
+         gtTxOutClk      => gtTxOutClk,
+         gtTxPllRst      => gtTxPllRst,
+         txPllClk        => txPllClk,
+         txPllRst        => txPllRst,
+         gtTxPllLock     => gtTxPllLock,
+         -- GTH FPGA IO
+         gtRxP           => pgpGtRxP,
+         gtRxN           => pgpGtRxN,
+         gtTxP           => pgpGtTxP,
+         gtTxN           => pgpGtTxN,
+         -- Rx ports
+         rxUsrClk        => phyRxClk,
+         rxUsrClkRst     => phyRxRst,
+         rxReset         => phyRxInit,
+         rxResetDone     => phyRxActive,
+         rxValid         => phyRxValid,
+         rxHeader        => phyRxHeader,
+         rxData          => phyRxData,
+         rxSlip          => phyRxSlip,
+         rxAligned       => locRxOut.gearboxAligned,
+         -- Tx Ports
+         txUsrClk        => phyTxClk,
+         txUsrClkRst     => phyTxRst,
+         txReset         => stableRst,
+         txResetDone     => phyTxActive,
+         txHeader        => phyTxHeader,
+         txData          => phyTxData,
+         txValid         => phyTxValid,
+         txReady         => phyTxDataRdy,
+         -- Debug Interface
+         loopback        => loopback,
+         txPreCursor     => txPreCursor,
+         txPostCursor    => txPostCursor,
+         txDiffCtrl      => txDiffCtrl,
+         -- AXI-Lite DRP Interface
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C),
+         axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C),
+         axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C),
+         axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C));
+
+end rtl;

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -38,7 +38,7 @@ entity Pgp4Gtp7Wrapper is
       NUM_VC_G                    : positive range 1 to 16      := 4;
       SPEED_GRADE_G               : positive range 1 to 3       := 3;
       RATE_G                      : string                      := "6.25Gbps";  -- or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_250_C;
+      REFCLK_FREQ_G               : real                        := 250.0E+6;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -202,7 +202,7 @@ begin
          generic map (
             TPD_G         => TPD_G,
             EN_DRP_G      => EN_QPLL_DRP_G,
-            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            REFCLK_FREQ_G => REFCLK_FREQ_G,
             RATE_G        => RATE_G)
          port map (
             -- Stable Clock and Reset

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -1,0 +1,430 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTP7 Wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity Pgp4Gtp7Wrapper is
+   generic (
+      TPD_G                       : time                        := 1 ns;
+      ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
+      NUM_LANES_G                 : positive range 1 to 4       := 1;
+      NUM_VC_G                    : positive range 1 to 16      := 4;
+      SPEED_GRADE_G               : positive range 1 to 3       := 3;
+      RATE_G                      : string                      := "6.25Gbps";  -- or "3.125Gbps"
+      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_250_C;
+      REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean                     := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
+      PGP_TX_ENABLE_G             : boolean                     := true;
+      TX_CELL_WORDS_MAX_G         : integer                     := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                      := "INDEXED";   -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean                     := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean                     := false;
+      EN_PGP_MON_G                : boolean                     := false;
+      EN_GT_DRP_G                 : boolean                     := false;
+      EN_QPLL_DRP_G               : boolean                     := false;
+      TX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
+      AXIL_CLK_FREQ_G             : real                        := 156.25E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk         : in  sl;       -- GT needs a stable clock to "boot up"
+      stableRst         : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtTxN          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
+      -- GT Clocking
+      pgpRefClkP        : in  sl                                                     := '0';
+      pgpRefClkN        : in  sl                                                     := '1';
+      pgpRefClkIn       : in  sl                                                     := '0';
+      pgpRefClkOut      : out sl;
+      pgpRefClkDiv2Bufg : out sl;
+      -- Clocking
+      pgpClk            : out slv(NUM_LANES_G-1 downto 0);
+      pgpClkRst         : out slv(NUM_LANES_G-1 downto 0);
+      -- Non VC Rx Signals
+      pgpRxIn           : in  Pgp4RxInArray(NUM_LANES_G-1 downto 0);
+      pgpRxOut          : out Pgp4RxOutArray(NUM_LANES_G-1 downto 0);
+      -- Non VC Tx Signals
+      pgpTxIn           : in  Pgp4TxInArray(NUM_LANES_G-1 downto 0);
+      pgpTxOut          : out Pgp4TxOutArray(NUM_LANES_G-1 downto 0);
+      -- Frame Transmit Interface
+      pgpTxMasters      : in  AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpTxSlaves       : out AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters      : out AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpRxCtrl         : in  AxiStreamCtrlArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);  -- Used in implementation only
+      pgpRxSlaves       : in  AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0) := (others => AXI_STREAM_SLAVE_FORCE_C);  -- Used in simulation only
+      -- Debug Interface
+      debugClk          : out slv(2 downto 0);  -- Copy of the TX PLL Clocks
+      debugRst          : out slv(2 downto 0);  -- Copy of the TX PLL Resets
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk           : in  sl                                                     := '0';  -- Stable Clock
+      axilRst           : in  sl                                                     := '0';
+      axilReadMaster    : in  AxiLiteReadMasterType                                  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave     : out AxiLiteReadSlaveType                                   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster   : in  AxiLiteWriteMasterType                                 := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave    : out AxiLiteWriteSlaveType                                  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4Gtp7Wrapper;
+
+architecture rtl of Pgp4Gtp7Wrapper is
+
+   constant CLKIN_PERIOD_C : real := ite((RATE_G = "6.25Gbps"), 2.56, 5.12);  -- 390.625 MHz for 6.25Gbps configuration
+
+   constant BANDWIDTH_C : string := ite((SPEED_GRADE_G = 3), "HIGH", "OPTIMIZED");
+
+   constant CLKFBOUT_MULT_C : positive := ite((SPEED_GRADE_G = 3), ite((RATE_G = "6.25Gbps"), 4, 8), ite((RATE_G = "6.25Gbps"), 3, 6));
+
+   constant CLKOUT0_DIVIDE_C : positive := ite((SPEED_GRADE_G = 3), ite((RATE_G = "6.25Gbps"), 16, 32), ite((RATE_G = "6.25Gbps"), 12, 24));  -- 97.656 MHz for 6.25Gbps configuration
+
+   constant CLKOUT1_DIVIDE_C : positive := ite((SPEED_GRADE_G = 3), ite((RATE_G = "6.25Gbps"), 4, 8), ite((RATE_G = "6.25Gbps"), 3, 6));  -- 390.625 MHz for 6.25Gbps configuration
+
+   constant CLKOUT2_DIVIDE_C : positive := ite((SPEED_GRADE_G = 3), ite((RATE_G = "6.25Gbps"), 8, 16), ite((RATE_G = "6.25Gbps"), 6, 12));  -- 195.312 MHz for 6.25Gbps configuration
+
+   signal qPllOutClk     : Slv2Array(3 downto 0) := (others => "00");
+   signal qPllOutRefClk  : Slv2Array(3 downto 0) := (others => "00");
+   signal qPllLock       : Slv2Array(3 downto 0) := (others => "00");
+   signal qPllRefClkLost : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRst        : Slv2Array(3 downto 0) := (others => "00");
+
+   signal gtTxOutClk   : slv(3 downto 0) := (others => '0');
+   signal gtTxPllRst   : slv(3 downto 0) := (others => '0');
+   signal gtTxPllLock  : slv(3 downto 0) := (others => '0');
+   signal pllOut       : slv(2 downto 0) := (others => '0');
+   signal txPllClk     : slv(2 downto 0) := (others => '0');
+   signal txPllRst     : slv(2 downto 0) := (others => '0');
+   signal lockedStrobe : slv(3 downto 0) := (others => '0');
+   signal pllLock      : sl;
+
+   signal pgpRefClkDiv2  : sl;
+   signal pgpRefClk      : sl;
+   signal clkFb          : sl;
+   signal gtTxOutClkBufg : sl;
+
+   constant NUM_AXIL_MASTERS_C : integer := NUM_LANES_G+1;
+   constant QPLL_AXIL_INDEX_C  : integer := NUM_AXIL_MASTERS_C-1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) :=
+      genAxiLiteConfig(NUM_AXIL_MASTERS_C, AXIL_BASE_ADDR_G, 16, 13);
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+begin
+
+   pgpRefClkOut <= pgpRefClk;
+
+   INT_REFCLK : if (REFCLK_G = false) generate
+
+      U_BUFG : BUFG
+         port map (
+            I => pgpRefClkDiv2,
+            O => pgpRefClkDiv2Bufg);
+
+      U_pgpRefClk : IBUFDS_GTE2
+         port map (
+            I     => pgpRefClkP,
+            IB    => pgpRefClkN,
+            CEB   => '0',
+            ODIV2 => pgpRefClkDiv2,
+            O     => pgpRefClk);
+
+   end generate;
+
+   EXT_REFCLK : if (REFCLK_G = true) generate
+
+      pgpRefClkDiv2Bufg <= '0';
+      pgpRefClk         <= pgpRefClkIn;
+
+   end generate;
+
+   REAL_PGP : if (not ROGUE_SIM_EN_G) generate
+
+
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+
+      U_QPLL : entity surf.Pgp3Gtp7Qpll -- Same IP core for both PGPv3 and PGPv4
+         generic map (
+            TPD_G         => TPD_G,
+            EN_DRP_G      => EN_QPLL_DRP_G,
+            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            RATE_G        => RATE_G)
+         port map (
+            -- Stable Clock and Reset
+            stableClk       => stableClk,                            -- [in]
+            stableRst       => stableRst,                            -- [in]
+            -- QPLL Interface
+            pgpRefClk       => pgpRefClk,
+            qPllOutClk      => qPllOutClk,
+            qPllOutRefClk   => qPllOutRefClk,
+            qPllLock        => qPllLock,
+            qpllRefClkLost  => qpllRefClkLost,
+            qpllRst         => qpllRst,
+            -- AXI-Lite Interface
+            axilClk         => axilClk,                              -- [in]
+            axilRst         => axilRst,                              -- [in]
+            axilReadMaster  => axilReadMasters(QPLL_AXIL_INDEX_C),   -- [in]
+            axilReadSlave   => axilReadSlaves(QPLL_AXIL_INDEX_C),    -- [out]
+            axilWriteMaster => axilWriteMasters(QPLL_AXIL_INDEX_C),  -- [in]
+            axilWriteSlave  => axilWriteSlaves(QPLL_AXIL_INDEX_C));  -- [out]
+
+      -----------
+      -- PGP Core
+      -----------
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Pgp : entity surf.Pgp4Gtp7
+            generic map (
+               TPD_G                       => TPD_G,
+               RATE_G                      => RATE_G,
+               CLKIN_PERIOD_G              => CLKIN_PERIOD_C,
+               BANDWIDTH_G                 => BANDWIDTH_C,
+               CLKFBOUT_MULT_G             => CLKFBOUT_MULT_C,
+               CLKOUT0_DIVIDE_G            => CLKOUT0_DIVIDE_C,
+               CLKOUT1_DIVIDE_G            => CLKOUT1_DIVIDE_C,
+               CLKOUT2_DIVIDE_G            => CLKOUT2_DIVIDE_C,
+               ----------------------------------------------------------------------------------------------
+               -- PGP Settings
+               ----------------------------------------------------------------------------------------------
+               PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+               RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+               PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+               NUM_VC_G                    => NUM_VC_G,
+               TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+               TX_MUX_MODE_G               => TX_MUX_MODE_G,
+               TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+               TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+               TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+               TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+               EN_PGP_MON_G                => EN_PGP_MON_G,
+               EN_DRP_G                    => EN_GT_DRP_G,
+               TX_POLARITY_G               => TX_POLARITY_G(i),
+               RX_POLARITY_G               => RX_POLARITY_G(i),
+               AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+               AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+            port map (
+               -- Stable Clock and Reset
+               stableClk       => stableClk,
+               stableRst       => stableRst,
+               -- QPLL Interface
+               qPllOutClk      => qPllOutClk(i),
+               qPllOutRefClk   => qPllOutRefClk(i),
+               qPllLock        => qPllLock(i),
+               qpllRefClkLost  => qpllRefClkLost(i),
+               qpllRst         => qpllRst(i),
+               -- TX PLL Interface
+               gtTxOutClk      => gtTxOutClk(i),
+               gtTxPllRst      => gtTxPllRst(i),
+               txPllClk        => txPllClk,
+               txPllRst        => txPllRst,
+               gtTxPllLock     => gtTxPllLock(i),
+               -- Gt Serial IO
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- Clocking
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxCtrl       => pgpRxCtrl(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+
+         MASTER_LOCK : if (i = 0) generate
+            gtTxPllLock(0) <= pllLock;
+         end generate;
+
+         SLAVE_LOCK : if (i /= 0) generate
+            -- Prevent the gtTxPllRst of this lane disrupting the other lanes in the QUAD
+            U_PwrUpRst : entity surf.PwrUpRst
+               generic map (
+                  TPD_G      => TPD_G,
+                  DURATION_G => 125)
+               port map (
+                  arst   => gtTxPllRst(i),
+                  clk    => stableClk,
+                  rstOut => lockedStrobe(i));
+            -- Trick the GT state machine of lock transition
+            gtTxPllLock(i) <= pllLock and not(lockedStrobe(i));
+         end generate;
+
+      end generate GEN_LANE;
+
+      U_Bufg : BUFH
+         port map (
+            I => gtTxOutClk(0),
+            O => gtTxOutClkBufg);
+
+      U_TX_PLL : PLLE2_ADV
+         generic map (
+            BANDWIDTH      => BANDWIDTH_C,
+            CLKIN1_PERIOD  => CLKIN_PERIOD_C,
+            DIVCLK_DIVIDE  => 1,
+            CLKFBOUT_MULT  => CLKFBOUT_MULT_C,
+            CLKOUT0_DIVIDE => CLKOUT0_DIVIDE_C,
+            CLKOUT1_DIVIDE => CLKOUT1_DIVIDE_C,
+            CLKOUT2_DIVIDE => CLKOUT2_DIVIDE_C)
+         port map (
+            DCLK     => axilClk,
+            DRDY     => open,
+            DEN      => '0',
+            DWE      => '0',
+            DADDR    => (others => '0'),
+            DI       => (others => '0'),
+            DO       => open,
+            PWRDWN   => '0',
+            RST      => gtTxPllRst(0),
+            CLKIN1   => gtTxOutClkBufg,
+            CLKIN2   => '0',
+            CLKINSEL => '1',
+            CLKFBOUT => clkFb,
+            CLKFBIN  => clkFb,
+            LOCKED   => pllLock,
+            CLKOUT0  => pllOut(0),
+            CLKOUT1  => pllOut(1),
+            CLKOUT2  => pllOut(2));
+
+      U_txPllClk0 : BUFG
+         port map (
+            I => pllOut(0),
+            O => txPllClk(0));
+
+      U_txPllClk1 : BUFG
+         port map (
+            I => pllOut(1),
+            O => txPllClk(1));
+
+      U_txPllClk2 : BUFG
+         port map (
+            I => pllOut(2),
+            O => txPllClk(2));
+
+      GEN_RST : for i in 2 downto 0 generate
+         U_RstSync : entity surf.RstSync
+            generic map (
+               TPD_G          => TPD_G,
+               IN_POLARITY_G  => '0',
+               OUT_POLARITY_G => '1')
+            port map (
+               clk      => txPllClk(i),
+               asyncRst => pllLock,
+               syncRst  => txPllRst(i));
+      end generate;
+
+      debugClk <= txPllClk;
+      debugRst <= txPllRst;
+
+   end generate REAL_PGP;
+
+   SIM_PGP : if (ROGUE_SIM_EN_G) generate
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+            generic map(
+               TPD_G      => TPD_G,
+               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               NUM_VC_G   => NUM_VC_G)
+            port map(
+               -- GT Ports
+               pgpRefClk       => pgpRefClk,
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- PGP Clock and Reset
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxSlaves     => pgpRxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+      end generate GEN_LANE;
+   end generate SIM_PGP;
+
+end rtl;

--- a/protocols/pgp/pgp4/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtp7/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
@@ -1,0 +1,324 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTX7 Core Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library UNISIM;
+use UNISIM.VCOMPONENTS.all;
+
+entity Pgp4Gtx7 is
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      RATE_G                      : string                := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_DRP_G                    : boolean               := false;
+      EN_PGP_MON_G                : boolean               := false;
+      TX_POLARITY_G               : sl                    := '0';
+      RX_POLARITY_G               : sl                    := '0';
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
+      AXIL_CLK_FREQ_G             : real                  := 156.25E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk       : in  sl;         -- GT needs a stable clock to "boot up"
+      stableRst       : in  sl;
+      -- QPLL Interface
+      qpllLock        : in  sl;
+      qpllclk         : in  sl;
+      qpllrefclk      : in  sl;
+      qpllRefClkLost  : in  sl;
+      qpllRst         : out sl;
+      -- TX PLL Interface
+      gtTxOutClk      : out sl;
+      gtTxPllRst      : out sl;
+      txPllClk        : in  slv(1 downto 0);
+      txPllRst        : in  slv(1 downto 0);
+      gtTxPllLock     : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP        : out sl;
+      pgpGtTxN        : out sl;
+      pgpGtRxP        : in  sl;
+      pgpGtRxN        : in  sl;
+      -- Clocking
+      pgpClk          : out sl;
+      pgpClkRst       : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn         : in  Pgp4RxInType;
+      pgpRxOut        : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn         : in  Pgp4TxInType;
+      pgpTxOut        : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters    : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves     : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters    : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl       : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4Gtx7;
+
+architecture rtl of Pgp4Gtx7 is
+
+   -- clocks
+   signal pgpRxClkInt : sl;
+   signal pgpRxRstInt : sl;
+   signal pgpTxClkInt : sl;
+   signal pgpTxRstInt : sl;
+
+   -- PgpRx Signals
+   signal phyRxClk      : sl;
+   signal phyRxRst      : sl;
+   signal phyRxInit     : sl;
+   signal phyRxActive   : sl;
+   signal phyRxValid    : sl;
+   signal phyRxHeader   : slv(1 downto 0);
+   signal phyRxData     : slv(63 downto 0);
+   signal phyRxStartSeq : sl;
+   signal phyRxSlip     : sl;
+
+   -- PgpTx Signals
+   signal phyTxActive   : sl;
+   signal phyTxStart    : sl;
+   signal phyTxDataRdy  : sl;
+   signal phyTxData     : slv(63 downto 0);
+   signal phyTxHeader   : slv(1 downto 0);
+
+   constant NUM_AXIL_MASTERS_C : integer := 2;
+   constant PGP_AXIL_INDEX_C   : integer := 0;
+   constant DRP_AXIL_INDEX_C   : integer := 1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
+      PGP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G,
+         addrBits      => 12,
+         connectivity  => X"FFFF"),
+      DRP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G + X"1000",
+         addrBits      => 11,
+         connectivity  => X"FFFF"));
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+   signal loopback     : slv(2 downto 0);
+   signal txDiffCtrl   : slv(4 downto 0);
+   signal txPreCursor  : slv(4 downto 0);
+   signal txPostCursor : slv(4 downto 0);
+
+begin
+
+   assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps") or (RATE_G = "10.3125Gbps"))
+      report "RATE_G: Must be either 3.125Gbps, 6.25Gbps or 10.3125Gbps"
+      severity error;
+
+   pgpClk    <= pgpTxClkInt;
+   pgpClkRst <= pgpTxRstInt;
+
+   GEN_XBAR : if (EN_DRP_G and EN_PGP_MON_G) generate
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+   end generate GEN_XBAR;
+
+   -- If DRP or PGP_MON not enabled, no crossbar needed
+   -- If neither enabled, default values will auto-terminate the bus
+   GEN_DRP_ONLY : if (EN_DRP_G and not EN_PGP_MON_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(DRP_AXIL_INDEX_C);
+      axilWriteMasters(DRP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(DRP_AXIL_INDEX_C);
+      axilReadMasters(DRP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_DRP_ONLY;
+
+   GEN_PGP_MON_ONLY : if (EN_PGP_MON_G and not EN_DRP_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(PGP_AXIL_INDEX_C);
+      axilWriteMasters(PGP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(PGP_AXIL_INDEX_C);
+      axilReadMasters(PGP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_PGP_MON_ONLY;
+
+
+   U_Pgp4Core : entity surf.Pgp4Core
+      generic map (
+         TPD_G                       => TPD_G,
+         NUM_VC_G                    => NUM_VC_G,
+         PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+         RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+         PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+         TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         TX_MUX_MODE_G               => TX_MUX_MODE_G,
+         TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+         EN_PGP_MON_G                => EN_PGP_MON_G,
+         STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+         ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+         AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+      port map (
+         -- Tx User interface
+         pgpTxClk        => pgpTxClkInt,                         -- [in]
+         pgpTxRst        => pgpTxRstInt,                         -- [in]
+         pgpTxIn         => pgpTxIn,                             -- [in]
+         pgpTxOut        => pgpTxOut,                            -- [out]
+         pgpTxMasters    => pgpTxMasters,                        -- [in]
+         pgpTxSlaves     => pgpTxSlaves,                         -- [out]
+         -- Tx PHY interface
+         phyTxActive     => phyTxActive,                         -- [in]
+         phyTxReady      => phyTxDataRdy,                        -- [in]
+         phyTxStart      => phyTxStart,                          -- [out]
+         phyTxData       => phyTxData,                           -- [out]
+         phyTxHeader     => phyTxHeader,                         -- [out]
+         -- Rx User interface
+         pgpRxClk        => pgpTxClkInt,                         -- [in]
+         pgpRxRst        => pgpTxRstInt,                         -- [in]
+         pgpRxIn         => pgpRxIn,                             -- [in]
+         pgpRxOut        => pgpRxOut,                            -- [out]
+         pgpRxMasters    => pgpRxMasters,                        -- [out]
+         pgpRxCtrl       => pgpRxCtrl,                           -- [in]
+         -- Rx PHY interface
+         phyRxClk        => phyRxClk,                            -- [in]
+         phyRxRst        => phyRxRst,                            -- [in]
+         phyRxInit       => phyRxInit,                           -- [out]
+         phyRxActive     => phyRxActive,                         -- [in]
+         phyRxValid      => phyRxValid,                          -- [in]
+         phyRxHeader     => phyRxHeader,                         -- [in]
+         phyRxData       => phyRxData,                           -- [in]
+         phyRxStartSeq   => '0',                                 -- [in]
+         phyRxSlip       => phyRxSlip,                           -- [out]
+         -- Debug Interface
+         loopback        => loopback,                            -- [out]
+         txDiffCtrl      => txDiffCtrl,                          -- [out]
+         txPreCursor     => txPreCursor,                         -- [out]
+         txPostCursor    => txPostCursor,                        -- [out]
+         -- AXI-Lite Register Interface (axilClk domain)
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(PGP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(PGP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(PGP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(PGP_AXIL_INDEX_C));  -- [out]
+
+   --------------------------
+   -- Wrapper for GTH IP core
+   --------------------------
+   U_Pgp3Gtx7IpWrapper : entity surf.Pgp3Gtx7IpWrapper -- Same IP core for both PGPv3 and PGPv4
+      generic map (
+         TPD_G         => TPD_G,
+         TX_POLARITY_G => TX_POLARITY_G,
+         RX_POLARITY_G => RX_POLARITY_G,
+         EN_DRP_G      => EN_DRP_G,
+         RATE_G        => RATE_G)
+      port map (
+         stableClk       => stableClk,                           -- [in]
+         stableRst       => stableRst,                           -- [in]
+         -- QPLL Interface
+         qpllLock        => qpllLock,                            -- [in]
+         qpllclk         => qpllclk,                             -- [in]
+         qpllrefclk      => qpllrefclk,                          -- [in]
+         qpllRefClkLost  => qpllRefClkLost,                      -- [in]
+         qpllRst         => qpllRst,                             -- [out]
+         -- TX PLL Interface
+         gtTxOutClk      => gtTxOutClk,
+         gtTxPllRst      => gtTxPllRst,
+         txPllClk        => txPllClk,
+         txPllRst        => txPllRst,
+         gtTxPllLock     => gtTxPllLock,
+         -- GTH FPGA IO
+         gtRxP           => pgpGtRxP,                            -- [in]
+         gtRxN           => pgpGtRxN,                            -- [in]
+         gtTxP           => pgpGtTxP,                            -- [out]
+         gtTxN           => pgpGtTxN,                            -- [out]
+         -- Rx ports
+         rxReset         => phyRxInit,                           -- [in]
+         rxResetDone     => phyRxActive,                         -- [out]
+         rxUsrClk        => open,                                -- [out]
+         rxUsrClk2       => phyRxClk,                            -- [out]
+         rxUsrClkRst     => phyRxRst,                            -- [out]
+         rxData          => phyRxData,                           -- [out]
+         rxDataValid     => phyRxValid,                          -- [out]
+         rxHeader        => phyRxHeader,                         -- [out]
+         rxHeaderValid   => open,                                -- [out]
+         rxGearboxSlip   => phyRxSlip,                           -- [in]
+         -- Tx Ports
+         txReset         => '0',                                 -- [in]
+         txResetDone     => phyTxActive,                         -- [out]
+         txUsrClk        => open,                                -- [out]
+         txUsrClk2       => pgpTxClkInt,                         -- [out]
+         txUsrClkRst     => pgpTxRstInt,                         -- [out]
+         txDataRdy       => phyTxDataRdy,                        -- [out]
+         txData          => phyTxData,                           -- [in]
+         txHeader        => phyTxHeader,                         -- [in]
+         txStart         => phyTxStart,                          -- [in]
+         -- Debug Interface
+         loopback        => loopback,                            -- [in]
+         txPreCursor     => txPreCursor,                         -- [in]
+         txPostCursor    => txPostCursor,                        -- [in]
+         txDiffCtrl      => txDiffCtrl,                          -- [in]
+         -- AXI-Lite DRP Interface
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C));  -- [out]
+
+end rtl;

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -37,7 +37,7 @@ entity Pgp4Gtx7Wrapper is
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
       RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
-      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_312_C;
+      REFCLK_FREQ_G               : real                        := 312.5E+6;
       REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
       ----------------------------------------------------------------------------------------------
       -- PGP Settings
@@ -183,7 +183,7 @@ begin
          generic map (
             TPD_G         => TPD_G,
             EN_DRP_G      => EN_QPLL_DRP_G,
-            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            REFCLK_FREQ_G => REFCLK_FREQ_G,
             RATE_G        => RATE_G)
          port map (
             -- Stable Clock and Reset

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -1,0 +1,360 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTX7 Wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity Pgp4Gtx7Wrapper is
+   generic (
+      TPD_G                       : time                        := 1 ns;
+      ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
+      NUM_LANES_G                 : positive range 1 to 4       := 1;
+      NUM_VC_G                    : positive range 1 to 16      := 4;
+      RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      REFCLK_TYPE_G               : Pgp4RefClkType              := REFCLK_312_C;
+      REFCLK_G                    : boolean                     := false;  --  FALSE: use pgpRefClkP/N,  TRUE: use pgpRefClkIn
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean                     := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
+      PGP_TX_ENABLE_G             : boolean                     := true;
+      TX_CELL_WORDS_MAX_G         : integer                     := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                      := "INDEXED";      -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean                     := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean                     := true;
+      EN_PGP_MON_G                : boolean                     := false;
+      EN_GT_DRP_G                 : boolean                     := false;
+      EN_QPLL_DRP_G               : boolean                     := false;
+      TX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
+      ERROR_CNT_WIDTH_G           : natural range 1 to 32       := 8;
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
+      AXIL_CLK_FREQ_G             : real                        := 156.25E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk         : in  sl;       -- GT needs a stable clock to "boot up"
+      stableRst         : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtTxN          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
+      -- GT Clocking
+      pgpRefClkP        : in  sl                                                     := '0';
+      pgpRefClkN        : in  sl                                                     := '1';
+      pgpRefClkIn       : in  sl                                                     := '0';
+      pgpRefClkOut      : out sl;
+      pgpRefClkDiv2Bufg : out sl;
+      -- Clocking
+      pgpClk            : out slv(NUM_LANES_G-1 downto 0);
+      pgpClkRst         : out slv(NUM_LANES_G-1 downto 0);
+      -- Non VC Rx Signals
+      pgpRxIn           : in  Pgp4RxInArray(NUM_LANES_G-1 downto 0);
+      pgpRxOut          : out Pgp4RxOutArray(NUM_LANES_G-1 downto 0);
+      -- Non VC Tx Signals
+      pgpTxIn           : in  Pgp4TxInArray(NUM_LANES_G-1 downto 0);
+      pgpTxOut          : out Pgp4TxOutArray(NUM_LANES_G-1 downto 0);
+      -- Frame Transmit Interface
+      pgpTxMasters      : in  AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpTxSlaves       : out AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters      : out AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpRxCtrl         : in  AxiStreamCtrlArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);  -- Used in implementation only
+      pgpRxSlaves       : in  AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0) := (others => AXI_STREAM_SLAVE_FORCE_C);  -- Used in simulation only
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk           : in  sl                                                     := '0';  -- Stable Clock
+      axilRst           : in  sl                                                     := '0';
+      axilReadMaster    : in  AxiLiteReadMasterType                                  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave     : out AxiLiteReadSlaveType                                   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster   : in  AxiLiteWriteMasterType                                 := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave    : out AxiLiteWriteSlaveType                                  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4Gtx7Wrapper;
+
+architecture rtl of Pgp4Gtx7Wrapper is
+
+   signal qpllLock       : slv(3 downto 0) := (others => '0');
+   signal qpllClk        : slv(3 downto 0) := (others => '0');
+   signal qpllRefclk     : slv(3 downto 0) := (others => '0');
+   signal qpllRefClkLost : slv(3 downto 0) := (others => '0');
+   signal qpllRst        : slv(3 downto 0) := (others => '0');
+
+   signal gtTxOutClk   : slv(3 downto 0) := (others => '0');
+   signal gtTxPllRst   : slv(3 downto 0) := (others => '0');
+   signal gtTxPllLock  : slv(3 downto 0) := (others => '0');
+   signal txPllClk     : slv(1 downto 0) := (others => '0');
+   signal txPllRst     : slv(1 downto 0) := (others => '0');
+   signal lockedStrobe : slv(3 downto 0) := (others => '0');
+   signal pllLock      : sl;
+
+   signal pgpRefClkDiv2 : sl;
+   signal pgpRefClk     : sl;
+
+   constant NUM_AXIL_MASTERS_C : integer := NUM_LANES_G+1;
+   constant QPLL_AXIL_INDEX_C  : integer := NUM_AXIL_MASTERS_C-1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) :=
+      genAxiLiteConfig(NUM_AXIL_MASTERS_C, AXIL_BASE_ADDR_G, 16, 13);
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+begin
+
+   pgpRefClkOut <= pgpRefClk;
+
+   INT_REFCLK : if (REFCLK_G = false) generate
+
+      U_BUFG : BUFG
+         port map (
+            I => pgpRefClkDiv2,
+            O => pgpRefClkDiv2Bufg);
+
+      U_pgpRefClk : IBUFDS_GTE2
+         port map (
+            I     => pgpRefClkP,
+            IB    => pgpRefClkN,
+            CEB   => '0',
+            ODIV2 => pgpRefClkDiv2,
+            O     => pgpRefClk);
+
+   end generate;
+
+   EXT_REFCLK : if (REFCLK_G = true) generate
+
+      pgpRefClkDiv2Bufg <= '0';
+      pgpRefClk         <= pgpRefClkIn;
+
+   end generate;
+
+   REAL_PGP : if (not ROGUE_SIM_EN_G) generate
+
+
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+
+      U_QPLL : entity surf.Pgp3Gtx7Qpll -- Same IP core for both PGPv3 and PGPv4
+         generic map (
+            TPD_G         => TPD_G,
+            EN_DRP_G      => EN_QPLL_DRP_G,
+            REFCLK_TYPE_G => REFCLK_TYPE_G,
+            RATE_G        => RATE_G)
+         port map (
+            -- Stable Clock and Reset
+            stableClk       => stableClk,                            -- [in]
+            stableRst       => stableRst,                            -- [in]
+            -- QPLL Clocking
+            pgpRefClk       => pgpRefClk,                            -- [in]
+            qpllLock        => qpllLock,                             -- [out]
+            qpllClk         => qpllClk,                              -- [out]
+            qpllRefclk      => qpllRefclk,                           -- [out]
+            qpllRefClkLost  => qpllRefClkLost,                       -- [out]
+            qpllRst         => qpllRst,                              -- [in]
+            axilClk         => axilClk,                              -- [in]
+            axilRst         => axilRst,                              -- [in]
+            axilReadMaster  => axilReadMasters(QPLL_AXIL_INDEX_C),   -- [in]
+            axilReadSlave   => axilReadSlaves(QPLL_AXIL_INDEX_C),    -- [out]
+            axilWriteMaster => axilWriteMasters(QPLL_AXIL_INDEX_C),  -- [in]
+            axilWriteSlave  => axilWriteSlaves(QPLL_AXIL_INDEX_C));  -- [out]
+
+      -----------
+      -- PGP Core
+      -----------
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Pgp : entity surf.Pgp4Gtx7
+            generic map (
+               TPD_G                       => TPD_G,
+               RATE_G                      => RATE_G,
+               ----------------------------------------------------------------------------------------------
+               -- PGP Settings
+               ----------------------------------------------------------------------------------------------
+               PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+               RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+               PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+               NUM_VC_G                    => NUM_VC_G,
+               TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+               TX_MUX_MODE_G               => TX_MUX_MODE_G,
+               TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+               TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+               TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+               TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+               EN_PGP_MON_G                => EN_PGP_MON_G,
+               EN_DRP_G                    => EN_GT_DRP_G,
+               TX_POLARITY_G               => TX_POLARITY_G(i),
+               RX_POLARITY_G               => RX_POLARITY_G(i),
+               AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
+               ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
+               AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+            port map (
+               -- Stable Clock and Reset
+               stableClk       => stableClk,
+               stableRst       => stableRst,
+               -- QPLL Interface
+               qpllLock        => qpllLock(i),
+               qpllClk         => qpllClk(i),
+               qpllRefclk      => qpllRefclk(i),
+               qpllRefClkLost  => qpllRefClkLost(i),
+               qpllRst         => qpllRst(i),
+               -- TX PLL Interface
+               gtTxOutClk      => gtTxOutClk(i),
+               gtTxPllRst      => gtTxPllRst(i),
+               txPllClk        => txPllClk,
+               txPllRst        => txPllRst,
+               gtTxPllLock     => gtTxPllLock(i),
+               -- Gt Serial IO
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- Clocking
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxCtrl       => pgpRxCtrl(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+
+         MASTER_LOCK : if (i = 0) generate
+            gtTxPllLock(0) <= pllLock;
+         end generate;
+
+         SLAVE_LOCK : if (i /= 0) generate
+            -- Prevent the gtTxPllRst of this lane disrupting the other lanes in the QUAD
+            U_PwrUpRst : entity surf.PwrUpRst
+               generic map (
+                  TPD_G      => TPD_G,
+                  DURATION_G => 125)
+               port map (
+                  arst   => gtTxPllRst(i),
+                  clk    => stableClk,
+                  rstOut => lockedStrobe(i));
+            -- Trick the GT state machine of lock transition
+            gtTxPllLock(i) <= pllLock and not(lockedStrobe(i));
+         end generate;
+
+      end generate GEN_LANE;
+
+      U_TX_PLL : entity surf.ClockManager7
+         generic map(
+            TPD_G            => TPD_G,
+            TYPE_G           => "PLL",
+            BANDWIDTH_G      => "OPTIMIZED",
+            INPUT_BUFG_G     => true,
+            FB_BUFG_G        => false,
+            NUM_CLOCKS_G     => 2,
+            CLKIN_PERIOD_G   => ite((RATE_G = "10.3125Gbps"), 3.103, ite((RATE_G = "6.25Gbps"), 5.12, 10.24)),
+            DIVCLK_DIVIDE_G  => 1,
+            CLKFBOUT_MULT_G  => ite((RATE_G = "10.3125Gbps"), 3, ite((RATE_G = "6.25Gbps"), 5, 10)),
+            CLKOUT0_DIVIDE_G => ite((RATE_G = "10.3125Gbps"), 3, ite((RATE_G = "6.25Gbps"), 5, 10)),
+            CLKOUT1_DIVIDE_G => ite((RATE_G = "10.3125Gbps"), 6, ite((RATE_G = "6.25Gbps"), 10, 20)))
+         port map(
+            clkIn  => gtTxOutClk(0),
+            rstIn  => gtTxPllRst(0),
+            clkOut => txPllClk,
+            rstOut => txPllRst,
+            locked => pllLock);
+
+   end generate REAL_PGP;
+
+   SIM_PGP : if (ROGUE_SIM_EN_G) generate
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+            generic map(
+               TPD_G      => TPD_G,
+               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               NUM_VC_G   => NUM_VC_G)
+            port map(
+               -- GT Ports
+               pgpRefClk       => pgpRefClk,
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- PGP Clock and Reset
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxSlaves     => pgpRxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+      end generate GEN_LANE;
+   end generate SIM_PGP;
+
+end rtl;

--- a/protocols/pgp/pgp4/gtx7/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtx7/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
@@ -1,0 +1,309 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTY Ultrascale+ Core Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library UNISIM;
+use UNISIM.VCOMPONENTS.all;
+
+entity Pgp4GtyUs is
+   generic (
+      TPD_G                       : time                  := 1 ns;
+      RATE_G                      : string                := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      SYNTH_MODE_G                : string                := "inferred";
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean               := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer               := 32;
+      PGP_TX_ENABLE_G             : boolean               := true;
+      NUM_VC_G                    : integer range 1 to 16 := 4;
+      TX_CELL_WORDS_MAX_G         : integer               := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                := "INDEXED";  -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array             := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7  := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean               := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
+      EN_DRP_G                    : boolean               := false;
+      EN_PGP_MON_G                : boolean               := false;
+      TX_POLARITY_G               : sl                    := '0';
+      RX_POLARITY_G               : sl                    := '0';
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
+      AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk    : in  sl;            -- GT needs a stable clock to "boot up"
+      stableRst    : in  sl;
+      -- QPLL Interface
+      qpllLock     : in  slv(1 downto 0);
+      qpllclk      : in  slv(1 downto 0);
+      qpllrefclk   : in  slv(1 downto 0);
+      qpllRst      : out slv(1 downto 0);
+      -- Gt Serial IO
+      pgpGtTxP     : out sl;
+      pgpGtTxN     : out sl;
+      pgpGtRxP     : in  sl;
+      pgpGtRxN     : in  sl;
+      -- Clocking
+      pgpClk       : out sl;
+      pgpClkRst    : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn      : in  Pgp4RxInType;
+      pgpRxOut     : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn      : in  Pgp4TxInType;
+      pgpTxOut     : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxCtrl    : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GtyUs;
+
+architecture rtl of Pgp4GtyUs is
+
+   -- clocks
+   signal pgpRxClkInt : sl;
+   signal pgpRxRstInt : sl;
+   signal pgpTxClkInt : sl;
+   signal pgpTxRstInt : sl;
+
+   -- PgpRx Signals
+--   signal gtRxUserReset : sl;
+   signal phyRxClk      : sl;
+   signal phyRxRst      : sl;
+   signal phyRxInit     : sl;
+   signal phyRxActive   : sl;
+   signal phyRxValid    : sl;
+   signal phyRxHeader   : slv(1 downto 0);
+   signal phyRxData     : slv(63 downto 0);
+   signal phyRxStartSeq : sl;
+   signal phyRxSlip     : sl;
+
+
+   -- PgpTx Signals
+--   signal gtTxUserReset : sl;
+   signal phyTxActive   : sl;
+   signal phyTxStart    : sl;
+   signal phyTxData     : slv(63 downto 0);
+   signal phyTxHeader   : slv(1 downto 0);
+
+   constant NUM_AXIL_MASTERS_C : integer := 2;
+   constant PGP_AXIL_INDEX_C   : integer := 0;
+   constant DRP_AXIL_INDEX_C   : integer := 1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
+      PGP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G,
+         addrBits      => 12,
+         connectivity  => X"FFFF"),
+      DRP_AXIL_INDEX_C => (
+         baseAddr      => AXIL_BASE_ADDR_G + X"1000",
+         addrBits      => 11,
+         connectivity  => X"FFFF"));
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+   signal loopback     : slv(2 downto 0);
+   signal txDiffCtrl   : slv(4 downto 0);
+   signal txPreCursor  : slv(4 downto 0);
+   signal txPostCursor : slv(4 downto 0);
+
+begin
+
+   assert ((RATE_G = "3.125Gbps") or (RATE_G = "6.25Gbps") or (RATE_G = "10.3125Gbps"))
+      report "RATE_G: Must be either 3.125Gbps or 6.25Gbps or 10.3125Gbps"
+      severity error;
+
+   pgpClk    <= pgpTxClkInt;
+   pgpClkRst <= pgpTxRstInt;
+
+   --gtRxUserReset <= phyRxInit or pgpRxIn.resetRx;
+   --gtTxUserReset <= pgpTxRst;
+
+   GEN_XBAR : if (EN_DRP_G and EN_PGP_MON_G) generate
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+   end generate GEN_XBAR;
+
+   -- If DRP or PGP_MON not enabled, no crossbar needed
+   -- If neither enabled, default values will auto-terminate the bus
+   GEN_DRP_ONLY : if (EN_DRP_G and not EN_PGP_MON_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(DRP_AXIL_INDEX_C);
+      axilWriteMasters(DRP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(DRP_AXIL_INDEX_C);
+      axilReadMasters(DRP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_DRP_ONLY;
+
+   GEN_PGP_MON_ONLY : if (EN_PGP_MON_G and not EN_DRP_G) generate
+      axilWriteSlave                     <= axilWriteSlaves(PGP_AXIL_INDEX_C);
+      axilWriteMasters(PGP_AXIL_INDEX_C) <= axilWriteMaster;
+      axilReadSlave                      <= axilReadSlaves(PGP_AXIL_INDEX_C);
+      axilReadMasters(PGP_AXIL_INDEX_C)  <= axilReadMaster;
+   end generate GEN_PGP_MON_ONLY;
+
+
+   U_Pgp4Core_1 : entity surf.Pgp4Core
+      generic map (
+         TPD_G                       => TPD_G,
+         NUM_VC_G                    => NUM_VC_G,
+         PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+         RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+         PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+         TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+         TX_MUX_MODE_G               => TX_MUX_MODE_G,
+         TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+         TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+         TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+         TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+         EN_PGP_MON_G                => EN_PGP_MON_G,
+         AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+      port map (
+         -- Tx User interface
+         pgpTxClk        => pgpTxClkInt,                         -- [in]
+         pgpTxRst        => pgpTxRstInt,                         -- [in]
+         pgpTxIn         => pgpTxIn,                             -- [in]
+         pgpTxOut        => pgpTxOut,                            -- [out]
+         pgpTxMasters    => pgpTxMasters,                        -- [in]
+         pgpTxSlaves     => pgpTxSlaves,                         -- [out]
+         -- Tx PHY interface
+         phyTxActive     => phyTxActive,                         -- [in]
+         phyTxReady      => '1',                                 -- [in]
+         phyTxStart      => phyTxStart,                          -- [out]
+         phyTxData       => phyTxData,                           -- [out]
+         phyTxHeader     => phyTxHeader,                         -- [out]
+         -- Rx User interface
+         pgpRxClk        => pgpTxClkInt,                         -- [in]
+         pgpRxRst        => pgpTxRstInt,                         -- [in]
+         pgpRxIn         => pgpRxIn,                             -- [in]
+         pgpRxOut        => pgpRxOut,                            -- [out]
+         pgpRxMasters    => pgpRxMasters,                        -- [out]
+         pgpRxCtrl       => pgpRxCtrl,                           -- [in]
+         -- Rx PHY interface
+         phyRxClk        => phyRxClk,                            -- [in]
+         phyRxRst        => phyRxRst,                            -- [in]
+         phyRxInit       => phyRxInit,                           -- [out]
+         phyRxActive     => phyRxActive,                         -- [in]
+         phyRxValid      => phyRxValid,                          -- [in]
+         phyRxHeader     => phyRxHeader,                         -- [in]
+         phyRxData       => phyRxData,                           -- [in]
+         phyRxStartSeq   => phyRxStartSeq,                       -- [in]
+         phyRxSlip       => phyRxSlip,                           -- [out]
+         -- Debug Interface
+         loopback        => loopback,                            -- [out]
+         txDiffCtrl      => txDiffCtrl,                          -- [out]
+         txPreCursor     => txPreCursor,                         -- [out]
+         txPostCursor    => txPostCursor,                        -- [out]
+         -- AXI-Lite Register Interface (axilClk domain)
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(PGP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(PGP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(PGP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(PGP_AXIL_INDEX_C));  -- [out]
+
+   --------------------------
+   -- Wrapper for GTH IP core
+   --------------------------
+   U_Pgp3GtyUsIpWrapper_1 : entity surf.Pgp3GtyUsIpWrapper -- Same IP core for both PGPv3 and PGPv4
+      generic map (
+         TPD_G         => TPD_G,
+         TX_POLARITY_G => TX_POLARITY_G,
+         RX_POLARITY_G => RX_POLARITY_G,
+         RATE_G        => RATE_G,
+         EN_DRP_G      => EN_DRP_G)
+      port map (
+         stableClk       => stableClk,                           -- [in]
+         stableRst       => stableRst,                           -- [in]
+         qpllLock        => qpllLock,                            -- [in]
+         qpllclk         => qpllclk,                             -- [in]
+         qpllrefclk      => qpllrefclk,                          -- [in]
+         qpllRst         => qpllRst,                             -- [out]
+         gtRxP           => pgpGtRxP,                            -- [in]
+         gtRxN           => pgpGtRxN,                            -- [in]
+         gtTxP           => pgpGtTxP,                            -- [out]
+         gtTxN           => pgpGtTxN,                            -- [out]
+         rxReset         => phyRxInit,                           -- [in]
+         rxUsrClkActive  => open,                                -- [out]
+         rxResetDone     => phyRxActive,                         -- [out]
+         rxUsrClk        => open,                                -- [out]
+         rxUsrClk2       => phyRxClk,                            -- [out]
+         rxUsrClkRst     => phyRxRst,                            -- [out]
+         rxData          => phyRxData,                           -- [out]
+         rxDataValid     => phyRxValid,                          -- [out]
+         rxHeader        => phyRxHeader,                         -- [out]
+         rxHeaderValid   => open,                                -- [out]
+         rxStartOfSeq    => phyRxStartSeq,                       -- [out]
+         rxGearboxSlip   => phyRxSlip,                           -- [in]
+         rxOutClk        => open,                                -- [out]
+         txReset         => '0',                                 -- [in]
+         txUsrClkActive  => open,                                -- [out]
+         txResetDone     => phyTxActive,                         -- [out]
+         txUsrClk        => open,                                -- [out]
+         txUsrClk2       => pgpTxClkInt,                         -- [out]
+         txUsrClkRst     => pgpTxRstInt,                         -- [out]
+         txData          => phyTxData,                           -- [in]
+         txHeader        => phyTxHeader,                         -- [in]
+         txOutClk        => open,                                -- [out]
+         loopback        => loopback,                            -- [in]
+         txDiffCtrl      => txDiffCtrl,                          -- [in]
+         txPreCursor     => txPreCursor,                         -- [in]
+         txPostCursor    => txPostCursor,                        -- [in]
+         axilClk         => axilClk,                             -- [in]
+         axilRst         => axilRst,                             -- [in]
+         axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C),   -- [in]
+         axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C),    -- [out]
+         axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C),  -- [in]
+         axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C));  -- [out]
+
+
+end rtl;

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
@@ -1,0 +1,311 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 GTY Ultrascale+ Wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity Pgp4GtyUsWrapper is
+   generic (
+      TPD_G                       : time                        := 1 ns;
+      ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
+      SYNTH_MODE_G                : string                      := "inferred";
+      MEMORY_TYPE_G               : string                      := "block";
+      NUM_LANES_G                 : positive range 1 to 4       := 1;
+      NUM_VC_G                    : positive range 1 to 16      := 4;
+      REFCLK_G                    : boolean                     := false;  --  FALSE: pgpRefClkP/N,  TRUE: pgpRefClkIn
+      RATE_G                      : string                      := "10.3125Gbps";  -- or "6.25Gbps" or "3.125Gbps"
+      ----------------------------------------------------------------------------------------------
+      -- PGP Settings
+      ----------------------------------------------------------------------------------------------
+      PGP_RX_ENABLE_G             : boolean                     := true;
+      RX_ALIGN_SLIP_WAIT_G        : integer                     := 32;
+      PGP_TX_ENABLE_G             : boolean                     := true;
+      TX_CELL_WORDS_MAX_G         : integer                     := PGP4_DEFAULT_TX_CELL_WORDS_MAX_C;  -- Number of 64-bit words per cell
+      TX_MUX_MODE_G               : string                      := "INDEXED";      -- Or "ROUTED"
+      TX_MUX_TDEST_ROUTES_G       : Slv8Array                   := (0      => "--------");  -- Only used in ROUTED mode
+      TX_MUX_TDEST_LOW_G          : integer range 0 to 7        := 0;
+      TX_MUX_ILEAVE_EN_G          : boolean                     := true;
+      TX_MUX_ILEAVE_ON_NOTVALID_G : boolean                     := true;
+      EN_PGP_MON_G                : boolean                     := false;
+      EN_GTH_DRP_G                : boolean                     := false;
+      EN_QPLL_DRP_G               : boolean                     := false;
+      TX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      RX_POLARITY_G               : slv(3 downto 0)             := x"0";
+      AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
+      AXIL_CLK_FREQ_G             : real                        := 125.0E+6);
+   port (
+      -- Stable Clock and Reset
+      stableClk         : in  sl;       -- GT needs a stable clock to "boot up"
+      stableRst         : in  sl;
+      -- Gt Serial IO
+      pgpGtTxP          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtTxN          : out slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxP          : in  slv(NUM_LANES_G-1 downto 0);
+      pgpGtRxN          : in  slv(NUM_LANES_G-1 downto 0);
+      -- GT Clocking
+      pgpRefClkP        : in  sl                                                     := '0';  -- 156.25 MHz
+      pgpRefClkN        : in  sl                                                     := '1';  -- 156.25 MHz
+      pgpRefClkIn       : in  sl                                                     := '0';  -- 156.25 MHz
+      pgpRefClkOut      : out sl;
+      pgpRefClkDiv2Bufg : out sl;
+      -- Clocking
+      pgpClk            : out slv(NUM_LANES_G-1 downto 0);
+      pgpClkRst         : out slv(NUM_LANES_G-1 downto 0);
+      -- Non VC Rx Signals
+      pgpRxIn           : in  Pgp4RxInArray(NUM_LANES_G-1 downto 0);
+      pgpRxOut          : out Pgp4RxOutArray(NUM_LANES_G-1 downto 0);
+      -- Non VC Tx Signals
+      pgpTxIn           : in  Pgp4TxInArray(NUM_LANES_G-1 downto 0);
+      pgpTxOut          : out Pgp4TxOutArray(NUM_LANES_G-1 downto 0);
+      -- Frame Transmit Interface
+      pgpTxMasters      : in  AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpTxSlaves       : out AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters      : out AxiStreamMasterArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);
+      pgpRxCtrl         : in  AxiStreamCtrlArray((NUM_LANES_G*NUM_VC_G)-1 downto 0);  -- Used in implementation only
+      pgpRxSlaves       : in  AxiStreamSlaveArray((NUM_LANES_G*NUM_VC_G)-1 downto 0) := (others => AXI_STREAM_SLAVE_FORCE_C);  -- Used in simulation only
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk           : in  sl                                                     := '0';  -- Stable Clock
+      axilRst           : in  sl                                                     := '0';
+      axilReadMaster    : in  AxiLiteReadMasterType                                  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave     : out AxiLiteReadSlaveType                                   := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+      axilWriteMaster   : in  AxiLiteWriteMasterType                                 := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave    : out AxiLiteWriteSlaveType                                  := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+end Pgp4GtyUsWrapper;
+
+architecture rtl of Pgp4GtyUsWrapper is
+
+   signal qpllLock   : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllClk    : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRefclk : Slv2Array(3 downto 0) := (others => "00");
+   signal qpllRst    : Slv2Array(3 downto 0) := (others => "00");
+
+   signal pgpRefClkDiv2 : sl;
+   signal pgpRefClk     : sl;
+
+   constant NUM_AXIL_MASTERS_C : integer := NUM_LANES_G+1;
+   constant QPLL_AXIL_INDEX_C  : integer := NUM_AXIL_MASTERS_C-1;
+
+   constant XBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) :=
+      genAxiLiteConfig(NUM_AXIL_MASTERS_C, AXIL_BASE_ADDR_G, 16, 13);
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+
+begin
+
+   pgpRefClkOut <= pgpRefClk;
+
+   INT_REFCLK : if (REFCLK_G = false) generate
+
+      U_BUFG_GT : BUFG_GT
+         port map (
+            I       => pgpRefClkDiv2,
+            CE      => '1',
+            CLR     => '0',
+            CEMASK  => '1',
+            CLRMASK => '1',
+            DIV     => "000",           -- Divide by 1
+            O       => pgpRefClkDiv2Bufg);
+
+      U_pgpRefClk : IBUFDS_GTE4
+         generic map (
+            REFCLK_EN_TX_PATH  => '0',
+            REFCLK_HROW_CK_SEL => "00",  -- 2'b00: ODIV2 = O
+            REFCLK_ICNTL_RX    => "00")
+         port map (
+            I     => pgpRefClkP,
+            IB    => pgpRefClkN,
+            CEB   => '0',
+            ODIV2 => pgpRefClkDiv2,
+            O     => pgpRefClk);
+
+   end generate;
+
+   EXT_REFCLK : if (REFCLK_G = true) generate
+
+      pgpRefClkDiv2Bufg <= '0';
+      pgpRefClk         <= pgpRefClkIn;
+
+   end generate;
+
+   REAL_PGP : if (not ROGUE_SIM_EN_G) generate
+
+      U_XBAR : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 1,
+            NUM_MASTER_SLOTS_G => NUM_AXIL_MASTERS_C,
+            MASTERS_CONFIG_G   => XBAR_CONFIG_C)
+         port map (
+            axiClk              => axilClk,
+            axiClkRst           => axilRst,
+            sAxiWriteMasters(0) => axilWriteMaster,
+            sAxiWriteSlaves(0)  => axilWriteSlave,
+            sAxiReadMasters(0)  => axilReadMaster,
+            sAxiReadSlaves(0)   => axilReadSlave,
+            mAxiWriteMasters    => axilWriteMasters,
+            mAxiWriteSlaves     => axilWriteSlaves,
+            mAxiReadMasters     => axilReadMasters,
+            mAxiReadSlaves      => axilReadSlaves);
+
+      U_QPLL : entity surf.Pgp3GtyUsQpll -- Same IP core for both PGPv3 and PGPv4
+         generic map (
+            TPD_G    => TPD_G,
+            RATE_G   => RATE_G,
+            EN_DRP_G => EN_QPLL_DRP_G)
+         port map (
+            -- Stable Clock and Reset
+            stableClk       => stableClk,                            -- [in]
+            stableRst       => stableRst,                            -- [in]
+            -- QPLL Clocking
+            pgpRefClk       => pgpRefClk,                            -- [in]
+            qpllLock        => qpllLock,                             -- [out]
+            qpllClk         => qpllClk,                              -- [out]
+            qpllRefclk      => qpllRefclk,                           -- [out]
+            qpllRst         => qpllRst,                              -- [in]
+            axilClk         => axilClk,                              -- [in]
+            axilRst         => axilRst,                              -- [in]
+            axilReadMaster  => axilReadMasters(QPLL_AXIL_INDEX_C),   -- [in]
+            axilReadSlave   => axilReadSlaves(QPLL_AXIL_INDEX_C),    -- [out]
+            axilWriteMaster => axilWriteMasters(QPLL_AXIL_INDEX_C),  -- [in]
+            axilWriteSlave  => axilWriteSlaves(QPLL_AXIL_INDEX_C));  -- [out]
+
+      -----------
+      -- PGP Core
+      -----------
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Pgp : entity surf.Pgp4GtyUs
+            generic map (
+               TPD_G                       => TPD_G,
+               RATE_G                      => RATE_G,
+               SYNTH_MODE_G                => SYNTH_MODE_G,
+               ----------------------------------------------------------------------------------------------
+               -- PGP Settings
+               ----------------------------------------------------------------------------------------------
+               PGP_RX_ENABLE_G             => PGP_RX_ENABLE_G,
+               RX_ALIGN_SLIP_WAIT_G        => RX_ALIGN_SLIP_WAIT_G,
+               PGP_TX_ENABLE_G             => PGP_TX_ENABLE_G,
+               NUM_VC_G                    => NUM_VC_G,
+               TX_CELL_WORDS_MAX_G         => TX_CELL_WORDS_MAX_G,
+               TX_MUX_MODE_G               => TX_MUX_MODE_G,
+               TX_MUX_TDEST_ROUTES_G       => TX_MUX_TDEST_ROUTES_G,
+               TX_MUX_TDEST_LOW_G          => TX_MUX_TDEST_LOW_G,
+               TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
+               TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
+               EN_PGP_MON_G                => EN_PGP_MON_G,
+               EN_DRP_G                    => EN_GTH_DRP_G,
+               TX_POLARITY_G               => TX_POLARITY_G(i),
+               RX_POLARITY_G               => RX_POLARITY_G(i),
+               AXIL_BASE_ADDR_G            => XBAR_CONFIG_C(i).baseAddr,
+               AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
+            port map (
+               -- Stable Clock and Reset
+               stableClk       => stableClk,
+               stableRst       => stableRst,
+               -- QPLL Interface
+               qpllLock        => qpllLock(i),
+               qpllClk         => qpllClk(i),
+               qpllRefclk      => qpllRefclk(i),
+               qpllRst         => qpllRst(i),
+               -- Gt Serial IO
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- Clocking
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxCtrl       => pgpRxCtrl(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+
+      end generate GEN_LANE;
+
+   end generate REAL_PGP;
+
+   SIM_PGP : if (ROGUE_SIM_EN_G) generate
+      GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
+         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+            generic map(
+               TPD_G      => TPD_G,
+               SYNTH_MODE_G  => SYNTH_MODE_G,
+               MEMORY_TYPE_G => MEMORY_TYPE_G,
+               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               NUM_VC_G   => NUM_VC_G)
+            port map(
+               -- GT Ports
+               pgpRefClk       => pgpRefClk,
+               pgpGtTxP        => pgpGtTxP(i),
+               pgpGtTxN        => pgpGtTxN(i),
+               pgpGtRxP        => pgpGtRxP(i),
+               pgpGtRxN        => pgpGtRxN(i),
+               -- PGP Clock and Reset
+               pgpClk          => pgpClk(i),
+               pgpClkRst       => pgpClkRst(i),
+               -- Non VC Rx Signals
+               pgpRxIn         => pgpRxIn(i),
+               pgpRxOut        => pgpRxOut(i),
+               -- Non VC Tx Signals
+               pgpTxIn         => pgpTxIn(i),
+               pgpTxOut        => pgpTxOut(i),
+               -- Frame Transmit Interface
+               pgpTxMasters    => pgpTxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpTxSlaves     => pgpTxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- Frame Receive Interface
+               pgpRxMasters    => pgpRxMasters(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               pgpRxSlaves     => pgpRxSlaves(((i+1)*NUM_VC_G)-1 downto (i*NUM_VC_G)),
+               -- AXI-Lite Register Interface (axilClk domain)
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
+      end generate GEN_LANE;
+   end generate SIM_PGP;
+
+end rtl;

--- a/protocols/pgp/pgp4/gtyUs+/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtyUs+/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -1,0 +1,45 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load the Core
+loadRuckusTcl "$::DIR_PATH/core"
+
+# Get the family type
+set family [getFpgaFamily]
+
+if { ${family} eq {artix7} } {
+   loadRuckusTcl "$::DIR_PATH/gtp7"
+}
+
+if { ${family} eq {kintex7} } {
+   loadRuckusTcl "$::DIR_PATH/gtx7"
+}
+
+if { ${family} eq {zynq} } {
+   if { [ regexp "XC7Z(015|012).*" [string toupper "$::env(PRJ_PART)"] ] } {
+      loadRuckusTcl "$::DIR_PATH/gtp7"
+   } else {
+      loadRuckusTcl "$::DIR_PATH/gtx7"
+   }
+}
+
+# if { ${family} eq {virtex7} } {
+   # loadRuckusTcl "$::DIR_PATH/gth7"
+# }
+
+if { ${family} eq {kintexu} } {
+   loadRuckusTcl "$::DIR_PATH/gthUs"
+}
+
+if { ${family} eq {kintexuplus} ||
+     ${family} eq {zynquplus} ||
+     ${family} eq {zynquplusRFSOC} ||
+     ${family} eq {qzynquplusRFSOC} } {
+   loadRuckusTcl "$::DIR_PATH/gthUs+"
+   loadRuckusTcl "$::DIR_PATH/gtyUs+"
+}
+
+if { ${family} eq {virtexuplus} ||
+     ${family} eq {virtexuplusHBM} } {
+   loadRuckusTcl "$::DIR_PATH/gtyUs+"
+}

--- a/protocols/pgp/ruckus.tcl
+++ b/protocols/pgp/ruckus.tcl
@@ -5,5 +5,6 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/eth"
 loadRuckusTcl "$::DIR_PATH/pgp2b"
 loadRuckusTcl "$::DIR_PATH/pgp3"
+loadRuckusTcl "$::DIR_PATH/pgp4"
 
 loadSource -lib surf -dir "$::DIR_PATH/shared"

--- a/python/surf/protocols/pgp/_Pgp4AxiL.py
+++ b/python/surf/protocols/pgp/_Pgp4AxiL.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# This file is part of 'SLAC Firmware Standard Library'.
+# It is subject to the license terms in the LICENSE.txt file found in the
+# top-level directory of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of 'SLAC Firmware Standard Library', including this file,
+# may be copied, modified, propagated, or distributed except according to
+# the terms contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import surf.protocols.pgp as pgp
+
+class Pgp4AxiL(pgp.Pgp3AxiL):
+    def __init__(self,
+                 description = "Configuration and status a PGP 4 link",
+                 **kwargs):
+        super().__init__(description=description, **kwargs)

--- a/python/surf/protocols/pgp/__init__.py
+++ b/python/surf/protocols/pgp/__init__.py
@@ -9,4 +9,5 @@
 ##############################################################################
 from surf.protocols.pgp._Pgp2bAxi   import *
 from surf.protocols.pgp._Pgp3AxiL   import *
+from surf.protocols.pgp._Pgp4AxiL   import *
 from surf.protocols.pgp._PgpEthAxiL import *


### PR DESCRIPTION
### Description
- adding PGPv4 source code
- bug fixes for Pgp3Tb.vhd
- reuse the .XDC files from PGPv3 for PGPv4 for GTX7/GTP7
- removed the 'PGP3_' prefix in the Pgp3RefClkType types
- reduced USER codes from 8 to 1
- Changed REFCLK_TYPE_G to REFCLK_FREQ_G
  - converting Pgp3RefClkType/Pgp4RefClkType enum to real type
  - This might break existing PGPv3 builds