### PR TITLE
PGPv4 AXI-Lite Module + Additional Packetizer Debug signals

### DIFF
--- a/protocols/packetizer/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/protocols/packetizer/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -67,23 +67,35 @@ package AxiStreamPacketizer2Pkg is
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
 
    type Packetizer2DebugType is record
-      initDone    : sl;
-      sof         : sl;
-      eof         : sl;
-      eofe        : sl;
-      sop         : sl;
-      eop         : sl;
-      packetError : sl;
+      initDone     : sl;
+      sof          : sl;
+      eof          : sl;
+      eofe         : sl;
+      sop          : sl;
+      eop          : sl;
+      packetError  : sl;
+      sofError     : sl;
+      seqError     : sl;
+      versionError : sl;
+      crcModeError : sl;
+      eofeError    : sl;
+      crcError     : sl;
    end record Packetizer2DebugType;
    type Packetizer2DebugArray is array (natural range<>) of Packetizer2DebugType;
    constant PACKETIZER2_DEBUG_INIT_C : Packetizer2DebugType := (
-      initDone    => '0',
-      sof         => '0',
-      eof         => '0',
-      eofe        => '0',
-      sop         => '0',
-      eop         => '0',
-      packetError => '0');
+      initDone     => '0',
+      sof          => '0',
+      eof          => '0',
+      eofe         => '0',
+      sop          => '0',
+      eop          => '0',
+      packetError  => '0',
+      sofError     => '0',
+      seqError     => '0',
+      versionError => '0',
+      crcModeError => '0',
+      eofeError    => '0',
+      crcError     => '0');
 
    function crcStrToSlv (CRC_MODE_C : string) return slv;
 

--- a/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip10G.xdc
+++ b/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip10G.xdc
@@ -8,6 +8,6 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 
-create_clock -period 3.10303 [get_pins -hier -filter {name=~*gt0_Pgp3Gtx7Ip10G_i*gtxe2_i*TXOUTCLK}]
-create_clock -period 3.10303 [get_pins -hier -filter {name=~*gt0_Pgp3Gtx7Ip10G_i*gtxe2_i*RXOUTCLK}]
+create_clock -period 3.102 [get_pins -hier -filter {name=~*gt0_Pgp3Gtx7Ip10G_i*gtxe2_i*TXOUTCLK}]
+create_clock -period 3.102 [get_pins -hier -filter {name=~*gt0_Pgp3Gtx7Ip10G_i*gtxe2_i*RXOUTCLK}]
 set_false_path -to [get_cells -hierarchical -filter {NAME =~ *data_sync_reg1}]

--- a/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
@@ -1,0 +1,550 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: AXI-Lite block to manage the PGPv4 interface
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use IEEE.STD_LOGIC_ARITH.all;
+use IEEE.STD_LOGIC_UNSIGNED.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4AxiL is
+   generic (
+      TPD_G              : time                  := 1 ns;
+      COMMON_TX_CLK_G    : boolean               := false;  -- Set to true if axiClk and pgpTxClk are the same clock
+      COMMON_RX_CLK_G    : boolean               := false;  -- Set to true if axiClk and pgpRxClk are the same clock
+      WRITE_EN_G         : boolean               := true;  -- Set to false when on remote end of a link
+      NUM_VC_G           : integer range 1 to 16 := 4;
+      STATUS_CNT_WIDTH_G : natural range 1 to 32 := 16;
+      ERROR_CNT_WIDTH_G  : natural range 1 to 32 := 8;
+      AXIL_CLK_FREQ_G    : real                  := 125.0E+6);
+   port (
+      -- TX PGP Interface (pgpTxClk)
+      pgpTxClk        : in  sl;
+      pgpTxRst        : in  sl;
+      pgpTxIn         : out Pgp4TxInType;
+      pgpTxOut        : in  Pgp4TxOutType;
+      locTxIn         : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
+      -- RX PGP Interface (pgpRxClk)
+      pgpRxClk        : in  sl;
+      pgpRxRst        : in  sl;
+      pgpRxIn         : out Pgp4RxInType;
+      pgpRxOut        : in  Pgp4RxOutType;
+      locRxIn         : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
+      -- Debug Interface (axilClk domain)
+      txDiffCtrl      : out slv(4 downto 0);
+      txPreCursor     : out slv(4 downto 0);
+      txPostCursor    : out slv(4 downto 0);
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl;
+      axilRst         : in  sl;
+      axilReadMaster  : in  AxiLiteReadMasterType;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType;
+      axilWriteSlave  : out AxiLiteWriteSlaveType);
+end Pgp4AxiL;
+
+architecture mapping of Pgp4AxiL is
+
+   constant RX_STATUS_CNT_SIZE_C : integer := 2;
+   constant RX_ERROR_CNT_SIZE_C  : integer := 16;
+
+   constant TX_STATUS_CNT_SIZE_C : integer := 2;
+   constant TX_ERROR_CNT_SIZE_C  : integer := 3;
+
+   type RegType is record
+      countReset     : sl;
+      skpInterval    : slv(31 downto 0);
+      loopBack       : slv(2 downto 0);
+      flowCntlDis    : sl;
+      txDisable      : sl;
+      resetTx        : sl;
+      resetRx        : sl;
+      txDiffCtrl     : slv(4 downto 0);
+      txPreCursor    : slv(4 downto 0);
+      txPostCursor   : slv(4 downto 0);
+      axilWriteSlave : AxiLiteWriteSlaveType;
+      axilReadSlave  : AxiLiteReadSlaveType;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      countReset     => '0',
+      skpInterval    => PGP4_TX_IN_INIT_C.skpInterval,
+      loopBack       => (others => '0'),
+      flowCntlDis    => PGP4_TX_IN_INIT_C.flowCntlDis,
+      txDisable      => PGP4_TX_IN_INIT_C.disable,
+      resetTx        => PGP4_TX_IN_INIT_C.resetTx,
+      resetRx        => PGP4_RX_IN_INIT_C.resetRx,
+      txDiffCtrl     => (others => '1'),
+      txPreCursor    => "00111",
+      txPostCursor   => "00111",
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C,
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   -- RX
+   signal rxClkFreq    : slv(31 downto 0);
+   signal resetRx      : sl;
+   signal remLinkData  : slv(47 downto 0);
+   signal rxOpCodeData : slv(47 downto 0);
+
+   signal remRxPause    : slv(NUM_VC_G-1 downto 0);
+   signal remRxPauseCnt : SlVectorArray(NUM_VC_G-1 downto 0, STATUS_CNT_WIDTH_G-1 downto 0);
+
+   signal remRxOverflow    : slv(NUM_VC_G-1 downto 0);
+   signal remRxOverflowCnt : SlVectorArray(NUM_VC_G-1 downto 0, ERROR_CNT_WIDTH_G-1 downto 0);
+
+   signal rxStatus    : slv(RX_STATUS_CNT_SIZE_C-1 downto 0);
+   signal rxStatusCnt : SlVectorArray(RX_STATUS_CNT_SIZE_C-1 downto 0, STATUS_CNT_WIDTH_G-1 downto 0);
+
+   signal rxError    : slv(RX_ERROR_CNT_SIZE_C-1 downto 0);
+   signal rxErrorCnt : SlVectorArray(RX_ERROR_CNT_SIZE_C-1 downto 0, ERROR_CNT_WIDTH_G-1 downto 0);
+
+   -- TX
+   signal txClkFreq    : slv(31 downto 0);
+   signal skpInterval  : slv(31 downto 0);
+   signal flowCntlDis  : sl;
+   signal txDisable    : sl;
+   signal resetTx      : sl;
+   signal locData      : slv(47 downto 0);
+   signal txOpCodeData : slv(47 downto 0);
+
+   signal locPause    : slv(NUM_VC_G-1 downto 0);
+   signal locPauseCnt : SlVectorArray(NUM_VC_G-1 downto 0, STATUS_CNT_WIDTH_G-1 downto 0);
+
+   signal locOverflow    : slv(NUM_VC_G-1 downto 0);
+   signal locOverflowCnt : SlVectorArray(NUM_VC_G-1 downto 0, ERROR_CNT_WIDTH_G-1 downto 0);
+
+   signal txStatus    : slv(TX_STATUS_CNT_SIZE_C-1 downto 0);
+   signal txStatusCnt : SlVectorArray(TX_STATUS_CNT_SIZE_C-1 downto 0, STATUS_CNT_WIDTH_G-1 downto 0);
+
+   signal txError    : slv(TX_ERROR_CNT_SIZE_C-1 downto 0);
+   signal txErrorCnt : SlVectorArray(TX_ERROR_CNT_SIZE_C-1 downto 0, ERROR_CNT_WIDTH_G-1 downto 0);
+
+begin
+
+   ---------------
+   -- Set TX input
+   ---------------
+   pgpTxIn.disable     <= locTxIn.disable or txDisable;
+   pgpTxIn.flowCntlDis <= locTxIn.flowCntlDis or flowCntlDis;
+   pgpTxIn.resetTx     <= locTxIn.resetTx or resetTx;
+   pgpTxIn.skpInterval <= skpInterval when(WRITE_EN_G) else locTxIn.skpInterval;
+   pgpTxIn.opCodeEn    <= locTxIn.opCodeEn;
+   pgpTxIn.opCodeData  <= locTxIn.opCodeData;
+   pgpTxIn.locData     <= locTxIn.locData;
+
+   ---------------
+   -- Set RX input
+   ---------------
+   pgpRxIn.loopback <= locRxIn.loopback or r.loopBack;
+   pgpRxIn.resetRx  <= locRxIn.resetRx or resetRx;
+
+   ---------------------
+   -- AXI-Lite Registers
+   ---------------------
+   process (axilReadMaster, axilRst, axilWriteMaster, locData, locOverflowCnt,
+            locPause, locPauseCnt, r, remLinkData, remRxOverflowCnt,
+            remRxPause, remRxPauseCnt, rxClkFreq, rxError, rxErrorCnt,
+            rxOpCodeData, rxStatus, rxStatusCnt, txClkFreq, txError,
+            txErrorCnt, txOpCodeData, txStatus, txStatusCnt) is
+      variable v      : RegType;
+      variable axilEp : AxiLiteEndpointType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      axiSlaveWaitTxn(axilEp, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
+
+      ----------------------------------------------------------------------------------------------
+      -- Control = 0x000 in SW
+      ----------------------------------------------------------------------------------------------
+
+      axiSlaveRegister (axilEp, x"000", 0, v.countReset);
+      axiSlaveRegisterR(axilEp, x"004", 0, ite(WRITE_EN_G, '1', '0'));
+      axiSlaveRegisterR(axilEp, x"004", 8, toSlv(NUM_VC_G, 8));
+      axiSlaveRegisterR(axilEp, x"004", 16, toSlv(STATUS_CNT_WIDTH_G, 8));
+      axiSlaveRegisterR(axilEp, x"004", 24, toSlv(ERROR_CNT_WIDTH_G, 8));
+
+      if (WRITE_EN_G) then
+         axiSlaveRegister (axilEp, x"008", 0, v.skpInterval);
+         axiSlaveRegister (axilEp, x"00C", 0, v.loopback);
+         axiSlaveRegister (axilEp, x"00C", 3, v.flowCntlDis);
+         axiSlaveRegister (axilEp, x"00C", 4, v.txDisable);
+         axiSlaveRegister (axilEp, x"00C", 5, v.resetTx);
+         axiSlaveRegister (axilEp, x"00C", 6, v.resetTx);
+         axiSlaveRegister (axilEp, x"00C", 8, v.txDiffCtrl);
+         axiSlaveRegister (axilEp, x"00C", 16, v.txPreCursor);
+         axiSlaveRegister (axilEp, x"00C", 24, v.txPostCursor);
+      else
+         axiSlaveRegisterR(axilEp, x"008", 0, r.skpInterval);
+         axiSlaveRegisterR(axilEp, x"00C", 0, r.loopback);
+         axiSlaveRegisterR(axilEp, x"00C", 3, r.flowCntlDis);
+         axiSlaveRegisterR(axilEp, x"00C", 4, r.txDisable);
+         axiSlaveRegisterR(axilEp, x"00C", 5, r.resetTx);
+         axiSlaveRegisterR(axilEp, x"00C", 6, r.resetTx);
+         axiSlaveRegisterR(axilEp, x"00C", 8, r.txDiffCtrl);
+         axiSlaveRegisterR(axilEp, x"00C", 16, r.txPreCursor);
+         axiSlaveRegisterR(axilEp, x"00C", 24, r.txPostCursor);
+      end if;
+
+      ----------------------------------------------------------------------------------------------
+      -- RX Status: Offset = 0x400 in SW
+      ----------------------------------------------------------------------------------------------
+
+      for i in 0 to NUM_VC_G-1 loop
+         axiSlaveRegisterR(axilEp, x"400"+toSlv(i*4, 12), 0, muxSlVectorArray(remRxPauseCnt, i));  -- 0x400:0x43F
+         axiSlaveRegisterR(axilEp, x"440"+toSlv(i*4, 12), 0, muxSlVectorArray(remRxOverflowCnt, i));  -- 0x440:0x47F
+      end loop;
+
+      for i in 0 to RX_STATUS_CNT_SIZE_C-1 loop
+         axiSlaveRegisterR(axilEp, x"500"+toSlv(i*4, 12), 0, muxSlVectorArray(rxStatusCnt, i));
+      end loop;
+
+      for i in 0 to RX_ERROR_CNT_SIZE_C-1 loop
+         axiSlaveRegisterR(axilEp, x"600"+toSlv(i*4, 12), 0, muxSlVectorArray(rxErrorCnt, i));
+      end loop;
+
+      axiSlaveRegisterR(axilEp, x"710", 0, rxError);
+      axiSlaveRegisterR(axilEp, x"720", 0, remLinkData);
+      axiSlaveRegisterR(axilEp, x"730", 0, rxOpCodeData);
+      axiSlaveRegisterR(axilEp, x"740", 0, remRxPause);
+      axiSlaveRegisterR(axilEp, x"750", 0, rxClkFreq);
+
+      ----------------------------------------------------------------------------------------------
+      -- TX Status: Offset = 0x800 in SW
+      ----------------------------------------------------------------------------------------------
+
+      for i in 0 to NUM_VC_G-1 loop
+         axiSlaveRegisterR(axilEp, x"800"+toSlv(i*4, 12), 0, muxSlVectorArray(locPauseCnt, i));  -- 0x800:0x83F
+         axiSlaveRegisterR(axilEp, x"840"+toSlv(i*4, 12), 0, muxSlVectorArray(locOverflowCnt, i));  -- 0x840:0x87F
+      end loop;
+
+      for i in 0 to TX_STATUS_CNT_SIZE_C-1 loop
+         axiSlaveRegisterR(axilEp, x"900"+toSlv(i*4, 12), 0, muxSlVectorArray(txStatusCnt, i));
+      end loop;
+
+      for i in 0 to TX_ERROR_CNT_SIZE_C-1 loop
+         axiSlaveRegisterR(axilEp, x"A00"+toSlv(i*4, 12), 0, muxSlVectorArray(txErrorCnt, i));
+      end loop;
+
+      axiSlaveRegisterR(axilEp, x"B10", 0, txError);
+      axiSlaveRegisterR(axilEp, x"B20", 0, locData);
+      axiSlaveRegisterR(axilEp, x"B30", 0, txOpCodeData);
+      axiSlaveRegisterR(axilEp, x"B40", 0, locPause);
+      axiSlaveRegisterR(axilEp, x"B50", 0, txClkFreq);
+
+      ----------------------------------------------------------------------------------------------
+
+      axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
+
+      -- Outputs
+      axilReadSlave  <= r.axilReadSlave;
+      axilWriteSlave <= r.axilWriteSlave;
+      txDiffCtrl     <= r.txDiffCtrl;
+      txPreCursor    <= r.txPreCursor;
+      txPostCursor   <= r.txPostCursor;
+
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Next register assignment
+      rin <= v;
+
+   end process;
+
+   process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process;
+
+   ----------------------------------------------------------------------------------------------
+   -- RX SYNC
+   ----------------------------------------------------------------------------------------------
+   U_RxClkFreq : entity surf.SyncClockFreq
+      generic map (
+         TPD_G          => TPD_G,
+         REF_CLK_FREQ_G => AXIL_CLK_FREQ_G,
+         COMMON_CLK_G   => true,        -- locClk = refClk
+         CNT_WIDTH_G    => 32)
+      port map (
+         freqOut => rxClkFreq,
+         clkIn   => pgpRxClk,
+         locClk  => axilClk,
+         refClk  => axilClk);
+
+   U_RxSyncVec : entity surf.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_RX_CLK_G,
+         WIDTH_G       => 1)
+      port map (
+         clk        => pgpRxClk,
+         dataIn(0)  => r.resetRx,
+         dataOut(0) => resetRx);
+
+   U_remLinkData : entity surf.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         DATA_WIDTH_G => 48)
+      port map (
+         wr_clk => pgpRxClk,
+         din    => pgpRxOut.remLinkData,
+         rd_clk => axilClk,
+         dout   => remLinkData);
+
+   U_RxOpCode : entity surf.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         DATA_WIDTH_G => 48)
+      port map (
+         rst    => r.countReset,
+         wr_clk => pgpRxClk,
+         wr_en  => pgpRxOut.opCodeEn,
+         din    => pgpRxOut.opCodeData,
+         rd_clk => axilClk,
+         dout   => rxOpCodeData);
+
+   U_remRxPause : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         CNT_WIDTH_G  => STATUS_CNT_WIDTH_G,
+         WIDTH_G      => NUM_VC_G)
+      port map (
+         statusIn     => pgpRxOut.remRxPause(NUM_VC_G-1 downto 0),
+         statusOut    => remRxPause,
+         cntOut       => remRxPauseCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '1'),
+         wrClk        => pgpRxClk,
+         wrRst        => pgpRxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_remRxOverflow : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
+         WIDTH_G      => NUM_VC_G)
+      port map (
+         statusIn     => pgpRxOut.remRxOverflow(NUM_VC_G-1 downto 0),
+         statusOut    => remRxOverflow,
+         cntOut       => remRxOverflowCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '0'),
+         wrClk        => pgpRxClk,
+         wrRst        => pgpRxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_rxStatusCnt : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         CNT_WIDTH_G  => STATUS_CNT_WIDTH_G,
+         WIDTH_G      => RX_STATUS_CNT_SIZE_C)
+      port map (
+         statusIn(0)  => pgpRxOut.frameRx,
+         statusIn(1)  => pgpRxOut.opCodeEn,
+         statusOut    => rxStatus,
+         cntOut       => rxStatusCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '1'),
+         wrClk        => pgpRxClk,
+         wrRst        => pgpRxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_rxErrorCnt : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_RX_CLK_G,
+         CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
+         WIDTH_G      => RX_ERROR_CNT_SIZE_C)
+      port map (
+         statusIn(0)  => pgpRxOut.phyRxActive,
+         statusIn(1)  => pgpRxOut.phyRxInit,
+         statusIn(2)  => pgpRxOut.gearboxAligned,
+         statusIn(3)  => pgpRxOut.linkReady,
+         statusIn(4)  => pgpRxOut.remRxLinkReady,
+         statusIn(5)  => pgpRxOut.frameRxErr,
+         statusIn(6)  => pgpRxOut.linkDown,
+         statusIn(7)  => pgpRxOut.linkError,
+         statusIn(8)  => pgpRxOut.ebOverflow,
+         statusIn(9)  => pgpRxOut.cellError,
+         statusIn(10)  => pgpRxOut.cellSofError,
+         statusIn(11)  => pgpRxOut.cellSeqError,
+         statusIn(12)  => pgpRxOut.cellVersionError,
+         statusIn(13)  => pgpRxOut.cellCrcModeError,
+         statusIn(14)  => pgpRxOut.cellCrcError,
+         statusIn(15)  => pgpRxOut.cellEofeError,
+         statusOut    => rxError,
+         cntOut       => rxErrorCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '0'),
+         wrClk        => pgpRxClk,
+         wrRst        => pgpRxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   ----------------------------------------------------------------------------------------------
+   -- TX SYNC
+   ----------------------------------------------------------------------------------------------
+   U_TxClkFreq : entity surf.SyncClockFreq
+      generic map (
+         TPD_G          => TPD_G,
+         REF_CLK_FREQ_G => AXIL_CLK_FREQ_G,
+         COMMON_CLK_G   => true,        -- locClk = refClk
+         CNT_WIDTH_G    => 32)
+      port map (
+         freqOut => txClkFreq,
+         clkIn   => pgpTxClk,
+         locClk  => axilClk,
+         refClk  => axilClk);
+
+   U_SKP_SYNC : entity surf.SynchronizerVector  -- Using Synchronizer (instead of Fifo) to save on LUTs and because rarely changed and Pgp4TxProtocol.vhd includes a register changed detection logic
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_TX_CLK_G,
+         WIDTH_G       => 32)
+      port map (
+         clk     => pgpTxClk,
+         dataIn  => r.skpInterval,
+         dataOut => pgpTxIn.skpInterval);
+
+   U_TxSyncVec : entity surf.SynchronizerVector
+      generic map (
+         TPD_G         => TPD_G,
+         BYPASS_SYNC_G => COMMON_TX_CLK_G,
+         WIDTH_G       => 3)
+      port map (
+         clk        => pgpTxClk,
+         dataIn(0)  => r.flowCntlDis,
+         dataIn(1)  => r.txDisable,
+         dataIn(2)  => r.resetTx,
+         dataOut(0) => flowCntlDis,
+         dataOut(1) => txDisable,
+         dataOut(2) => resetTx);
+
+   U_locData : entity surf.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         DATA_WIDTH_G => 48)
+      port map (
+         wr_clk => pgpTxClk,
+         din    => locTxIn.locData,
+         rd_clk => axilClk,
+         dout   => locData);
+
+   U_TxOpCode : entity surf.SynchronizerFifo
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         DATA_WIDTH_G => 48)
+      port map (
+         rst    => r.countReset,
+         wr_clk => pgpTxClk,
+         wr_en  => locTxIn.opCodeEn,
+         din    => locTxIn.opCodeData,
+         rd_clk => axilClk,
+         dout   => txOpCodeData);
+
+   U_locPause : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         CNT_WIDTH_G  => STATUS_CNT_WIDTH_G,
+         WIDTH_G      => NUM_VC_G)
+      port map (
+         statusIn     => pgpTxOut.locPause(NUM_VC_G-1 downto 0),
+         statusOut    => locPause,
+         cntOut       => locPauseCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '1'),
+         wrClk        => pgpTxClk,
+         wrRst        => pgpTxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_locOverflow : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
+         WIDTH_G      => NUM_VC_G)
+      port map (
+         statusIn     => pgpTxOut.locOverflow(NUM_VC_G-1 downto 0),
+         statusOut    => locOverflow,
+         cntOut       => locOverflowCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '0'),
+         wrClk        => pgpTxClk,
+         wrRst        => pgpTxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_txStatusCnt : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         CNT_WIDTH_G  => STATUS_CNT_WIDTH_G,
+         WIDTH_G      => TX_STATUS_CNT_SIZE_C)
+      port map (
+         statusIn(0)  => pgpTxOut.frameTx,
+         statusIn(1)  => locTxIn.opCodeEn,
+         statusOut    => txStatus,
+         cntOut       => txStatusCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '1'),
+         wrClk        => pgpTxClk,
+         wrRst        => pgpTxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+   U_txErrorCnt : entity surf.SyncStatusVector
+      generic map (
+         TPD_G        => TPD_G,
+         COMMON_CLK_G => COMMON_TX_CLK_G,
+         CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
+         WIDTH_G      => TX_ERROR_CNT_SIZE_C)
+      port map (
+         statusIn(0)  => pgpTxOut.phyTxActive,
+         statusIn(1)  => pgpTxOut.linkReady,
+         statusIn(2)  => pgpTxOut.frameTxErr,
+         statusOut    => txError,
+         cntOut       => txErrorCnt,
+         cntRstIn     => r.countReset,
+         rollOverEnIn => (others => '0'),
+         wrClk        => pgpTxClk,
+         wrRst        => pgpTxRst,
+         rdClk        => axilClk,
+         rdRst        => axilRst);
+
+end mapping;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Core.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Core.vhd
@@ -38,6 +38,7 @@ entity Pgp4Core is
       TX_MUX_ILEAVE_EN_G          : boolean               := true;
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_PGP_MON_G                : boolean               := true;
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
       ERROR_CNT_WIDTH_G           : natural range 1 to 32 := 8;
       AXIL_CLK_FREQ_G             : real                  := 125.0E+6);
@@ -162,12 +163,13 @@ begin
          phyRxSlip      => phyRxSlip);      -- [out]
 
    GEN_PGP_MON : if (EN_PGP_MON_G) generate
-      U_Pgp3Axi_1 : entity surf.Pgp3AxiL  -- Same AXI-Lite module as PGPv3
+      U_Pgp4AxiL : entity surf.Pgp4AxiL
          generic map (
             TPD_G              => TPD_G,
             COMMON_TX_CLK_G    => false,
             COMMON_RX_CLK_G    => false,
-            WRITE_EN_G         => true,
+            WRITE_EN_G         => WRITE_EN_G,
+            NUM_VC_G           => NUM_VC_G,
             STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
             ERROR_CNT_WIDTH_G  => ERROR_CNT_WIDTH_G,
             AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G)
@@ -182,9 +184,6 @@ begin
             pgpRxIn         => pgpRxInInt,       -- [out]
             pgpRxOut        => pgpRxOutInt,      -- [in]
             locRxIn         => pgpRxIn,          -- [in]
-            statusWord      => open,             -- [out]
-            statusSend      => open,             -- [out]
-            phyRxClk        => phyRxClk,         -- [in]
             txDiffCtrl      => txDiffCtrl,       -- [out]
             txPreCursor     => txPreCursor,      -- [out]
             txPostCursor    => txPostCursor,     -- [out]

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Pkg.vhd
@@ -23,24 +23,29 @@ library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
 use surf.SsiPkg.all;
-use surf.Pgp3Pkg.all;
 
 package Pgp4Pkg is
 
    constant PGP4_VERSION_C : slv(7 downto 0) := toSlv(4, 8);  -- Version = 0x04
 
-   constant PGP4_DEFAULT_TX_CELL_WORDS_MAX_C : positive := PGP3_DEFAULT_TX_CELL_WORDS_MAX_C;
+   constant PGP4_DEFAULT_TX_CELL_WORDS_MAX_C : positive := 128;  -- Number of 64-bit words per cell
 
-   constant PGP4_AXIS_CONFIG_C : AxiStreamConfigType := PGP3_AXIS_CONFIG_C;
+   constant PGP4_AXIS_CONFIG_C : AxiStreamConfigType :=
+      ssiAxiStreamConfig(
+         dataBytes => 8,
+         tKeepMode => TKEEP_COMP_C,
+         tUserMode => TUSER_FIRST_LAST_C,
+         tDestBits => 4,
+         tUserBits => 2);
 
    -- Define K code BTFs
-   constant PGP4_IDLE_C : slv(7 downto 0) := PGP3_IDLE_C;
-   constant PGP4_SOF_C  : slv(7 downto 0) := PGP3_SOF_C;
-   constant PGP4_EOF_C  : slv(7 downto 0) := PGP3_EOF_C;
-   constant PGP4_SOC_C  : slv(7 downto 0) := PGP3_SOC_C;
-   constant PGP4_EOC_C  : slv(7 downto 0) := PGP3_EOC_C;
-   constant PGP4_SKP_C  : slv(7 downto 0) := PGP3_SKP_C;
-   constant PGP4_USER_C : slv(7 downto 0) := PGP3_USER_C(0);
+   constant PGP4_IDLE_C : slv(7 downto 0) := X"99";
+   constant PGP4_SOF_C  : slv(7 downto 0) := X"AA";
+   constant PGP4_EOF_C  : slv(7 downto 0) := X"55";
+   constant PGP4_SOC_C  : slv(7 downto 0) := X"CC";
+   constant PGP4_EOC_C  : slv(7 downto 0) := X"33";
+   constant PGP4_SKP_C  : slv(7 downto 0) := X"66";
+   constant PGP4_USER_C : slv(7 downto 0) := X"78";
 
    constant PGP4_VALID_BTF_ARRAY_C : Slv8Array := (
       0 => PGP4_IDLE_C,
@@ -51,10 +56,10 @@ package Pgp4Pkg is
       5 => PGP4_SKP_C,
       6 => PGP4_USER_C);
 
-   constant PGP4_D_HEADER_C : slv(1 downto 0) := PGP3_D_HEADER_C;
-   constant PGP4_K_HEADER_C : slv(1 downto 0) := PGP3_K_HEADER_C;
+   constant PGP4_D_HEADER_C : slv(1 downto 0) := "01";
+   constant PGP4_K_HEADER_C : slv(1 downto 0) := "10";
 
-   constant PGP4_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := PGP3_SCRAMBLER_TAPS_C;
+   constant PGP4_SCRAMBLER_TAPS_C : IntegerArray(0 to 1) := (0 => 39, 1 => 58);
 
    subtype PGP4_BTF_FIELD_C is natural range 63 downto 56;
    subtype PGP4_K_CODE_CRC_FIELD_C is natural range 55 downto 48;
@@ -69,7 +74,7 @@ package Pgp4Pkg is
    subtype PGP4_EOFC_BYTES_LAST_FIELD_C is natural range 15 downto 12;
    subtype PGP4_EOFC_CRC_FIELD_C is natural range 47 downto 16;
 
-   constant PGP4_CRC_POLY_C : slv(31 downto 0) := PGP3_CRC_POLY_C;
+   constant PGP4_CRC_POLY_C : slv(31 downto 0) := X"04C11DB7";
 
    function pgp4MakeLinkInfo (
       locRxFifoCtrl  : AxiStreamCtrlArray;
@@ -86,21 +91,101 @@ package Pgp4Pkg is
       kCodeWord : slv(63 downto 0))
       return slv;
 
-   subtype Pgp4TxInType is Pgp3TxInType;
-   subtype Pgp4TxInArray is Pgp3TxInArray;
-   constant PGP4_TX_IN_INIT_C : Pgp4TxInType := PGP3_TX_IN_INIT_C;
+   type Pgp4TxInType is record
+      disable     : sl;
+      flowCntlDis : sl;
+      resetTx     : sl;
+      skpInterval : slv(31 downto 0);
+      opCodeEn    : sl;
+      opCodeData  : slv(47 downto 0);
+      locData     : slv(47 downto 0);
+   end record Pgp4TxInType;
+   type Pgp4TxInArray is array (natural range<>) of Pgp4TxInType;
+   constant PGP4_TX_IN_INIT_C : Pgp4TxInType := (
+      disable     => '0',
+      flowCntlDis => '0',
+      resetTx     => '0',
+      skpInterval => toSlv(5000, 32),
+      opCodeEn    => '0',
+      opCodeData  => (others => '0'),
+      locData     => (others => '0'));
 
-   subtype Pgp4TxOutType is Pgp3TxOutType;
-   subtype Pgp4TxOutArray is Pgp3TxOutArray;
-   constant PGP4_TX_OUT_INIT_C : Pgp4TxOutType := PGP3_TX_OUT_INIT_C;
+   type Pgp4TxOutType is record
+      locPause    : slv(15 downto 0);
+      locOverflow : slv(15 downto 0);
+      phyTxActive : sl;
+      linkReady   : sl;
+      opCodeReady : sl;
+      frameTx     : sl;                 -- A good frame was transmitted
+      frameTxErr  : sl;                 -- An errored frame was transmitted
+   end record;
+   type Pgp4TxOutArray is array (natural range<>) of Pgp4TxOutType;
+   constant PGP4_TX_OUT_INIT_C : Pgp4TxOutType := (
+      locPause    => (others => '0'),
+      locOverflow => (others => '0'),
+      phyTxActive => '0',
+      linkReady   => '0',
+      opCodeReady => '0',
+      frameTx     => '0',
+      frameTxErr  => '0');
 
-   subtype Pgp4RxInType is Pgp3RxInType;
-   subtype Pgp4RxInArray is Pgp3RxInArray;
-   constant PGP4_RX_IN_INIT_C : Pgp4RxInType := PGP3_RX_IN_INIT_C;
+   type Pgp4RxInType is record
+      loopback : slv(2 downto 0);
+      resetRx  : sl;
+   end record Pgp4RxInType;
+   type Pgp4RxInArray is array (natural range<>) of Pgp4RxInType;
+   constant PGP4_RX_IN_INIT_C : Pgp4RxInType := (
+      loopback => (others => '0'),
+      resetRx  => '0');
 
-   subtype Pgp4RxOutType is Pgp3RxOutType;
-   subtype Pgp4RxOutArray is Pgp3RxOutArray;
-   constant PGP4_RX_OUT_INIT_C : Pgp4RxOutType := PGP3_RX_OUT_INIT_C;
+   type Pgp4RxOutType is record
+      phyRxActive      : sl;
+      phyRxInit        : sl;
+      gearboxAligned   : sl;
+      linkReady        : sl;                -- locRxLinkReady
+      remRxLinkReady   : sl;                -- Far end RX has link
+      frameRx          : sl;                -- A good frame was received
+      frameRxErr       : sl;                -- An errored frame was received
+      linkDown         : sl;                -- A link down event has occurred
+      linkError        : sl;                -- A link error has occurred
+      ebOverflow       : sl;
+      opCodeEn         : sl;                -- Opcode valid
+      opCodeData       : slv(47 downto 0);  -- Opcode data
+      remLinkData      : slv(47 downto 0);  -- Far end side User Data
+      remRxOverflow    : slv(15 downto 0);  -- Far end RX overflow status
+      remRxPause       : slv(15 downto 0);  -- Far end pause status
+      cellError        : sl;                -- A cell error has occurred
+      cellSofError     : sl;
+      cellSeqError     : sl;
+      cellVersionError : sl;
+      cellCrcModeError : sl;
+      cellCrcError     : sl;
+      cellEofeError    : sl;
+   end record Pgp4RxOutType;
+   type Pgp4RxOutArray is array (natural range<>) of Pgp4RxOutType;
+   constant PGP4_RX_OUT_INIT_C : Pgp4RxOutType := (
+      phyRxActive      => '0',
+      phyRxInit        => '0',
+      gearboxAligned   => '0',
+      linkReady        => '0',
+      remRxLinkReady   => '0',
+      frameRx          => '0',
+      frameRxErr       => '0',
+      linkDown         => '0',
+      linkError        => '0',
+      ebOverflow       => '0',
+      opCodeEn         => '0',
+      opCodeData       => (others => '0'),
+      remLinkData      => (others => '0'),
+      remRxOverflow    => (others => '0'),
+      remRxPause       => (others => '0'),
+      cellError        => '0',
+      cellSofError     => '0',
+      cellSeqError     => '0',
+      cellVersionError => '0',
+      cellCrcModeError => '0',
+      cellCrcError     => '0',
+      cellEofeError    => '0');
 
 end package Pgp4Pkg;
 

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -212,25 +212,23 @@ begin
    pgpRxOut.linkReady      <= pgpRxOutProtocol.linkReady;
    pgpRxOut.frameRx        <= depacketizerDebug.eof;
    pgpRxOut.frameRxErr     <= depacketizerDebug.eofe;
-   pgpRxOut.cellError      <= depacketizerDebug.packetError;
+
+   pgpRxOut.cellError        <= depacketizerDebug.packetError;
+   pgpRxOut.cellSofError     <= depacketizerDebug.sofError;
+   pgpRxOut.cellSeqError     <= depacketizerDebug.seqError;
+   pgpRxOut.cellVersionError <= depacketizerDebug.versionError;
+   pgpRxOut.cellCrcModeError <= depacketizerDebug.crcModeError;
+   pgpRxOut.cellCrcError     <= depacketizerDebug.crcError;
+   pgpRxOut.cellEofeError    <= depacketizerDebug.eofeError;
+
    pgpRxOut.opCodeEn       <= pgpRxOutProtocol.opCodeEn;
-   pgpRxOut.opCodeNumber   <= pgpRxOutProtocol.opCodeNumber;
    pgpRxOut.opCodeData     <= pgpRxOutProtocol.opCodeData;
-   pgpRxOut.remLinkData    <= x"00" & remLinkData; -- PAD MSB with zeros to maintain PGPv3 interface compatibility
+   pgpRxOut.remLinkData    <= remLinkData;
    pgpRxOut.remRxLinkReady <= remRxLinkReadyInt;
 
-   pgpRxOut.phyRxData   <= phyRxData;
-   pgpRxOut.phyRxHeader <= phyRxHeader;
-   pgpRxOut.phyRxValid  <= phyRxValid;
-   pgpRxOut.phyRxInit   <= phyRxInitInt;
-
+   pgpRxOut.phyRxInit      <= phyRxInitInt;
    pgpRxOut.gearboxAligned <= gearboxAligned;
-
-   pgpRxOut.ebData     <= ebData;
-   pgpRxOut.ebHeader   <= ebHeader;
-   pgpRxOut.ebValid    <= ebValid;
-   pgpRxOut.ebOverflow <= ebOverflow;
-   pgpRxOut.ebStatus   <= ebStatus;
+   pgpRxOut.ebOverflow     <= ebOverflow;
 
    CTRL_OUT : for i in 15 downto 0 generate
       USED : if (i < NUM_VC_G) generate

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
@@ -50,7 +50,7 @@ entity Pgp4GthUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
-      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUs.vhd
@@ -50,6 +50,7 @@ entity Pgp4GthUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
+      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
@@ -210,6 +211,7 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         WRITE_EN_G                  => WRITE_EN_G,
          STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
          ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
@@ -55,7 +55,7 @@ entity Pgp4GthUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
-      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean                     := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
@@ -55,6 +55,7 @@ entity Pgp4GthUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
+      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
@@ -224,6 +225,7 @@ begin
                TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
                TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
                EN_PGP_MON_G                => EN_PGP_MON_G,
+               WRITE_EN_G                  => WRITE_EN_G,
                EN_DRP_G                    => EN_GTH_DRP_G,
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
@@ -49,6 +49,7 @@ entity Pgp4GthUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
+      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
@@ -209,6 +210,7 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         WRITE_EN_G                  => WRITE_EN_G,
          STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
          ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUs.vhd
@@ -49,7 +49,7 @@ entity Pgp4GthUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
-      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -55,6 +55,7 @@ entity Pgp4GthUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
+      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
@@ -225,6 +226,7 @@ begin
                TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
                TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
                EN_PGP_MON_G                => EN_PGP_MON_G,
+               WRITE_EN_G                  => WRITE_EN_G,
                EN_DRP_G                    => EN_GTH_DRP_G,
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -55,7 +55,7 @@ entity Pgp4GthUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
-      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean                     := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
@@ -54,7 +54,7 @@ entity Pgp4Gtp7 is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
-      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7.vhd
@@ -54,6 +54,7 @@ entity Pgp4Gtp7 is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
+      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
@@ -230,6 +231,7 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         WRITE_EN_G                  => WRITE_EN_G,
          STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
          ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -55,7 +55,7 @@ entity Pgp4Gtp7Wrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GT_DRP_G                 : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
-      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean                     := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -55,6 +55,7 @@ entity Pgp4Gtp7Wrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GT_DRP_G                 : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
+      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
@@ -251,6 +252,7 @@ begin
                TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
                TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
                EN_PGP_MON_G                => EN_PGP_MON_G,
+               WRITE_EN_G                  => WRITE_EN_G,
                EN_DRP_G                    => EN_GT_DRP_G,
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
@@ -49,7 +49,7 @@ entity Pgp4Gtx7 is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
-      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7.vhd
@@ -49,6 +49,7 @@ entity Pgp4Gtx7 is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
+      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       STATUS_CNT_WIDTH_G          : natural range 1 to 32 := 16;
@@ -210,6 +211,7 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         WRITE_EN_G                  => WRITE_EN_G,
          STATUS_CNT_WIDTH_G          => STATUS_CNT_WIDTH_G,
          ERROR_CNT_WIDTH_G           => ERROR_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -54,6 +54,7 @@ entity Pgp4Gtx7Wrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GT_DRP_G                 : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
+      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;
@@ -225,6 +226,7 @@ begin
                TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
                TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
                EN_PGP_MON_G                => EN_PGP_MON_G,
+               WRITE_EN_G                  => WRITE_EN_G,
                EN_DRP_G                    => EN_GT_DRP_G,
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -54,7 +54,7 @@ entity Pgp4Gtx7Wrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GT_DRP_G                 : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
-      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean                     := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       STATUS_CNT_WIDTH_G          : natural range 1 to 32       := 16;

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
@@ -48,7 +48,7 @@ entity Pgp4GtyUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
-      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean               := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUs.vhd
@@ -48,6 +48,7 @@ entity Pgp4GtyUs is
       TX_MUX_ILEAVE_ON_NOTVALID_G : boolean               := true;
       EN_DRP_G                    : boolean               := false;
       EN_PGP_MON_G                : boolean               := false;
+      WRITE_EN_G                  : boolean               := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : sl                    := '0';
       RX_POLARITY_G               : sl                    := '0';
       AXIL_BASE_ADDR_G            : slv(31 downto 0)      := (others => '0');
@@ -206,6 +207,7 @@ begin
          TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
          TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
          EN_PGP_MON_G                => EN_PGP_MON_G,
+         WRITE_EN_G                  => WRITE_EN_G,
          AXIL_CLK_FREQ_G             => AXIL_CLK_FREQ_G)
       port map (
          -- Tx User interface

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
@@ -54,7 +54,7 @@ entity Pgp4GtyUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
-      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
+      WRITE_EN_G                  : boolean                     := true;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
@@ -54,6 +54,7 @@ entity Pgp4GtyUsWrapper is
       EN_PGP_MON_G                : boolean                     := false;
       EN_GTH_DRP_G                : boolean                     := false;
       EN_QPLL_DRP_G               : boolean                     := false;
+      WRITE_EN_G                  : boolean                     := false;  -- Set to false when on remote end of a link
       TX_POLARITY_G               : slv(3 downto 0)             := x"0";
       RX_POLARITY_G               : slv(3 downto 0)             := x"0";
       AXIL_BASE_ADDR_G            : slv(31 downto 0)            := (others => '0');
@@ -221,6 +222,7 @@ begin
                TX_MUX_ILEAVE_EN_G          => TX_MUX_ILEAVE_EN_G,
                TX_MUX_ILEAVE_ON_NOTVALID_G => TX_MUX_ILEAVE_ON_NOTVALID_G,
                EN_PGP_MON_G                => EN_PGP_MON_G,
+               WRITE_EN_G                  => WRITE_EN_G,
                EN_DRP_G                    => EN_GTH_DRP_G,
                TX_POLARITY_G               => TX_POLARITY_G(i),
                RX_POLARITY_G               => RX_POLARITY_G(i),

--- a/python/surf/protocols/pgp/_Pgp4AxiL.py
+++ b/python/surf/protocols/pgp/_Pgp4AxiL.py
@@ -8,10 +8,413 @@
 # the terms contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-import surf.protocols.pgp as pgp
+import pyrogue as pr
 
-class Pgp4AxiL(pgp.Pgp3AxiL):
+class Pgp4AxiLCtrl(pr.Device):
     def __init__(self,
-                 description = "Configuration and status a PGP 4 link",
+                 description = "Configuration of PGP 4 link",
+                 writeEn     = False,
                  **kwargs):
         super().__init__(description=description, **kwargs)
+
+        mode = 'RW' if writeEn else 'RO'
+
+        self.add(pr.RemoteCommand(
+            name        = 'CountReset',
+            description = "Status Counter Reset Command",
+            offset      = 0x000,
+            bitOffset   = 0,
+            bitSize     = 1,
+            function    = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'WRITE_EN_G',
+            offset    = 0x004,
+            bitOffset = 0,
+            bitSize   = 1,
+            base      = pr.Bool,
+            mode      = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'NUM_VC_G',
+            offset    = 0x004,
+            bitOffset = 8,
+            bitSize   = 8,
+            disp      = '{:d}',
+            mode      = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'STATUS_CNT_WIDTH_G',
+            offset    = 0x004,
+            bitOffset = 16,
+            bitSize   = 8,
+            disp      = '{:d}',
+            mode      = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'ERROR_CNT_WIDTH_G',
+            offset    = 0x004,
+            bitOffset = 24,
+            bitSize   = 8,
+            disp      = '{:d}',
+            mode      = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'SkipInterval',
+            description = "TX skip k-code interval",
+            offset      = 0x008,
+            mode        = mode,
+            disp        = '{:d}',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = "Loopback",
+            description = "GT Loopback Mode",
+            offset      = 0x00C,
+            bitOffset   = 0,
+            bitSize     = 3,
+            mode        = mode,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'FlowControlDisable',
+            offset    = 0x00C,
+            bitOffset = 3,
+            bitSize   = 1,
+            base      = pr.Bool,
+            mode      = mode,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'TxDisable',
+            offset    = 0x00C,
+            bitOffset = 4,
+            bitSize   = 1,
+            base      = pr.Bool,
+            mode      = mode,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'ResetTx',
+            offset    = 0x00C,
+            bitOffset = 5,
+            bitSize   = 1,
+            base      = pr.Bool,
+            mode      = mode,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'ResetRx',
+            offset    = 0x00C,
+            bitOffset = 6,
+            bitSize   = 1,
+            base      = pr.Bool,
+            mode      = mode,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TxDiffCtrl',
+            mode         = mode,
+            offset       = 0x00C,
+            bitOffset    = 8,
+            bitSize      = 5,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TxPreCursor',
+            mode         = mode,
+            offset       = 0x00C,
+            bitOffset    = 16,
+            bitSize      = 5,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TxPostCursor',
+            mode         = mode,
+            offset       = 0x00C,
+            bitOffset    = 24,
+            bitSize      = 5,
+        ))
+
+    def countReset(self):
+        self.CountReset()
+
+class Pgp4AxiLRxStatus(pr.Device):
+    def __init__(self,
+                 description     = "RX Status of PGP 4 link",
+                 numVc           = 4,
+                 statusCountBits = 16,
+                 errorCountBits  = 8,
+                 **kwargs):
+        super().__init__(description=description, **kwargs)
+
+        devOffset = 0x400
+
+        def addStatusCountVar(**ecvkwargs):
+            self.add(pr.RemoteVariable(
+                bitSize      = statusCountBits,
+                mode         = 'RO',
+                disp         = '{:d}',
+                pollInterval = 1,
+                **ecvkwargs))
+
+        def addErrorCountVar(**ecvkwargs):
+            self.add(pr.RemoteVariable(
+                bitSize      = errorCountBits,
+                mode         = 'RO',
+                disp         = '{:d}',
+                pollInterval = 1,
+                **ecvkwargs))
+
+        for i in range(numVc):
+            addStatusCountVar(
+                name   = f'RemPauseCnt[{i}]',
+                offset = (0x400+(4*i)-devOffset),
+            )
+
+        for i in range(numVc):
+            addErrorCountVar(
+                name   = f'RemOverflowCnt[{i}]',
+                offset = (0x440+(4*i)-devOffset),
+            )
+
+        addStatusCountVar(
+            name   = 'FrameCnt',
+            offset = (0x500-devOffset),
+        )
+
+        addStatusCountVar(
+            name   = 'OpCodeEnCnt',
+            offset = (0x504-devOffset),
+        )
+
+        statusList = [
+            ['PhyRxActive',True],
+            ['PhyRxInit',False],
+            ['GearboxAligned',True],
+            ['LinkReady',True],
+            ['RemRxLinkReady',True],
+            ['FrameError',False],
+            ['LinkDown',False],
+            ['LinkError',False],
+            ['EbOverflow',False],
+            ['CellError',False],
+            ['CellSofError',False],
+            ['CellSeqError',False],
+            ['CellVersionError',False],
+            ['CellCrcModeError',False],
+            ['CellCrcError',False],
+            ['CellEofeError',False],
+        ]
+
+        for i in range(len(statusList)):
+            addErrorCountVar(
+                name   = (statusList[i][0]+'Cnt'),
+                offset = (0x600+(4*i)-devOffset),
+            )
+
+        for i in range(len(statusList)):
+            if statusList[i][1]:
+                self.add(pr.RemoteVariable(
+                    name         = statusList[i][0],
+                    offset       = (0x710-devOffset),
+                    bitOffset    = i,
+                    bitSize      = 1,
+                    base         = pr.Bool,
+                    mode         = 'RO',
+                    pollInterval = 1,
+                ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'RemLinkData',
+            offset       = (0x720-devOffset),
+            bitSize      = 48,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'RemOpCodeData',
+            offset       = (0x730-devOffset),
+            bitSize      = 48,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'RemRxPause',
+            offset       = (0x740-devOffset),
+            bitSize      = numVc,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "RxClockFreqRaw",
+            offset       = (0x750-devOffset),
+            bitSize      = 32,
+            mode         = 'RO',
+            hidden       = True,
+            pollInterval = 1,
+        ))
+
+        self.add(pr.LinkVariable(
+            name         = "RxClockFrequency",
+            units        = "MHz",
+            mode         = 'RO',
+            dependencies = [self.RxClockFreqRaw],
+            linkedGet    = lambda: self.RxClockFreqRaw.value() * 1.0e-6,
+            disp         = '{:0.3f}',
+        ))
+
+class Pgp4AxiLTxStatus(pr.Device):
+    def __init__(self,
+                 description     = "TX Status of PGP 4 link",
+                 numVc           = 4,
+                 statusCountBits = 16,
+                 errorCountBits  = 8,
+                 **kwargs):
+        super().__init__(description=description, **kwargs)
+
+        devOffset = 0x800
+
+        def addStatusCountVar(**ecvkwargs):
+            self.add(pr.RemoteVariable(
+                bitSize      = statusCountBits,
+                mode         = 'RO',
+                disp         = '{:d}',
+                pollInterval = 1,
+                **ecvkwargs))
+
+        def addErrorCountVar(**ecvkwargs):
+            self.add(pr.RemoteVariable(
+                bitSize      = errorCountBits,
+                mode         = 'RO',
+                disp         = '{:d}',
+                pollInterval = 1,
+                **ecvkwargs))
+
+        for i in range(numVc):
+            addStatusCountVar(
+                name   = f'LocPauseCnt[{i}]',
+                offset = (0x800+(4*i)-devOffset),
+            )
+
+        for i in range(numVc):
+            addErrorCountVar(
+                name   = f'LocOverflowCnt[{i}]',
+                offset = (0x840+(4*i)-devOffset),
+            )
+
+        addStatusCountVar(
+            name   = 'FrameCnt',
+            offset = (0x900-devOffset),
+        )
+
+        addStatusCountVar(
+            name   = 'OpCodeEnCnt',
+            offset = (0x904-devOffset),
+        )
+
+        statusList = [
+            ['phyTxActive',True],
+            ['LinkReady',True],
+            ['FrameError',False],
+        ]
+
+        for i in range(len(statusList)):
+            addErrorCountVar(
+                name   = (statusList[i][0]+'Cnt'),
+                offset = (0xA00+(4*i)-devOffset),
+            )
+
+        for i in range(len(statusList)):
+            if statusList[i][1]:
+                self.add(pr.RemoteVariable(
+                    name         = statusList[i][0],
+                    offset       = (0xB10-devOffset),
+                    bitOffset    = i,
+                    bitSize      = 1,
+                    base         = pr.Bool,
+                    mode         = 'RO',
+                    pollInterval = 1,
+                ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'LocLinkData',
+            offset       = (0xB20-devOffset),
+            bitSize      = 48,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'LocOpCodeData',
+            offset       = (0xB30-devOffset),
+            bitSize      = 48,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'LocTxPause',
+            offset       = (0xB40-devOffset),
+            bitSize      = numVc,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "TxClockFreqRaw",
+            offset       = (0xB50-devOffset),
+            bitSize      = 32,
+            mode         = 'RO',
+            hidden       = True,
+            pollInterval = 1,
+        ))
+
+        self.add(pr.LinkVariable(
+            name         = "TxClockFrequency",
+            units        = "MHz",
+            mode         = 'RO',
+            dependencies = [self.TxClockFreqRaw],
+            linkedGet    = lambda: self.TxClockFreqRaw.value() * 1.0e-6,
+            disp         = '{:0.3f}',
+        ))
+
+class Pgp4AxiL(pr.Device):
+    def __init__(self,
+                 description     = "Configuration and status a PGP 4 link",
+                 numVc           = 4,
+                 statusCountBits = 16,
+                 errorCountBits  = 8,
+                 writeEn         = False,
+                 **kwargs):
+        super().__init__(description=description, **kwargs)
+
+        self.add(Pgp4AxiLCtrl(
+            name    = 'Ctrl',
+            offset  = 0x000,
+            writeEn = writeEn,
+        ))
+
+        self.add(Pgp4AxiLRxStatus(
+            name            = 'RxStatus',
+            offset          = 0x400,
+            numVc           = numVc,
+            statusCountBits = statusCountBits,
+            errorCountBits  = errorCountBits,
+        ))
+
+        self.add(Pgp4AxiLTxStatus(
+            name            = 'TxStatus',
+            offset          = 0x800,
+            numVc           = numVc,
+            statusCountBits = statusCountBits,
+            errorCountBits  = errorCountBits,
+        ))


### PR DESCRIPTION
### Description
- adding more error types to Packetizer2DebugType record
- mapping WRITE_EN_G to PGPv4 top-level modules
- adding new Pgp4AxiL FW/SW module
  -  Migrating PGPv4 to use this AXI-Lite module instead of the legacy PGPv3
-  fixed timing rounding error in Pgp3Gtx7Ip10G.xdc