### PR TITLE
Fix broken VCS compile for AxiStreamPacketizer2 and AxiStreamDepacketizer2

### DIFF
--- a/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
@@ -33,7 +33,7 @@ entity AxiStreamPacketizer2 is
       REG_EN_G             : boolean                := false;
       CRC_MODE_G           : string                 := "DATA";  -- or "NONE" or "FULL"
       CRC_POLY_G           : slv(31 downto 0)       := x"04C11DB7";
-      MAX_PACKET_BYTES_G   : positive               := 256*8;  -- Must be a multiple of 8
+      MAX_PACKET_BYTES_G   : positive               := 256*8;   -- Must be a multiple of 8
       SEQ_CNT_SIZE_G       : positive range 4 to 16 := 16;
       TDEST_BITS_G         : natural                := 8;
       INPUT_PIPE_STAGES_G  : natural                := 0;
@@ -74,6 +74,7 @@ architecture rtl of AxiStreamPacketizer2 is
    constant CRC_EN_C         : boolean         := (CRC_MODE_G /= "NONE");
    constant CRC_HEAD_TAIL_C  : boolean         := (CRC_MODE_G = "FULL");
    constant ADDR_WIDTH_C     : positive        := ite((TDEST_BITS_G = 0), 1, TDEST_BITS_G);
+   constant RAM_DATA_WIDTH_C : positive        := 32+1+SEQ_CNT_SIZE_G;
 
    type StateType is (
       IDLE_S,
@@ -135,6 +136,8 @@ architecture rtl of AxiStreamPacketizer2 is
    signal outputAxisMaster : AxiStreamMasterType;
    signal outputAxisSlave  : AxiStreamSlaveType;
 
+   signal ramDin             : slv(RAM_DATA_WIDTH_C-1 downto 0);
+   signal ramDout            : slv(RAM_DATA_WIDTH_C-1 downto 0);
    signal ramPacketSeqOut    : slv(SEQ_CNT_SIZE_G-1 downto 0);
    signal ramPacketActiveOut : sl;
    signal ramCrcRem          : slv(31 downto 0) := (others => '1');
@@ -188,6 +191,13 @@ begin
    -- Packet Count ram
    -- track current frame number, packet count and physical channel for each tDest
    -------------------------------------------------------------------------------
+   ramDin(31 downto 0)                   <= rin.crcRem;
+   ramDin(32)                            <= rin.packetActive;
+   ramDin(33+SEQ_CNT_SIZE_G-1 downto 33) <= rin.packetSeq;
+
+   ramCrcRem          <= ramDout(31 downto 0);
+   ramPacketActiveOut <= ramDout(32);
+   ramPacketSeqOut    <= ramDout(33+SEQ_CNT_SIZE_G-1 downto 33);
    U_DualPortRam_1 : entity surf.DualPortRam
       generic map (
          TPD_G         => TPD_G,
@@ -199,19 +209,15 @@ begin
          DATA_WIDTH_G  => (32+1+SEQ_CNT_SIZE_G),
          ADDR_WIDTH_G  => ADDR_WIDTH_C)
       port map (
-         clka                                 => axisClk,
-         rsta                                 => axisRst,
-         wea                                  => rin.ramWe,
-         addra                                => rin.activeTDest,
-         dina(31 downto 0)                    => rin.crcRem,
-         dina(32)                             => rin.packetActive,
-         dina(33+SEQ_CNT_SIZE_G-1 downto 33)  => rin.packetSeq,
-         clkb                                 => axisClk,
-         rstb                                 => axisRst,
-         addrb                                => ramAddrr,
-         doutb(31 downto 0)                   => ramCrcRem,
-         doutb(32)                            => ramPacketActiveOut,
-         doutb(33+SEQ_CNT_SIZE_G-1 downto 33) => ramPacketSeqOut);
+         clka  => axisClk,
+         rsta  => axisRst,
+         wea   => rin.ramWe,
+         addra => rin.activeTDest,
+         dina  => ramDin,
+         clkb  => axisClk,
+         rstb  => axisRst,
+         addrb => ramAddrr,
+         doutb => ramDout);
 
    ramAddrr <= inputAxisMaster.tDest(ADDR_WIDTH_C-1 downto 0) when (TDEST_BITS_G > 0) else (others => '0');
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
VCS is annoyingly pedantic and would now allow complex port maps. This has been fixed by assigning to SLV slices first and then assigning the entire SLV in the port map.


### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
```
Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd, 208
RTL
  
           dina(33+SEQ_CNT_SIZE_G-1 downto 33)  => rin.packetSeq,
               ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.


Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd, 214
RTL
  
           doutb(33+SEQ_CNT_SIZE_G-1 downto 33) => ramPacketSeqOut);
                ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.

"/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd": errors: 2; warnings: 0.
Parsing design file '/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd'

Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd, 189
RTL
  
           dina(34+SEQ_CNT_SIZE_G-1 downto 34)  => rin.packetSeq,
               ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.


Error-[LOADEXPRFNAMENOTSTATIC] Illegal parameter association
/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd, 193
RTL
  
           douta(34+SEQ_CNT_SIZE_G-1 downto 34) => ramPacketSeqOut);
                ^
  The formal part of association element must be a locally static name.
  Please refer to section 6.1 of the VHDL93 LRM for details about locally 
  static name.

"/afs/slac.stanford.edu/u/re/bareese/projects/warm-tdm/firmware/submodules/surf/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd": errors: 2; warnings: 0.
```

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
This error was introduced in #797.