### PR TITLE
Dac38J84.yaml: Fix `InitDac` sequence

### DIFF
--- a/yaml/Dac38J84.yaml
+++ b/yaml/Dac38J84.yaml
@@ -314,11 +314,15 @@ Dac38J84: &Dac38J84
 
         # Disable and initialize JESD
         - entry:    InitJesd
-          value:    0x1E
+          value:    0xF
+        - entry:    JesdRstN
+          value:    0x0
 
         # Enable JESD
         - entry:    InitJesd
-          value:    0x01
+          value:    0x0
+        - entry:    JesdRstN
+          value:    0x1
 
         # Enable TX
         - entry:    EnableTx


### PR DESCRIPTION
The register `InitJesd` was broken down into `InitJesd` and `JesdRstN` registers in https://github.com/slaclab/surf/pull/743, but the init sequence was not updated.

### Description
@leosap reported that after the changes done in https://github.com/slaclab/surf/pull/743 the DAC were not properly initialized.

The issue was related to the register `InitJesd` (originally a 5-bit register) which was broken down into `InitJesd`(most significative 4 bits) and `JesdRstN` (less significative bit), but the `InitDac` was not updated accordingly. 

This PR fixes that init sequence by using the new `InitJesd` and `JesdRstN` registers.
