### PR TITLE
Fix AxiLiteCrossbar for Vivado quirk

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -172,13 +172,12 @@ begin
 
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if ((
-                        StdMatch(       -- Use std_match to allow dontcares ('-')
-                           sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
-                           MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        or MASTERS_CONFIG_G(m).addrBits = 32)
-                         and (
-                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                     if ((MASTERS_CONFIG_G(m).addrBits = 32)
+                         or (
+                            StdMatch(   -- Use std_match to allow dontcares ('-')
+                               sAxiWriteMasters(s).awaddr(31 downto MASTERS_CONFIG_G(m).addrBits),
+                               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                            and (MASTERS_CONFIG_G(m).connectivity(s) = '1')))
                      then
                         v.slave(s).wrReqs(m) := '1';
                         v.slave(s).wrReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);
@@ -245,13 +244,12 @@ begin
                if (sAxiReadMasters(s).arvalid = '1') then
                   for m in MASTERS_CONFIG_G'range loop
                      -- Check for address match
-                     if ((
-                        StdMatch(       -- Use std_match to allow dontcares ('-')
-                           sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
-                           MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
-                        or MASTERS_CONFIG_G(m).addrBits = 32)
-                         and (
-                            MASTERS_CONFIG_G(m).connectivity(s) = '1'))
+                     if ((MASTERS_CONFIG_G(m).addrBits = 32)
+                         or (
+                            StdMatch(   -- Use std_match to allow dontcares ('-')
+                               sAxiReadMasters(s).araddr(31 downto MASTERS_CONFIG_G(m).addrBits),
+                               MASTERS_CONFIG_G(m).baseAddr(31 downto MASTERS_CONFIG_G(m).addrBits))
+                            and (MASTERS_CONFIG_G(m).connectivity(s) = '1')))
                      then
                         v.slave(s).rdReqs(m) := '1';
                         v.slave(s).rdReqNum  := conv_std_logic_vector(m, REQ_NUM_SIZE_C);


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
#802 added a special case to allow creation of an AxiLiteCrossbar MUX. It turns out that this special case check needs to come before the `StdMatch` address check, because Vivado doesn't allow `std_match` to be called with null inputs. (VCS does). By moving the `if ((MASTERS_CONFIG_G(m).addrBits = 32)` check first, it short circuits the subsequent `StdMatch` call and appeases Vivado.

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
#802