### PR TITLE
ESCORE-618: RogueSideBand: Fix failed message send on first cycle after reset

### DIFF
--- a/axi/simlink/src/RogueSideBand.c
+++ b/axi/simlink/src/RogueSideBand.c
@@ -59,6 +59,7 @@ void RogueSideBandRestart(RogueSideBandData *data, portDataT *portData) {
 void RogueSideBandSend ( RogueSideBandData *data, portDataT *portData ) {
    zmq_msg_t msg;
    uint8_t  ba[4];
+   char buffer[200];
 
    if ( (zmq_msg_init_size(&msg,4) < 0) ) {  
       vhpi_assert("RogueSideBand: Failed to init message",vhpiFatal);
@@ -73,14 +74,15 @@ void RogueSideBandSend ( RogueSideBandData *data, portDataT *portData ) {
    memcpy(zmq_msg_data(&msg), ba, 4);
 
    // Send data
-   if ( zmq_msg_send(&msg,data->zmqPush,ZMQ_DONTWAIT) < 0 ) {
-         vhpi_assert("RogueSideBand: Failed to send message",vhpiFatal);
+   if ( zmq_msg_send(&msg,data->zmqPush, 0) < 0 ) {
+         sprintf(buffer, "RogueSideBand: Failed to send opcode: %x, remData: %x, on port %i\n", data->txOpCode, data->txRemData, data->port);
+         vhpi_assert(buffer, vhpiFatal);
    }
    if (data->txOpCodeEn) {
-     vhpi_printf("%lu RogueSideBand: Sent Opcode: %x\n", portData->simTime, data->txOpCode);
+     vhpi_printf("%lu RogueSideBand: Sent Opcode: %x on port %i\n", portData->simTime, data->txOpCode, data->port);
    }
    if (data->txRemDataChanged) {
-     vhpi_printf("%lu RogueSideBand: Sent remData: %x\n", portData->simTime, data->txRemData);
+     vhpi_printf("%lu RogueSideBand: Sent remData: %x on port %i\n", portData->simTime, data->txRemData, data->port);
    }
 }
 
@@ -104,11 +106,11 @@ int RogueSideBandRecv ( RogueSideBandData *data, portDataT *portData ) {
       if ( rd[0] == 0x01 ) {
          data->rxOpCode   = rd[1];
          data->rxOpCodeEn = 1;
-         vhpi_printf("%lu RogueSideBand: Got opcode 0x%0.2x\n",portData->simTime,data->rxOpCode);
+         vhpi_printf("%lu RogueSideBand: Got opcode 0x%0.2x on port %i\n",portData->simTime,data->rxOpCode, data->port+1);
       }
       if ( rd[2] == 0x01 ) {
          data->rxRemData = rd[3];
-         vhpi_printf("%lu RogueSideBand: Got data 0x%0.2x\n",portData->simTime,data->rxRemData);
+         vhpi_printf("%lu RogueSideBand: Got data 0x%0.2x on port %i\n",portData->simTime,data->rxRemData, data->port+1);
       }
 
    }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This fixes a bug where opcodes and remote data would fail to send on the first cycle after a reset. 

This was done by removing the `ZMQ_DONTWAIT` attribute to `zmq_msg_send()`. It is possible that the ZMQ channel is simply not ready yet immediately following a reset, so letting the send call block until it is ready lets it work.

I'm not sure if there are other consequences to removing `ZMQ_DONTWAIT` but I haven't noticed any yet.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESCORE-618

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
