### PR TITLE
Updates to SspLowSpeedDecoders and SelectIoRxGearboxAligner

### DIFF
--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder10b12bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time     := 1 ns;
+      SIMULATION_G    : boolean  := false;
+      DLY_STEP_SIZE_G : positive := 1;
+      NUM_LANE_G      : positive := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
+            SIMULATION_G    => SIMULATION_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -23,10 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder10b12bWrapper is
    generic (
-      TPD_G           : time     := 1 ns;
-      SIMULATION_G    : boolean  := false;
-      DLY_STEP_SIZE_G : positive := 1;
-      NUM_LANE_G      : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -80,9 +80,9 @@ begin
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
             TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,
             DATA_WIDTH_G    => DATA_WIDTH_C,
-            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
-            SIMULATION_G    => SIMULATION_G)
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder12b14bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time     := 1 ns;
+      SIMULATION_G    : boolean  := false;
+      DLY_STEP_SIZE_G : positive := 1;
+      NUM_LANE_G      : positive := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
+            SIMULATION_G    => SIMULATION_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -23,10 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder12b14bWrapper is
    generic (
-      TPD_G           : time     := 1 ns;
-      SIMULATION_G    : boolean  := false;
-      DLY_STEP_SIZE_G : positive := 1;
-      NUM_LANE_G      : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -80,9 +80,9 @@ begin
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
             TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,            
             DATA_WIDTH_G    => DATA_WIDTH_C,
-            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
-            SIMULATION_G    => SIMULATION_G)
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -23,10 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder8b10bWrapper is
    generic (
-      TPD_G           : time     := 1 ns;
-      SIMULATION_G    : boolean  := false;
-      DLY_STEP_SIZE_G : positive := 1;
-      NUM_LANE_G      : positive := 1);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1;
+      NUM_LANE_G      : positive                := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -80,9 +80,9 @@ begin
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
             TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,            
             DATA_WIDTH_G    => DATA_WIDTH_C,
-            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
-            SIMULATION_G    => SIMULATION_G)
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -23,9 +23,10 @@ use surf.AxiLitePkg.all;
 
 entity SspLowSpeedDecoder8b10bWrapper is
    generic (
-      TPD_G        : time     := 1 ns;
-      SIMULATION_G : boolean  := false;
-      NUM_LANE_G   : positive := 1);
+      TPD_G           : time     := 1 ns;
+      SIMULATION_G    : boolean  := false;
+      DLY_STEP_SIZE_G : positive := 1;
+      NUM_LANE_G      : positive := 1);
    port (
       -- Deserialization Interface (deserClk domain)
       deserClk        : in  sl;
@@ -78,9 +79,10 @@ begin
 
       U_Lane : entity surf.SspLowSpeedDecoderLane
          generic map (
-            TPD_G        => TPD_G,
-            DATA_WIDTH_G => DATA_WIDTH_C,
-            SIMULATION_G => SIMULATION_G)
+            TPD_G           => TPD_G,
+            DATA_WIDTH_G    => DATA_WIDTH_C,
+            DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
+            SIMULATION_G    => SIMULATION_G)
          port map (
             -- Clock and Reset Interface
             clk            => deserClk,

--- a/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
@@ -22,10 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SspLowSpeedDecoderLane is
    generic (
-      TPD_G           : time     := 1 ns;
-      DATA_WIDTH_G    : positive := 10;
-      DLY_STEP_SIZE_G : positive := 1;
-      SIMULATION_G    : boolean  := false);
+      TPD_G           : time                    := 1 ns;
+      SIMULATION_G    : boolean                 := false;
+      DATA_WIDTH_G    : positive                := 10;
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1);
    port (
       -- Clock and Reset Interface
       clk            : in  sl;

--- a/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
@@ -22,9 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SspLowSpeedDecoderLane is
    generic (
-      TPD_G        : time     := 1 ns;
-      DATA_WIDTH_G : positive := 10;
-      SIMULATION_G : boolean  := false);
+      TPD_G           : time     := 1 ns;
+      DATA_WIDTH_G    : positive := 10;
+      DLY_STEP_SIZE_G : positive := 1;
+      SIMULATION_G    : boolean  := false);
    port (
       -- Clock and Reset Interface
       clk            : in  sl;
@@ -128,9 +129,10 @@ begin
 
    U_GearboxAligner : entity surf.SelectIoRxGearboxAligner
       generic map (
-         TPD_G        => TPD_G,
-         CODE_TYPE_G  => "LINE_CODE",
-         SIMULATION_G => SIMULATION_G)
+         TPD_G           => TPD_G,
+         CODE_TYPE_G     => "LINE_CODE",
+         DLY_STEP_SIZE_G => DLY_STEP_SIZE_G,
+         SIMULATION_G    => SIMULATION_G)
       port map (
          -- Clock and Reset
          clk             => clk,

--- a/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
+++ b/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
@@ -22,9 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SelectIoRxGearboxAligner is
    generic (
-      TPD_G        : time    := 1 ns;
-      CODE_TYPE_G  : string  := "LINE_CODE";  -- or "SCRAMBLER"
-      SIMULATION_G : boolean := false);
+      TPD_G        : time     := 1 ns;
+      CODE_TYPE_G  : string   := "LINE_CODE";  -- or "SCRAMBLER"
+      STEP_SIZE_G  : positive := 1;
+      SIMULATION_G : boolean  := false);
    port (
       -- Clock and Reset
       clk             : in  sl;
@@ -134,7 +135,7 @@ begin
          else
 
             -- Increment the counter
-            v.dlyConfig := r.dlyConfig + 1;
+            v.dlyConfig := r.dlyConfig + STEP_SIZE_G;
 
             -- Reset the flag
             v.firstError := '1';
@@ -281,7 +282,7 @@ begin
 
                      -- Update the Delay module
                      v.dlyLoad(1) := '1';
-                     v.dlyConfig  := r.dlyConfig + 1;
+                     v.dlyConfig  := r.dlyConfig + STEP_SIZE_G;
 
                      -- Next state
                      v.state := SLIP_WAIT_S;
@@ -311,7 +312,7 @@ begin
 
                   -- Update the Delay module
                   v.dlyLoad(1) := '1';
-                  v.dlyConfig  := r.dlyConfig + 1;
+                  v.dlyConfig  := r.dlyConfig + STEP_SIZE_G;
 
                   -- Check for last count or first header error after min. eye width
                   if (scanCnt >= 255) or (v.errorDet = '1') then

--- a/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
+++ b/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
@@ -22,10 +22,10 @@ use surf.StdRtlPkg.all;
 
 entity SelectIoRxGearboxAligner is
    generic (
-      TPD_G        : time     := 1 ns;
-      CODE_TYPE_G  : string   := "LINE_CODE";  -- or "SCRAMBLER"
-      STEP_SIZE_G  : positive := 1;
-      SIMULATION_G : boolean  := false);
+      TPD_G           : time     := 1 ns;
+      CODE_TYPE_G     : string   := "LINE_CODE";  -- or "SCRAMBLER"
+      DLY_STEP_SIZE_G : positive := 1;
+      SIMULATION_G    : boolean  := false);
    port (
       -- Clock and Reset
       clk             : in  sl;
@@ -135,7 +135,7 @@ begin
          else
 
             -- Increment the counter
-            v.dlyConfig := r.dlyConfig + STEP_SIZE_G;
+            v.dlyConfig := r.dlyConfig + DLY_STEP_SIZE_G;
 
             -- Reset the flag
             v.firstError := '1';
@@ -282,7 +282,7 @@ begin
 
                      -- Update the Delay module
                      v.dlyLoad(1) := '1';
-                     v.dlyConfig  := r.dlyConfig + STEP_SIZE_G;
+                     v.dlyConfig  := r.dlyConfig + DLY_STEP_SIZE_G;
 
                      -- Next state
                      v.state := SLIP_WAIT_S;
@@ -312,7 +312,7 @@ begin
 
                   -- Update the Delay module
                   v.dlyLoad(1) := '1';
-                  v.dlyConfig  := r.dlyConfig + STEP_SIZE_G;
+                  v.dlyConfig  := r.dlyConfig + DLY_STEP_SIZE_G;
 
                   -- Check for last count or first header error after min. eye width
                   if (scanCnt >= 255) or (v.errorDet = '1') then

--- a/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
+++ b/xilinx/general/rtl/SelectIoRxGearboxAligner.vhd
@@ -23,9 +23,9 @@ use surf.StdRtlPkg.all;
 entity SelectIoRxGearboxAligner is
    generic (
       TPD_G           : time     := 1 ns;
+      SIMULATION_G    : boolean  := false;      
       CODE_TYPE_G     : string   := "LINE_CODE";  -- or "SCRAMBLER"
-      DLY_STEP_SIZE_G : positive := 1;
-      SIMULATION_G    : boolean  := false);
+      DLY_STEP_SIZE_G : positive range 1 to 255 := 1);  -- 1 for Ultrascale or 16 for 7-Series
    port (
       -- Clock and Reset
       clk             : in  sl;


### PR DESCRIPTION
### Description
- Ultrascale: CNTVALUEIN=dlyCfg(8 downto 0), 7-series: CNTVALUEIN=dlyCfg(8 downto 4)
- `DLY_STEP_SIZE_G` can be set to 16 to improve the locking up duration for 7-series since the lower 4 bits on the dlyCfg bus are unused