### PR TITLE
SpiSlave - Fix CPHA_G='0' corner case

### DIFF
--- a/protocols/spi/rtl/SpiSlave.vhd
+++ b/protocols/spi/rtl/SpiSlave.vhd
@@ -199,6 +199,10 @@ begin
       if (r.wrStb = '1' and (rdStb = '1' or isLeadingEdge)) then
          v.wrStb                            := '0';
          v.shiftReg(WORD_SIZE_G-1 downto 0) := rdData;
+         -- Hack special case
+         if (CPHA_G = '0') then
+            v.shiftReg(WORD_SIZE_G downto 1) := rdData;
+         end if;
       end if;
 
       if (rst = '1') then


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

When CPHA_G='0', rdData must load into the shift register with 1 shift already applied.