### PR TITLE
Allow true AxiLiteCrossbarMux that can access the entire address space

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -172,10 +172,11 @@ begin
 
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if (
+                     if ((
                         StdMatch(       -- Use std_match to allow dontcares ('-')
                            sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                        or MASTERS_CONFIG_G(m).addrBits = 32)
                         and (
                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then
@@ -244,10 +245,11 @@ begin
                if (sAxiReadMasters(s).arvalid = '1') then
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if (
+                     if ((
                         StdMatch(       -- Use std_match to allow dontcares ('-')
                            sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                        or MASTERS_CONFIG_G(m).addrBits = 32)
                         and (
                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then

--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -273,7 +273,7 @@ begin
 
                if (r.sAxiReadSlaves(s).rvalid = '1' and sAxiReadMasters(s).rready = '1') then
                   v.sAxiReadSlaves(s).rvalid := '0';
-                  v.slave(s).rdState := S_WAIT_AXI_TXN_S;
+                  v.slave(s).rdState         := S_WAIT_AXI_TXN_S;
                end if;
 
             -- Transaction is acked
@@ -369,9 +369,10 @@ begin
          -- Don't allow baseAddr bits to be overwritten
          -- They can't be anyway based on the logic above, but Vivado can't figure that out.
          -- This helps optimization happen properly
-         v.mAxiWriteMasters(m).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
-            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
-
+         if (MASTERS_CONFIG_G(m).addrBits > 0) then
+            v.mAxiWriteMasters(m).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
+               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
+         end if;
 
 
          -- Read path processing
@@ -422,8 +423,10 @@ begin
          -- Don't allow baseAddr bits to be overwritten
          -- They can't be anyway based on the logic above, but Vivado can't figure that out.
          -- This helps optimization happen properly
-         v.mAxiReadMasters(m).araddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
-            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
+         if (MASTERS_CONFIG_G(m).addrBits > 0) then
+            v.mAxiReadMasters(m).araddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
+               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
+         end if;
 
       end loop;
 

--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -177,8 +177,8 @@ begin
                            sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
                         or MASTERS_CONFIG_G(m).addrBits = 32)
-                        and (
-                           MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                         and (
+                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then
                         v.slave(s).wrReqs(m) := '1';
                         v.slave(s).wrReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -250,8 +250,8 @@ begin
                            sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
                            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
                         or MASTERS_CONFIG_G(m).addrBits = 32)
-                        and (
-                           MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                         and (
+                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
                      then
                         v.slave(s).rdReqs(m) := '1';
                         v.slave(s).rdReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -371,10 +371,8 @@ begin
          -- Don't allow baseAddr bits to be overwritten
          -- They can't be anyway based on the logic above, but Vivado can't figure that out.
          -- This helps optimization happen properly
-         if (MASTERS_CONFIG_G(m).addrBits > 0) then
-            v.mAxiWriteMasters(m).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
-               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
-         end if;
+         v.mAxiWriteMasters(m).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
+            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
 
 
          -- Read path processing
@@ -425,10 +423,8 @@ begin
          -- Don't allow baseAddr bits to be overwritten
          -- They can't be anyway based on the logic above, but Vivado can't figure that out.
          -- This helps optimization happen properly
-         if (MASTERS_CONFIG_G(m).addrBits > 0) then
-            v.mAxiReadMasters(m).araddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
-               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
-         end if;
+         v.mAxiReadMasters(m).araddr(31 downto MASTERS_CONFIG_G(m).addrBits) :=
+            MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits);
 
       end loop;
 

--- a/axi/axi-lite/rtl/AxiLitePkg.vhd
+++ b/axi/axi-lite/rtl/AxiLitePkg.vhd
@@ -237,7 +237,7 @@ package AxiLitePkg is
    -------------------------------------------------------------------------------------------------
    type AxiLiteCrossbarMasterConfigType is record
       baseAddr     : slv(31 downto 0);
-      addrBits     : natural;
+      addrBits     : natural range 1 to 32;
       connectivity : slv(15 downto 0);
    end record;
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The `AxiLiteCrossbar` had a corner case when used in "mux mode". In "mux mode", multiple slave ports connect to a single master. Due to the corner case, there was no way to specify that all slave ports have access to the entire address space of the single master. The workaround has been to specify access to 31 bits of address space, which is usually good enough.

This change allows the full address space to be used as follows:
```vhdl
   U_AxiLiteCrossbar_MUX : entity surf.AxiLiteCrossbar
      generic map (
         TPD_G              => TPD_G,
         NUM_SLAVE_SLOTS_G  => 2,
         NUM_MASTER_SLOTS_G => 1,
         MASTERS_CONFIG_G   => (
            0               => (
               baseAddr     => X"00000000",
               addrBits     => 32,
               connectivity => X"FFFF")),
         DEBUG_G            => false)
      port map (
         axiClk              => axilClk,               -- [in]
         axiClkRst           => axilRst,               -- [in]
         sAxiWriteMasters    => mLocAxilWriteMasters,  -- [in]
         sAxiWriteSlaves     => mLocAxilWriteSlaves,   -- [out]
         sAxiReadMasters     => mLocAxilReadMasters,   -- [in]
         sAxiReadSlaves      => mLocAxilReadSlaves,    -- [out]
         mAxiWriteMasters(0) => mAxilWriteMaster,      -- [out]
         mAxiWriteSlaves(0)  => mAxilWriteSlave,       -- [in]
         mAxiReadMasters(0)  => mAxilReadMaster,       -- [out]
         mAxiReadSlaves(0)   => mAxilReadSlave);       -- [in]
```

Note that `addrBits` is set to `32`. In this case, all addresses match on the port, so the `baseAddr` doesn't really matter.

