### PR TITLE
Release Candidate v2.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ $ git lfs install
 
 [Support Homepage](https://confluence.slac.stanford.edu/display/ppareg/Build+System%3A+Vivado+Support)
 
+[Bug Tracking](https://jira.slac.stanford.edu/projects/ESSURF)
+
 <!--- ########################################################################################### -->

--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -172,12 +172,13 @@ begin
 
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if (
+                     if ((
                         StdMatch(       -- Use std_match to allow dontcares ('-')
                            sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        and (
-                           MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                        or MASTERS_CONFIG_G(m).addrBits = 32)
+                         and (
+                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then
                         v.slave(s).wrReqs(m) := '1';
                         v.slave(s).wrReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -244,12 +245,13 @@ begin
                if (sAxiReadMasters(s).arvalid = '1') then
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if (
+                     if ((
                         StdMatch(       -- Use std_match to allow dontcares ('-')
                            sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        and (
-                           MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                        or MASTERS_CONFIG_G(m).addrBits = 32)
+                         and (
+                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then
                         v.slave(s).rdReqs(m) := '1';
                         v.slave(s).rdReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -273,7 +275,7 @@ begin
 
                if (r.sAxiReadSlaves(s).rvalid = '1' and sAxiReadMasters(s).rready = '1') then
                   v.sAxiReadSlaves(s).rvalid := '0';
-                  v.slave(s).rdState := S_WAIT_AXI_TXN_S;
+                  v.slave(s).rdState         := S_WAIT_AXI_TXN_S;
                end if;
 
             -- Transaction is acked
@@ -371,7 +373,6 @@ begin
          -- This helps optimization happen properly
          v.mAxiWriteMasters(m).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
             MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
-
 
 
          -- Read path processing

--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -172,13 +172,12 @@ begin
 
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if ((
-                        StdMatch(       -- Use std_match to allow dontcares ('-')
-                           sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
-                           MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        or MASTERS_CONFIG_G(m).addrBits = 32)
-                         and (
-                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                     if ((MASTERS_CONFIG_G(m).addrBits = 32)
+                         or (
+                            StdMatch(   -- Use std_match to allow dontcares ('-')
+                               sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
+                               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                            and (MASTERS_CONFIG_G(m).connectivity(s) = '1')))
                      then
                         v.slave(s).wrReqs(m) := '1';
                         v.slave(s).wrReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -245,13 +244,12 @@ begin
                if (sAxiReadMasters(s).arvalid = '1') then
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if ((
-                        StdMatch(       -- Use std_match to allow dontcares ('-')
-                           sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
-                           MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        or MASTERS_CONFIG_G(m).addrBits = 32)
-                         and (
-                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                     if ((MASTERS_CONFIG_G(m).addrBits = 32)
+                         or (
+                            StdMatch(   -- Use std_match to allow dontcares ('-')
+                               sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
+                               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                            and (MASTERS_CONFIG_G(m).connectivity(s) = '1')))
                      then
                         v.slave(s).rdReqs(m) := '1';
                         v.slave(s).rdReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);

--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -237,7 +237,7 @@ package AxiLitePkg is
    -------------------------------------------------------------------------------------------------
    type AxiLiteCrossbarMasterConfigType is record
       baseAddr     : slv(31 downto 0);
-      addrBits     : natural;
+      addrBits     : natural range 1 to 32;
       connectivity : slv(15 downto 0);
    end record;
 

--- a/axi/axi-stream/rtl/AxiStreamDeMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamDeMux.vhd
@@ -27,21 +27,24 @@ entity AxiStreamDeMux is
    generic (
       TPD_G          : time                   := 1 ns;
       NUM_MASTERS_G  : integer range 1 to 256 := 12;
-      MODE_G         : string                 := "INDEXED";          -- Or "ROUTED"
+      MODE_G         : string                 := "INDEXED";  -- Or "ROUTED" Or "DYNAMIC"
       TDEST_ROUTES_G : slv8Array              := (0 => "--------");  -- Only used in ROUTED mode
       PIPE_STAGES_G  : integer range 0 to 16  := 0;
       TDEST_HIGH_G   : integer range 0 to 7   := 7;
       TDEST_LOW_G    : integer range 0 to 7   := 0);
    port (
       -- Clock and reset
-      axisClk      : in  sl;
-      axisRst      : in  sl;
+      axisClk           : in  sl;
+      axisRst           : in  sl;
+      -- Dynamic Route Table (only used when MODE_G = "DYNAMIC")
+      dynamicRouteMasks : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");
+      dynamicRouteDests  : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");
       -- Slave
-      sAxisMaster  : in  AxiStreamMasterType;
-      sAxisSlave   : out AxiStreamSlaveType;
+      sAxisMaster       : in  AxiStreamMasterType;
+      sAxisSlave        : out AxiStreamSlaveType;
       -- Masters
-      mAxisMasters : out AxiStreamMasterArray(NUM_MASTERS_G-1 downto 0);
-      mAxisSlaves  : in  AxiStreamSlaveArray(NUM_MASTERS_G-1 downto 0));
+      mAxisMasters      : out AxiStreamMasterArray(NUM_MASTERS_G-1 downto 0);
+      mAxisSlaves       : in  AxiStreamSlaveArray(NUM_MASTERS_G-1 downto 0));
 end AxiStreamDeMux;
 
 architecture structure of AxiStreamDeMux is
@@ -63,6 +66,9 @@ architecture structure of AxiStreamDeMux is
 
 begin
 
+   assert (MODE_G = "INDEXED" or MODE_G = "ROUTED" or MODE_G = "DYNAMIC")
+      report "MODE_G must be [INDEXED,ROUTED,DYNAMIC]" severity failure;
+
    assert (MODE_G /= "INDEXED" or (TDEST_HIGH_G - TDEST_LOW_G + 1 >= log2(NUM_MASTERS_G)))
       report "In INDEXED mode, TDest range " & integer'image(TDEST_HIGH_G) & " downto " & integer'image(TDEST_LOW_G) &
       " is too small for NUM_MASTERS_G=" & integer'image(NUM_MASTERS_G)
@@ -73,7 +79,7 @@ begin
       " must equal NUM_MASTERS_G: " & integer'image(NUM_MASTERS_G)
       severity error;
 
-   comb : process (axisRst, pipeAxisSlaves, r, sAxisMaster) is
+   comb : process (axisRst, dynamicRouteDests, dynamicRouteMasks, pipeAxisSlaves, r, sAxisMaster) is
       variable v   : RegType;
       variable idx : natural;
       variable i   : natural;
@@ -103,6 +109,15 @@ begin
          for i in 0 to NUM_MASTERS_G-1 loop
             if (std_match(sAxisMaster.tDest, TDEST_ROUTES_G(i))) then
                idx := i;
+               exit;
+            end if;
+         end loop;
+      elsif (MODE_G = "DYNAMIC") then
+         idx := NUM_MASTERS_G;
+         for i in 0 to NUM_MASTERS_G-1 loop
+            if ((sAxisMaster.tDest and dynamicRouteMasks(i)) = (dynamicRouteDests(i) and dynamicRouteMasks(i))) then
+               idx := i;
+               exit;
             end if;
          end loop;
       end if;

--- a/axi/simlink/src/RogueSideBand.c
+++ b/axi/simlink/src/RogueSideBand.c
@@ -59,6 +59,7 @@ void RogueSideBandRestart(RogueSideBandData *data, portDataT *portData) {
 void RogueSideBandSend ( RogueSideBandData *data, portDataT *portData ) {
    zmq_msg_t msg;
    uint8_t  ba[4];
+   char buffer[200];
 
    if ( (zmq_msg_init_size(&msg,4) < 0) ) {  
       vhpi_assert("RogueSideBand: Failed to init message",vhpiFatal);
@@ -73,14 +74,15 @@ void RogueSideBandSend ( RogueSideBandData *data, portDataT *portData ) {
    memcpy(zmq_msg_data(&msg), ba, 4);
 
    // Send data
-   if ( zmq_msg_send(&msg,data->zmqPush,ZMQ_DONTWAIT) < 0 ) {
-         vhpi_assert("RogueSideBand: Failed to send message",vhpiFatal);
+   if ( zmq_msg_send(&msg,data->zmqPush, 0) < 0 ) {
+         sprintf(buffer, "RogueSideBand: Failed to send opcode: %x, remData: %x, on port %i\n", data->txOpCode, data->txRemData, data->port);
+         vhpi_assert(buffer, vhpiFatal);
    }
    if (data->txOpCodeEn) {
-     vhpi_printf("%lu RogueSideBand: Sent Opcode: %x\n", portData->simTime, data->txOpCode);
+     vhpi_printf("%lu RogueSideBand: Sent Opcode: %x on port %i\n", portData->simTime, data->txOpCode, data->port);
    }
    if (data->txRemDataChanged) {
-     vhpi_printf("%lu RogueSideBand: Sent remData: %x\n", portData->simTime, data->txRemData);
+     vhpi_printf("%lu RogueSideBand: Sent remData: %x on port %i\n", portData->simTime, data->txRemData, data->port);
    }
 }
 
@@ -104,11 +106,11 @@ int RogueSideBandRecv ( RogueSideBandData *data, portDataT *portData ) {
       if ( rd[0] == 0x01 ) {
          data->rxOpCode   = rd[1];
          data->rxOpCodeEn = 1;
-         vhpi_printf("%lu RogueSideBand: Got opcode 0x%0.2x\n",portData->simTime,data->rxOpCode);
+         vhpi_printf("%lu RogueSideBand: Got opcode 0x%0.2x on port %i\n",portData->simTime,data->rxOpCode, data->port+1);
       }
       if ( rd[2] == 0x01 ) {
          data->rxRemData = rd[3];
-         vhpi_printf("%lu RogueSideBand: Got data 0x%0.2x\n",portData->simTime,data->rxRemData);
+         vhpi_printf("%lu RogueSideBand: Got data 0x%0.2x on port %i\n",portData->simTime,data->rxRemData, data->port+1);
       }
 
    }

--- a/base/general/rtl/AsyncGearbox.vhd
+++ b/base/general/rtl/AsyncGearbox.vhd
@@ -72,11 +72,14 @@ architecture mapping of AsyncGearbox is
    signal gearboxMasterBitOrder : sl;
    signal almostFull            : sl;
    signal writeEnable           : sl;
+   signal asyncFifoRst          : sl;
 
 begin
 
    fastClk <= slaveClk when SLAVE_FASTER_C else masterClk;
    fastRst <= slaveRst when SLAVE_FASTER_C else masterRst;
+
+   asyncFifoRst <= slaveRst or masterRst;
 
    U_SynchronizerOneShot_1 : entity surf.SynchronizerOneShot
       generic map (
@@ -116,7 +119,7 @@ begin
             ADDR_WIDTH_G  => FIFO_ADDR_WIDTH_G
             )
          port map (
-            rst         => slaveRst,         -- [in]
+            rst         => asyncFifoRst,     -- [in]
             wr_clk      => slaveClk,         -- [in]
             wr_en       => writeEnable,      -- [in]
             din         => slaveData,        -- [in]
@@ -179,7 +182,7 @@ begin
             PIPE_STAGES_G => OUTPUT_PIPE_STAGES_G,
             ADDR_WIDTH_G  => FIFO_ADDR_WIDTH_G)
          port map (
-            rst         => fastRst,         -- [in]
+            rst         => asyncFifoRst,    -- [in]
             wr_clk      => fastClk,         -- [in]
             wr_en       => writeEnable,     -- [in]
             din         => gearboxDataOut,  -- [in]

--- a/base/general/rtl/StdRtlPkg.vhd
+++ b/base/general/rtl/StdRtlPkg.vhd
@@ -75,7 +75,8 @@ package StdRtlPkg is
    function toSl (bool       : boolean) return sl;
    function toString (bool   : boolean) return string;
    function toBoolean (str   : string) return boolean;
-   function toSlv(bools : BooleanArray) return slv;
+   function toSlv(bools      : BooleanArray) return slv;
+   function toBooleanArray (vec : slv)      return BooleanArray;
 
    -- Unary reduction operators, also unnecessary in VHDL 2008
    function uOr (vec  : slv) return sl;
@@ -848,6 +849,15 @@ package body StdRtlPkg is
       end loop;
       return ret;
    end function toSlv;
+
+   function toBooleanArray (vec : slv)  return BooleanArray is
+      variable ret : BooleanArray(vec'range);
+   begin
+      for i in vec'range loop
+         ret(i) := toBoolean(vec(i));
+      end loop;
+      return ret;
+   end function toBooleanArray;
 
    --------------------------------------------------------------------------------------------------
    -- Decode and genmux

--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -10,12 +10,15 @@ loadSource -lib surf -dir "$::DIR_PATH/logic" -fileType "VHDL 2008"
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb" -fileType "VHDL 2008"
 
-# Add the fixed and floating point packages (maybe this will get include automatically in a later Vivado release)
-set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+# These fixed and float point VHDL libraries were not included until Vivado 2020.2 release
+if { $::env(VIVADO_VERSION) < 2020.2 } {
+   # Add the fixed and floating point packages (maybe this will get include automatically in a later Vivado release)
+   set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+}

--- a/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
@@ -33,7 +33,7 @@ entity AxiStreamPacketizer2 is
       REG_EN_G             : boolean                := false;
       CRC_MODE_G           : string                 := "DATA";  -- or "NONE" or "FULL"
       CRC_POLY_G           : slv(31 downto 0)       := x"04C11DB7";
-      MAX_PACKET_BYTES_G   : positive               := 256*8;  -- Must be a multiple of 8
+      MAX_PACKET_BYTES_G   : positive               := 256*8;   -- Must be a multiple of 8
       SEQ_CNT_SIZE_G       : positive range 4 to 16 := 16;
       TDEST_BITS_G         : natural                := 8;
       INPUT_PIPE_STAGES_G  : natural                := 0;
@@ -74,6 +74,7 @@ architecture rtl of AxiStreamPacketizer2 is
    constant CRC_EN_C         : boolean         := (CRC_MODE_G /= "NONE");
    constant CRC_HEAD_TAIL_C  : boolean         := (CRC_MODE_G = "FULL");
    constant ADDR_WIDTH_C     : positive        := ite((TDEST_BITS_G = 0), 1, TDEST_BITS_G);
+   constant RAM_DATA_WIDTH_C : positive        := 32+1+SEQ_CNT_SIZE_G;
 
    type StateType is (
       IDLE_S,
@@ -135,6 +136,8 @@ architecture rtl of AxiStreamPacketizer2 is
    signal outputAxisMaster : AxiStreamMasterType;
    signal outputAxisSlave  : AxiStreamSlaveType;
 
+   signal ramDin             : slv(RAM_DATA_WIDTH_C-1 downto 0);
+   signal ramDout            : slv(RAM_DATA_WIDTH_C-1 downto 0);
    signal ramPacketSeqOut    : slv(SEQ_CNT_SIZE_G-1 downto 0);
    signal ramPacketActiveOut : sl;
    signal ramCrcRem          : slv(31 downto 0) := (others => '1');
@@ -188,6 +191,13 @@ begin
    -- Packet Count ram
    -- track current frame number, packet count and physical channel for each tDest
    -------------------------------------------------------------------------------
+   ramDin(31 downto 0)                   <= rin.crcRem;
+   ramDin(32)                            <= rin.packetActive;
+   ramDin(33+SEQ_CNT_SIZE_G-1 downto 33) <= rin.packetSeq;
+
+   ramCrcRem          <= ramDout(31 downto 0);
+   ramPacketActiveOut <= ramDout(32);
+   ramPacketSeqOut    <= ramDout(33+SEQ_CNT_SIZE_G-1 downto 33);
    U_DualPortRam_1 : entity surf.DualPortRam
       generic map (
          TPD_G         => TPD_G,
@@ -199,19 +209,15 @@ begin
          DATA_WIDTH_G  => (32+1+SEQ_CNT_SIZE_G),
          ADDR_WIDTH_G  => ADDR_WIDTH_C)
       port map (
-         clka                                 => axisClk,
-         rsta                                 => axisRst,
-         wea                                  => rin.ramWe,
-         addra                                => rin.activeTDest,
-         dina(31 downto 0)                    => rin.crcRem,
-         dina(32)                             => rin.packetActive,
-         dina(33+SEQ_CNT_SIZE_G-1 downto 33)  => rin.packetSeq,
-         clkb                                 => axisClk,
-         rstb                                 => axisRst,
-         addrb                                => ramAddrr,
-         doutb(31 downto 0)                   => ramCrcRem,
-         doutb(32)                            => ramPacketActiveOut,
-         doutb(33+SEQ_CNT_SIZE_G-1 downto 33) => ramPacketSeqOut);
+         clka  => axisClk,
+         rsta  => axisRst,
+         wea   => rin.ramWe,
+         addra => rin.activeTDest,
+         dina  => ramDin,
+         clkb  => axisClk,
+         rstb  => axisRst,
+         addrb => ramAddrr,
+         doutb => ramDout);
 
    ramAddrr <= inputAxisMaster.tDest(ADDR_WIDTH_C-1 downto 0) when (TDEST_BITS_G > 0) else (others => '0');
 

--- a/protocols/pgp/pgp4/core/tb/RoguePgp4Sim.vhd
+++ b/protocols/pgp/pgp4/core/tb/RoguePgp4Sim.vhd
@@ -1,0 +1,134 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Wrapper on RogueStreamSim to simulate a PGPv4
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity RoguePgp4Sim is
+   generic (
+      TPD_G         : time                        := 1 ns;
+      PORT_NUM_G    : natural range 1024 to 49151 := 9000;
+      NUM_VC_G      : integer range 1 to 16       := 4;
+      EN_SIDEBAND_G : boolean                     := true);
+   port (
+      -- GT Ports
+      pgpRefClk       : in  sl;
+      pgpGtRxP        : in  sl;
+      pgpGtRxN        : in  sl;
+      pgpGtTxP        : out sl                     := '0';
+      pgpGtTxN        : out sl                     := '1';
+      -- PGP Clock and Reset
+      pgpClk          : out sl;
+      pgpClkRst       : out sl;
+      -- Non VC Rx Signals
+      pgpRxIn         : in  Pgp4RxInType;
+      pgpRxOut        : out Pgp4RxOutType;
+      -- Non VC Tx Signals
+      pgpTxIn         : in  Pgp4TxInType;
+      pgpTxOut        : out Pgp4TxOutType;
+      -- Frame Transmit Interface
+      pgpTxMasters    : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves     : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Frame Receive Interface
+      pgpRxMasters    : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpRxSlaves     : in  AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk         : in  sl                     := '0';  -- Stable Clock
+      axilRst         : in  sl                     := '0';
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C);
+end entity RoguePgp4Sim;
+
+architecture sim of RoguePgp4Sim is
+
+   signal clk : sl := '0';
+   signal rst : sl := '1';
+
+   signal txOut : Pgp4TxOutType := PGP4_TX_OUT_INIT_C;
+   signal rxOut : Pgp4RxOutType := PGP4_RX_OUT_INIT_C;
+
+begin
+
+   pgpClk    <= clk;
+   pgpClkRst <= rst;
+
+   pgpTxOut <= txOut;
+   pgpRxOut <= rxOut;
+
+   clk <= pgpRefClk;
+
+   PwrUpRst_Inst : entity surf.PwrUpRst
+      generic map (
+         TPD_G          => TPD_G,
+         IN_POLARITY_G  => '1',
+         OUT_POLARITY_G => '1',
+         DURATION_G     => 50)
+      port map (
+         clk    => clk,
+         rstOut => rst);
+
+   GEN_VEC : for i in NUM_VC_G-1 downto 0 generate
+      U_PGP_VC : entity surf.RogueTcpStreamWrap
+         generic map (
+            TPD_G         => TPD_G,
+            PORT_NUM_G    => (PORT_NUM_G + i*2),
+            SSI_EN_G      => true,
+            CHAN_COUNT_G  => 1,
+            TDEST_MASK_G  => toSlv(i,8),
+            AXIS_CONFIG_G => PGP4_AXIS_CONFIG_C)
+         port map (
+            axisClk     => clk,              -- [in]
+            axisRst     => rst,              -- [in]
+            sAxisMaster => pgpTxMasters(i),  -- [in]
+            sAxisSlave  => pgpTxSlaves(i),   -- [out]
+            mAxisMaster => pgpRxMasters(i),  -- [out]
+            mAxisSlave  => pgpRxSlaves(i));  -- [in]
+   end generate GEN_VEC;
+
+   GEN_SIDEBAND : if (EN_SIDEBAND_G) generate
+      U_RogueSideBandWrap_1 : entity surf.RogueSideBandWrap
+         generic map (
+            TPD_G      => TPD_G,
+            PORT_NUM_G => PORT_NUM_G + 32)
+         port map (
+            sysClk     => clk,
+            sysRst     => rst,
+            txOpCode   => pgpTxIn.opCodeData(7 downto 0),
+            txOpCodeEn => pgpTxIn.opCodeEn,
+            txRemData  => pgpTxIn.locData(7 downto 0),
+            rxOpCode   => rxOut.opCodeData(7 downto 0),
+            rxOpCodeEn => rxOut.opCodeEn,
+            rxRemData  => rxOut.remLinkData(7 downto 0));
+   end generate GEN_SIDEBAND;
+
+   txOut.phyTxActive <= '1';
+   txOut.linkReady   <= '1';
+
+   rxOut.phyRxActive    <= '1';
+   rxOut.linkReady      <= '1';
+   rxOut.remRxLinkReady <= '1';
+
+end sim;

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
@@ -276,7 +276,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
-         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+         U_Rogue : entity surf.RoguePgp4Sim
             generic map(
                TPD_G      => TPD_G,
                SYNTH_MODE_G  => SYNTH_MODE_G,

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -277,7 +277,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
-         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+         U_Rogue : entity surf.RoguePgp4Sim
             generic map(
                TPD_G      => TPD_G,
                PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -392,7 +392,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
-         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+         U_Rogue : entity surf.RoguePgp4Sim
             generic map(
                TPD_G      => TPD_G,
                PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -322,7 +322,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
-         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+         U_Rogue : entity surf.RoguePgp4Sim
             generic map(
                TPD_G      => TPD_G,
                PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
@@ -271,7 +271,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
-         U_Rogue : entity surf.RoguePgp3Sim -- Same IP core for both PGPv3 and PGPv4
+         U_Rogue : entity surf.RoguePgp4Sim
             generic map(
                TPD_G      => TPD_G,
                SYNTH_MODE_G  => SYNTH_MODE_G,

--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -1,0 +1,164 @@
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import pyrogue as pr
+import rogue
+
+import threading
+import time
+import queue
+
+class _Regs(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self._queue = queue.Queue()
+        self._pollThread = threading.Thread(target=self._pollWorker)
+        self._pollThread.start()
+
+        self.add(pr.RemoteVariable(
+            name      = 'Rnw',
+            offset    = 0x00,
+            bitOffset = 0,
+            bitSize   = 1,
+            enum      = {
+                0: "Write",
+                1: "Read",
+            },
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'Done',
+            mode      = 'RO',
+            offset    = 0x04,
+            bitOffset = 0,
+            bitSize   = 1,
+            base      = pr.Bool,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'Resp',
+            offset    = 0x04,
+            bitOffset = 1,
+            bitSize   = 2,
+            enum      = {
+                0 : 'OK',
+                1 : 'EXOK',
+                2 : 'SLVERR',
+                3 : 'DECERR',
+            },
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'Addr',
+            offset    = 0x08,
+            bitOffset = 0,
+            bitSize   = 32,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name      = 'Data',
+            offset    = 0x0C,
+            bitOffset = 0,
+            bitSize   = 32,
+        ))
+
+    def proxyTransaction(self, transaction):
+        self._queue.put(transaction)
+
+    def _pollWorker(self):
+        while True:
+            #print('Main thread loop start')
+            transaction = self._queue.get()
+            with self._memLock, transaction.lock():
+                #tranId = transaction.id()
+                #print(f'Woke the pollWorker with id: {tranId}')
+
+                # Get the transaction address and write it to the proxy address register
+                addr = transaction.address()
+                #print('Writing address')
+                self.Addr.set(addr, write=True)
+                #print(f'Wrote address {addr:x}')
+
+                if transaction.type() == rogue.interfaces.memory.Write:
+                    # Convert data bytes to int and write data to proxy register
+                    transaction.getData(self._dataBa, 0)
+                    data = int.from_bytes(self._dataBa, 'little', signed=False)
+                    self.Data.set(data, write=True)
+                    #print(f'Wrote data {data:x}')
+
+                    # Kick off the proxy transaction
+                    self.Rnw.setDisp('Write', write=True)
+                    #print(f'Started write transaction: {tranId}')
+
+                elif (transaction.type() == rogue.interfaces.memory.Read) or (transaction.type() == rogue.interfaces.memory.Verify):
+
+                    # Kick off the read proxy txn
+                    self.Rnw.setDisp('Read', write=True)
+                    #print(f'Started read transaction: {tranId}')
+
+                else:
+                    # Post transactions not allowed
+                    transaction.error(f'Unsupported transaction type {transaction.type()}')
+                    return
+
+                # Poll done register
+                # Probably need some timeout here
+                done = False
+                while done is False:
+                    done = self.Done.get(read=True)
+                    #print(f'Polled done: {done}')
+                    time.sleep(.1)
+
+                # Check for error flags
+                resp = self.Resp.get(read=True)
+                #print(f'Resp: {resp}')
+                if resp != 0:
+                    transaction.error(f'AXIL tranaction failed with RESP: {resp}')
+
+                # Finish the transaction
+                elif self.Rnw.valueDisp() == 'Write':
+                    transaction.done()
+                else:
+                    data = self.Data.get(read=True)
+                    #print(f'Got read data: {data:x}')
+                    dataBa = bytearray(data.to_bytes(4, 'little', signed=False))
+                    #print(dataBa)
+                    transaction.setData(dataBa, 0)
+                    transaction.done()
+
+class _ProxySlave(rogue.interfaces.memory.Slave):
+
+    def __init__(self, regs):
+        super().__init__(4,4)
+        self._regs = regs
+
+    def _doTransaction(self, transaction):
+        #print('_ProxySlave._doTransaction')
+        self._regs.proxyTransaction(transaction)
+
+class AxiLiteMasterProxy(pr.Device):
+
+    def __init__(self, hidden=True,**kwargs):
+        super().__init__(hidden=hidden,**kwargs)
+
+        self.add(_Regs(
+            name    = 'Regs',
+            memBase = self,
+            offset  = 0x0000,
+            hidden  = hidden,
+        ))
+        self.proxy = _ProxySlave(self.Regs)
+
+    def add(self, node):
+        pr.Node.add(self, node)
+
+        if isinstance(node, pr.Device):
+            if node._memBase is None:
+                node._setSlave(self.proxy)

--- a/python/surf/axi/__init__.py
+++ b/python/surf/axi/__init__.py
@@ -19,4 +19,5 @@ from surf.axi._AxiVersionLegacy             import *
 from surf.axi._AxiStreamDmaFifo             import *
 from surf.axi._AxiStreamDmaV2               import *
 from surf.axi._AxiStreamScatterGather       import *
+from surf.axi._AxiLiteMasterProxy           import *
 


### PR DESCRIPTION
### Description
- Axi lite proxy software #768
- ESCORE-618: RogueSideBand: Fix failed message send on first cycle after reset #799
- Allow true AxiLiteCrossbarMux that can access the entire address space #802
- Allow external refclk for Pgp2bGtx7VarLatWrapper #803
- Add dynamic routing capability to AxiStreamDemux #804
- Add StdRtlPkg function to convert SLV into a BooleanArray #806
- PGPv4 Rogue Simulation Update #807
- Fix broken VCS compile for AxiStreamPacketizer2 and AxiStreamDepacketizer2 #808
- Bug fix for AsyncGearbox's FIFO reset #810
- dsp/ruckus.tcl + VIvado 2020.2 update #811
- Update README.md + JIRA #812
- Fix AxiLiteCrossbar for Vivado quirk #814