### PR TITLE
Bug fix for rxResetDoneOut when RX clock goes away

### DIFF
--- a/xilinx/7Series/gth7/rtl/Gth7Core.vhd
+++ b/xilinx/7Series/gth7/rtl/Gth7Core.vhd
@@ -282,6 +282,7 @@ architecture rtl of Gth7Core is
 
    signal rxUserResetInt : sl;
    signal rxFsmResetDone : sl;
+   signal rxResetDoneAll : sl;
    signal rxRstTxUserRdy : sl;
    signal rxPmaResetDone : sl;
 
@@ -472,6 +473,7 @@ begin
    --------------------------------------------------------------------------------------------------
    -- Synchronize rxFsmResetDone to rxUsrClk to use as reset for external logic.
    --------------------------------------------------------------------------------------------------
+   rxResetDoneAll <= rxResetDone and rxFsmResetDone;
    RstSync_RxResetDone : entity surf.RstSync
       generic map (
          TPD_G          => TPD_G,
@@ -479,7 +481,7 @@ begin
          OUT_POLARITY_G => '0')
       port map (
          clk      => rxUsrClkIn,
-         asyncRst => rxFsmResetDone,
+         asyncRst => rxResetDoneAll,
          syncRst  => rxResetDoneOut);   -- Output
 
    -------------------------------------------------------------------------------------------------

--- a/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
+++ b/xilinx/7Series/gtp7/rtl/Gtp7Core.vhd
@@ -293,6 +293,7 @@ architecture rtl of Gtp7Core is
 
    signal rxUserResetInt : sl;
    signal rxFsmResetDone : sl;
+   signal rxResetDoneAll : sl;
    signal rxRstTxUserRdy : sl;
    signal rxPmaResetDone : sl;
 
@@ -473,6 +474,7 @@ begin
    --------------------------------------------------------------------------------------------------
    -- Synchronize rxFsmResetDone to rxUsrClk to use as reset for external logic.
    --------------------------------------------------------------------------------------------------
+   rxResetDoneAll <= rxResetDone and rxFsmResetDone;
    RstSync_RxResetDone : entity surf.RstSync
       generic map (
          TPD_G          => TPD_G,
@@ -480,7 +482,7 @@ begin
          OUT_POLARITY_G => '0')
       port map (
          clk      => rxUsrClkIn,
-         asyncRst => rxFsmResetDone,
+         asyncRst => rxResetDoneAll,
          syncRst  => rxResetDoneOut);   -- Output
 
    -------------------------------------------------------------------------------------------------

--- a/xilinx/7Series/gtx7/rtl/Gtx7Core.vhd
+++ b/xilinx/7Series/gtx7/rtl/Gtx7Core.vhd
@@ -321,6 +321,7 @@ architecture rtl of Gtx7Core is
 
    signal rxUserResetInt : sl;
    signal rxFsmResetDone : sl;
+   signal rxResetDoneAll : sl;
    signal rxRstTxUserRdy : sl;          --
 
    signal rxRecClkStable         : sl;
@@ -505,6 +506,7 @@ begin
    --------------------------------------------------------------------------------------------------
    -- Synchronize rxFsmResetDone to rxUsrClk to use as reset for external logic.
    --------------------------------------------------------------------------------------------------
+   rxResetDoneAll <= rxResetDone and rxFsmResetDone;
    RstSync_RxResetDone : entity surf.RstSync
       generic map (
          TPD_G          => TPD_G,
@@ -512,7 +514,7 @@ begin
          OUT_POLARITY_G => '0')
       port map (
          clk      => rxUsrClkIn,
-         asyncRst => rxFsmResetDone,
+         asyncRst => rxResetDoneAll,
          syncRst  => rxResetDoneOut);   -- Output
 
    -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description
- `Gtx7RxRst_Inst.Synchronizer_RXRESETDONE` can potentially be HIGH if the clock is removed before the rxResetDone = 0x0 has propagated through the pipeline
  - I have observed this in my hardware testing 
- This patch makes sure that the GTX7's rxResetDone is gated with the GTX7's RST FSM output such that rxResetDoneOut = 0x0 if rxResetDone = 0x0 