### PR TITLE
Fixing VCS compile error SaciSlave2 does not exist anymore

### DIFF
--- a/protocols/saci/sim/SaciSlaveWrapper.vhd
+++ b/protocols/saci/sim/SaciSlaveWrapper.vhd
@@ -48,7 +48,7 @@ begin
 
   saciRsp <= saciRspInt when saciSelL = '0' else 'Z';
 
-  SaciSlave_i : entity surf.SaciSlave2
+  SaciSlave_i : entity surf.SaciSlave
     generic map (
       TPD_G => TPD_G)
     port map (


### PR DESCRIPTION
This affects simulation code only. The VCS fails due to non existing SaciSlave2 module.
