### PR TITLE
Release Candidate v2.23.6

### DIFF
--- a/protocols/salt/rtl/7Series/SaltRxDeser.vhd
+++ b/protocols/salt/rtl/7Series/SaltRxDeser.vhd
@@ -23,6 +23,7 @@ use surf.StdRtlPkg.all;
 entity SaltRxDeser is
    generic (
       TPD_G           : time   := 1 ns;
+      SIM_DEVICE_G    : string := "ULTRASCALE";
       IODELAY_GROUP_G : string := "SALT_GROUP";
       REF_FREQ_G      : real   := 200.0);  -- IDELAYCTRL's REFCLK (in units of Hz)
    port (

--- a/protocols/salt/rtl/7Series/SaltTxSer.vhd
+++ b/protocols/salt/rtl/7Series/SaltTxSer.vhd
@@ -25,7 +25,8 @@ use unisim.vcomponents.all;
 
 entity SaltTxSer is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SIM_DEVICE_G : string := "7SERIES");
    port (
       -- SELECTIO Ports
       txP    : out sl;

--- a/protocols/salt/rtl/SaltCore.vhd
+++ b/protocols/salt/rtl/SaltCore.vhd
@@ -23,6 +23,7 @@ entity SaltCore is
    generic (
       TPD_G               : time    := 1 ns;
       SIMULATION_G        : boolean := false;
+      SIM_DEVICE_G        : string  := "ULTRASCALE";
       TX_ENABLE_G         : boolean := true;
       RX_ENABLE_G         : boolean := true;
       COMMON_TX_CLK_G     : boolean := false;  -- Set to true if sAxisClk and clk are the same clock
@@ -87,7 +88,8 @@ begin
 
       U_SaltTxLvds : entity surf.SaltTxLvds
          generic map(
-            TPD_G => TPD_G)
+            TPD_G        => TPD_G,
+            SIM_DEVICE_G => SIM_DEVICE_G)
          port map(
             -- Clocks and Resets
             clk125MHz => clk125MHz,
@@ -139,6 +141,7 @@ begin
          generic map(
             TPD_G           => TPD_G,
             SIMULATION_G    => SIMULATION_G,
+            SIM_DEVICE_G    => SIM_DEVICE_G,
             IODELAY_GROUP_G => IODELAY_GROUP_G,
             REF_FREQ_G      => REF_FREQ_G)
          port map(

--- a/protocols/salt/rtl/SaltRxLvds.vhd
+++ b/protocols/salt/rtl/SaltRxLvds.vhd
@@ -25,6 +25,7 @@ entity SaltRxLvds is
    generic (
       TPD_G           : time    := 1 ns;
       SIMULATION_G    : boolean := false;
+      SIM_DEVICE_G    : string  := "ULTRASCALE";
       IODELAY_GROUP_G : string  := "SALT_GROUP";
       REF_FREQ_G      : real    := 200.0);  -- IDELAYCTRL's REFCLK (in units of Hz)
    port (
@@ -98,6 +99,7 @@ begin
    U_SaltRxDeser : entity surf.SaltRxDeser
       generic map (
          TPD_G           => TPD_G,
+         SIM_DEVICE_G    => SIM_DEVICE_G,
          IODELAY_GROUP_G => IODELAY_GROUP_G,
          REF_FREQ_G      => REF_FREQ_G)
       port map (

--- a/protocols/salt/rtl/SaltTxLvds.vhd
+++ b/protocols/salt/rtl/SaltTxLvds.vhd
@@ -23,7 +23,8 @@ use surf.Code8b10bPkg.all;
 
 entity SaltTxLvds is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SIM_DEVICE_G : string := "ULTRASCALE");
    port (
       -- Clocks and Resets
       clk125MHz : in  sl;
@@ -168,7 +169,8 @@ begin
 
    U_TxSer : entity surf.SaltTxSer
       generic map (
-         TPD_G => TPD_G)
+         TPD_G        => TPD_G,
+         SIM_DEVICE_G => SIM_DEVICE_G)
       port map (
          -- SELECTIO Ports
          txP    => txP,

--- a/protocols/salt/rtl/UltraScale/SaltRxDeser.vhd
+++ b/protocols/salt/rtl/UltraScale/SaltRxDeser.vhd
@@ -23,6 +23,7 @@ use surf.StdRtlPkg.all;
 entity SaltRxDeser is
    generic (
       TPD_G           : time   := 1 ns;
+      SIM_DEVICE_G    : string := "ULTRASCALE";
       IODELAY_GROUP_G : string := "SALT_GROUP";
       REF_FREQ_G      : real   := 200.0);  -- IDELAYCTRL's REFCLK (in units of Hz)
    port (
@@ -46,7 +47,8 @@ begin
 
    U_Deser : entity surf.SelectioDeserLaneUltraScale
       generic map (
-         TPD_G => TPD_G)
+         TPD_G        => TPD_G,
+         SIM_DEVICE_G => SIM_DEVICE_G)
       port map (
          -- SELECTIO Ports
          rxP     => rxP,

--- a/protocols/salt/rtl/UltraScale/SaltTxSer.vhd
+++ b/protocols/salt/rtl/UltraScale/SaltTxSer.vhd
@@ -25,7 +25,8 @@ use unisim.vcomponents.all;
 
 entity SaltTxSer is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SIM_DEVICE_G : string := "ULTRASCALE");
    port (
       -- SELECTIO Ports
       txP    : out sl;

--- a/protocols/salt/rtl/UltraScale/SaltTxSer.vhd
+++ b/protocols/salt/rtl/UltraScale/SaltTxSer.vhd
@@ -48,7 +48,7 @@ begin
    U_OSERDESE3 : OSERDESE3
       generic map (
          DATA_WIDTH => 8,
-         SIM_DEVICE => "ULTRASCALE")
+         SIM_DEVICE => SIM_DEVICE_G)
       port map (
          CLK    => clkx4,
          CLKDIV => clkx1,

--- a/xilinx/UltraScale/general/rtl/SelectioDeserLaneUltraScale.vhd
+++ b/xilinx/UltraScale/general/rtl/SelectioDeserLaneUltraScale.vhd
@@ -25,7 +25,8 @@ use unisim.vcomponents.all;
 
 entity SelectioDeserLaneUltraScale is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G        : time   := 1 ns;
+      SIM_DEVICE_G : string := "ULTRASCALE");
    port (
       -- SELECTIO Ports
       rxP     : in  sl;
@@ -58,7 +59,7 @@ begin
    U_DELAY : entity surf.Idelaye3Wrapper
       generic map (
          DELAY_FORMAT     => "COUNT",
-         SIM_DEVICE       => "ULTRASCALE",
+         SIM_DEVICE       => SIM_DEVICE_G,
          DELAY_VALUE      => 0,
          REFCLK_FREQUENCY => 300.0,     -- IDELAYCTRL not used in COUNT mode
          UPDATE_MODE      => "ASYNC",
@@ -84,7 +85,7 @@ begin
          DATA_WIDTH     => 8,
          FIFO_ENABLE    => "FALSE",
          FIFO_SYNC_MODE => "FALSE",
-         SIM_DEVICE     => "ULTRASCALE")
+         SIM_DEVICE     => SIM_DEVICE_G)
       port map (
          D           => rxDly,
          Q           => dataOut,

--- a/xilinx/UltraScale/general/rtl/SelectioDeserUltraScale.vhd
+++ b/xilinx/UltraScale/general/rtl/SelectioDeserUltraScale.vhd
@@ -28,6 +28,7 @@ entity SelectioDeserUltraScale is
    generic (
       TPD_G            : time     := 1 ns;
       SIMULATION_G     : boolean  := false;
+      SIM_DEVICE_G     : string   := "ULTRASCALE";
       EXT_PLL_G        : boolean  := false;
       NUM_LANE_G       : positive := 1;
       CLKIN_PERIOD_G   : real     := 10.0;  -- 100 MHz
@@ -208,7 +209,8 @@ begin
 
       U_Lane : entity surf.SelectioDeserLaneUltraScale
          generic map (
-            TPD_G => TPD_G)
+            TPD_G        => TPD_G,
+            SIM_DEVICE_G => SIM_DEVICE_G)
          port map (
             -- SELECTIO Ports
             rxP     => rxP(i),


### PR DESCRIPTION
### Description
-  Bug fix for SaltCore with Ultrascale+
- exposing SIM_DEVICE_G to top level of SaltCore
  - SIM_DEVICE_G must be "ULTRASCALE_PLUS" for Ultrascale+ else I get a router error in Vivado
  - https://forums.xilinx.com/t5/Versal-and-UltraScale/XAPP1315-LVDS-Source-Synchronous-7-1-Serialization-and/td-p/914461