### PR TITLE
Bugfix in RogueTcpStreamWrap

### DIFF
--- a/axi/simlink/sim/RogueTcpStreamWrap.vhd
+++ b/axi/simlink/sim/RogueTcpStreamWrap.vhd
@@ -62,7 +62,7 @@ architecture RogueTcpStreamWrap of RogueTcpStreamWrap is
 
    -- Generate a correct channel mask if using CHAN_COUNT_G
    constant CHAN_MASK_C : slv(7 downto 0) := ite(CHAN_MASK_G /= X"00", CHAN_MASK_G,
-                                                 toSlv(2**bitSize(CHAN_COUNT_G-1)-1, 8));
+                                                 toSlv(2**log2(CHAN_COUNT_G)-1, 8));
 
    function channelMap return Slv8Array
    is


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
`CHAN_MASK_C` was being calculated incorrectly when done based on CHAN_COUNT_G.

