### PR TITLE
Release Candidate v2.19.2

### DIFF
--- a/base/ram/inferred/SimpleDualPortRam.vhd
+++ b/base/ram/inferred/SimpleDualPortRam.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 
@@ -65,9 +64,9 @@ architecture rtl of SimpleDualPortRam is
    type mem_type is array ((2**ADDR_WIDTH_G)-1 downto 0) of slv(FULL_DATA_WIDTH_C-1 downto 0);
    shared variable mem : mem_type := (others => INIT_C);
 
-   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
+   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
 
-   signal weaByteInt : slv(weaByte'range);
+   signal weaByteInt : slv(weaByte'range) := (others => '0');
 
    -- Attribute for XST (Xilinx Synthesis)
    attribute ram_style        : string;

--- a/base/ram/inferred/TrueDualPortRam.vhd
+++ b/base/ram/inferred/TrueDualPortRam.vhd
@@ -72,11 +72,11 @@ architecture rtl of TrueDualPortRam is
    type mem_type is array ((2**ADDR_WIDTH_G)-1 downto 0) of slv(FULL_DATA_WIDTH_C-1 downto 0);
    shared variable mem : mem_type := (others => INIT_C);
 
-   signal doutAInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
-   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
+   signal doutAInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
+   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
 
-   signal weaByteInt : slv(weaByte'range);
-   signal webByteInt : slv(webByte'range);
+   signal weaByteInt : slv(weaByte'range) := (others => '0');
+   signal webByteInt : slv(webByte'range) := (others => '0');
 
    -- Attribute for XST (Xilinx Synthesizer)
    attribute ram_style        : string;

--- a/dsp/fixed/CfixedMult.vhd
+++ b/dsp/fixed/CfixedMult.vhd
@@ -64,13 +64,13 @@ architecture rtl of cfixedMult is
 
    constant C_HIGH_BIT_C : integer := a.re'high + b.re'high + 1;
    constant C_LOW_BIT_C  : integer := a.re'low  + b.re'low;
-   
+
    signal c    : cfixed( re(C_HIGH_BIT_C downto C_LOW_BIT_C), im(C_HIGH_BIT_C downto C_LOW_BIT_C)) := (
          re => (others => '0'),
          im => (others => '0'));
-         
+
    signal cVld : sl := '1';
-   
+
    signal aInt : cfixed(re(a.re'range), im(a.im'range));
    signal bInt : cfixed(re(b.re'range), im(b.im'range));
 
@@ -79,21 +79,21 @@ begin
    aInt <= swap(a) when SWAP_INP_A_G else a;
    bInt <= swap(b) when SWAP_INP_B_G else b;
 
-   GEN_RND_SIMPLE : if RND_SIMPLE_G generate 
+   GEN_RND_SIMPLE : if RND_SIMPLE_G generate
       c.re(y.re'low - 1) <= '1';
       c.im(y.im'low - 1) <= '1';
    end generate GEN_RND_SIMPLE;
 
    U_MULT_ADD : entity surf.CfixedMultAdd
       generic map (
-         TPD_G                => TPD_G, 
+         TPD_G                => TPD_G,
          REG_OUT_G            => REG_OUT_G,
          CIN_REG_G            => 1,
-         ACCUMULATE_G         => ACCUMULATE_G, 
-         OUT_OVERFLOW_STYLE_G => OUT_OVERFLOW_STYLE_G, 
+         ACCUMULATE_G         => ACCUMULATE_G,
+         OUT_OVERFLOW_STYLE_G => OUT_OVERFLOW_STYLE_G,
          OUT_ROUNDING_STYLE_G => OUT_ROUNDING_STYLE_G)
       port map (
-         clk  => clk, 
+         clk  => clk,
          rst  => rst,
          a    => aInt,
          aVld => aVld,
@@ -101,7 +101,7 @@ begin
          bVld => bVld,
          c    => c,
          cVld => cVld,
-         y    => y, 
+         y    => y,
          yVld => yVld);
 
 end architecture rtl;

--- a/dsp/fixed/SfixedDelay.vhd
+++ b/dsp/fixed/SfixedDelay.vhd
@@ -43,7 +43,7 @@ architecture rtl of sfixedDelay is
 
    signal slvDelayIn  : slv(SLV_LEN_C-1 downto 0);
    signal slvDelayOut : slv(SLV_LEN_C-1 downto 0);
-   
+
 begin
 
    slvDelayIn(slvDelayIn'high)                                            <= validIn;

--- a/dsp/fixed/SfixedPreAddMultAdd.vhd
+++ b/dsp/fixed/SfixedPreAddMultAdd.vhd
@@ -105,7 +105,7 @@ begin
       v.vld(0) := aVld and dVld and bVld and cVld;
       v.vld(LATENCY_G-1 downto 1)  := r.vld(LATENCY_G-2 downto 0);
 
-      
+
       if ADD_A_G then
          v.preAdd := r.dreg + r.areg;
       else

--- a/dsp/tb/SinCosLutTb.vhd
+++ b/dsp/tb/SinCosLutTb.vhd
@@ -84,7 +84,7 @@ begin
                write(lin, comma);
                write(lin, to_real(dout.im));
                writeline(outf, lin);
-            when RUN_CNT_C => 
+            when RUN_CNT_C =>
                run <= false;
                report CR & LF & CR & LF &
                   "Test PASSED!" & CR & LF

--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -40,6 +40,7 @@ entity AxiSpiMaster is
       DATA_SIZE_G       : natural  := 8;
       MODE_G            : string   := "RW";  -- Or "WO" (write only),  "RO" (read only)
       SHADOW_EN_G       : boolean  := false;
+      SHADOW_MEM_TYPE_G : string   := "block";
       CPHA_G            : sl       := '0';
       CPOL_G            : sl       := '0';
       CLK_PERIOD_G      : real     := 6.4E-9;
@@ -73,14 +74,10 @@ architecture rtl of AxiSpiMaster is
    signal rdData : slv(PACKET_SIZE_C-1 downto 0);
    signal rdEn   : sl;
 
-   type StateType is (WAIT_AXI_TXN_S, WAIT_CYCLE_S, WAIT_CYCLE_SHADOW_S, WAIT_SPI_TXN_DONE_S);
+   type StateType is (WAIT_AXI_TXN_S, WAIT_CYCLE_S, WAIT_CYCLE_SHADOW_S, WAIT_SPI_TXN_DONE_S, SHADOW_READ_DONE_S);
 
 
-   type mem_type is array ((2**ADDRESS_SIZE_G)-1 downto 0) of slv(DATA_SIZE_G-1 downto 0);
-   signal mem     : mem_type := (others => (others => '0'));
    signal memData : slv(DATA_SIZE_G-1 downto 0) := (others => '0');
-   signal memAddr : slv(ADDRESS_SIZE_G-1 downto 0) := (others => '0');
-   signal memWe   : sl := '0';
 
    -- Registers
    type RegType is record
@@ -107,11 +104,32 @@ architecture rtl of AxiSpiMaster is
 
 begin
 
+   SHADOW_RAM_GEN : if (SHADOW_EN_G) generate
+      U_DualPortRam_1 : entity surf.DualPortRam
+         generic map (
+            TPD_G         => TPD_G,
+            MEMORY_TYPE_G => SHADOW_MEM_TYPE_G,
+            REG_EN_G      => false,
+            DATA_WIDTH_G  => DATA_SIZE_G,
+            ADDR_WIDTH_G  => ADDRESS_SIZE_G)
+         port map (
+            clka  => axiClk,                                                     -- [in]
+            ena   => '1',                                                        -- [in]
+            wea   => r.wrEn,                                                     -- [in]
+            rsta  => axiRst,                                                     -- [in]
+            addra => r.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G),  -- [in]
+            dina  => r.wrData(DATA_SIZE_G-1 downto 0),                           -- [in]
+            douta => memData,                                                    -- [out]
+            clkb  => axiClk,                                                     -- [in]
+            enb   => '1',                                                        -- [in]
+            rstb  => axiRst,                                                     -- [in]
+            addrb => shadowAddr,                                                 -- [in]
+            doutb => shadowData);                                                -- [out]
 
-   memAddr <= r.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G);
-   memWe   <= r.wrEn;
+   end generate SHADOW_RAM_GEN;
 
-   comb : process (axiReadMaster, axiRst, axiWriteMaster, r, rdData, rdEn, memData) is
+
+   comb : process (axiReadMaster, axiRst, axiWriteMaster, memData, r, rdData, rdEn) is
       variable v         : RegType;
       variable axiStatus : AxiLiteStatusType;
    begin
@@ -123,14 +141,14 @@ begin
          when WAIT_AXI_TXN_S =>
 
             if (axiStatus.readEnable = '1') then
-               if (MODE_G = "WO") then
-                  axiSlaveReadResponse(v.axiReadSlave, AXI_RESP_DECERR_C);
-               elsif (SHADOW_EN_G) then
-                  v.state                   := WAIT_CYCLE_SHADOW_S; -- just go to wait a cycle for memData to update
-                  v.wrData(PACKET_SIZE_C-1) := '1';                 -- indicate axi lite read in WAIT_SPI_TXN_DONE_S checking
+               if (SHADOW_EN_G) then
+                  v.state                   := WAIT_CYCLE_SHADOW_S;  -- just go to wait a cycle for memData to update
+                  v.wrData(PACKET_SIZE_C-1) := '1';  -- indicate axi lite read in WAIT_SPI_TXN_DONE_S checking
                   if (ADDRESS_SIZE_G > 0) then
-                     v.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G) := axiReadMaster.araddr(2+ADDRESS_SIZE_G-1 downto 2); -- setup memAddr
+                     v.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G) := axiReadMaster.araddr(2+ADDRESS_SIZE_G-1 downto 2);  -- setup memAddr
                   end if;
+               elsif (MODE_G = "WO") then
+                  axiSlaveReadResponse(v.axiReadSlave, AXI_RESP_DECERR_C);
                else
                   -- No read bit when mode is read-only
                   if (MODE_G /= "RO") then
@@ -182,23 +200,24 @@ begin
 
          when WAIT_CYCLE_SHADOW_S =>
             -- wait for memData
-            v.state := WAIT_SPI_TXN_DONE_S;
+            v.state := SHADOW_READ_DONE_S;
 
          when WAIT_SPI_TXN_DONE_S =>
 
             if (rdEn = '1') then
                v.state := WAIT_AXI_TXN_S;
-
                if (MODE_G = "WO" or (MODE_G = "RW" and r.wrData(PACKET_SIZE_C-1) = '0')) then
                   axiSlaveWriteResponse(v.axiWriteSlave);
-               elsif (SHADOW_EN_G) then
-                  v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := memData;
-                  axiSlaveReadResponse(v.axiReadSlave);
                else
                   v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := rdData(DATA_SIZE_G-1 downto 0);
                   axiSlaveReadResponse(v.axiReadSlave);
                end if;
             end if;
+
+         when SHADOW_READ_DONE_S =>
+            v.axiReadSlave.rdata(DATA_SIZE_G-1 downto 0) := memData;
+            axiSlaveReadResponse(v.axiReadSlave);
+            v.state                                      := WAIT_AXI_TXN_S;
 
          when others => null;
       end case;
@@ -218,19 +237,6 @@ begin
       axiReadSlave  <= r.axiReadSlave;
 
    end process comb;
-
-   shadow_mem : process (axiClk) is
-   begin
-      if (SHADOW_EN_G) then
-         if (rising_edge(axiClk)) then
-            if (memWe = '1') then
-               mem(conv_integer(memAddr)) <= r.wrData(DATA_SIZE_G-1 downto 0);
-            end if;
-            memData    <= mem(conv_integer(memAddr))    after TPD_G;
-            shadowData <= mem(conv_integer(shadowAddr)) after TPD_G;
-         end if;
-      end if;
-   end process shadow_mem;
 
    seq : process (axiClk) is
    begin

--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder10b12bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder12b14bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,            
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -80,7 +80,7 @@ begin
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
             TPD_G           => TPD_G,
-            SIMULATION_G    => SIMULATION_G,            
+            SIMULATION_G    => SIMULATION_G,
             DATA_WIDTH_G    => DATA_WIDTH_C,
             DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder8b10bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,            
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -80,7 +80,7 @@ begin
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
             TPD_G           => TPD_G,
-            SIMULATION_G    => SIMULATION_G,            
+            SIMULATION_G    => SIMULATION_G,
             DATA_WIDTH_G    => DATA_WIDTH_C,
             DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (

--- a/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
@@ -22,9 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SspLowSpeedDecoderLane is
    generic (
-      TPD_G        : time     := 1 ns;
-      DATA_WIDTH_G : positive := 10;
-      SIMULATION_G : boolean  := false);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DATA_WIDTH_G    : positive                := 10;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1);
    port (
       -- Clock and Reset Interface
       clk            : in  sl;
@@ -128,9 +129,10 @@ begin
 
    U_GearboxAligner : entity surf.SelectIoRxGearboxAligner
       generic map (
-         TPD_G        => TPD_G,
-         CODE_TYPE_G  => "LINE_CODE",
-         SIMULATION_G => SIMULATION_G)
+         TPD_G           => TPD_G,
+         CODE_TYPE_G     => "LINE_CODE",
+         DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
+         SIMULATION_G    => SIMULATION_G)
       port map (
          -- Clock and Reset
          clk             => clk,

--- a/xilinx/UltraScale+/gthUs/rtl/Gthe4ChannelDummy.vhd
+++ b/xilinx/UltraScale+/gthUs/rtl/Gthe4ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gthe4ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gthe4ChannelDummy;
 
 architecture mapping of Gthe4ChannelDummy is
@@ -111,7 +112,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,

--- a/xilinx/UltraScale+/gthUs/rtl/Gtye4ChannelDummy.vhd
+++ b/xilinx/UltraScale+/gthUs/rtl/Gtye4ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gtye4ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gtye4ChannelDummy;
 
 architecture mapping of Gtye4ChannelDummy is
@@ -111,7 +112,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,

--- a/xilinx/UltraScale/gthUs/rtl/Gthe3ChannelDummy.vhd
+++ b/xilinx/UltraScale/gthUs/rtl/Gthe3ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gthe3ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gthe3ChannelDummy;
 
 architecture mapping of Gthe3ChannelDummy is
@@ -105,7 +106,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,

--- a/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
+++ b/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
@@ -22,9 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SelectIoRxGearboxAligner is
    generic (
-      TPD_G        : time    := 1 ns;
-      CODE_TYPE_G  : string  := "LINE_CODE";  -- or "SCRAMBLER"
-      SIMULATION_G : boolean := false);
+      TPD_G           : time     := 1 ns;
+      SIMULATION_G    : boolean  := false;      
+      CODE_TYPE_G     : string   := "LINE_CODE";  -- or "SCRAMBLER"
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1);  -- 1 for Ultrascale or 16 for 7-Series
    port (
       -- Clock and Reset
       clk             : in  sl;
@@ -134,7 +135,7 @@ begin
          else
 
             -- Increment the counter
-            v.dlyConfig := r.dlyConfig + 1;
+            v.dlyConfig := r.dlyConfig + DLY_STEP_SIZE_G;
 
             -- Reset the flag
             v.firstError := '1';
@@ -281,7 +282,7 @@ begin
 
                      -- Update the Delay module
                      v.dlyLoad(1) := '1';
-                     v.dlyConfig  := r.dlyConfig + 1;
+                     v.dlyConfig  := r.dlyConfig + DLY_STEP_SIZE_G;
 
                      -- Next state
                      v.state := SLIP_WAIT_S;
@@ -311,7 +312,7 @@ begin
 
                   -- Update the Delay module
                   v.dlyLoad(1) := '1';
-                  v.dlyConfig  := r.dlyConfig + 1;
+                  v.dlyConfig  := r.dlyConfig + DLY_STEP_SIZE_G;
 
                   -- Check for last count or first header error after min. eye width
                   if (scanCnt >= 255) or (v.errorDet = '1') then

--- a/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
+++ b/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
@@ -23,7 +23,7 @@ use surf.StdRtlPkg.all;
 entity SelectIoRxGearboxAligner is
    generic (
       TPD_G           : time     := 1 ns;
-      SIMULATION_G    : boolean  := false;      
+      SIMULATION_G    : boolean  := false;
       CODE_TYPE_G     : string   := "LINE_CODE";  -- or "SCRAMBLER"
       DLY_STEP_SIZE_G : positive range 1 to 255 := 1);  -- 1 for Ultrascale or 16 for 7-Series
    port (

--- a/xilinx/general/tb/MmcmEmulation.vhd
+++ b/xilinx/general/tb/MmcmEmulation.vhd
@@ -114,7 +114,7 @@ architecture MmcmEmulation of MmcmEmulation is
 
 begin
 
-   LOCKED  <= uAnd(phasedUp) when(RST = '0') else '0';
+   LOCKED  <= uAnd(phasedUp);
    CLKOUT0 <= clkOut(0);
    CLKOUT1 <= clkOut(1);
    CLKOUT2 <= clkOut(2);


### PR DESCRIPTION
### Description
- reverted locked behavior for mmcm simulation #860
- Update SimpleDualPortRam.vhd and TrueDualPortRam.vhd #862
- exposing rxoutclk for GTH3, GTH4 and GTY4 dummy terminations modules #863
- Updates to SspLowSpeedDecoders and SelectIoRxGearboxAligner #864
- adding EXT_QPLL_G generic to Gtpe2ChannelDummy.vhd #865
- whitespace removal #866
- Use DualPortRam instead of local inferred RAM for AxiSpiMaster shadow RAM #801