### PR TITLE
Add dynamic routing capability to AxiStreamDemux

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamDeMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamDeMux.vhd
@@ -36,7 +36,7 @@ entity AxiStreamDeMux is
       -- Clock and reset
       axisClk           : in  sl;
       axisRst           : in  sl;
-      -- Dynamic Route Table (only used when MODE_G = "DYNAMIC"
+      -- Dynamic Route Table (only used when MODE_G = "DYNAMIC")
       dynamicRouteMasks : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");
       dynamicRouteDests  : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");
       -- Slave

--- a/axi/axi-stream/rtl/AxiStreamDeMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamDeMux.vhd
@@ -27,7 +27,7 @@ entity AxiStreamDeMux is
    generic (
       TPD_G          : time                   := 1 ns;
       NUM_MASTERS_G  : integer range 1 to 256 := 12;
-      MODE_G         : string                 := "INDEXED";  -- Or "ROUTED"
+      MODE_G         : string                 := "INDEXED";  -- Or "ROUTED" Or "DYNAMIC"
       TDEST_ROUTES_G : slv8Array              := (0 => "--------");  -- Only used in ROUTED mode
       PIPE_STAGES_G  : integer range 0 to 16  := 0;
       TDEST_HIGH_G   : integer range 0 to 7   := 7;
@@ -65,6 +65,9 @@ architecture structure of AxiStreamDeMux is
    signal rin : RegType;
 
 begin
+
+   assert (MODE_G = "INDEXED" or MODE_G = "ROUTED" or MODE_G = "DYNAMIC")
+      report "MODE_G must be [INDEXED,ROUTED,DYNAMIC]" severity failure;
 
    assert (MODE_G /= "INDEXED" or (TDEST_HIGH_G - TDEST_LOW_G + 1 >= log2(NUM_MASTERS_G)))
       report "In INDEXED mode, TDest range " & integer'image(TDEST_HIGH_G) & " downto " & integer'image(TDEST_LOW_G) &

--- a/axi/axi-stream/rtl/AxiStreamDeMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamDeMux.vhd
@@ -76,7 +76,7 @@ begin
       " must equal NUM_MASTERS_G: " & integer'image(NUM_MASTERS_G)
       severity error;
 
-   comb : process (axisRst, pipeAxisSlaves, r, sAxisMaster) is
+   comb : process (axisRst, dynamicRouteDests, dynamicRouteMasks, pipeAxisSlaves, r, sAxisMaster) is
       variable v   : RegType;
       variable idx : natural;
       variable i   : natural;
@@ -110,6 +110,7 @@ begin
             end if;
          end loop;
       elsif (MODE_G = "DYNAMIC") then
+         idx := NUM_MASTERS_G;
          for i in 0 to NUM_MASTERS_G-1 loop
             if ((sAxisMaster.tDest and dynamicRouteMasks(i)) = (dynamicRouteDests(i) and dynamicRouteMasks(i))) then
                idx := i;


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This new feature allows an AxiStreamMux to route dynamically based on input port routing tables.

It also changes the evaluation order of the route table, so that the lower index in the table is matched first and given priority.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
The dynamic routing feature is activated using the new `"DYNAMIC"` `MODE_G` option.

Two new ports, `dynamicRouteDests` and `dynamicRouteMasks` allow the route table to be passed dynamically via ports rather than statically via the `TDEST_ROUTES_G` generic. The `TDEST_ROUTES_G` generic allows for dontcares, so two ports are needed to keep its functionality. The `dynamicRouteMasks` input specifies bits that are dontcare with a '0'. The `dynamicRouteDests` input specifies the matching TDEST.

For instance, the following are identical.

```vhdl
TDEST_ROUTES_G => (
   0 => "00000000", -- TDEST 0 to port 0
   1 => "000001--") -- TDEST 4,5,6,7 to port 1
```
```vhdl
dynmaicRouteDests(0) => "00000000",
dynamicRouteDests(1) => "00000100",
dynamicRouteMasks(0) => "11111111", -- No dontcares for port 0
dynamicRouteMasks(1) => "11111100" - Doncare on bits 0 and 1
```
