### PR TITLE
Fix invalid characters in Qsfp and Sfp DateCode description.

### DIFF
--- a/python/surf/devices/transceivers/_Qsfp.py
+++ b/python/surf/devices/transceivers/_Qsfp.py
@@ -228,7 +228,7 @@ class Qsfp(pr.Device):
 
         self.addRemoteVariables(
             name         = 'DateCode',
-            description  = 'Vendor’s manufacturing date code (ASCII)',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
             offset       = (212 << 2),
             bitSize      = 8,
             mode         = 'RO',
@@ -240,7 +240,7 @@ class Qsfp(pr.Device):
 
         self.add(pr.LinkVariable(
             name         = 'ManufactureDate',
-            description  = 'Vendor’s manufacturing date code (ASCII)',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
             mode         = 'RO',
             linkedGet    = transceivers.getDate,
             dependencies = [self.DateCode[x] for x in [0,1,4,5,2,3] ],

--- a/python/surf/devices/transceivers/_Sfp.py
+++ b/python/surf/devices/transceivers/_Sfp.py
@@ -134,7 +134,7 @@ class Sfp(pr.Device):
 
         self.addRemoteVariables(
             name         = 'DateCode',
-            description  = 'Vendor’s manufacturing date code (ASCII)',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
             offset       = (84 << 2),
             bitSize      = 8,
             mode         = 'RO',
@@ -146,7 +146,7 @@ class Sfp(pr.Device):
 
         self.add(pr.LinkVariable(
             name         = 'ManufactureDate',
-            description  = 'Vendor’s manufacturing date code (ASCII)',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
             mode         = 'RO',
             linkedGet    = transceivers.getDate,
             dependencies = [self.DateCode[x] for x in range(6)],


### PR DESCRIPTION
Replaces some unicode only characters w/ ascii compatible characters.

### Description
Avoids an exception being thrown when we call rogue's saveAddressMap() function.

### Details
Looks like a cut/paste from a vendor description.   The apostrophe is a unicode slanted apostrophe
instead of the standard ascii apostrophe.
