### PR TITLE
reverted locked behavior for mmcm simulation

### DIFF
--- a/xilinx/general/tb/MmcmEmulation.vhd
+++ b/xilinx/general/tb/MmcmEmulation.vhd
@@ -114,7 +114,7 @@ architecture MmcmEmulation of MmcmEmulation is
 
 begin
 
-   LOCKED  <= uAnd(phasedUp) when(RST = '0') else '0';
+   LOCKED  <= uAnd(phasedUp);
    CLKOUT0 <= clkOut(0);
    CLKOUT1 <= clkOut(1);
    CLKOUT2 <= clkOut(2);


### PR DESCRIPTION
### Description
- reverting back due to weird behavior in VCS