### PR TITLE
Fix DeviceDna integer range violation

### DIFF
--- a/xilinx/7Series/general/rtl/DeviceDna7Series.vhd
+++ b/xilinx/7Series/general/rtl/DeviceDna7Series.vhd
@@ -70,7 +70,7 @@ architecture rtl of DeviceDna7Series is
    signal locClk  : sl;
    signal locRst  : sl;
 
-   signal locClkInv : sl;
+   signal locClkInv  : sl;
    signal locClkInvR : sl;
 
 begin
@@ -138,12 +138,14 @@ begin
             if r.dnaShift = '1' then
                -- Shift register
                v.dnaValue := r.dnaValue(DNA_SHIFT_LENGTH_C-2 downto 0) & dnaDout;
-               -- Increment the counter
-               v.bitCount := r.bitCount + 1;
                -- Check the counter value
                if (r.bitCount = DNA_SHIFT_LENGTH_C-1) then
                   -- Next State
-                  v.state := DONE_S;
+                  v.bitCount := 0;
+                  v.state    := DONE_S;
+               else
+                  -- Increment the counter
+                  v.bitCount := r.bitCount + 1;
                end if;
             end if;
          ----------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The `DeviceDna7Series` module was briefly exceeding the range for v.bitCount. The latest VCS now catches this error.

The `if/else` block order has been tweaked to avoid exceeding the range.
