### PR TITLE
ClockManagerUltraScale Bug Fix

### DIFF
--- a/xilinx/UltraScale+/clocking/rtl/ClockManagerUltraScale.vhd
+++ b/xilinx/UltraScale+/clocking/rtl/ClockManagerUltraScale.vhd
@@ -39,7 +39,7 @@ entity ClockManagerUltraScale is
       CLKIN_PERIOD_G         : real                             := 10.0;  -- Input period in ns );
       DIVCLK_DIVIDE_G        : integer range 1 to 106           := 1;
       CLKFBOUT_MULT_F_G      : real range 1.0 to 128.0          := 1.0;
-      CLKFBOUT_MULT_G        : integer range 2 to 128           := 5;
+      CLKFBOUT_MULT_G        : integer range 1 to 19            := 5;
       CLKOUT0_DIVIDE_F_G     : real range 1.0 to 128.0          := 1.0;
       CLKOUT0_DIVIDE_G       : integer range 1 to 128           := 1;
       CLKOUT1_DIVIDE_G       : integer range 1 to 128           := 1;

--- a/xilinx/UltraScale/clocking/rtl/ClockManagerUltraScale.vhd
+++ b/xilinx/UltraScale/clocking/rtl/ClockManagerUltraScale.vhd
@@ -39,7 +39,7 @@ entity ClockManagerUltraScale is
       CLKIN_PERIOD_G         : real                             := 10.0;  -- Input period in ns );
       DIVCLK_DIVIDE_G        : integer range 1 to 106           := 1;
       CLKFBOUT_MULT_F_G      : real range 1.0 to 64.0           := 1.0;
-      CLKFBOUT_MULT_G        : integer range 2 to 64            := 5;
+      CLKFBOUT_MULT_G        : integer range 1 to 19            := 5;
       CLKOUT0_DIVIDE_F_G     : real range 1.0 to 128.0          := 1.0;
       CLKOUT0_DIVIDE_G       : integer range 1 to 128           := 1;
       CLKOUT1_DIVIDE_G       : integer range 1 to 128           := 1;


### PR DESCRIPTION
### Description
- For ClockManagerUltraScale.vhd, fixed the range on CLKFBOUT_MULT_G
- For PLLE3_ADV:
```
         if (CLKFBOUT_MULT < M_MIN or CLKFBOUT_MULT > M_MAX) then 
          assert FALSE report "Error : [Unisim PLLE3_ADV-112] CLKFBOUT_MULT is not in range 1 to 19 ." severity error;
         end if; 
```
- For PLLE4_ADV:
```
         if (CLKFBOUT_MULT < M_MIN or CLKFBOUT_MULT > M_MAX) then 
          assert FALSE report "Error : [Unisim PLLE4_ADV-112] CLKFBOUT_MULT is not in range 1 to 19 ." severity error;
         end if; 
```