### PR TITLE
exposing rxoutclk for GTH3, GTH4 and GTY4 dummy terminations modules

### DIFF
--- a/xilinx/UltraScale+/gthUs/rtl/Gthe4ChannelDummy.vhd
+++ b/xilinx/UltraScale+/gthUs/rtl/Gthe4ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gthe4ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gthe4ChannelDummy;
 
 architecture mapping of Gthe4ChannelDummy is
@@ -111,7 +112,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,

--- a/xilinx/UltraScale+/gthUs/rtl/Gtye4ChannelDummy.vhd
+++ b/xilinx/UltraScale+/gthUs/rtl/Gtye4ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gtye4ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gtye4ChannelDummy;
 
 architecture mapping of Gtye4ChannelDummy is
@@ -111,7 +112,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,

--- a/xilinx/UltraScale/gthUs/rtl/Gthe3ChannelDummy.vhd
+++ b/xilinx/UltraScale/gthUs/rtl/Gthe3ChannelDummy.vhd
@@ -27,11 +27,12 @@ entity Gthe3ChannelDummy is
       SIMULATION_G : boolean  := false;
       WIDTH_G      : positive := 1);
    port (
-      refClk : in  sl;                  -- Required by DRC REQP #2
-      gtRxP  : in  slv(WIDTH_G-1 downto 0);
-      gtRxN  : in  slv(WIDTH_G-1 downto 0);
-      gtTxP  : out slv(WIDTH_G-1 downto 0);
-      gtTxN  : out slv(WIDTH_G-1 downto 0));
+      refClk   : in  sl;                -- Required by DRC REQP #2
+      rxoutclk : out slv(WIDTH_G-1 downto 0);  -- Required if terminating external OBUFDS_GTE
+      gtRxP    : in  slv(WIDTH_G-1 downto 0);
+      gtRxN    : in  slv(WIDTH_G-1 downto 0);
+      gtTxP    : out slv(WIDTH_G-1 downto 0);
+      gtTxN    : out slv(WIDTH_G-1 downto 0));
 end entity Gthe3ChannelDummy;
 
 architecture mapping of Gthe3ChannelDummy is
@@ -105,7 +106,7 @@ begin
                RXOSINTSTARTED       => open,
                RXOSINTSTROBEDONE    => open,
                RXOSINTSTROBESTARTED => open,
-               RXOUTCLK             => open,
+               RXOUTCLK             => rxoutclk(i),
                RXOUTCLKFABRIC       => open,
                RXOUTCLKPCS          => open,
                RXPHALIGNDONE        => open,


### PR DESCRIPTION
### Description
- Required if terminating external OBUFDS_GTE