### PR TITLE
Add priority generic to AxiStreamMux

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -26,36 +26,37 @@ use surf.AxiStreamPkg.all;
 
 entity AxiStreamMux is
    generic (
-      TPD_G                : time                   := 1 ns;
-      PIPE_STAGES_G        : integer range 0 to 16  := 0;
-      NUM_SLAVES_G         : integer range 1 to 256 := 4;
+      TPD_G                : time                    := 1 ns;
+      PIPE_STAGES_G        : integer range 0 to 16   := 0;
+      NUM_SLAVES_G         : integer range 1 to 256  := 4;
       -- In INDEXED mode, the output TDEST is set based on the selected slave index (default)
       -- In ROUTED mode, TDEST is set according to the TDEST_ROUTES_G table
       -- In PASSTHROUGH mode, TDEST is passed through from the slave untouched
-      MODE_G               : string                 := "INDEXED"; -- Note: Planning to rename "MODE_G" to "TDEST_MODE_G" in a future MAJOR release of SURF
+      MODE_G               : string                  := "INDEXED";  -- Note: Planning to rename "MODE_G" to "TDEST_MODE_G" in a future MAJOR release of SURF
       -- In ROUTED mode, an array mapping how TDEST should be assigned for each slave port
       -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.
-      TDEST_ROUTES_G       : Slv8Array              := (0 => "--------");
+      TDEST_ROUTES_G       : Slv8Array               := (0 => "--------");
       -- In INDEXED mode, the output TID is set based on the selected slave index
       -- In ROUTED mode, TID is set according to the TID_ROUTES_G table
       -- In PASSTHROUGH mode, TID is passed through from the slave untouched (default)
-      TID_MODE_G           : string                 := "PASSTHROUGH";
+      TID_MODE_G           : string                  := "PASSTHROUGH";
       -- In ROUTED mode, an array mapping how TID should be assigned for each slave port
-      TID_ROUTES_G         : Slv8Array              := (0 => "--------");
+      TID_ROUTES_G         : Slv8Array               := (0 => "--------");
+      PRIORITY_G           : IntegerArray            := (0 => 0);
       -- In INDEXED mode, assign slave index to TDEST at this bit offset
-      TDEST_LOW_G          : integer range 0 to 7   := 0;
+      TDEST_LOW_G          : integer range 0 to 7    := 0;
       -- Set to true if interleaving dests
-      ILEAVE_EN_G          : boolean                := false;
+      ILEAVE_EN_G          : boolean                 := false;
       -- Rearbitrate when tValid drops on selected channel, ignored when ILEAVE_EN_G=false
-      ILEAVE_ON_NOTVALID_G : boolean                := false;
+      ILEAVE_ON_NOTVALID_G : boolean                 := false;
       -- Max number of transactions between arbitrations, 0 = unlimited, ignored when ILEAVE_EN_G=false
-      ILEAVE_REARB_G      : natural range 0 to 4095 := 0;
+      ILEAVE_REARB_G       : natural range 0 to 4095 := 0;
       -- One cycle gap in stream between during re-arbitration.
       -- Set true for better timing, false for higher throughput.
-      REARB_DELAY_G        : boolean                := true;
+      REARB_DELAY_G        : boolean                 := true;
       -- Block selected slave txns arriving on same cycle as rearbitrate or disableSel from going through,
       -- creating 1 cycle gap. This might be needed logically but decreases throughput.
-      FORCED_REARB_HOLD_G  : boolean                := false);
+      FORCED_REARB_HOLD_G  : boolean                 := false);
 
    port (
       -- Clock and reset
@@ -64,7 +65,7 @@ entity AxiStreamMux is
       -- Slaves
       disableSel   : in  slv(NUM_SLAVES_G-1 downto 0) := (others => '0');
       rearbitrate  : in  sl                           := '0';
-      ileaveRearb  : in slv(11 downto 0)              := toSlv(ILEAVE_REARB_G,12);
+      ileaveRearb  : in  slv(11 downto 0)             := toSlv(ILEAVE_REARB_G, 12);
       sAxisMasters : in  AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
       sAxisSlaves  : out AxiStreamSlaveArray(NUM_SLAVES_G-1 downto 0);
 
@@ -102,27 +103,29 @@ architecture rtl of AxiStreamMux is
    signal pipeAxisMaster  : AxiStreamMasterType;
    signal pipeAxisSlave   : AxiStreamSlaveType;
 
+   signal intDisableSel : slv(NUM_SLAVES_G-1 downto 0);
+
 begin
 
-   assert ( (MODE_G = "PASSTHROUGH") or (MODE_G = "INDEXED") or (MODE_G = "ROUTED") )
+   assert ((MODE_G = "PASSTHROUGH") or (MODE_G = "INDEXED") or (MODE_G = "ROUTED"))
       report "MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
       severity error;
 
-   assert ( (MODE_G = "INDEXED") and (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G)) ) or (MODE_G /= "INDEXED")
+   assert ((MODE_G = "INDEXED") and (7 - TDEST_LOW_G + 1 >= log2(NUM_SLAVES_G))) or (MODE_G /= "INDEXED")
       report "In INDEXED mode, TDest range 7 downto " & integer'image(TDEST_LOW_G) &
       " is too small for NUM_SLAVES_G=" & integer'image(NUM_SLAVES_G)
       severity error;
 
-   assert ( (MODE_G = "ROUTED") and (TDEST_ROUTES_G'length = NUM_SLAVES_G) ) or (MODE_G /= "ROUTED")
+   assert ((MODE_G = "ROUTED") and (TDEST_ROUTES_G'length = NUM_SLAVES_G)) or (MODE_G /= "ROUTED")
       report "In ROUTED mode, length of TDEST_ROUTES_G: " & integer'image(TDEST_ROUTES_G'length) &
       " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
       severity error;
 
-   assert ( (TID_MODE_G = "PASSTHROUGH") or (TID_MODE_G = "INDEXED") or (TID_MODE_G = "ROUTED") )
+   assert ((TID_MODE_G = "PASSTHROUGH") or (TID_MODE_G = "INDEXED") or (TID_MODE_G = "ROUTED"))
       report "TID_MODE_G must be either [PASSTHROUGH,INDEXED,ROUTED]"
       severity error;
 
-   assert ( (TID_MODE_G = "ROUTED") and (TID_ROUTES_G'length = NUM_SLAVES_G) ) or (TID_MODE_G /= "ROUTED")
+   assert ((TID_MODE_G = "ROUTED") and (TID_ROUTES_G'length = NUM_SLAVES_G)) or (TID_MODE_G /= "ROUTED")
       report "In ROUTED mode, length of TID_ROUTES_G: " & integer'image(TID_ROUTES_G'length) &
       " must equal NUM_SLAVES_G: " & integer'image(NUM_SLAVES_G)
       severity error;
@@ -171,7 +174,31 @@ begin
 
    end process;
 
-   comb : process (axisRst, disableSel, ileaveRearb, pipeAxisSlave, r, rearbitrate, sAxisMastersTmp) is
+   -- When in INDEXED priority mode, tvalid on a given slave side index disables selection
+   -- for all channels with higer index
+   PRIORITY_CONTROL : process (disableSel, sAxisMasters) is
+      variable tmp : slv(NUM_SLAVES_G-1 downto 0);
+   begin
+      tmp := disableSel;
+
+      for ch in NUM_SLAVES_G-1 downto 0 loop
+         if (sAxisMasters(ch).tValid = '1') then
+            if (ch < PRIORITY_G'length) then
+               for sel in PRIORITY_G'range loop
+                  if (PRIORITY_G(ch) > PRIORITY_G(sel)) then
+                     tmp(sel) := '1';
+                  end if;
+               end loop;
+            end if;
+         end if;
+      end loop;
+
+      intDisableSel <= tmp;
+
+   end process PRIORITY_CONTROL;
+
+   comb : process (axisRst, ileaveRearb, intDisableSel, pipeAxisSlave, r, rearbitrate,
+                   sAxisMastersTmp) is
       variable v        : RegType;
       variable requests : slv(ARB_BITS_C-1 downto 0);
       variable selData  : AxiStreamMasterType;
@@ -223,7 +250,7 @@ begin
       -- Format requests
       requests := (others => '0');
       for i in 0 to (NUM_SLAVES_G-1) loop
-         requests(i) := sAxisMastersTmp(i).tValid and not disableSel(i);
+         requests(i) := sAxisMastersTmp(i).tValid and not intDisableSel(i);
       end loop;
 
       if (r.valid = '1') then
@@ -231,7 +258,7 @@ begin
          -- Also allow disableSel and rearbitrate to work at any time
          if (ILEAVE_EN_G) then
             if ((ILEAVE_ON_NOTVALID_G and selData.tValid = '0') or
-                (rearbitrate = '1' or disableSel(conv_integer(r.ackNum)) = '1')) then
+                (rearbitrate = '1' or intDisableSel(conv_integer(r.ackNum)) = '1')) then
                v.valid := '0';
             end if;
          end if;

--- a/protocols/rssi/v1/rtl/RssiCoreWrapper.vhd
+++ b/protocols/rssi/v1/rtl/RssiCoreWrapper.vhd
@@ -29,41 +29,42 @@ use surf.AxiLitePkg.all;
 
 entity RssiCoreWrapper is
    generic (
-      TPD_G                : time                 := 1 ns;
-      CLK_FREQUENCY_G      : real                 := 156.25E+6;  -- In units of Hz
-      TIMEOUT_UNIT_G       : real                 := 1.0E-3;  -- In units of seconds
-      SERVER_G             : boolean              := true;  -- Module is server or client
-      RETRANSMIT_ENABLE_G  : boolean              := true;  -- Enable/Disable retransmissions in tx module
-      WINDOW_ADDR_SIZE_G   : positive             := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Max number of segments in buffer
-      SEGMENT_ADDR_SIZE_G  : positive             := 7;  -- Unused (legacy generic)
-      BYPASS_CHUNKER_G     : boolean              := false;  -- Bypass the AXIS chunker layer
-      PIPE_STAGES_G        : natural              := 0;
-      APP_STREAMS_G        : positive             := 1;
-      APP_STREAM_ROUTES_G  : Slv8Array            := (0 => "--------");
-      APP_ILEAVE_EN_G      : boolean              := false;
-      BYP_TX_BUFFER_G      : boolean              := false;
-      BYP_RX_BUFFER_G      : boolean              := false;
-      SYNTH_MODE_G         : string               := "inferred";
-      MEMORY_TYPE_G        : string               := "block";
-      ILEAVE_ON_NOTVALID_G : boolean              := false;  -- Unused (legacy generic)
+      TPD_G                 : time         := 1 ns;
+      CLK_FREQUENCY_G       : real         := 156.25E+6;  -- In units of Hz
+      TIMEOUT_UNIT_G        : real         := 1.0E-3;     -- In units of seconds
+      SERVER_G              : boolean      := true;  -- Module is server or client
+      RETRANSMIT_ENABLE_G   : boolean      := true;  -- Enable/Disable retransmissions in tx module
+      WINDOW_ADDR_SIZE_G    : positive     := 3;  -- 2^WINDOW_ADDR_SIZE_G  = Max number of segments in buffer
+      SEGMENT_ADDR_SIZE_G   : positive     := 7;  -- Unused (legacy generic)
+      BYPASS_CHUNKER_G      : boolean      := false;      -- Bypass the AXIS chunker layer
+      PIPE_STAGES_G         : natural      := 0;
+      APP_STREAMS_G         : positive     := 1;
+      APP_STREAM_ROUTES_G   : Slv8Array    := (0 => "--------");
+      APP_STREAM_PRIORITY_G : IntegerArray := (0 => 0);  -- Determines priority of outbound streams
+      APP_ILEAVE_EN_G       : boolean      := false;
+      BYP_TX_BUFFER_G       : boolean      := false;
+      BYP_RX_BUFFER_G       : boolean      := false;
+      SYNTH_MODE_G          : string       := "inferred";
+      MEMORY_TYPE_G         : string       := "block";
+      ILEAVE_ON_NOTVALID_G  : boolean      := false;      -- Unused (legacy generic)
       -- AXIS Configurations
-      APP_AXIS_CONFIG_G    : AxiStreamConfigArray;
-      TSP_AXIS_CONFIG_G    : AxiStreamConfigType;
+      APP_AXIS_CONFIG_G     : AxiStreamConfigArray;
+      TSP_AXIS_CONFIG_G     : AxiStreamConfigType;
       -- Version and connection ID
-      INIT_SEQ_N_G         : natural              := 16#80#;
-      CONN_ID_G            : positive             := 16#12345678#;
-      VERSION_G            : positive             := 1;
-      HEADER_CHKSUM_EN_G   : boolean              := true;
+      INIT_SEQ_N_G          : natural      := 16#80#;
+      CONN_ID_G             : positive     := 16#12345678#;
+      VERSION_G             : positive     := 1;
+      HEADER_CHKSUM_EN_G    : boolean      := true;
       -- Window parameters of receiver module
-      MAX_NUM_OUTS_SEG_G   : positive             := 8;  -- Unused (legacy generic)
-      MAX_SEG_SIZE_G       : positive             := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
+      MAX_NUM_OUTS_SEG_G    : positive     := 8;  -- Unused (legacy generic)
+      MAX_SEG_SIZE_G        : positive     := 1024;  -- <= (2**SEGMENT_ADDR_SIZE_G)*8 Number of bytes
       -- RSSI Timeouts
-      ACK_TOUT_G           : positive             := 25;  -- unit depends on TIMEOUT_UNIT_G
-      RETRANS_TOUT_G       : positive             := 50;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
-      NULL_TOUT_G          : positive             := 200;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= 4*RETRANS_TOUT_G)
+      ACK_TOUT_G            : positive     := 25;  -- unit depends on TIMEOUT_UNIT_G
+      RETRANS_TOUT_G        : positive     := 50;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= MAX_NUM_OUTS_SEG_G*Data segment transmission time)
+      NULL_TOUT_G           : positive     := 200;  -- unit depends on TIMEOUT_UNIT_G  (Recommended >= 4*RETRANS_TOUT_G)
       -- Counters
-      MAX_RETRANS_CNT_G    : positive             := 2;
-      MAX_CUM_ACK_CNT_G    : positive             := 3);
+      MAX_RETRANS_CNT_G     : positive     := 2;
+      MAX_CUM_ACK_CNT_G     : positive     := 3);
    port (
       -- Clock and Reset
       clk_i             : in  sl;
@@ -182,6 +183,7 @@ begin
          NUM_SLAVES_G         => APP_STREAMS_G,
          MODE_G               => "ROUTED",
          TDEST_ROUTES_G       => APP_STREAM_ROUTES_G,
+         PRIORITY_G           => APP_STREAM_PRIORITY_G,
          ILEAVE_EN_G          => APP_ILEAVE_EN_G,
          ILEAVE_ON_NOTVALID_G => true,  -- Because of ILEAVE_REARB_G value != power of 2, forcing rearb on not(tValid)
          ILEAVE_REARB_G       => (MAX_SEG_SIZE_G/CONV_AXIS_CONFIG_C.TDATA_BYTES_C) - 3,  -- AxiStreamPacketizer2.PROTO_WORDS_C=3

--- a/python/surf/devices/micron/_AxiMicronMt28ew.py
+++ b/python/surf/devices/micron/_AxiMicronMt28ew.py
@@ -203,7 +203,10 @@ class AxiMicronMt28ew(pr.Device):
         # Reset the PROM
         self._resetCmd()
         # Create a burst data array
-        dataArray = [0] * 256
+        if self._useVars:
+            dataArray = self.BurstData.get(read=False)
+        else:
+            dataArray = [0] * 256
 
         # Set the block transfer size
         if self._useVars:

--- a/python/surf/devices/micron/_AxiMicronN25Q.py
+++ b/python/surf/devices/micron/_AxiMicronN25Q.py
@@ -253,7 +253,10 @@ class AxiMicronN25Q(pr.Device):
         wordCnt = 0
         byteCnt = 0
         # Create a burst data array
-        dataArray = [0] * 64
+        if self._useVars:
+            dataArray = self.getDataReg(read=False)
+        else:
+            dataArray = [0] * 64
         # Setup the status bar
         with click.progressbar(
             length   = self._mcs.size,
@@ -476,8 +479,8 @@ class AxiMicronN25Q(pr.Device):
         else:
             self._rawWrite(offset=0x200,data=values,tryCount=self._tryCount) # Deprecated
 
-    def getDataReg(self):
+    def getDataReg(self,read=True):
         if self._useVars:
-            return self.DataReg.get()
+            return self.DataReg.get(read=read)
         else:
             return (self._rawRead(offset=0x200,numWords=64,tryCount=self._tryCount)) # Deprecated

--- a/python/surf/devices/micron/_AxiMicronP30.py
+++ b/python/surf/devices/micron/_AxiMicronP30.py
@@ -207,7 +207,10 @@ class AxiMicronP30(pr.Device):
 
     def writeProm(self):
         # Create a burst data array
-        dataArray = [0] * 256
+        if self._useVars:
+            dataArray = self.BurstData.get(read=False)
+        else:
+            dataArray = [0] * 256
 
         # Set the block transfer size
         if self._useVars:


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

This change allows AxiStreamMux to give priority to specific input streams rather than pure round-robin arbitration.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

The `PRIORITY_G` generic allows each input stream index to be given a priority value. Input streams with higher priority will always be selected over those with lower priority when both are active.

In the below example, channel 2 has the highest priority value, so it will always be selected over the others when trying to push data through the mux. Channel 0 has the next highest priority. It will be selected over channels 1 and 3 if all channels are active at once. Channels 1 and 3 have the lowest priority, and effectively share round robin access with each other when channels 0 and 2 are not active.

```vhdl
      U_AxiStreamMux_DATA : entity surf.AxiStreamMux
         generic map (
            TPD_G                => TPD_G,
            NUM_SLAVES_G         => RSSI_ROUTES_C'length,
            MODE_G               => "ROUTED",
            TDEST_ROUTES_G       => RSSI_ROUTES_C,
            PRIORITY_G                => (
               0  => 1,
               1  => 0,
               2 => 2,
               3 => 0),
            ILEAVE_EN_G          => true,
            ILEAVE_ON_NOTVALID_G => true,
            ILEAVE_REARB_G       => (512/8)-3)
         port map (
            axisClk      => ethClk,                                  -- [in]
            axisRst      => ethRst,                                  -- [in]
            sAxisMasters => dataRssiIbMasters,                       -- [in]
            sAxisSlaves  => dataRssiIbSlaves,                        -- [out]
            mAxisMaster  => rogueMuxAxisMasters(DATA_RSSI_INDEX_C),  -- [out]
            mAxisSlave   => rogueMuxAxisSlaves(DATA_RSSI_INDEX_C));  -- [in]      
```

#### Backward compatibility
This is fully backward compatible. If PRIORITY_G is not set, the default is unchanged - all streams have equal priority.

#### RSSI
RssiCoreWrapper now has an `APP_STREAM_PRIORITY_G` generic that is passed to `PRIORITY_G` of the internal mux. This allows RSSI app streams to be given outgoing priority.