### PR TITLE
Add StdRtlPkg function to convert SLV into a BooleanArray

### DIFF
--- a/base/general/rtl/StdRtlPkg.vhd
+++ b/base/general/rtl/StdRtlPkg.vhd
@@ -75,7 +75,8 @@ package StdRtlPkg is
    function toSl (bool       : boolean) return sl;
    function toString (bool   : boolean) return string;
    function toBoolean (str   : string) return boolean;
-   function toSlv(bools : BooleanArray) return slv;
+   function toSlv(bools      : BooleanArray) return slv;
+   function toBooleanArray (vec : slv)      return BooleanArray;
 
    -- Unary reduction operators, also unnecessary in VHDL 2008
    function uOr (vec  : slv) return sl;
@@ -848,6 +849,15 @@ package body StdRtlPkg is
       end loop;
       return ret;
    end function toSlv;
+
+   function toBooleanArray (vec : slv)  return BooleanArray is
+      variable ret : BooleanArray(vec'range);
+   begin
+      for i in vec'range loop
+         ret(i) := toBoolean(vec(i));
+      end loop;
+      return ret;
+   end function toBooleanArray;
 
    --------------------------------------------------------------------------------------------------
    -- Decode and genmux


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
New function in StdRtlPkg converts an arbitrary length `slv` into a `BooleanArray`

This function comes in handy when instantiating the `XadcSimpleCore`, which takes a BooleanArray to enable VAUX channels.

```vhdl
   U_XadcSimpleCore_1 : entity surf.XadcSimpleCore
      generic map (
         TPD_G                    => TPD_G,
         SEQUENCER_MODE_G         => "CONTINUOUS",
         SAMPLING_MODE_G          => "CONTINUOUS",
         ADCCLK_RATIO_G           => 5,
         SEQ_VCCINT_SEL_EN_G      => true,
         SEQ_VCCAUX_SEL_EN_G      => true,
         SEQ_VCCBRAM_SEL_EN_G     => true,
         SEQ_VAUX_SEL_EN_G        => toBooleanArray("0000001100000011"))
      port map (
         axilClk             => axilClk,                           -- [in]
         axilRst             => axilRst,                        
         ...
 ```

