### PR TITLE
switching to 'getFpgaArch' proc for fpga type casing

### DIFF
--- a/devices/AnalogDevices/ad9249/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/ruckus.tcl
@@ -6,7 +6,7 @@ loadSource -lib surf -dir "$::DIR_PATH/core"
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7}  ||
      ${family} eq {kintex7} ||

--- a/devices/AnalogDevices/ad9249/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/ruckus.tcl
@@ -20,7 +20,6 @@ if { ${family} eq {kintexu} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/UltraScale"
 }

--- a/devices/Marvell/Sgmii88E1111/ruckus.tcl
+++ b/devices/Marvell/Sgmii88E1111/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadSource -lib surf -dir "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintexu} ||
      ${family} eq {kintexuplus} ||

--- a/devices/Marvell/Sgmii88E1111/ruckus.tcl
+++ b/devices/Marvell/Sgmii88E1111/ruckus.tcl
@@ -12,7 +12,6 @@ if { ${family} eq {kintexu} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadSource -lib surf -dir  "$::DIR_PATH/lvdsUltraScale"
 }

--- a/devices/Ti/dp83867/ruckus.tcl
+++ b/devices/Ti/dp83867/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadSource -lib surf -dir "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintexu} ||
      ${family} eq {kintexuplus} ||

--- a/devices/Ti/dp83867/ruckus.tcl
+++ b/devices/Ti/dp83867/ruckus.tcl
@@ -12,7 +12,6 @@ if { ${family} eq {kintexu} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadSource -lib surf -dir  "$::DIR_PATH/lvdsUltraScale"
 }

--- a/ethernet/Caui4Core/ruckus.tcl
+++ b/ethernet/Caui4Core/ruckus.tcl
@@ -8,7 +8,6 @@ if { ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
 }

--- a/ethernet/Caui4Core/ruckus.tcl
+++ b/ethernet/Caui4Core/ruckus.tcl
@@ -2,7 +2,7 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||

--- a/ethernet/GigEthCore/ruckus.tcl
+++ b/ethernet/GigEthCore/ruckus.tcl
@@ -34,8 +34,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale+"
    loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
    loadRuckusTcl "$::DIR_PATH/lvdsUltraScale"

--- a/ethernet/GigEthCore/ruckus.tcl
+++ b/ethernet/GigEthCore/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"

--- a/ethernet/TenGigEthCore/ruckus.tcl
+++ b/ethernet/TenGigEthCore/ruckus.tcl
@@ -22,8 +22,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale+"
    loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
 }

--- a/ethernet/TenGigEthCore/ruckus.tcl
+++ b/ethernet/TenGigEthCore/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintex7} ||
      ${family} eq {zynq} } {

--- a/ethernet/XauiCore/ruckus.tcl
+++ b/ethernet/XauiCore/ruckus.tcl
@@ -22,8 +22,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale+"
    loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
 }

--- a/ethernet/XauiCore/ruckus.tcl
+++ b/ethernet/XauiCore/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintex7} ||
      ${family} eq {zynq} } {

--- a/ethernet/XlauiCore/ruckus.tcl
+++ b/ethernet/XlauiCore/ruckus.tcl
@@ -22,8 +22,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale+"
    # loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
 }

--- a/ethernet/XlauiCore/ruckus.tcl
+++ b/ethernet/XlauiCore/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintex7} ||
      ${family} eq {zynq} } {

--- a/protocols/clink/ruckus.tcl
+++ b/protocols/clink/ruckus.tcl
@@ -22,7 +22,6 @@ if { ${family} eq {kintexu} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadSource -lib surf -dir  "$::DIR_PATH/UltraScale"
 }

--- a/protocols/clink/ruckus.tcl
+++ b/protocols/clink/ruckus.tcl
@@ -2,7 +2,7 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/glink/ruckus.tcl
+++ b/protocols/glink/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 #############################################################################
 # Note: Our G-Link implementation only supported by the Xilinx 7-Series FPGAs

--- a/protocols/htsp/ruckus.tcl
+++ b/protocols/htsp/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||

--- a/protocols/pgp/pgp2b/ruckus.tcl
+++ b/protocols/pgp/pgp2b/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"

--- a/protocols/pgp/pgp2b/ruckus.tcl
+++ b/protocols/pgp/pgp2b/ruckus.tcl
@@ -33,8 +33,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale+"
    loadRuckusTcl "$::DIR_PATH/gtyUltraScale+"
 }

--- a/protocols/pgp/pgp3/gtp7/xdc/Pgp3Gtp7Ip3G.xdc
+++ b/protocols/pgp/pgp3/gtp7/xdc/Pgp3Gtp7Ip3G.xdc
@@ -1,10 +1,10 @@
 ##############################################################################
 ## This file is part of 'SLAC Firmware Standard Library'.
-## It is subject to the license terms in the LICENSE.txt file found in the 
-## top-level directory of this distribution and at: 
-##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-## No part of 'SLAC Firmware Standard Library', including this file, 
-## may be copied, modified, propagated, or distributed except according to 
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 

--- a/protocols/pgp/pgp3/gtp7/xdc/Pgp3Gtp7Ip6G.xdc
+++ b/protocols/pgp/pgp3/gtp7/xdc/Pgp3Gtp7Ip6G.xdc
@@ -1,10 +1,10 @@
 ##############################################################################
 ## This file is part of 'SLAC Firmware Standard Library'.
-## It is subject to the license terms in the LICENSE.txt file found in the 
-## top-level directory of this distribution and at: 
-##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-## No part of 'SLAC Firmware Standard Library', including this file, 
-## may be copied, modified, propagated, or distributed except according to 
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 

--- a/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip10G.xdc
+++ b/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip10G.xdc
@@ -1,10 +1,10 @@
 ##############################################################################
 ## This file is part of 'SLAC Firmware Standard Library'.
-## It is subject to the license terms in the LICENSE.txt file found in the 
-## top-level directory of this distribution and at: 
-##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-## No part of 'SLAC Firmware Standard Library', including this file, 
-## may be copied, modified, propagated, or distributed except according to 
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 

--- a/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip3G.xdc
+++ b/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip3G.xdc
@@ -1,10 +1,10 @@
 ##############################################################################
 ## This file is part of 'SLAC Firmware Standard Library'.
-## It is subject to the license terms in the LICENSE.txt file found in the 
-## top-level directory of this distribution and at: 
-##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-## No part of 'SLAC Firmware Standard Library', including this file, 
-## may be copied, modified, propagated, or distributed except according to 
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 

--- a/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip6G.xdc
+++ b/protocols/pgp/pgp3/gtx7/xdc/Pgp3Gtx7Ip6G.xdc
@@ -1,10 +1,10 @@
 ##############################################################################
 ## This file is part of 'SLAC Firmware Standard Library'.
-## It is subject to the license terms in the LICENSE.txt file found in the 
-## top-level directory of this distribution and at: 
-##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-## No part of 'SLAC Firmware Standard Library', including this file, 
-## may be copied, modified, propagated, or distributed except according to 
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 

--- a/protocols/pgp/pgp3/ruckus.tcl
+++ b/protocols/pgp/pgp3/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/core"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"

--- a/protocols/pgp/pgp3/ruckus.tcl
+++ b/protocols/pgp/pgp3/ruckus.tcl
@@ -33,8 +33,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUs+"
    loadRuckusTcl "$::DIR_PATH/gtyUs+"
 }

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -6,7 +6,7 @@ loadRuckusTcl "$::DIR_PATH/core"
 loadRuckusTcl "$::DIR_PATH/asic"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7} } {
    loadRuckusTcl "$::DIR_PATH/gtp7"

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -34,8 +34,7 @@ if { ${family} eq {kintexu} } {
 
 if { ${family} eq {kintexuplus} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/gthUs+"
    loadRuckusTcl "$::DIR_PATH/gtyUs+"
 }

--- a/protocols/salt/ruckus.tcl
+++ b/protocols/salt/ruckus.tcl
@@ -2,7 +2,7 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7}  ||
      ${family} eq {kintex7} ||

--- a/protocols/xvc-udp/ruckus.tcl
+++ b/protocols/xvc-udp/ruckus.tcl
@@ -25,8 +25,7 @@ if { [isVersal] == true } {
         ${family} eq {virtexuplus} ||
         ${family} eq {virtexuplusHBM} ||
         ${family} eq {zynquplus} ||
-        ${family} eq {zynquplusRFSOC} ||
-        ${family} eq {qzynquplusRFSOC} } {
+        ${family} eq {zynquplusRFSOC} } {
       set dirType "UltraScale"
    }
 

--- a/protocols/xvc-udp/ruckus.tcl
+++ b/protocols/xvc-udp/ruckus.tcl
@@ -11,7 +11,7 @@ if { [isVersal] == true } {
    loadSource -lib surf -dir "$::DIR_PATH/rtl"
 
    # Get the family type
-   set family [getFpgaFamily]
+   set family [getFpgaArch]
 
    if { ${family} eq {artix7}  ||
         ${family} eq {kintex7} ||

--- a/xilinx/7Series/ruckus.tcl
+++ b/xilinx/7Series/ruckus.tcl
@@ -7,7 +7,7 @@ loadRuckusTcl "$::DIR_PATH/xadc"
 loadRuckusTcl "$::DIR_PATH/sem"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} == "artix7" } {
    loadRuckusTcl "$::DIR_PATH/gtp7"

--- a/xilinx/ruckus.tcl
+++ b/xilinx/ruckus.tcl
@@ -5,7 +5,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadRuckusTcl "$::DIR_PATH/general"
 
 # Get the family type
-set family [getFpgaFamily]
+set family [getFpgaArch]
 
 if { ${family} eq {artix7}  ||
      ${family} eq {kintex7} ||

--- a/xilinx/ruckus.tcl
+++ b/xilinx/ruckus.tcl
@@ -22,7 +22,6 @@ if { ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||
      ${family} eq {zynquplus} ||
-     ${family} eq {zynquplusRFSOC} ||
-     ${family} eq {qzynquplusRFSOC} } {
+     ${family} eq {zynquplusRFSOC} } {
    loadRuckusTcl "$::DIR_PATH/UltraScale+"
 }


### PR DESCRIPTION
### Description
- Reduces the number of cases that we need to support in ruckus.tcl with respect to defense grade variants