### PR TITLE
Update SimpleDualPortRam.vhd and TrueDualPortRam.vhd

### DIFF
--- a/base/ram/inferred/SimpleDualPortRam.vhd
+++ b/base/ram/inferred/SimpleDualPortRam.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 
@@ -65,9 +64,9 @@ architecture rtl of SimpleDualPortRam is
    type mem_type is array ((2**ADDR_WIDTH_G)-1 downto 0) of slv(FULL_DATA_WIDTH_C-1 downto 0);
    shared variable mem : mem_type := (others => INIT_C);
 
-   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
+   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
 
-   signal weaByteInt : slv(weaByte'range);
+   signal weaByteInt : slv(weaByte'range) := (others => '0');
 
    -- Attribute for XST (Xilinx Synthesis)
    attribute ram_style        : string;

--- a/base/ram/inferred/TrueDualPortRam.vhd
+++ b/base/ram/inferred/TrueDualPortRam.vhd
@@ -72,11 +72,11 @@ architecture rtl of TrueDualPortRam is
    type mem_type is array ((2**ADDR_WIDTH_G)-1 downto 0) of slv(FULL_DATA_WIDTH_C-1 downto 0);
    shared variable mem : mem_type := (others => INIT_C);
 
-   signal doutAInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
-   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0);
+   signal doutAInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
+   signal doutBInt : slv(FULL_DATA_WIDTH_C-1 downto 0) := (others => '0');
 
-   signal weaByteInt : slv(weaByte'range);
-   signal webByteInt : slv(webByte'range);
+   signal weaByteInt : slv(weaByte'range) := (others => '0');
+   signal webByteInt : slv(webByte'range) := (others => '0');
 
    -- Attribute for XST (Xilinx Synthesizer)
    attribute ram_style        : string;


### PR DESCRIPTION
### Description
- Initializing the signals such that they are not `U` at the start of the simulation
