### PR TITLE
FirFilter - Fix incorrect range when truncating result

### DIFF
--- a/dsp/fixed/FirFilterMultiChannel.vhd
+++ b/dsp/fixed/FirFilterMultiChannel.vhd
@@ -253,7 +253,7 @@ begin
          for j in PARALLEL_G-1 downto 0 loop
 
             -- Truncating the LSBs
-            v.mAxisMaster.tData(j*WIDTH_G+WIDTH_G-1 downto j*WIDTH_G) := cascout(TAP_SIZE_G-1, j)(2*WIDTH_G-1 downto WIDTH_G);
+            v.mAxisMaster.tData(j*WIDTH_G+WIDTH_G-1 downto j*WIDTH_G) := cascout(TAP_SIZE_G-1, j)(2*WIDTH_G-2 downto WIDTH_G-1);
 
          end loop;
 

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -173,7 +173,7 @@ begin
          end loop;
 
          -- Truncating the LSBs
-         v.tData := cascout(TAP_SIZE_G-1)(2*WIDTH_G-1 downto WIDTH_G);
+         v.tData := cascout(TAP_SIZE_G-1)(2*WIDTH_G-2 downto WIDTH_G-1);
 
          -- Check the latency init counter
          if (r.cnt = TAP_SIZE_G-1) then


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

The FIR result truncation was off by one.

Now when I load a coefficient of 1.0 (actually .9999...) to a single tap and leave the other coefficients at 0.0, I get out the same thing that went in, as expected.

This change has been applied to both single and multi channel modules, but I've only tested the single channel.