### PR TITLE
Epix10ka devel changes

### DIFF
--- a/protocols/saci/rtl/SaciMultiPixelPkg.vhd
+++ b/protocols/saci/rtl/SaciMultiPixelPkg.vhd
@@ -25,7 +25,7 @@ use surf.StdRtlPkg.all;
 
 package SaciMultiPixelPkg is
 
-   constant FPGA_VERSION_C : slv(31 downto 0) := x"00000000";
+   constant FPGA_VERSION_C : slv(31 downto 0) := x"E0000000";
 
    type MultiPixelWriteType is record
       asic       : slv(1 downto 0);
@@ -91,26 +91,13 @@ package body SaciMultiPixelPkg is
    begin
       return toSlv(asic*(2**22), 32);
    end function;
-
+   
+   
+   -- SaciMultiPixel.vhd and SaciMultiPixelPkg.vhd is only intended for the oldest ePix100a
+   -- removing version dependency for all other ASIC types
    function getNumColumns (version : slv ) return integer is
    begin
-      assert (version(31 downto 24) = x"E0" or
-              version(31 downto 24) = x"EA" or
-              version(31 downto 24) = x"E2" or
-              version(31 downto 24) = x"E3") report "Unable to determine ASIC type from version string!" severity failure;
-      --Epix 100p and Epix100a
-      if (version(31 downto 24) = x"E0" or version(31 downto 24) = x"EA") then
-         return EPIX100_COLS_PER_ROW;
-      --Epix 10k
-      elsif (version(31 downto 24) = x"E2") then
-         return EPIX10K_COLS_PER_ROW;
-      --Epix S
-      elsif (version(31 downto 24) = x"E3") then
-         return EPIXS_COLS_PER_ROW;
-      --Other (default to Epix 100)
-      else
-         return EPIX100_COLS_PER_ROW;
-      end if;
+      return EPIX100_COLS_PER_ROW;
    end function;
 
    function getWordsPerSuperRow (version : slv ) return integer is

--- a/python/surf/devices/analog_devices/_Ad9249.py
+++ b/python/surf/devices/analog_devices/_Ad9249.py
@@ -412,9 +412,9 @@ class Ad9249ReadoutGroup(pr.Device):
 
         else:
             self.FreezeDebug(1)
-            for block in self._blocks:
-                if block.bulkOpEn:
-                    pr.startTransaction(block, type=rim.Read, checkEach=checkEach, **kwargs)
+            #for block in self._blocks:
+            #    if block.bulkOpEn:
+            #        pr.startTransaction(block, type=rim.Read, checkEach=checkEach, **kwargs)
             self.FreezeDebug(0)
 
             if recurse:


### PR DESCRIPTION
Fixing 2 issues:

1. SaciMultiPixel.vhd and SaciMultiPixelPkg.vhd is only intended for the oldest ePix100a. Removing version dependency for all other ASIC types. SaciMultiPixelPkg.vhd was causing the VCS simulation to fail.

SaciMultiPixel.vhd and SaciMultiPixelPkg.vhd is an attempt to port the ePix100a bug workaround (matrix programming). This was originally implemented by Kurtis and Jack and it exists in the old firmware release used by LCLS DAQ. This port was never tested as it is not required for newer ASICs like the ePix10ka. The SaciMultiPixel procedure can be easily implemented in the DAQ software. My recommendation is to remove those two files from surf and one instance (U_SaciMultiPixel) from the EpixCoreGen2.vhd.

2. Commenting out part of the code in the _Ad9249.py causing an error (No bulkOpEn field).

