### PR TITLE
Allow non-contiguous auxiliary channels in XADC Rogue Device

### DIFF
--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -20,7 +20,7 @@ import pyrogue as pr
 class Xadc(pr.Device):
     def __init__(self,
                  description = "AXI-Lite XADC for Xilinx 7 Series (Refer to PG091 & PG019)",
-                 auxChannels = 0,
+                 auxChannels = [],
                  zynq        = False,
                  **kwargs):
         super().__init__(description=description, **kwargs)
@@ -303,16 +303,15 @@ class Xadc(pr.Device):
                 the 16-bit register.      """,
         )
 
-        self.addRemoteVariables(
-            name         = "AuxRaw",
-            offset       =  0x240,
-            bitSize      =  12,
-            bitOffset    =  4,
-            base         = pr.UInt,
-            mode         = "RO",
-            number       =  auxChannels,
-            stride       =  4,
-            description = """
+        for ch in auxChannels:
+            self.add(pr.RemoteVariable(
+                name         = "AuxRaw[{ch}]",
+                offset       =  0x240 + ch*4,
+                bitSize      =  12,
+                bitOffset    =  4,
+                base         = pr.UInt,
+                mode         = "RO",
+                description = """
                 The results of the conversions on auxiliary analog input
                 channels are stored in this register. The data is MSB
                 justified in the 16-bit register (Read Only). The 12 MSBs correspond to

--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -20,10 +20,13 @@ import pyrogue as pr
 class Xadc(pr.Device):
     def __init__(self,
                  description = "AXI-Lite XADC for Xilinx 7 Series (Refer to PG091 & PG019)",
-                 auxChannels = [],
+                 auxChannels = 0,
                  zynq        = False,
                  **kwargs):
         super().__init__(description=description, **kwargs)
+
+        if isinstance(auxChannels, int):
+            auxChannels = list(range(auxChannels))
 
         def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
             self.add(pr.RemoteVariable(

--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -308,7 +308,7 @@ class Xadc(pr.Device):
 
         for ch in auxChannels:
             self.add(pr.RemoteVariable(
-                name         = "AuxRaw[{ch}]",
+                name         = f'AuxRaw[{ch}]',
                 offset       =  0x240 + ch*4,
                 bitSize      =  12,
                 bitOffset    =  4,

--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -321,15 +321,14 @@ class Xadc(pr.Device):
                 the transfer function shown in Figure 2-1, page 24 or
                 Figure 2-2, page 25 of UG480 (v1.2) depending on analog input mode
                 settings.""",
-        )
+            ))
 
-        for i in range(auxChannels):
             self.add(pr.LinkVariable(
-                name=f'Aux[{i}]',
+                name=f'Aux[{ch}]',
                 units='V',
                 disp='{:1.3f}',
                 mode='RO',
-                variable=self.AuxRaw[i],
+                variable=self.AuxRaw[ch],
                 linkedGet=self.convAuxVoltage))
 
         if (zynq):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
Previously the `Xadc` Device allowed only the number of aux channels to be set using the `auxChannels` attribute. But board designs might not necessarily use channels in numerical order. This change allows the channel numbers to be passed in via a list:

```python
self.add(surf.xilinx.Xadc(
    enabled = False,
    offset = 0x00001000,
    auxChannels = [0, 1, 8, 9])) # Use aux channels 0, 1, 8 and 9
```

### Details
The interface still allows an `int` to be passed to `auxChannels` so backward compatibility is ensured.
