### PR TITLE
bug fix for PGPv3/PGPv4

### DIFF
--- a/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
@@ -236,7 +236,7 @@ begin
 
    end generate;
 
-   comb : process (inputAxisMaster, linkGood, outputAxisSlave, r, ramCrcRem,
+   comb : process (inputAxisMaster, linkGood, outputAxisSlave, r, ramCrcRem, crcOut,
                    ramPacketActiveOut, ramPacketSeqOut, ramSentEofeOut) is
       variable v         : RegType;
       variable sof       : sl;

--- a/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
@@ -21,7 +21,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -30,14 +29,15 @@ use surf.AxiStreamPacketizer2Pkg.all;
 
 entity AxiStreamDepacketizer2 is
    generic (
-      TPD_G                : time             := 1 ns;
-      MEMORY_TYPE_G        : string           := "distributed";
-      REG_EN_G             : boolean          := false;
-      CRC_MODE_G           : string           := "DATA";  -- or "NONE" or "FULL"
-      CRC_POLY_G           : slv(31 downto 0) := x"04C11DB7";
-      TDEST_BITS_G         : natural          := 8;
-      INPUT_PIPE_STAGES_G  : natural          := 0;
-      OUTPUT_PIPE_STAGES_G : natural          := 1);
+      TPD_G                : time                   := 1 ns;
+      MEMORY_TYPE_G        : string                 := "distributed";
+      REG_EN_G             : boolean                := false;
+      CRC_MODE_G           : string                 := "DATA";  -- or "NONE" or "FULL"
+      CRC_POLY_G           : slv(31 downto 0)       := x"04C11DB7";
+      SEQ_CNT_SIZE_G       : positive range 4 to 16 := 16;
+      TDEST_BITS_G         : natural                := 8;
+      INPUT_PIPE_STAGES_G  : natural                := 0;
+      OUTPUT_PIPE_STAGES_G : natural                := 1);
    port (
       -- Clock and Reset
       axisClk     : in  sl;
@@ -78,7 +78,7 @@ architecture rtl of AxiStreamDepacketizer2 is
    type RegType is record
       state            : StateType;
       activeTDest      : slv(ADDR_WIDTH_C-1 downto 0);
-      packetSeq        : slv(15 downto 0);
+      packetSeq        : slv(SEQ_CNT_SIZE_G-1 downto 0);
       packetActive     : sl;
       sentEofe         : sl;
       ramWe            : sl;
@@ -120,7 +120,7 @@ architecture rtl of AxiStreamDepacketizer2 is
    signal outputAxisMaster : AxiStreamMasterType;
    signal outputAxisSlave  : AxiStreamSlaveType;
 
-   signal ramPacketSeqOut    : slv(15 downto 0);
+   signal ramPacketSeqOut    : slv(SEQ_CNT_SIZE_G-1 downto 0);
    signal ramPacketActiveOut : sl;
    signal ramSentEofeOut     : sl;
    signal ramCrcRem          : slv(31 downto 0) := (others => '1');
@@ -176,21 +176,21 @@ begin
          DOA_REG_G     => REG_EN_G,
          DOB_REG_G     => REG_EN_G,
          BYTE_WR_EN_G  => false,
-         DATA_WIDTH_G  => 18+32,
+         DATA_WIDTH_G  => (32+2+SEQ_CNT_SIZE_G),
          ADDR_WIDTH_G  => ADDR_WIDTH_C)
       port map (
-         clka                => axisClk,
-         rsta                => axisRst,
-         wea                 => rin.ramWe,
-         addra               => ramAddrr,
-         dina(15 downto 0)   => rin.packetSeq,
-         dina(16)            => rin.packetActive,
-         dina(17)            => rin.sentEofe,
-         dina(49 downto 18)  => crcRem,
-         douta(15 downto 0)  => ramPacketSeqOut,
-         douta(16)           => ramPacketActiveOut,
-         douta(17)           => ramSentEofeOut,
-         douta(49 downto 18) => ramCrcRem);
+         clka                                 => axisClk,
+         rsta                                 => axisRst,
+         wea                                  => rin.ramWe,
+         addra                                => ramAddrr,
+         dina(31 downto 0)                    => crcRem,
+         dina(32)                             => rin.packetActive,
+         dina(33)                             => rin.sentEofe,
+         dina(34+SEQ_CNT_SIZE_G-1 downto 34)  => rin.packetSeq,
+         douta(31 downto 0)                   => ramCrcRem,
+         douta(32)                            => ramPacketActiveOut,
+         douta(33)                            => ramSentEofeOut,
+         douta(34+SEQ_CNT_SIZE_G-1 downto 34) => ramPacketSeqOut);
 
    ramAddrr <= rin.activeTDest when (TDEST_BITS_G > 0) else (others => '0');
    crcIn    <= endianSwap(inputAxisMaster.tData(63 downto 0));
@@ -236,9 +236,8 @@ begin
 
    end generate;
 
-   comb : process (inputAxisMaster, linkGood, outputAxisSlave, r,
-                   ramCrcRem, ramPacketActiveOut, ramPacketSeqOut, crcOut,
-                   ramSentEofeOut) is
+   comb : process (inputAxisMaster, linkGood, outputAxisSlave, r, ramCrcRem,
+                   ramPacketActiveOut, ramPacketSeqOut, ramSentEofeOut) is
       variable v         : RegType;
       variable sof       : sl;
       variable lastBytes : integer;
@@ -301,7 +300,7 @@ begin
 
       -- Reset debug strobes flag
       v.debug          := PACKETIZER2_DEBUG_INIT_C;
-      v.debug.initDone := r.debug.initDone; --- Don't touch initDone
+      v.debug.initDone := r.debug.initDone;  --- Don't touch initDone
 
       -- Don't write new packet number by default
       v.ramWe := '0';
@@ -338,7 +337,7 @@ begin
             -- Check for data
             if (inputAxisMaster.tValid = '1') then
                -- Check for 2 read cycle latency
-               if (MEMORY_TYPE_G/="distributed") and (REG_EN_G) then
+               if (MEMORY_TYPE_G /= "distributed") and (REG_EN_G) then
                   v.state := WAIT_S;
                -- Else 1 read cycle latency
                else
@@ -371,7 +370,7 @@ begin
             v.outputAxisMaster(1).tId(7 downto 0)                := inputAxisMaster.tData(PACKETIZER2_HDR_TID_FIELD_C);
             v.outputAxisMaster(1).tUser(7 downto 0)              := inputAxisMaster.tData(PACKETIZER2_HDR_TUSER_FIELD_C);
             sof                                                  := inputAxisMaster.tData(PACKETIZER2_HDR_SOF_BIT_C);
-            v.packetSeq                                          := inputAxisMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C);
+            v.packetSeq                                          := inputAxisMaster.tData(PACKETIZER2_HDR_SEQ_FIELD_C'low+SEQ_CNT_SIZE_G-1 downto PACKETIZER2_HDR_SEQ_FIELD_C'low);
 
             -- Advance the output pipeline
             if (r.outputAxisMaster(1).tValid = '1' and v.outputAxisMaster(0).tValid = '0') then
@@ -384,7 +383,7 @@ begin
                v.crcDataValid := toSl(CRC_HEAD_TAIL_C);
 
                -- Check for BRAM or REG_EN_G used
-               if (MEMORY_TYPE_G/="distributed") or (REG_EN_G) then
+               if (MEMORY_TYPE_G /= "distributed") or (REG_EN_G) then
                   -- Default next state if v.state=MOVE_S not applied later in the combinatorial chain
                   v.state := IDLE_S;
                end if;
@@ -497,7 +496,7 @@ begin
                      -- Can sent tail right now
                      doTail;
                      -- Check for BRAM used
-                     if (MEMORY_TYPE_G/="distributed") or (REG_EN_G) then
+                     if (MEMORY_TYPE_G /= "distributed") or (REG_EN_G) then
                         -- Next state (1 or 2 cycle read latency)
                         v.state := IDLE_S;
                      else
@@ -514,7 +513,7 @@ begin
             -- Can sent tail right now
             doTail;
             -- Check for BRAM used
-            if (MEMORY_TYPE_G/="distributed") or (REG_EN_G) then
+            if (MEMORY_TYPE_G /= "distributed") or (REG_EN_G) then
                -- Next state (1 or 2 cycle read latency)
                v.state := IDLE_S;
             else
@@ -541,7 +540,7 @@ begin
                -- Wait for link to come back up
                if (linkGood = '1') then
                   -- Check for BRAM or REG_EN_G used
-                  if (MEMORY_TYPE_G/="distributed") or (REG_EN_G) then
+                  if (MEMORY_TYPE_G /= "distributed") or (REG_EN_G) then
                      -- Next state (1 or 2 cycle read latency)
                      v.state := IDLE_S;
                   else
@@ -576,13 +575,13 @@ begin
       -- Check for read transaction
       if (r.activeTDest /= v.activeTDest) then
          -- zero latency
-         if (MEMORY_TYPE_G="distributed") and (REG_EN_G = false) then
+         if (MEMORY_TYPE_G = "distributed") and (REG_EN_G = false) then
             v.rdLat := 0;
          -- 1 cycle latency
-         elsif (MEMORY_TYPE_G="distributed") and (REG_EN_G = true) then
+         elsif (MEMORY_TYPE_G = "distributed") and (REG_EN_G = true) then
             v.rdLat := 1;
          -- 1 cycle latency
-         elsif (MEMORY_TYPE_G/="distributed") and (REG_EN_G = false) then
+         elsif (MEMORY_TYPE_G /= "distributed") and (REG_EN_G = false) then
             v.rdLat := 1;
          -- 2 cycle latency
          else

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Rx.vhd
@@ -175,6 +175,7 @@ begin
          MEMORY_TYPE_G       => "distributed",
          CRC_MODE_G          => "DATA",
          CRC_POLY_G          => PGP3_CRC_POLY_C,
+         SEQ_CNT_SIZE_G      => 12,
          TDEST_BITS_G        => 4,
          INPUT_PIPE_STAGES_G => 1)
       port map (

--- a/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3Tx.vhd
@@ -186,6 +186,7 @@ begin
          CRC_MODE_G           => "DATA",
          CRC_POLY_G           => PGP3_CRC_POLY_C,
          MAX_PACKET_BYTES_G   => CELL_WORDS_MAX_G*8*2,
+         SEQ_CNT_SIZE_G       => 12,
          INPUT_PIPE_STAGES_G  => 1,
          OUTPUT_PIPE_STAGES_G => 1)
       port map (

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -178,6 +178,7 @@ begin
          MEMORY_TYPE_G       => "distributed",
          CRC_MODE_G          => "DATA",
          CRC_POLY_G          => PGP4_CRC_POLY_C,
+         SEQ_CNT_SIZE_G      => 12,
          TDEST_BITS_G        => 4,
          INPUT_PIPE_STAGES_G => 1)
       port map (

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Tx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Tx.vhd
@@ -186,6 +186,7 @@ begin
          CRC_MODE_G           => "DATA",
          CRC_POLY_G           => PGP4_CRC_POLY_C,
          MAX_PACKET_BYTES_G   => CELL_WORDS_MAX_G*8*2,
+         SEQ_CNT_SIZE_G       => 12,
          INPUT_PIPE_STAGES_G  => 1,
          OUTPUT_PIPE_STAGES_G => 1)
       port map (


### PR DESCRIPTION
### Description
- The issue is that only 12-bit sequence counter being sent on the PGP link but Packetizer Version2 expects a 16-bit value.  This was causing Sequence errors for large frames being sent across the link
- Added a SEQ_CNT_SIZE_G generic to allow the user to use non-16-bit sequence counter values
- In PGPv3 and PGPv4, we set the Packetizer and Depacketerizer to use `SEQ_CNT_SIZE_G = 12`