### PR TITLE
Allow external refclk for Pgp2bGtx7VarLatWrapper

### DIFF
--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
@@ -95,9 +95,9 @@ entity Pgp2bGtx7VarLatWrapper is
       pgpRxCtrl       : in  AxiStreamCtrlArray(3 downto 0);
       -- GT Pins
       gtClkP          : in  sl                     := '0';
-      gtClkN          : in  sl                     := '0';
+      gtClkN          : in  sl                     := '1';
       gtRefClk        : in  sl                     := '0';
-      gtRefClkG       : in  sl                     := '0';
+      gtRefClkBufg    : in  sl                     := '0';
       gtTxP           : out sl;
       gtTxN           : out sl;
       gtRxP           : in  sl;
@@ -148,7 +148,7 @@ begin
    end generate;
 
    REFCLK_BUF : if (USE_REFCLK_G) generate
-      stableClock <= gtRefClkG;
+      stableClock <= gtRefClkBufg;
       refClk      <= gtRefClk;
    end generate REFCLK_BUF;
 

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
@@ -38,6 +38,7 @@ entity Pgp2bGtx7VarLatWrapper is
       -- MMCM internal frequency is set by:
       --    FVCO = 1000 * CLKFBOUT_MULT_F_G/(CLKIN1_PERIOD_G * DIVCLK_DIVIDE_G)
       -- And must be within the specified operating range of the PLL (around 1Ghz)
+      USE_REFCLK_G       : boolean                 := false;
       CLKIN_PERIOD_G     : real                    := 16.0;   -- gtClkP/2
       DIVCLK_DIVIDE_G    : natural range 1 to 106  := 2;
       CLKFBOUT_MULT_F_G  : real range 1.0 to 64.0  := 31.875;
@@ -95,6 +96,7 @@ entity Pgp2bGtx7VarLatWrapper is
       -- GT Pins
       gtClkP          : in  sl;
       gtClkN          : in  sl;
+      gtRefClk        : in  sl;
       gtTxP           : out sl;
       gtTxN           : out sl;
       gtRxP           : in  sl;
@@ -128,18 +130,29 @@ begin
    pgpRst    <= pgpReset;
    stableClk <= stableClock;
 
-   IBUFDS_GTE2_Inst : IBUFDS_GTE2
-      port map (
-         I     => gtClkP,
-         IB    => gtClkN,
-         CEB   => '0',
-         ODIV2 => refClkDiv2,
-         O     => refClk);
+   IBUFDS_GEN : if (not USE_REFCLK_G) generate
+      IBUFDS_GTE2_Inst : IBUFDS_GTE2
+         port map (
+            I     => gtClkP,
+            IB    => gtClkN,
+            CEB   => '0',
+            ODIV2 => refClkDiv2,
+            O     => refClk);
 
-   BUFG_Inst : BUFG
-      port map (
-         I => refClkDiv2,
-         O => stableClock);
+      BUFG_Inst : BUFG
+         port map (
+            I => refClkDiv2,
+            O => stableClock);
+
+   end generate GEN_CLK_BUF;
+
+   REFCLK_BUF : if (USE_REFCLK_G) generate
+      BUFG_Inst : BUFG
+         port map (
+            I => gtRefClk,
+            O => stableClock);
+   end generate REFCLK_BUF;
+
 
    RstSync_Inst : entity surf.RstSync
       generic map(

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7VarLatWrapper.vhd
@@ -94,9 +94,10 @@ entity Pgp2bGtx7VarLatWrapper is
       pgpRxMasters    : out AxiStreamMasterArray(3 downto 0);
       pgpRxCtrl       : in  AxiStreamCtrlArray(3 downto 0);
       -- GT Pins
-      gtClkP          : in  sl;
-      gtClkN          : in  sl;
-      gtRefClk        : in  sl;
+      gtClkP          : in  sl                     := '0';
+      gtClkN          : in  sl                     := '0';
+      gtRefClk        : in  sl                     := '0';
+      gtRefClkG       : in  sl                     := '0';
       gtTxP           : out sl;
       gtTxN           : out sl;
       gtRxP           : in  sl;
@@ -144,13 +145,11 @@ begin
             I => refClkDiv2,
             O => stableClock);
 
-   end generate GEN_CLK_BUF;
+   end generate;
 
    REFCLK_BUF : if (USE_REFCLK_G) generate
-      BUFG_Inst : BUFG
-         port map (
-            I => gtRefClk,
-            O => stableClock);
+      stableClock <= gtRefClkG;
+      refClk      <= gtRefClk;
    end generate REFCLK_BUF;
 
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->
This PR allows the `Pgp2bGtx7VarLatWrapper` to be optionally driven by external `IBUFDS_GTE2` and `BUFG` clocks.

