### PR TITLE
increasing ethernet/TenGigEthCore PwrUpRst from 100ms to 1000ms

### DIFF
--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Clk.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Clk.vhd
@@ -66,7 +66,7 @@ begin
    PwrUpRst_Inst : entity surf.PwrUpRst
       generic map (
          TPD_G      => TPD_G,
-         DURATION_G => 15625000)        -- 100 ms
+         DURATION_G => 156250000)       -- 1000 ms
       port map (
          arst   => extRst,
          clk    => phyClock,
@@ -110,14 +110,14 @@ begin
          QPLL_CFG_G          => x"04801C7",
          QPLL_REFCLK_SEL_G   => QPLL_REFCLK_SEL_C,
          QPLL_FBDIV_G        => "0101000000",  -- 64B/66B Encoding
-         QPLL_FBDIV_RATIO_G  => '0',           -- 64B/66B Encoding
+         QPLL_FBDIV_RATIO_G  => '0',    -- 64B/66B Encoding
          QPLL_REFCLK_DIV_G   => 1)
       port map (
-         qPllRefClk     => refClk,             -- 156.25 MHz
+         qPllRefClk     => refClk,      -- 156.25 MHz
          qPllOutClk     => qPllOutClk,
          qPllOutRefClk  => qPllOutRefClk,
          qPllLock       => qPllLock,
-         qPllLockDetClk => '0',                -- IP Core ties this to GND (see note below)
+         qPllLockDetClk => '0',  -- IP Core ties this to GND (see note below)
          qPllRefClkLost => open,
          qPllPowerDown  => '0',
          qPllReset      => qpllReset);

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -102,7 +102,7 @@ begin
    PwrUpRst_Inst : entity surf.PwrUpRst
       generic map (
          TPD_G      => TPD_G,
-         DURATION_G => 15625000)        -- 100 ms
+         DURATION_G => 156250000)       -- 1000 ms
       port map (
          arst   => extRst,
          clk    => coreClock,
@@ -142,12 +142,12 @@ begin
 
       TenGigEthGthUltraScale_Inst : entity surf.TenGigEthGthUltraScale
          generic map (
-            TPD_G           => TPD_G,
-            PAUSE_EN_G      => PAUSE_EN_G,
+            TPD_G         => TPD_G,
+            PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G    => EN_AXI_REG_G,
+            EN_AXI_REG_G  => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -106,7 +106,7 @@ begin
    PwrUpRst_Inst : entity surf.PwrUpRst
       generic map (
          TPD_G      => TPD_G,
-         DURATION_G => 15625000)        -- 100 ms
+         DURATION_G => 156250000)       -- 1000 ms
       port map (
          arst   => extRst,
          clk    => coreClock,
@@ -145,12 +145,12 @@ begin
 
       TenGigEthGthUltraScale_Inst : entity surf.TenGigEthGthUltraScale
          generic map (
-            TPD_G           => TPD_G,
-            PAUSE_EN_G      => PAUSE_EN_G,
+            TPD_G         => TPD_G,
+            PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G    => EN_AXI_REG_G,
+            EN_AXI_REG_G  => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Clk.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Clk.vhd
@@ -68,7 +68,7 @@ begin
    PwrUpRst_Inst : entity surf.PwrUpRst
       generic map (
          TPD_G      => TPD_G,
-         DURATION_G => 15625000)        -- 100 ms
+         DURATION_G => 156250000)       -- 1000 ms
       port map (
          arst   => extRst,
          clk    => phyClock,
@@ -110,14 +110,14 @@ begin
          QPLL_CFG_G          => x"0680181",
          QPLL_REFCLK_SEL_G   => QPLL_REFCLK_SEL_C,
          QPLL_FBDIV_G        => "0101000000",  -- 64B/66B Encoding
-         QPLL_FBDIV_RATIO_G  => '0',           -- 64B/66B Encoding
+         QPLL_FBDIV_RATIO_G  => '0',    -- 64B/66B Encoding
          QPLL_REFCLK_DIV_G   => 1)
       port map (
-         qPllRefClk     => refClk,             -- 156.25 MHz
+         qPllRefClk     => refClk,      -- 156.25 MHz
          qPllOutClk     => qPllOutClk,
          qPllOutRefClk  => qPllOutRefClk,
          qPllLock       => qPllLock,
-         qPllLockDetClk => '0',                -- IP Core ties this to GND (see note below)
+         qPllLockDetClk => '0',  -- IP Core ties this to GND (see note below)
          qPllRefClkLost => open,
          qPllPowerDown  => '0',
          qPllReset      => qpllReset);

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
@@ -101,7 +101,7 @@ begin
    PwrUpRst_Inst : entity surf.PwrUpRst
       generic map (
          TPD_G      => TPD_G,
-         DURATION_G => 15625000)        -- 100 ms
+         DURATION_G => 156250000)       -- 1000 ms
       port map (
          arst   => extRst,
          clk    => coreClock,
@@ -139,12 +139,12 @@ begin
 
       TenGigEthGtyUltraScale_Inst : entity surf.TenGigEthGtyUltraScale
          generic map (
-            TPD_G           => TPD_G,
-            PAUSE_EN_G      => PAUSE_EN_G,
+            TPD_G         => TPD_G,
+            PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
-            EN_AXI_REG_G    => EN_AXI_REG_G,
+            EN_AXI_REG_G  => EN_AXI_REG_G,
             -- AXI Streaming Configurations
-            AXIS_CONFIG_G   => AXIS_CONFIG_G(i))
+            AXIS_CONFIG_G => AXIS_CONFIG_G(i))
          port map (
             -- Local Configurations
             localMac           => localMac(i),


### PR DESCRIPTION
### Description
- We have found empirically that 100ms is sometimes too short at power up and the ETH phy ready does not come up
- Increasing the power up reset duration seems to make the ETH PHY ready come up everytime now