### PR TITLE
Exposing PGP rogue sim's EN_SIDEBAND_G to top-level

### DIFF
--- a/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs+/rtl/Pgp3GthUsWrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp3GthUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       SYNTH_MODE_G                : string                      := "inferred";
       MEMORY_TYPE_G               : string                      := "block";
@@ -276,11 +277,12 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp3Sim
             generic map(
-               TPD_G      => TPD_G,
+               TPD_G         => TPD_G,
                SYNTH_MODE_G  => SYNTH_MODE_G,
                MEMORY_TYPE_G => MEMORY_TYPE_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gthUs/rtl/Pgp3GthUsWrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp3GthUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -277,9 +278,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp3Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtp7/rtl/Pgp3Gtp7Wrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp3Gtp7Wrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -392,9 +393,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp3Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp3/gtx7/rtl/Pgp3Gtx7Wrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp3Gtx7Wrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -322,9 +323,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp3Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp3/gtyUs+/rtl/Pgp3GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp3/gtyUs+/rtl/Pgp3GtyUsWrapper.vhd
@@ -32,6 +32,7 @@ entity Pgp3GtyUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       SYNTH_MODE_G                : string                      := "inferred";
       MEMORY_TYPE_G               : string                      := "block";
@@ -271,11 +272,12 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp3Sim
             generic map(
-               TPD_G      => TPD_G,
+               TPD_G         => TPD_G,
                SYNTH_MODE_G  => SYNTH_MODE_G,
                MEMORY_TYPE_G => MEMORY_TYPE_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs+/rtl/Pgp4GthUsWrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp4GthUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       SYNTH_MODE_G                : string                      := "inferred";
       MEMORY_TYPE_G               : string                      := "block";
@@ -282,6 +283,7 @@ begin
                SYNTH_MODE_G  => SYNTH_MODE_G,
                MEMORY_TYPE_G => MEMORY_TYPE_G,
                PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
                NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports

--- a/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gthUs/rtl/Pgp4GthUsWrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp4GthUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -279,9 +280,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp4Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtp7/rtl/Pgp4Gtp7Wrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp4Gtp7Wrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -394,9 +395,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp4Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
+++ b/protocols/pgp/pgp4/gtx7/rtl/Pgp4Gtx7Wrapper.vhd
@@ -33,6 +33,7 @@ entity Pgp4Gtx7Wrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       NUM_LANES_G                 : positive range 1 to 4       := 1;
       NUM_VC_G                    : positive range 1 to 16      := 4;
@@ -324,9 +325,10 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp4Sim
             generic map(
-               TPD_G      => TPD_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               TPD_G         => TPD_G,
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,

--- a/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
+++ b/protocols/pgp/pgp4/gtyUs+/rtl/Pgp4GtyUsWrapper.vhd
@@ -32,6 +32,7 @@ entity Pgp4GtyUsWrapper is
    generic (
       TPD_G                       : time                        := 1 ns;
       ROGUE_SIM_EN_G              : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G        : boolean                     := true;
       ROGUE_SIM_PORT_NUM_G        : natural range 1024 to 49151 := 9000;
       SYNTH_MODE_G                : string                      := "inferred";
       MEMORY_TYPE_G               : string                      := "block";
@@ -273,11 +274,12 @@ begin
       GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
          U_Rogue : entity surf.RoguePgp4Sim
             generic map(
-               TPD_G      => TPD_G,
+               TPD_G         => TPD_G,
                SYNTH_MODE_G  => SYNTH_MODE_G,
                MEMORY_TYPE_G => MEMORY_TYPE_G,
-               PORT_NUM_G => (ROGUE_SIM_PORT_NUM_G+(i*34)),
-               NUM_VC_G   => NUM_VC_G)
+               PORT_NUM_G    => (ROGUE_SIM_PORT_NUM_G+(i*34)),
+               EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G,
+               NUM_VC_G      => NUM_VC_G)
             port map(
                -- GT Ports
                pgpRefClk       => pgpRefClk,


### PR DESCRIPTION
### Description
- Useful to be able to disable that feature if not used in the simulation (not always used)