### PR TITLE
fixed flow control bug in SspEncoder8b10b.vhd & SspEncoder12b14b.vhd

### DIFF
--- a/protocols/ssp/rtl/SspEncoder12b14b.vhd
+++ b/protocols/ssp/rtl/SspEncoder12b14b.vhd
@@ -48,7 +48,6 @@ end entity SspEncoder12b14b;
 
 architecture rtl of SspEncoder12b14b is
 
-   signal readyOutInt : sl;
    signal framedData  : slv(11 downto 0) := (others => '0');
    signal framedDataK : slv(0 downto 0)  := (others => '0');
    signal validInt    : sl;
@@ -98,7 +97,7 @@ begin
          dataIn   => framedData,
          dataKIn  => framedDataK(0),
          validOut => validOut,
-         readyOut => readyOutInt,
+         readyOut => readyOut,
          dataOut  => dataOut);
 
 end architecture rtl;

--- a/protocols/ssp/rtl/SspEncoder8b10b.vhd
+++ b/protocols/ssp/rtl/SspEncoder8b10b.vhd
@@ -48,7 +48,6 @@ end entity SspEncoder8b10b;
 
 architecture rtl of SspEncoder8b10b is
 
-   signal readyOutInt : sl;
    signal framedData  : slv(15 downto 0);
    signal framedDataK : slv(1 downto 0);
    signal validInt    : sl;
@@ -99,7 +98,7 @@ begin
          dataIn   => framedData,
          dataKIn  => framedDataK,
          validOut => validOut,
-         readyOut => readyOutInt,
+         readyOut => readyOut,
          dataOut  => dataOut);
 
 end architecture rtl;

--- a/protocols/ssp/rtl/SspFramer.vhd
+++ b/protocols/ssp/rtl/SspFramer.vhd
@@ -16,15 +16,13 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use IEEE.STD_LOGIC_UNSIGNED.all;
-use IEEE.STD_LOGIC_ARITH.all;
-
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
 
 library surf;
 use surf.StdRtlPkg.all;
 
 entity SspFramer is
-
    generic (
       TPD_G           : time    := 1 ns;
       RST_POLARITY_G  : sl      := '0';
@@ -39,49 +37,44 @@ entity SspFramer is
       SSP_SOF_K_G     : slv;
       SSP_EOF_CODE_G  : slv;
       SSP_EOF_K_G     : slv);
-
    port (
+      -- Clock and Reset
       clk      : in  sl;
       rst      : in  sl := RST_POLARITY_G;
+      -- Inbound Ports
       validIn  : in  sl;
       readyIn  : out sl;
       dataIn   : in  slv(WORD_SIZE_G-1 downto 0);
       sof      : in  sl := '0';
       eof      : in  sl := '0';
+      -- Outbound Ports
       validOut : out sl;
       readyOut : in  sl := '1';
       dataOut  : out slv(WORD_SIZE_G-1 downto 0);
       dataKOut : out slv(K_SIZE_G-1 downto 0));
-
 end entity SspFramer;
 
 architecture rtl of SspFramer is
 
-   constant IDLE_MODE_C : sl := '0';
-   constant DATA_MODE_C : sl := '1';
+   type StateType is (
+      IDLE_S,
+      DATA_S,
+      EOF_S);
 
    type RegType is record
-      readyIn     : sl;
-      validOut    : sl;
-      mode        : sl;
-      eofLast     : sl;
-      eof         : sl;
-      dataInLast  : slv(WORD_SIZE_G-1 downto 0);
-      validInLast : sl;
-      dataOut     : slv(WORD_SIZE_G-1 downto 0);
-      dataKOut    : slv(K_SIZE_G-1 downto 0);
+      readyIn  : sl;
+      validOut : sl;
+      dataOut  : slv(WORD_SIZE_G-1 downto 0);
+      dataKOut : slv(K_SIZE_G-1 downto 0);
+      state    : StateType;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      readyIn     => '0',
-      validOut    => toSl(not FLOW_CTRL_EN_G),
-      mode        => '0',
-      eofLast     => '0',
-      eof         => '0',
-      dataInLast  => (others => '0'),
-      validInLast => '0',
-      dataKOut    => (others => '0'),
-      dataOut     => (others => '0'));
+      readyIn  => '0',
+      validOut => toSl(not FLOW_CTRL_EN_G),
+      dataKOut => (others => '0'),
+      dataOut  => (others => '0'),
+      state    => IDLE_S);
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -91,61 +84,97 @@ begin
    comb : process (dataIn, eof, r, readyOut, rst, sof, validIn) is
       variable v : RegType;
    begin
+      -- Latch the current value
       v := r;
 
-      v.readyIn := readyOut;
-
-      if (readyOut = '1' and FLOW_CTRL_EN_G) then
+      -- Flow control
+      v.readyIn := '0';
+      if (readyOut = '1') or (FLOW_CTRL_EN_G = false) then
          v.validOut := '0';
       end if;
 
-      if (v.validOut = '0' or FLOW_CTRL_EN_G = false) then
-         v.validOut    := '1';
-         v.dataInLast  := dataIn;
-         v.validInLast := validIn;
-         v.eofLast     := eof;
+      -- State machine
+      case r.state is
+         ----------------------------------------------------------------------
+         when IDLE_S =>
+            -- Check if we are ready to move data
+            if (v.validOut = '0') then
 
-         -- Send commas while waiting for valid, then send SOF
-         if (r.mode = IDLE_MODE_C) then
-            v.dataOut  := SSP_IDLE_CODE_G;
-            v.dataKOut := SSP_IDLE_K_G;
-            if (validIn = '1' and (sof = '1' or AUTO_FRAME_G)) then
-               v.dataOut  := SSP_SOF_CODE_G;
-               v.dataKOut := SSP_SOF_K_G;
-               v.mode     := DATA_MODE_C;
-            end if;
+               -- Send commas
+               v.validOut := '1';
+               v.dataOut  := SSP_IDLE_CODE_G;
+               v.dataKOut := SSP_IDLE_K_G;
 
-         -- Send pipline delayed data, send eof when delayed valid falls
-         elsif (r.mode = DATA_MODE_C) then
-            v.dataOut  := r.dataInLast;
-            v.dataKOut := slvZero(K_SIZE_G);
-            v.eof      := r.validInLast and r.eofLast;
-            if (r.validInLast = '0') then
-               if (AUTO_FRAME_G or r.eof = '1') then
-                  v.dataOut  := SSP_EOF_CODE_G;
-                  v.dataKOut := SSP_EOF_K_G;
-                  v.mode     := IDLE_MODE_C;
-                  v.readyIn  := '0';
-               else
-                  -- if not auto framing and valid drops, insert idle char
-                  v.dataOut  := SSP_IDLE_CODE_G;
-                  v.dataKOut := SSP_EOF_K_G;
+               -- Check for data
+               if (validIn = '1' and (sof = '1' or AUTO_FRAME_G)) then
+
+                  -- Send the SOF
+                  v.dataOut  := SSP_SOF_CODE_G;
+                  v.dataKOut := SSP_SOF_K_G;
+
+                  -- Next state
+                  v.state := DATA_S;
+
                end if;
             end if;
-         end if;
-      end if;
+         ----------------------------------------------------------------------
+         when DATA_S =>
+            -- Check if we are ready to move data
+            if (v.validOut = '0') then
 
-      readyIn <= v.readyIn;
+               -- Send commas
+               v.validOut := '1';
+               v.dataOut  := SSP_IDLE_CODE_G;
+               v.dataKOut := SSP_IDLE_K_G;
 
-      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
-         v := REG_INIT_C;
-      end if;
+               -- Check for data
+               if (validIn = '1') then
 
-      rin      <= v;
+                  -- Accept the data
+                  v.readyIn := '1';
+
+                  -- Move the data
+                  v.dataOut  := dataIn;
+                  v.dataKOut := slvZero(K_SIZE_G);
+
+                  -- Check for EOF
+                  if (eof = '1') then
+                     -- Next state
+                     v.state := EOF_S;
+                  end if;
+
+               end if;
+            end if;
+         ----------------------------------------------------------------------
+         when EOF_S =>
+            -- Check if we are ready to move data
+            if (v.validOut = '0') then
+
+               -- Send EOF
+               v.validOut := '1';
+               v.dataOut  := SSP_EOF_CODE_G;
+               v.dataKOut := SSP_EOF_K_G;
+
+               -- Next state
+               v.state := IDLE_S;
+
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Outputs
+      readyIn  <= v.readyIn;
       dataOut  <= r.dataOut;
       dataKOut <= r.dataKOut;
       validOut <= r.validOut;
 
+      -- Reset
+      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
 
    end process comb;
 
@@ -159,4 +188,4 @@ begin
       end if;
    end process seq;
 
-end architecture rtl;
+end rtl;


### PR DESCRIPTION
### Description
- The ready on the line encoders were connected to a `signal` but that signals was not connected to anything and was not driven
  - Showed up as `U` in simulation
-  Removed the signal and driving the line encoder ready from top-level port
- overhauled SspFramer to fix a flow control bug and eaiser to read