### PR TITLE
Fix AxiStreamTap

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamTap.vhd
+++ b/axi/axi-stream/rtl/AxiStreamTap.vhd
@@ -48,8 +48,8 @@ end AxiStreamTap;
 
 architecture structure of AxiStreamTap is
 
-   constant ROUTES_C : Slv8Array := (0 => "--------",
-                                     1 => toSlv(TAP_DEST_G, 8));
+   constant ROUTES_C : Slv8Array := (0 => toSlv(TAP_DEST_G, 8),
+                                     1 => "--------");
 
    signal iAxisMaster : AxiStreamMasterType;
    signal iAxisSlave  : AxiStreamSlaveType;
@@ -66,10 +66,10 @@ begin
       port map (
          sAxisMaster     => sAxisMaster,
          sAxisSlave      => sAxisSlave,
-         mAxisMasters(0) => iAxisMaster,
-         mAxisMasters(1) => tmAxisMaster,
-         mAxisSlaves(0)  => iAxisSlave,
-         mAxisSlaves(1)  => tmAxisSlave,
+         mAxisMasters(0) => tmAxisMaster,
+         mAxisMasters(1) => iAxisMaster,
+         mAxisSlaves(0)  => tmAxisSlave,
+         mAxisSlaves(1)  => iAxisSlave,
          axisClk         => axisClk,
          axisRst         => axisRst);
 
@@ -86,10 +86,10 @@ begin
       port map (
          axisClk         => axisClk,
          axisRst         => axisRst,
-         sAxisMasters(0) => iAxisMaster,
-         sAxisMasters(1) => tsAxisMaster,
-         sAxisSlaves(0)  => iAxisSlave,
-         sAxisSlaves(1)  => tsAxisSlave,
+         sAxisMasters(0) => tsAxisMaster,
+         sAxisMasters(1) => iAxisMaster,
+         sAxisSlaves(0)  => tsAxisSlave,
+         sAxisSlaves(1)  => iAxisSlave,
          mAxisMaster     => mAxisMaster,
          mAxisSlave      => mAxisSlave);
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
AxiStreamDemux now evaluates routes from low index to high index. This broke AxiStreamTap as everything was being routed to index 0.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESSURF-19
### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
