### PR TITLE
Release Candidate v2.23.5

### DIFF
--- a/yaml/AxiStreamMonAxiL.yaml
+++ b/yaml/AxiStreamMonAxiL.yaml
@@ -59,6 +59,36 @@ AxiStreamMonChannel: &AxiStreamMonChannel
       pollSecs:    1.0
       description: "Min Frame Rate"
     ########################################################
+    Bandwidth:
+      at:
+        offset:    0x18
+      class:       IntField
+      sizeBits:    64
+      lsBit:       0
+      mode:        RO
+      pollSecs:    1.0
+      description: "Current Bandwidth"
+    ########################################################
+    BandwidthMax:
+      at:
+        offset:    0x20
+      class:       IntField
+      sizeBits:    64
+      lsBit:       0
+      mode:        RO
+      pollSecs:    1.0
+      description: "Max Bandwidth"
+    ########################################################
+    BandwidthMin:
+      at:
+        offset:    0x28
+      class:       IntField
+      sizeBits:    64
+      lsBit:       0
+      mode:        RO
+      pollSecs:    1.0
+      description: "Min Bandwidth"
+    ########################################################
     FrameSize:
       at:
         offset:    0x30


### PR DESCRIPTION
Add missing bandwidth register to `AxiStreamMonAxiL.yaml`, based on its [pyrogue definition](https://github.com/slaclab/surf/blob/master/python/surf/axi/_AxiStreamMonAxiL.py#L88-L119).

### Description
We added the YAML definition for the `AxiStreamMonAxiL` module in #882, but the Bandwidth related register were missing. This PR adds those missing definitions. 

### JIRA
[ESLMPS-139](https://jira.slac.stanford.edu/browse/ESLMPS-139)

### Related
#882 

