### PR TITLE
dsp/ruckus.tcl + VIvado 2020.2 update

### DIFF
--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -10,12 +10,15 @@ loadSource -lib surf -dir "$::DIR_PATH/logic" -fileType "VHDL 2008"
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb" -fileType "VHDL 2008"
 
-# Add the fixed and floating point packages (maybe this will get include automatically in a later Vivado release)
-set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
-loadSource -lib surf -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+# These fixed and float point VHDL libraries were not included until Vivado 2020.2 release
+if { $::env(VIVADO_VERSION) < 2020.2 } {
+   # Add the fixed and floating point packages (maybe this will get include automatically in a later Vivado release)
+   set vhdl2008Path "$::env(XILINX_VIVADO)/data/vhdl/src/ieee_2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_float_types.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/fixed_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg.vhdl"      -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_generic_pkg-body.vhdl" -lib "ieee" -fileType "VHDL 2008"
+   loadSource -lib surf -path "${vhdl2008Path}/float_pkg.vhdl"              -lib "ieee" -fileType "VHDL 2008"
+}


### PR DESCRIPTION
### Description
- Vivado 2020.2 (or later) now include these `proposed` IEEE libraries into the standard Vivado IEEE VHDL libraries
- Casing on Vivado version to determine if we include local copy of us VIvado VHDL library copy
