### PR TITLE
Use DualPortRam instead of local inferred RAM for AxiSpiMaster shadow RAM

### DIFF
--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -238,19 +238,6 @@ begin
 
    end process comb;
 
---    shadow_mem : process (axiClk) is
---    begin
---       if (SHADOW_EN_G) then
---          if (rising_edge(axiClk)) then
---             if (memWe = '1') then
---                mem(conv_integer(memAddr)) <= r.wrData(DATA_SIZE_G-1 downto 0);
---             end if;
---             memData    <= mem(conv_integer(memAddr))    after TPD_G;
---             shadowData <= mem(conv_integer(shadowAddr)) after TPD_G;
---          end if;
---       end if;
---    end process shadow_mem;
-
    seq : process (axiClk) is
    begin
       if (rising_edge(axiClk)) then

--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -40,6 +40,7 @@ entity AxiSpiMaster is
       DATA_SIZE_G       : natural  := 8;
       MODE_G            : string   := "RW";  -- Or "WO" (write only),  "RO" (read only)
       SHADOW_EN_G       : boolean  := false;
+      SHADOW_MEM_TYPE_G : string   := "block";
       CPHA_G            : sl       := '0';
       CPOL_G            : sl       := '0';
       CLK_PERIOD_G      : real     := 6.4E-9;
@@ -107,7 +108,7 @@ begin
       U_DualPortRam_1 : entity surf.DualPortRam
          generic map (
             TPD_G         => TPD_G,
-            MEMORY_TYPE_G => "distributed",
+            MEMORY_TYPE_G => SHADOW_MEM_TYPE_G,
             REG_EN_G      => false,
             DATA_WIDTH_G  => DATA_SIZE_G,
             ADDR_WIDTH_G  => ADDRESS_SIZE_G)


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The locally inferred RAM would create an enormous `mem` signal in simulation even if `SHADOW_EN_G=false`. This change uses a `DualPortRam` within a `generate` block instead.

