### PR TITLE
ESSURF-20 - AxiStreamTap Mux Mode Fix

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamTap.vhd
+++ b/axi/axi-stream/rtl/AxiStreamTap.vhd
@@ -78,7 +78,7 @@ begin
          TPD_G                => TPD_G,
          PIPE_STAGES_G        => PIPE_STAGES_G,
          NUM_SLAVES_G         => 2,
-         MODE_G               => "ROUTED",
+         MODE_G               => "PASSTRHOUGH",
          TDEST_ROUTES_G       => ROUTES_C,
          ILEAVE_EN_G          => true,
          ILEAVE_ON_NOTVALID_G => ILEAVE_ON_NOTVALID_G,


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The output mux now uses `MODE_G => "PASSTHROUGH"` so as not to modify the incoming TDESTs.


### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESSURF-20
### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
