### PR TITLE
SspLowSpeedDecoder Updates

### DIFF
--- a/protocols/ssp/rtl/SspDecoder10b12b.vhd
+++ b/protocols/ssp/rtl/SspDecoder10b12b.vhd
@@ -45,6 +45,7 @@ entity SspDecoder10b12b is
       eof            : out sl;
       eofe           : out sl;
       -- Decoder Monitoring
+      idleCode       : out sl;
       validDec       : out sl;
       codeError      : out sl;
       dispError      : out sl);
@@ -52,6 +53,7 @@ end entity SspDecoder10b12b;
 
 architecture rtl of SspDecoder10b12b is
 
+   signal idleInt      : sl;
    signal validDecInt  : sl;
    signal codeErrorInt : sl;
    signal dispErrorInt : sl;
@@ -77,6 +79,7 @@ begin
          codeError => codeErrorInt,
          dispError => dispErrorInt);
 
+   idleCode  <= idleInt;
    validDec  <= validDecInt;
    codeError <= codeErrorInt;
    dispError <= dispErrorInt;
@@ -110,6 +113,7 @@ begin
          dataOut        => dataOut,
          validOut       => validOut,
          errorOut       => errorOut,
+         idle           => idleInt,
          sof            => sof,
          eof            => eof,
          eofe           => eofe);

--- a/protocols/ssp/rtl/SspDecoder12b14b.vhd
+++ b/protocols/ssp/rtl/SspDecoder12b14b.vhd
@@ -46,6 +46,7 @@ entity SspDecoder12b14b is
       eof            : out sl;
       eofe           : out sl;
       -- Decoder Monitoring
+      idleCode       : out sl;
       validDec       : out sl;
       codeError      : out sl;
       dispError      : out sl);
@@ -53,6 +54,7 @@ end entity SspDecoder12b14b;
 
 architecture rtl of SspDecoder12b14b is
 
+   signal idleInt      : sl;
    signal validDecInt  : sl;
    signal codeErrorInt : sl;
    signal dispErrorInt : sl;
@@ -78,6 +80,7 @@ begin
          codeError => codeErrorInt,
          dispError => dispErrorInt);
 
+   idleCode  <= idleInt;
    validDec  <= validDecInt;
    codeError <= codeErrorInt;
    dispError <= dispErrorInt;
@@ -111,6 +114,7 @@ begin
          validOut       => validOut,
          dataOut        => dataOut,
          errorOut       => errorOut,
+         idle           => idleInt,
          sof            => sof,
          eof            => eof,
          eofe           => eofe);

--- a/protocols/ssp/rtl/SspDecoder8b10b.vhd
+++ b/protocols/ssp/rtl/SspDecoder8b10b.vhd
@@ -85,8 +85,8 @@ begin
 
    idleCode  <= idleInt;
    validDec  <= validDecInt;
-   codeError <= codeErrorInt;
-   -- codeError <= (not(idleInt) or codeErrorInt) when(gearboxAligned = '0') else codeErrorInt;
+   -- codeError <= codeErrorInt;
+   codeError <= (not(idleInt) or codeErrorInt) when(gearboxAligned = '0') else codeErrorInt;
    dispError <= dispErrorInt;
 
    codeErrorInt <= uor(codeErrorVec);

--- a/protocols/ssp/rtl/SspDecoder8b10b.vhd
+++ b/protocols/ssp/rtl/SspDecoder8b10b.vhd
@@ -45,6 +45,7 @@ entity SspDecoder8b10b is
       eof            : out sl;
       eofe           : out sl;
       -- Decoder Monitoring
+      idleCode       : out sl;
       validDec       : out sl;
       codeError      : out sl;
       dispError      : out sl);
@@ -55,6 +56,7 @@ architecture rtl of SspDecoder8b10b is
    signal codeErrorVec : slv(1 downto 0);
    signal dispErrorVec : slv(1 downto 0);
 
+   signal idleInt      : sl;
    signal validDecInt  : sl;
    signal codeErrorInt : sl;
    signal dispErrorInt : sl;
@@ -81,8 +83,10 @@ begin
          codeErr  => codeErrorVec,
          dispErr  => dispErrorVec);
 
+   idleCode  <= idleInt;
    validDec  <= validDecInt;
-   codeError <= (not(idle) or codeErrorInt) when(gearboxAligned = '0') else codeErrorInt;
+   codeError <= codeErrorInt;
+   -- codeError <= (not(idleInt) or codeErrorInt) when(gearboxAligned = '0') else codeErrorInt;
    dispError <= dispErrorInt;
 
    codeErrorInt <= uor(codeErrorVec);
@@ -117,7 +121,7 @@ begin
          dataOut        => dataOut,
          validOut       => validOut,
          errorOut       => errorOut,
-         idle           => idle,
+         idle           => idleInt,
          sof            => sof,
          eof            => eof,
          eofe           => eofe);

--- a/protocols/ssp/rtl/SspDecoder8b10b.vhd
+++ b/protocols/ssp/rtl/SspDecoder8b10b.vhd
@@ -85,8 +85,7 @@ begin
 
    idleCode  <= idleInt;
    validDec  <= validDecInt;
-   -- codeError <= codeErrorInt;
-   codeError <= (not(idleInt) or codeErrorInt) when(gearboxAligned = '0') else codeErrorInt;
+   codeError <= codeErrorInt;
    dispError <= dispErrorInt;
 
    codeErrorInt <= uor(codeErrorVec);

--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -66,6 +66,7 @@ architecture mapping of SspLowSpeedDecoder10b12bWrapper is
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
+   signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
 begin
 
@@ -99,6 +100,7 @@ begin
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
+            idleCode       => idleCode(i),
             -- SSP Frame Output
             rxLinkUp       => rxLinkUp(i),
             rxValid        => rxValid(i),
@@ -123,6 +125,7 @@ begin
          errorDet        => errorDet,
          bitSlip         => bitSlip,
          locked          => locked,
+         idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,
          usrDlyCfg       => usrDlyCfg,
          minEyeWidth     => minEyeWidth,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -60,6 +60,7 @@ architecture mapping of SspLowSpeedDecoder10b12bWrapper is
    signal minEyeWidth    : slv(7 downto 0);
    signal lockingCntCfg  : slv(23 downto 0);
    signal bypFirstBerDet : sl;
+   signal lockOnIdle     : sl;
    signal bitOrder       : slv(1 downto 0);
    signal errorMask      : slv(2 downto 0);
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
@@ -97,6 +98,7 @@ begin
             polarity       => polarity(i),
             bitOrder       => bitOrder,
             errorMask      => errorMask,
+            lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
@@ -134,6 +136,7 @@ begin
          polarity        => polarity,
          bitOrder        => bitOrder,
          errorMask       => errorMask,
+         lockOnIdle      => lockOnIdle,
          -- AXI-Lite Interface (axilClk domain)
          axilClk         => axilClk,
          axilRst         => axilRst,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -66,6 +66,7 @@ architecture mapping of SspLowSpeedDecoder12b14bWrapper is
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
+   signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
 begin
 
@@ -99,6 +100,7 @@ begin
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
+            idleCode       => idleCode(i),
             -- SSP Frame Output
             rxLinkUp       => rxLinkUp(i),
             rxValid        => rxValid(i),
@@ -123,6 +125,7 @@ begin
          errorDet        => errorDet,
          bitSlip         => bitSlip,
          locked          => locked,
+         idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,
          usrDlyCfg       => usrDlyCfg,
          minEyeWidth     => minEyeWidth,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -60,6 +60,7 @@ architecture mapping of SspLowSpeedDecoder12b14bWrapper is
    signal minEyeWidth    : slv(7 downto 0);
    signal lockingCntCfg  : slv(23 downto 0);
    signal bypFirstBerDet : sl;
+   signal lockOnIdle     : sl;
    signal bitOrder       : slv(1 downto 0);
    signal errorMask      : slv(2 downto 0);
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
@@ -97,6 +98,7 @@ begin
             polarity       => polarity(i),
             bitOrder       => bitOrder,
             errorMask      => errorMask,
+            lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
@@ -134,6 +136,7 @@ begin
          polarity        => polarity,
          bitOrder        => bitOrder,
          errorMask       => errorMask,
+         lockOnIdle      => lockOnIdle,
          -- AXI-Lite Interface (axilClk domain)
          axilClk         => axilClk,
          axilRst         => axilRst,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -60,6 +60,7 @@ architecture mapping of SspLowSpeedDecoder8b10bWrapper is
    signal minEyeWidth    : slv(7 downto 0);
    signal lockingCntCfg  : slv(23 downto 0);
    signal bypFirstBerDet : sl;
+   signal lockOnIdle     : sl;
    signal bitOrder       : slv(1 downto 0);
    signal errorMask      : slv(2 downto 0);
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
@@ -97,6 +98,7 @@ begin
             polarity       => polarity(i),
             bitOrder       => bitOrder,
             errorMask      => errorMask,
+            lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
@@ -134,6 +136,7 @@ begin
          polarity        => polarity,
          bitOrder        => bitOrder,
          errorMask       => errorMask,
+         lockOnIdle      => lockOnIdle,
          -- AXI-Lite Interface (axilClk domain)
          axilClk         => axilClk,
          axilRst         => axilRst,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -66,6 +66,7 @@ architecture mapping of SspLowSpeedDecoder8b10bWrapper is
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
+   signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
 begin
 
@@ -99,6 +100,7 @@ begin
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
             locked         => locked(i),
+            idleCode       => idleCode(i),
             -- SSP Frame Output
             rxLinkUp       => rxLinkUp(i),
             rxValid        => rxValid(i),
@@ -123,6 +125,7 @@ begin
          errorDet        => errorDet,
          bitSlip         => bitSlip,
          locked          => locked,
+         idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,
          usrDlyCfg       => usrDlyCfg,
          minEyeWidth     => minEyeWidth,

--- a/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
@@ -45,6 +45,7 @@ entity SspLowSpeedDecoderLane is
       errorDet       : out sl;
       bitSlip        : out sl;
       locked         : out sl;
+      idleCode       : out sl;
       -- SSP Frame Output
       rxLinkUp       : out sl;
       rxValid        : out sl;
@@ -58,24 +59,25 @@ architecture mapping of SspLowSpeedDecoderLane is
 
    constant ENCODE_WIDTH_C : positive := ite(DATA_WIDTH_G = 16, 20, DATA_WIDTH_G+2);
 
-   signal deserDataMask : slv(7 downto 0);
+   signal deserDataMask : slv(7 downto 0) := (others => '0');
 
-   signal reset          : sl;
-   signal gearboxAligned : sl;
-   signal slip           : sl;
-   signal validOut       : sl;
+   signal reset          : sl := '1';
+   signal gearboxAligned : sl := '0';
+   signal slip           : sl := '0';
+   signal validOut       : sl := '0';
+   signal idle           : sl := '0';
 
-   signal encodeValid : sl;
-   signal encodeData  : slv(ENCODE_WIDTH_C-1 downto 0);
+   signal encodeValid : sl                             := '0';
+   signal encodeData  : slv(ENCODE_WIDTH_C-1 downto 0) := (others => '0');
 
-   signal decodeValid     : sl;
-   signal decodeOutOfSync : sl;
-   signal decodeCodeErr   : sl;
-   signal decodeDispErr   : sl;
+   signal decodeValid     : sl := '0';
+   signal decodeOutOfSync : sl := '0';
+   signal decodeCodeErr   : sl := '0';
+   signal decodeDispErr   : sl := '0';
 
-   signal lineCodeErr     : sl;
-   signal lineCodeDispErr : sl;
-   signal linkOutOfSync   : sl;
+   signal lineCodeErr     : sl := '0';
+   signal lineCodeDispErr : sl := '0';
+   signal linkOutOfSync   : sl := '0';
 
 begin
 
@@ -89,6 +91,7 @@ begin
          bitSlip  <= slip;
          rxLinkUp <= gearboxAligned after TPD_G;
          locked   <= gearboxAligned after TPD_G;
+         idleCode <= idle           after TPD_G;
       end if;
    end process;
 
@@ -179,6 +182,7 @@ begin
             eof            => rxEof,
             eofe           => rxEofe,
             -- Decoder Monitoring
+            idleCode       => idle,
             validDec       => decodeValid,
             codeError      => decodeCodeErr,
             dispError      => decodeDispErr);
@@ -206,6 +210,7 @@ begin
             eof            => rxEof,
             eofe           => rxEofe,
             -- Decoder Monitoring
+            idleCode       => idle,
             validDec       => decodeValid,
             codeError      => decodeCodeErr,
             dispError      => decodeDispErr);
@@ -233,6 +238,7 @@ begin
             eof            => rxEof,
             eofe           => rxEofe,
             -- Decoder Monitoring
+            idleCode       => idle,
             validDec       => decodeValid,
             codeError      => decodeCodeErr,
             dispError      => decodeDispErr);

--- a/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
@@ -35,6 +35,7 @@ entity SspLowSpeedDecoderReg is
       errorDet        : in  slv(NUM_LANE_G-1 downto 0);
       bitSlip         : in  slv(NUM_LANE_G-1 downto 0);
       locked          : in  slv(NUM_LANE_G-1 downto 0);
+      idleCode        : in  slv(NUM_LANE_G-1 downto 0);
       enUsrDlyCfg     : out sl;
       usrDlyCfg       : out slv(8 downto 0);
       minEyeWidth     : out slv(7 downto 0);
@@ -120,8 +121,8 @@ begin
          mAxiWriteMaster => writeMaster,
          mAxiWriteSlave  => writeSlave);
 
-   comb : process (deserRst, dlyConfig, r, readMaster, statusCnt, statusOut,
-                   writeMaster) is
+   comb : process (deserRst, dlyConfig, idleCode, r, readMaster, statusCnt,
+                   statusOut, writeMaster) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndPointType;
    begin
@@ -156,6 +157,8 @@ begin
       axiSlaveRegister (axilEp, x"814", 0, v.polarity);
       axiSlaveRegister (axilEp, x"818", 0, v.bitOrder);
       axiSlaveRegister (axilEp, x"81C", 0, v.errorMask);
+
+      axiSlaveRegisterR(axilEp, x"900", 0, idleCode);
 
       axiSlaveRegister (axilEp, x"FF8", 0, v.rollOverEn);
       axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);

--- a/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
@@ -44,6 +44,7 @@ entity SspLowSpeedDecoderReg is
       polarity        : out slv(NUM_LANE_G-1 downto 0);
       bitOrder        : out slv(1 downto 0);
       errorMask       : out slv(2 downto 0);
+      lockOnIdle      : out sl;
       -- AXI-Lite Interface (axilClk domain)
       axilClk         : in  sl;
       axilRst         : in  sl;
@@ -67,6 +68,7 @@ architecture mapping of SspLowSpeedDecoderReg is
       polarity       : slv(NUM_LANE_G-1 downto 0);
       bitOrder       : slv(1 downto 0);
       errorMask      : slv(2 downto 0);
+      lockOnIdle     : sl;
       cntRst         : sl;
       rollOverEn     : slv(STATUS_SIZE_C-1 downto 0);
       readSlave      : AxiLiteReadSlaveType;
@@ -82,6 +84,7 @@ architecture mapping of SspLowSpeedDecoderReg is
       polarity       => (others => '0'),
       bitOrder       => (others => '0'),
       errorMask      => (others => '0'),
+      lockOnIdle     => '0',
       cntRst         => '1',
       rollOverEn     => (others => '0'),
       readSlave      => AXI_LITE_READ_SLAVE_INIT_C,
@@ -158,7 +161,9 @@ begin
       axiSlaveRegister (axilEp, x"818", 0, v.bitOrder);
       axiSlaveRegister (axilEp, x"81C", 0, v.errorMask);
 
+
       axiSlaveRegisterR(axilEp, x"900", 0, idleCode);
+      axiSlaveRegister (axilEp, x"904", 0, v.lockOnIdle);
 
       axiSlaveRegister (axilEp, x"FF8", 0, v.rollOverEn);
       axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);
@@ -177,6 +182,7 @@ begin
       polarity       <= r.polarity;
       bitOrder       <= r.bitOrder;
       errorMask      <= r.errorMask;
+      lockOnIdle     <= r.lockOnIdle;
 
       -- Synchronous Reset
       if (deserRst = '1') then

--- a/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
+++ b/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
@@ -47,7 +47,7 @@ class SspLowSpeedDecoderReg(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'Locked',
             offset       = 0x400,
-            bitSize      = 2,
+            bitSize      = numberLanes,
             mode         = 'RO',
             pollInterval = 1,
         ))
@@ -165,12 +165,20 @@ class SspLowSpeedDecoderReg(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = 'MaskOffOutOfSync ',
+            name         = 'MaskOffOutOfSync',
             description  = '1: Mask off OutOfSync (debug only) , 0: normal operation',
             offset       = 0x81C,
             bitSize      = 1,
             bitOffset    = 2,
             mode         = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'IdleCode',
+            offset       = 0x900,
+            bitSize      = numberLanes,
+            mode         = 'RO',
+            pollInterval = 1,
         ))
 
         self.add(pr.RemoteVariable(

--- a/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
+++ b/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
@@ -182,6 +182,14 @@ class SspLowSpeedDecoderReg(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
+            name         = 'LockOnIdleOnly',
+            description  = '1: requires only IDLE code during the lock up procedure then any any code link is locked , 0: any code for locking',
+            offset       = 0x904,
+            bitSize      = 1,
+            mode         = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
             name         = 'RollOverEn',
             description  = 'Rollover enable for status counters',
             offset       = 0xFF8,


### PR DESCRIPTION
### Description
- Added IDLE code detected to status register
  - Helpful for debugging
- Bug fix for SW locked register
  - Was always 2 bits and now based on `numberLanes` arg
- Added `LockOnIdleOnly` register 
  - Helpful for debugging