### PR TITLE
adding Pgp4TxLite

### DIFF
--- a/protocols/pgp/pgp4/asic/rtl/Pgp4TxLite.vhd
+++ b/protocols/pgp/pgp4/asic/rtl/Pgp4TxLite.vhd
@@ -1,0 +1,232 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Pgp4TxLite (no SOC/EOC support)
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4TxLite is
+   generic (
+      TPD_G          : time                  := 1 ns;
+      NUM_VC_G       : integer range 1 to 16 := 1;
+      SKIP_EN_G      : boolean               := false;
+      FLOW_CTRL_EN_G : boolean               := false);
+   port (
+      -- Transmit interface
+      pgpTxClk     : in  sl;
+      pgpTxRst     : in  sl;
+      pgpTxIn      : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
+      pgpTxOut     : out Pgp4TxOutType;
+      pgpTxActive  : in  sl;
+      pgpTxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      pgpTxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      -- Status of receive and remote FIFOs (Asynchronous)
+      locRxFifoCtrl  : in AxiStreamCtrlArray(NUM_VC_G-1 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+      locRxLinkReady : in sl                                      := '1';
+      remRxFifoCtrl  : in AxiStreamCtrlArray(NUM_VC_G-1 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+      remRxLinkReady : in sl                                      := '1';
+      -- PHY interface
+      phyTxActive : in  sl;
+      phyTxReady  : in  sl;
+      phyTxValid  : out sl;
+      phyTxStart  : out sl;
+      phyTxData   : out slv(63 downto 0);
+      phyTxHeader : out slv(1 downto 0));
+end entity Pgp4TxLite;
+
+architecture rtl of Pgp4TxLite is
+
+   -- Synchronized statuses
+   signal syncLocRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+   signal syncLocRxLinkReady : sl                                      := '1';
+   signal syncRemRxFifoCtrl  : AxiStreamCtrlArray(NUM_VC_G-1 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+   signal syncRemRxLinkReady : sl                                      := '1';
+
+   -- Pipeline signals
+   signal disableSel    : slv(NUM_VC_G-1 downto 0);
+   signal rearbitrate   : sl := '0';
+   signal muxedTxMaster : AxiStreamMasterType;
+   signal muxedTxSlave  : AxiStreamSlaveType;
+
+   signal phyTxActiveL : sl;
+   signal protTxValid  : sl;
+   signal protTxReady  : sl;
+   signal protTxStart  : sl;
+   signal protTxData   : slv(63 downto 0);
+   signal protTxHeader : slv(1 downto 0);
+
+begin
+
+   FLOW_CTRL_SYNC : if (FLOW_CTRL_EN_G) generate
+      -- Synchronize remote link and fifo status to tx clock
+      U_Synchronizer_REM : entity surf.Synchronizer
+         generic map (
+            TPD_G => TPD_G)
+         port map (
+            clk     => pgpTxClk,                              -- [in]
+            rst     => pgpTxRst,                              -- [in]
+            dataIn  => remRxLinkReady,                        -- [in]
+            dataOut => syncRemRxLinkReady);                   -- [out]
+      REM_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
+         U_SynchronizerVector_1 : entity surf.SynchronizerVector
+            generic map (
+               TPD_G   => TPD_G,
+               WIDTH_G => 2)
+            port map (
+               clk        => pgpTxClk,                        -- [in]
+               rst        => pgpTxRst,                        -- [in]
+               dataIn(0)  => remRxFifoCtrl(i).pause,          -- [in]
+               dataIn(1)  => remRxFifoCtrl(i).overflow,       -- [in]
+               dataOut(0) => syncRemRxFifoCtrl(i).pause,      -- [out]
+               dataOut(1) => syncRemRxFifoCtrl(i).overflow);  -- [out]
+      end generate;
+
+      -- Synchronize local rx status
+      U_Synchronizer_LOC : entity surf.Synchronizer
+         generic map (
+            TPD_G => TPD_G)
+         port map (
+            clk     => pgpTxClk,                           -- [in]
+            rst     => pgpTxRst,                           -- [in]
+            dataIn  => locRxLinkReady,                     -- [in]
+            dataOut => syncLocRxLinkReady);                -- [out]
+      LOC_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
+         U_Synchronizer_pause : entity surf.Synchronizer
+            generic map (
+               TPD_G => TPD_G)
+            port map (
+               clk     => pgpTxClk,                        -- [in]
+               rst     => pgpTxRst,                        -- [in]
+               dataIn  => locRxFifoCtrl(i).pause,          -- [in]
+               dataOut => syncLocRxFifoCtrl(i).pause);     -- [out]
+         U_Synchronizer_overflow : entity surf.SynchronizerOneShot
+            generic map (
+               TPD_G => TPD_G)
+            port map (
+               clk     => pgpTxClk,                        -- [in]
+               rst     => pgpTxRst,                        -- [in]
+               dataIn  => locRxFifoCtrl(i).overflow,       -- [in]
+               dataOut => syncLocRxFifoCtrl(i).overflow);  -- [out]
+      end generate;
+   end generate FLOW_CTRL_SYNC;
+
+   ------------------------------------------------------------------------
+   -- Use synchronized remote status to disable channels from mux selection
+   -- All flow control overridden by pgpTxIn 'disable' and 'flowCntlDis'
+   ------------------------------------------------------------------------
+   DISABLE_SEL : process (pgpTxIn, syncRemRxFifoCtrl) is
+   begin
+      for i in NUM_VC_G-1 downto 0 loop
+         if (pgpTxIn.disable = '1') then
+            disableSel(i) <= '1';
+         elsif (pgpTxIn.flowCntlDis = '1') then
+            disableSel(i) <= '0';
+         else
+            disableSel(i) <= syncRemRxFifoCtrl(i).pause;
+         end if;
+      end loop;
+   end process;
+
+   GEN_MUX : if (NUM_VC_G > 1) or (FLOW_CTRL_EN_G = true) generate
+      -- Multiplex the incoming TX streams with interleaving
+      U_AxiStreamMux_1 : entity surf.AxiStreamMux
+         generic map (
+            TPD_G                => TPD_G,
+            NUM_SLAVES_G         => NUM_VC_G,
+            MODE_G               => "INDEXED",
+            PIPE_STAGES_G        => 0,
+            TDEST_LOW_G          => 0,
+            ILEAVE_EN_G          => false,
+            ILEAVE_ON_NOTVALID_G => false)
+         port map (
+            axisClk      => pgpTxClk,       -- [in]
+            axisRst      => pgpTxRst,       -- [in]
+            disableSel   => disableSel,     -- [in]
+            rearbitrate  => '0',            -- [in]
+            sAxisMasters => pgpTxMasters,   -- [in]
+            sAxisSlaves  => pgpTxSlaves,    -- [out]
+            mAxisMaster  => muxedTxMaster,  -- [out]
+            mAxisSlave   => muxedTxSlave);  -- [in]
+   end generate GEN_MUX;
+
+   NO_MUX : if (NUM_VC_G = 1) and (FLOW_CTRL_EN_G = false) generate
+      muxedTxMaster  <= pgpTxMasters(0);
+      pgpTxSlaves(0) <= muxedTxSlave;
+   end generate NO_MUX;
+
+   ----------------------------------------------------------------------------------------
+   -- Feed packets into PGP TX Protocol engine
+   -- Translates Packetizer2 frames, status, and opcodes into unscrambled 64b66b characters
+   ----------------------------------------------------------------------------------------
+   U_Protocol : entity surf.Pgp4TxLiteProtocol
+      generic map (
+         TPD_G          => TPD_G,
+         NUM_VC_G       => NUM_VC_G,
+         SKIP_EN_G      => SKIP_EN_G,
+         FLOW_CTRL_EN_G => FLOW_CTRL_EN_G,
+         STARTUP_HOLD_G => 0)
+      port map (
+         pgpTxClk       => pgpTxClk,            -- [in]
+         pgpTxRst       => pgpTxRst,            -- [in]
+         pgpTxIn        => pgpTxIn,             -- [in]
+         pgpTxOut       => pgpTxOut,            -- [out]
+         pgpTxActive    => pgpTxActive,         -- [in]
+         pgpTxMaster    => muxedTxMaster,       -- [in]
+         pgpTxSlave     => muxedTxSlave,        -- [out]
+         locRxFifoCtrl  => syncLocRxFifoCtrl,   -- [in]
+         locRxLinkReady => syncLocRxLinkReady,  -- [in]
+         remRxLinkReady => syncRemRxLinkReady,  -- [in]
+         phyTxActive    => phyTxActive,         -- [in]
+         protTxReady    => protTxReady,         -- [in]
+         protTxValid    => protTxValid,         -- [out]
+         protTxStart    => protTxStart,         -- [out]
+         protTxData     => protTxData,          -- [out]
+         protTxHeader   => protTxHeader);       -- [out]
+
+   -- Scramble the data for 64b66b
+   U_Scrambler_1 : entity surf.Scrambler
+      generic map (
+         TPD_G            => TPD_G,
+         DIRECTION_G      => "SCRAMBLER",
+         DATA_WIDTH_G     => 64,
+         SIDEBAND_WIDTH_G => 3,
+         TAPS_G           => PGP4_SCRAMBLER_TAPS_C)
+      port map (
+         clk                        => pgpTxClk,      -- [in]
+         rst                        => phyTxActiveL,  -- [in]
+         -- Input Interface
+         inputValid                 => protTxValid,   -- [in]
+         inputReady                 => protTxReady,   -- [out]
+         inputData                  => protTxData,    -- [in]
+         inputSideband(1 downto 0)  => protTxHeader,  -- [in]
+         inputSideband(2)           => protTxStart,   -- [in]
+         -- Output Interface
+         outputValid                => phyTxValid,    -- [out]
+         outputReady                => phyTxReady,    -- [in]
+         outputData                 => phyTxData,     -- [out]
+         outputSideband(1 downto 0) => phyTxHeader,   -- [out]
+         outputSideband(2)          => phyTxStart);   -- [out]
+
+   phyTxActiveL <= not(phyTxActive);
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteProtocol.vhd
+++ b/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteProtocol.vhd
@@ -285,7 +285,7 @@ begin
                -- Check for EOF
                if (pgpTxMaster.tLast = '1') then
                   v.doEof      := '1';
-                  v.tUserLast  := axiStreamGetUserField(PGP4_AXIS_CONFIG_C, pgpTxMaster);
+                  v.tUserLast  := pgpTxMaster.tUser(15 downto 14);
                   v.frameTx    := '1';
                   v.frameTxErr := v.tUserLast(SSI_EOFE_C);
                end if;

--- a/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteProtocol.vhd
+++ b/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteProtocol.vhd
@@ -1,0 +1,463 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4Lite Transmit Protocol
+-- Takes pre-packetized AxiStream frames and creates a PGPv4 66/64 protocol
+-- stream (pre-scrambler). Inserts IDLE and SKP codes as needed. Inserts
+-- user K codes on request.
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiStreamPacketizer2Pkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4TxLiteProtocol is
+   generic (
+      TPD_G          : time                  := 1 ns;
+      NUM_VC_G       : integer range 1 to 16 := 1;
+      SKIP_EN_G      : boolean               := false;
+      FLOW_CTRL_EN_G : boolean               := false;
+      STARTUP_HOLD_G : integer               := 0);
+   port (
+      -- User Transmit interface
+      pgpTxClk       : in  sl;
+      pgpTxRst       : in  sl;
+      pgpTxIn        : in  Pgp4TxInType                            := PGP4_TX_IN_INIT_C;
+      pgpTxOut       : out Pgp4TxOutType;
+      pgpTxActive    : in  sl                                      := '1';
+      pgpTxMaster    : in  AxiStreamMasterType;
+      pgpTxSlave     : out AxiStreamSlaveType;
+      -- Status of local receive fifos
+      -- These get synchronized by the Pgp4Tx parent
+      locRxFifoCtrl  : in  AxiStreamCtrlArray(NUM_VC_G-1 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+      locRxLinkReady : in  sl                                      := '1';
+      remRxLinkReady : in  sl                                      := '1';
+      -- Output Interface
+      phyTxActive    : in  sl;
+      protTxReady    : in  sl;
+      protTxValid    : out sl;
+      protTxStart    : out sl;
+      protTxData     : out slv(63 downto 0);
+      protTxHeader   : out slv(1 downto 0));
+end entity Pgp4TxLiteProtocol;
+
+architecture rtl of Pgp4TxLiteProtocol is
+
+   type RegType is record
+      crcReset          : sl;
+      crcDataValid      : sl;
+      waitSof           : sl;
+      doEof             : sl;
+      tUserLast         : slv(1 downto 0);
+      pauseDly          : slv(NUM_VC_G-1 downto 0);
+      pauseEvent        : slv(NUM_VC_G-1 downto 0);
+      pauseEventSent    : slv(NUM_VC_G-1 downto 0);
+      overflowDly       : slv(NUM_VC_G-1 downto 0);
+      overflowEvent     : slv(NUM_VC_G-1 downto 0);
+      overflowEventSent : slv(NUM_VC_G-1 downto 0);
+      skpInterval       : slv(31 downto 0);
+      skpCount          : slv(31 downto 0);
+      startupCount      : integer;
+      pgpTxSlave        : AxiStreamSlaveType;
+      opCodeReady       : sl;
+      linkReady         : sl;
+      frameTx           : sl;
+      frameTxErr        : sl;
+      protTxValid       : sl;
+      protTxStart       : sl;
+      protTxData        : slv(63 downto 0);
+      protTxHeader      : slv(1 downto 0);
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      crcReset          => '0',
+      crcDataValid      => '0',
+      waitSof           => '1',
+      doEof             => '0',
+      tUserLast         => (others => '0'),
+      pauseDly          => (others => '0'),
+      pauseEvent        => (others => '0'),
+      pauseEventSent    => (others => '0'),
+      overflowDly       => (others => '0'),
+      overflowEvent     => (others => '0'),
+      overflowEventSent => (others => '0'),
+      skpInterval       => PGP4_TX_IN_INIT_C.skpInterval,
+      skpCount          => (others => '0'),
+      startupCount      => 0,
+      pgpTxSlave        => AXI_STREAM_SLAVE_INIT_C,
+      opCodeReady       => '0',
+      linkReady         => '0',
+      frameTx           => '0',
+      frameTxErr        => '0',
+      protTxValid       => '0',
+      protTxStart       => '0',
+      protTxData        => (others => '0'),
+      protTxHeader      => (others => '0'));
+
+   signal crcIn  : slv(63 downto 0);
+   signal crcOut : slv(31 downto 0);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal crcReset     : sl;
+   signal crcDataValid : sl;
+
+begin
+
+   U_Crc32 : entity surf.Crc32Parallel
+      generic map (
+         TPD_G            => TPD_G,
+         INPUT_REGISTER_G => false,
+         BYTE_WIDTH_G     => 8,
+         CRC_INIT_G       => X"FFFFFFFF")
+      port map (
+         crcOut       => crcOut,
+         crcRem       => open,
+         crcClk       => pgpTxClk,
+         crcDataValid => crcDataValid,
+         crcDataWidth => "111",
+         crcIn        => crcIn,
+         crcInit      => X"FFFFFFFF",
+         crcReset     => crcReset);
+
+   comb : process (crcOut, locRxFifoCtrl, locRxLinkReady, pgpTxIn, pgpTxMaster,
+                   pgpTxRst, phyTxActive, protTxReady, r, remRxLinkReady) is
+      variable v                  : RegType;
+      variable linkInfo           : slv(31 downto 0);
+      variable idleWord           : slv(63 downto 0);
+      variable dataEn             : sl;
+      variable rxFifoCtrl         : AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      variable resetEventMetaData : boolean;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Update the variables default values
+      resetEventMetaData := false;
+      rxFifoCtrl         := locRxFifoCtrl;
+
+      -- Detect 0->1 edges on locRxFifoCtrl(i).pause and locRxFifoCtrl(i).overflow
+      if (FLOW_CTRL_EN_G) then
+         for i in NUM_VC_G-1 downto 0 loop
+            -- Save last value for edge detection
+            v.pauseDly(i)    := locRxFifoCtrl(i).pause;
+            v.overflowDly(i) := locRxFifoCtrl(i).overflow;
+
+            -- Check for rising edge on pause
+            if (locRxFifoCtrl(i).pause = '1') and (r.pauseDly(i) = '0') then
+               v.pauseEvent(i) := '1';
+            end if;
+
+            -- Check for rising edge on overflow
+            if (locRxFifoCtrl(i).overflow = '1') and (r.overflowDly(i) = '0') then
+               v.overflowEvent(i) := '1';
+            end if;
+
+            -- Include the pauseEvent or overflowEvent in the linkInfo message
+            rxFifoCtrl(i).pause    := r.pauseEvent(i) or locRxFifoCtrl(i).pause;
+            rxFifoCtrl(i).overflow := r.overflowEvent(i) or locRxFifoCtrl(i).overflow;
+         end loop;
+      end if;
+
+      -- Generate the link information message
+      linkInfo := pgp4MakeLinkInfo(rxFifoCtrl, locRxLinkReady);
+
+      -- Generate the IDLE word
+      idleWord                        := (others => '0');
+      idleWord(PGP4_LINKINFO_FIELD_C) := linkInfo;
+      for i in NUM_VC_G-1 downto 0 loop
+         idleWord(i+32) := rxFifoCtrl(i).overflow;
+      end loop;
+      idleWord(PGP4_BTF_FIELD_C) := PGP4_IDLE_C;
+
+      if (SKIP_EN_G) then
+         -- Keep delay copy of skip interval configuration
+         v.skpInterval := pgpTxIn.skpInterval;
+
+         -- Check for change in configuration
+         if (r.skpInterval /= v.skpInterval) then
+            -- Force a skip
+            v.skpCount := v.skpInterval;
+         -- Check for counter roll over
+         elsif (r.skpCount /= r.skpInterval) then
+            -- Increment the counter
+            v.skpCount := r.skpCount + 1;
+         end if;
+      end if;
+
+      -- Don't accept new frame data by default
+      v.pgpTxSlave.tReady := '0';
+      v.opCodeReady       := '0';
+
+      v.frameTx      := '0';
+      v.frameTxErr   := '0';
+      v.crcReset     := '0';
+      v.crcDataValid := '0';
+
+      -- Check the handshaking
+      if (protTxReady = '1') then
+         v.protTxValid := '0';
+      end if;
+
+      dataEn := ite(pgpTxIn.flowCntlDis = '1' or FLOW_CTRL_EN_G = false, r.linkReady, remRxLinkReady);
+      if (STARTUP_HOLD_G = 0 and FLOW_CTRL_EN_G = false) then
+         dataEn := '1';
+      end if;
+
+      if (v.protTxValid = '0' and phyTxActive = '1') then
+
+         -- Send only IDLE and SKP for STARTUP_HOLD_G cycles after reset
+         if (r.startupCount = STARTUP_HOLD_G or STARTUP_HOLD_G = 0) then
+            -- Set the flags
+            v.linkReady   := '1';
+            v.protTxStart := '1';
+            v.protTxValid := '1';
+         else
+            -- Increment the counter
+            v.startupCount := r.startupCount + 1;
+         end if;
+
+         --------------------------------------------------------
+         -- Decide whether to send IDLE, SKP, USER or data frames
+         -- Coded in reverse order of priority
+         --------------------------------------------------------
+
+         -- Send IDLE k-code by default
+         resetEventMetaData := true;
+         v.protTxData       := idleWord;
+         v.protTxHeader     := PGP4_K_HEADER_C;
+
+         --------------------------------------------------------------------
+         --                   Header and Data and Footer                   --
+         --------------------------------------------------------------------
+
+         -- Send data if there is data to send
+         if (pgpTxMaster.tValid = '1' and dataEn = '1') then
+
+            -- Update the flag
+            resetEventMetaData := false;
+
+            -- Check for SOF
+            if (r.waitSof = '1') and (ssiGetUserSof(PGP4_AXIS_CONFIG_C, pgpTxMaster) = '1') then
+
+               -- Send an SOF
+               v.protTxData                        := (others => '0');
+               v.protTxData(PGP4_BTF_FIELD_C)      := PGP4_SOF_C;  -- Always SOF (never SOC)
+               v.protTxData(PGP4_LINKINFO_FIELD_C) := linkInfo;
+               v.protTxData(PGP4_SOFC_VC_FIELD_C)  := pgpTxMaster.tDest(3 downto 0);  -- Virtual Channel
+               v.protTxData(PGP4_SOFC_SEQ_FIELD_C) := (others => '0');  -- Pgp4TxLite does NOT support SOC/EOC
+               v.protTxHeader                      := PGP4_K_HEADER_C;
+
+               -- Update the flags
+               v.crcReset := '1';
+               v.waitSof  := '0';
+
+            -- Check if not doing EOF
+            elsif (r.doEof = '0') then
+
+               -- Accept the data
+               v.pgpTxSlave.tReady := '1';
+
+               -- Normal data forwarding
+               v.protTxData(63 downto 0) := pgpTxMaster.tData(63 downto 0);
+               v.protTxHeader            := PGP4_D_HEADER_C;
+               v.crcDataValid            := '1';
+
+               -- Check for EOF
+               if (pgpTxMaster.tLast = '1') then
+                  v.doEof      := '1';
+                  v.tUserLast  := axiStreamGetUserField(PGP4_AXIS_CONFIG_C, pgpTxMaster);
+                  v.frameTx    := '1';
+                  v.frameTxErr := v.tUserLast(SSI_EOFE_C);
+               end if;
+
+            end if;
+         end if;
+
+         --------------------------------------------------------------------
+         --                   Commands and Metadata                        --
+         --------------------------------------------------------------------
+
+         -- USER codes override data and delay SKP if they happen to coincide
+         if (pgpTxIn.opCodeEn = '1') and (dataEn = '1') then
+
+            -- Override any data acceptance.
+            v.pgpTxSlave.tReady := '0';
+
+            -- Accept the op-code
+            v.opCodeReady := '1';
+
+            -- Update the TX data bus
+            v.protTxData(PGP4_BTF_FIELD_C)         := PGP4_USER_C;
+            v.protTxData(PGP4_USER_OPCODE_FIELD_C) := pgpTxIn.opCodeData;
+            v.protTxHeader                         := PGP4_K_HEADER_C;
+            resetEventMetaData                     := false;
+
+            -- Check for SOF transition
+            if (r.waitSof = '1') and (v.waitSof = '0') then
+               -- Reset the flag
+               v.waitSof := '1';
+            end if;
+
+         elsif (r.skpCount = r.skpInterval) and (r.skpInterval /= 0) and SKIP_EN_G then
+
+            -- Reset the counter
+            v.skpCount := (others => '0');
+
+            -- Update the TX data bus
+            v.pgpTxSlave.tReady                  := '0';  -- Override any data acceptance.
+            v.protTxData(PGP4_SKIP_DATA_FIELD_C) := pgpTxIn.locData;
+            v.protTxData(PGP4_BTF_FIELD_C)       := PGP4_SKP_C;
+            v.protTxHeader                       := PGP4_K_HEADER_C;
+            resetEventMetaData                   := false;
+
+            -- Check for SOF transition
+            if (r.waitSof = '1') and (v.waitSof = '0') then
+               -- Reset the flag
+               v.waitSof := '1';
+            end if;
+
+         elsif (r.doEof = '1') and (dataEn = '1') then
+
+            -- EOF has priority over pause in this implementation just because its easier to code
+            -- and only makes a 1 cycle difference in latency
+            v.protTxData                               := (others => '0');
+            v.protTxData(PGP4_BTF_FIELD_C)             := PGP4_EOF_C;  -- Always EOF (never EOC)
+            v.protTxData(PGP4_EOFC_TUSER_FIELD_C)      := "000000" & r.tUserLast;
+            v.protTxData(PGP4_EOFC_BYTES_LAST_FIELD_C) := X"8";  -- Always 64-bit (8byte) for the last word
+            v.protTxData(PGP4_EOFC_CRC_FIELD_C)        := crcOut;      -- CRC
+            v.protTxHeader                             := PGP4_K_HEADER_C;
+
+            -- Reset the flags
+            v.doEof   := '0';
+            v.waitSof := '1';
+
+            -- Reset the metadata
+            resetEventMetaData := true;
+
+         elsif (FLOW_CTRL_EN_G) then
+
+
+            -- A local rx pause going high causes an IDLE char to be sent mid frame
+            -- So that the sending end is notified with minimum latency
+            for i in NUM_VC_G-1 downto 0 loop
+
+               -- Check for Pause event
+               if (r.pauseEvent(i) = '1') and (r.pauseEventSent(i) = '0') then
+                  v.pauseEventSent(i) := '1';
+                  v.pgpTxSlave.tReady := '0';
+                  v.protTxData        := idleWord;
+                  v.protTxHeader      := PGP4_K_HEADER_C;
+                  resetEventMetaData  := true;
+               end if;
+
+               -- Check for overflow event
+               if (r.overflowEvent(i) = '1') and (r.overflowEventSent(i) = '0') then
+                  v.overflowEventSent(i) := '1';
+                  v.pgpTxSlave.tReady    := '0';
+                  v.protTxData           := idleWord;
+                  v.protTxHeader         := PGP4_K_HEADER_C;
+                  resetEventMetaData     := true;
+               end if;
+
+            end loop;
+
+         end if;
+
+         -- Check if k-code word
+         if (v.protTxHeader = PGP4_K_HEADER_C) then
+            -- Insert the CSC
+            v.protTxData(PGP4_K_CODE_CRC_FIELD_C) := pgp4KCodeCrc(v.protTxData);
+         end if;
+
+         -- Check if TX is disabled
+         if (pgpTxIn.disable = '1') then
+            v.linkReady    := '0';
+            v.protTxStart  := '0';
+            v.startupCount := 0;
+            v.protTxData   := (others => '0');
+            v.protTxHeader := (others => '0');
+         end if;
+
+      end if;
+
+      -- Check if link down
+      if (phyTxActive = '0') then
+         v.linkReady    := '0';
+         v.protTxStart  := '0';
+         v.startupCount := 0;
+      end if;
+
+      -- Check if need to reset event meta data
+      if (resetEventMetaData) then
+         v.pauseEvent        := (others => '0');
+         v.pauseEventSent    := (others => '0');
+         v.overflowEvent     := (others => '0');
+         v.overflowEventSent := (others => '0');
+      end if;
+
+      -- Outputs
+      pgpTxSlave   <= v.pgpTxSlave;
+      crcReset     <= v.crcReset;
+      crcDataValid <= v.crcDataValid;
+
+      protTxData   <= r.protTxData;
+      protTxHeader <= r.protTxHeader;
+      protTxValid  <= r.protTxValid;
+      protTxStart  <= r.protTxStart;
+
+      pgpTxOut.phyTxActive <= phyTxActive;
+      pgpTxOut.linkReady   <= r.linkReady;
+      pgpTxOut.frameTx     <= r.frameTx;
+      pgpTxOut.frameTxErr  <= r.frameTxErr;
+      pgpTxOut.opCodeReady <= v.opCodeReady;
+
+      crcIn <= endianSwap(pgpTxMaster.tData(63 downto 0));
+
+      for i in 15 downto 0 loop
+         if (i < NUM_VC_G) then
+            pgpTxOut.locOverflow(i) <= locRxFifoCtrl(i).overflow;
+            pgpTxOut.locPause(i)    <= locRxFifoCtrl(i).pause;
+         else
+            pgpTxOut.locOverflow(i) <= '0';
+            pgpTxOut.locPause(i)    <= '0';
+         end if;
+      end loop;
+
+      -- Reset
+      if (pgpTxRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (pgpTxClk) is
+   begin
+      if (rising_edge(pgpTxClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/asic/rtl/Pgp4TxLiteWrapper.vhd
@@ -1,0 +1,92 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Wrapper for Pgp4TxLite (targeted/optimized for ASIC integration)
+-------------------------------------------------------------------------------
+-- This file is part of SURF. It is subject to
+-- the license terms in the LICENSE.txt file found in the top-level directory
+-- of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of SURF, including this file, may be
+-- copied, modified, propagated, or distributed except according to the terms
+-- contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4TxLiteWrapper is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      -- Clock and Reset
+      clk        : in  sl;
+      rst        : in  sl;                 -- Active HIGH reset
+      -- 64-bit Input Framing Interface
+      txValid    : in  sl;                 -- tValid
+      txReady    : out sl;                 -- tReady
+      txData     : in  slv(63 downto 0);   -- tData
+      txEnable   : in  sl;
+      txSof      : in  sl;                 -- tUser.FirstByte.BIT1
+      txEof      : in  sl;                 -- tLast
+      txEofe     : in  sl;                 -- tUser.LastByte.BIT0
+      -- 66-bit Output Interface
+      phyTxValid : out sl;
+      phyTxData  : out slv(65 downto 0));  -- 2-bit header packed on MSB
+end entity Pgp4TxLiteWrapper;
+
+architecture mapping of Pgp4TxLiteWrapper is
+
+   signal pgpTxIn : Pgp4TxInType := (
+      disable      => '0',              -- TX is enabled
+      flowCntlDis  => '1',  -- Disable PGPv4 pause flow control from RX side
+      resetTx      => '0',              -- Not resetting TX
+      skpInterval  => (others => '0'),  -- No skips (assumes clock source synchronous system)
+      opCodeEn     => '0',              -- OP-code mode not being implemented
+      opCodeData   => (others => '0'),
+      locData      => (others => '0'));  -- sideband locData not being implemented
+
+   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave  : AxiStreamSlaveType;
+
+begin
+
+   txReady                        <= pgpTxSlave.tReady;
+   pgpTxMaster.tValid             <= txValid;
+   pgpTxMaster.tData(63 downto 0) <= txData;
+   pgpTxMaster.tKeep(7 downto 0)  <= X"FF";  -- Assumes always 64-bit tData per clock cycle
+   pgpTxMaster.tUser(1)           <= txSof;
+   pgpTxMaster.tUser(14)          <= txEofe;
+   pgpTxMaster.tLast              <= txEof;
+
+   U_Pgp4TxLite : entity surf.Pgp4TxLite
+      generic map (
+         TPD_G          => TPD_G,
+         NUM_VC_G       => 1,           -- Only 1 VC per PGPv4 link
+         SKIP_EN_G      => false,  -- No skips (assumes clock source synchronous system)
+         FLOW_CTRL_EN_G => false)  -- no pause flow control from PGPv4.RX side
+      port map (
+         -- Transmit interface
+         pgpTxClk        => clk,
+         pgpTxRst        => rst,
+         pgpTxIn         => pgpTxIn,
+         pgpTxOut        => open,
+         pgpTxActive     => txEnable,
+         pgpTxMasters(0) => pgpTxMaster,
+         pgpTxSlaves(0)  => pgpTxSlave,
+         -- PHY interface
+         phyTxActive     => '1',
+         phyTxReady      => '1',
+         phyTxValid      => phyTxValid,
+         phyTxStart      => open,
+         phyTxData       => phyTxData(63 downto 0),
+         phyTxHeader     => phyTxData(65 downto 64));
+
+end architecture mapping;

--- a/protocols/pgp/pgp4/asic/ruckus.tcl
+++ b/protocols/pgp/pgp4/asic/ruckus.tcl
@@ -1,0 +1,8 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"
+
+# Load Simulation
+loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/protocols/pgp/pgp4/asic/tb/Pgp4TxLiteTb.vhd
+++ b/protocols/pgp/pgp4/asic/tb/Pgp4TxLiteTb.vhd
@@ -1,0 +1,205 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Simulation Pgp4Lite Testbed
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4TxLiteTb is
+
+end entity Pgp4TxLiteTb;
+
+architecture testbed of Pgp4TxLiteTb is
+
+   constant TPD_C : time := 1 ns;
+
+   constant PGP_CLK_PERIOD_C : time := 7 ns;
+   constant LOC_CLK_PERIOD_C : time := 11 ns;
+
+   constant TX_PACKET_LENGTH_C : slv(31 downto 0) := toSlv(256, 32);
+   constant NUMBER_PACKET_C    : slv(31 downto 0) := x"000000FF";
+
+   constant PRBS_SEED_SIZE_C : positive := 8*PGP4_AXIS_CONFIG_C.TDATA_BYTES_C;
+
+   signal pgpTxIn : Pgp4TxInType := (
+      disable     => '0',               -- TX is enabled
+      flowCntlDis => '1',  -- Disable PGPv4 pause flow control from RX side
+      resetTx     => '0',               -- Not resetting TX
+      skpInterval => (others => '0'),  -- No skips (assumes clock source synchronous system)
+      opCodeEn    => '0',               -- OP-code mode not being implemented
+      opCodeData  => (others => '0'),
+      locData     => (others => '0'));  -- sideband locData not being implemented
+   signal pgpRxOut : Pgp4RxOutType;
+
+   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal phyData   : slv(63 downto 0);
+   signal phyHeader : slv(1 downto 0);
+
+   signal pgpRxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+
+   signal passed   : sl := '0';
+   signal failed   : sl := '0';
+   signal updated  : sl := '0';
+   signal errorDet : sl := '0';
+   signal cnt      : slv(31 downto 0);
+
+   signal pgpClk : sl := '0';
+   signal pgpRst : sl := '1';
+
+   signal locClk : sl := '0';
+   signal locRst : sl := '1';
+
+begin
+
+   U_pgpClkRst : entity surf.ClkRst
+      generic map (
+         CLK_PERIOD_G      => PGP_CLK_PERIOD_C,
+         RST_START_DELAY_G => 0 ns,  -- Wait this long into simulation before asserting reset
+         RST_HOLD_TIME_G   => 1 us)     -- Hold reset for this long)
+      port map (
+         clkP => pgpClk,
+         rst  => pgpRst);
+
+   U_locClkRst : entity surf.ClkRst
+      generic map (
+         CLK_PERIOD_G      => LOC_CLK_PERIOD_C,
+         RST_START_DELAY_G => 0 ns,  -- Wait this long into simulation before asserting reset
+         RST_HOLD_TIME_G   => 1 us)     -- Hold reset for this long)
+      port map (
+         clkP => locClk,
+         rst  => locRst);
+
+   U_SsiPrbsTx : entity surf.SsiPrbsTx
+      generic map (
+         TPD_G                      => TPD_C,
+         PRBS_SEED_SIZE_G           => PRBS_SEED_SIZE_C,
+         AXI_EN_G                   => '0',
+         MASTER_AXI_STREAM_CONFIG_G => PGP4_AXIS_CONFIG_C)
+      port map (
+         -- Master Port (mAxisClk)
+         mAxisClk     => pgpClk,
+         mAxisRst     => pgpRst,
+         mAxisMaster  => pgpTxMaster,
+         mAxisSlave   => pgpTxSlave,
+         -- Trigger Signal (locClk domain)
+         locClk       => locClk,
+         locRst       => locRst,
+         trig         => pgpRxOut.linkReady,
+         packetLength => TX_PACKET_LENGTH_C);
+
+   U_Pgp4TxLite : entity surf.Pgp4TxLite
+      generic map (
+         TPD_G          => TPD_C,
+         NUM_VC_G       => 1,
+         SKIP_EN_G      => false,
+         FLOW_CTRL_EN_G => false)
+      port map (
+         -- Transmit interface
+         pgpTxClk        => pgpClk,
+         pgpTxRst        => pgpRst,
+         pgpTxIn         => pgpTxIn,
+         pgpTxOut        => open,
+         pgpTxActive     => '1',
+         pgpTxMasters(0) => pgpTxMaster,
+         pgpTxSlaves(0)  => pgpTxSlave,
+         -- PHY interface
+         phyTxActive     => '1',
+         phyTxReady      => '1',
+         phyTxData       => phyData,
+         phyTxHeader     => phyHeader);
+
+   U_Pgp4Rx : entity surf.Pgp4Rx
+      generic map (
+         TPD_G    => TPD_C,
+         NUM_VC_G => 1)
+      port map (
+         -- User Transmit interface
+         pgpRxClk        => pgpClk,
+         pgpRxRst        => pgpRst,
+         pgpRxMasters(0) => pgpRxMaster,
+         pgpRxCtrl(0)    => AXI_STREAM_CTRL_UNUSED_C,
+         pgpRxIn         => PGP4_RX_IN_INIT_C,
+         pgpRxOut        => pgpRxOut,
+         -- Phy interface
+         phyRxClk        => pgpClk,
+         phyRxRst        => pgpRst,
+         phyRxActive     => '1',
+         phyRxStartSeq   => '0',
+         phyRxValid      => '1',
+         phyRxData       => phyData,
+         phyRxHeader     => phyHeader);
+
+   U_SsiPrbsRx : entity surf.SsiPrbsRx
+      generic map (
+         TPD_G                     => TPD_C,
+         PRBS_SEED_SIZE_G          => PRBS_SEED_SIZE_C,
+         SLAVE_READY_EN_G          => false,
+         SLAVE_AXI_STREAM_CONFIG_G => PGP4_AXIS_CONFIG_C)
+      port map (
+         -- Streaming RX Data Interface (sAxisClk domain)
+         sAxisClk       => pgpClk,
+         sAxisRst       => pgpRst,
+         sAxisMaster    => pgpRxMaster,
+         -- Error Detection Signals (sAxisClk domain)
+         updatedResults => updated,
+         errorDet       => errorDet);
+
+   process(pgpClk)
+   begin
+      if rising_edge(pgpClk) then
+         if pgpRst = '1' then
+            cnt    <= (others => '0') after TPD_C;
+            passed <= '0'             after TPD_C;
+            failed <= '0'             after TPD_C;
+         elsif updated = '1' then
+            -- Check for packet error
+            if errorDet = '1' then
+               failed <= '1' after TPD_C;
+            end if;
+            -- Check the counter
+            if cnt = NUMBER_PACKET_C then
+               passed <= '1' after TPD_C;
+            else
+               -- Increment the counter
+               cnt <= cnt + 1 after TPD_C;
+            end if;
+         end if;
+      end if;
+   end process;
+
+   process(failed, passed)
+   begin
+      if failed = '1' then
+         assert false
+            report "Simulation Failed!" severity failure;
+      end if;
+      if passed = '1' then
+         assert false
+            report "Simulation Passed!" severity failure;
+      end if;
+   end process;
+
+end testbed;

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -3,6 +3,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"
+loadRuckusTcl "$::DIR_PATH/asic"
 
 # Get the family type
 set family [getFpgaFamily]


### PR DESCRIPTION
### Description
- Pgp4TxLite does `NOT` support following
  - AXI stream interleaving
  - SOC/EOC k-words
  - TKEEP for last transfer != 8-byte word (already 64-bit data words)
 - Add generates to optimize for no flow control 
 - Add generates to optimize for no SKIP codes
   -  Used only when dealing with a clock synchronous system
- Based on the `pgp3-lite` development branch that Ben previously worked on
- `Pgp4TxLiteWrapper.vhd` design to be a module to drop directly into an ASIC design
  - Similar framing signals as `SSP` protocol
- `Pgp4TxLite` protocol output is design to go directly into existing `Pgp4Rx` (no changes to RX required)
