### PR TITLE
Use DSP Clock Enable to Stall Filter Pipeline

### DIFF
--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -70,8 +70,8 @@ architecture mapping of FirFilterSingleChannel is
 
    type RegType is record
       cnt        : natural range 0 to TAP_SIZE_G-1;
-      datain     : slv(WIDTH_G-1 downto 0);
-      cascin     : CascArray;
+--      datain     : slv(WIDTH_G-1 downto 0);
+--      cascin     : CascArray;
       coeffin    : CoeffArray;
       ibReady    : sl;
       tValid     : sl;
@@ -81,8 +81,8 @@ architecture mapping of FirFilterSingleChannel is
    end record RegType;
    constant REG_INIT_C : RegType := (
       cnt        => 0,
-      datain     => (others => '0'),
-      cascin     => (others => (others => '0')),
+--      datain     => (others => '0'),
+--      cascin     => (others => (others => '0')),
       coeffin    => COEFFICIENTS_C,
       ibReady    => '0',
       tValid     => '0',
@@ -96,8 +96,9 @@ architecture mapping of FirFilterSingleChannel is
    signal cascin  : CascArray;
    signal cascout : CascArray;
 
-   signal datain : slv(WIDTH_G-1 downto 0);
-   signal tReady : sl;
+--   signal datain    : slv(WIDTH_G-1 downto 0);
+   signal tReady    : sl;
+   signal ibReadyFb : sl;
 
    signal readMaster  : AxiLiteReadMasterType;
    signal readSlave   : AxiLiteReadSlaveType;
@@ -159,18 +160,8 @@ begin
          v.ibReady := '1';
 
          -- Latch the value
-         v.datain := din;
+--         v.datain := din;
 
-         -- Load zero into the 1st tap's cascaded input
-         v.cascin(0) := (others => '0');
-
-         -- Map to the cascaded input
-         for i in TAP_SIZE_G-2 downto 0 loop
-
-            -- Use the previous cascade out values
-            v.cascin(i+1) := cascout(i);
-
-         end loop;
 
          -- Truncating the LSBs
          v.tData := cascout(TAP_SIZE_G-1)(2*WIDTH_G-2 downto WIDTH_G-1);
@@ -189,9 +180,10 @@ begin
       -- Outputs
       writeSlave <= r.writeSlave;
       readSlave  <= r.readSlave;
-      ibReady    <= v.ibReady;
-      datain     <= v.datain;
-      cascin     <= v.cascin;
+      ibReadyFb  <= v.ibReady;
+      ibReady    <= ibReadyFb;
+--      datain     <= v.datain;
+      --cascin     <= v.cascin;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -202,6 +194,15 @@ begin
       rin <= v;
 
    end process comb;
+
+   -- Load zero into the 1st tap's cascaded input
+   cascin(0) <= (others => '0');
+   -- Map to the cascaded input
+   CASC : for i in TAP_SIZE_G-2 downto 0 generate
+      -- Use the previous cascade out values
+      cascin(i+1) <= cascout(i);
+   end generate;
+
 
    seq : process (clk) is
    begin
@@ -220,8 +221,9 @@ begin
          port map (
             -- Clock Only (Infer into DSP)
             clk     => clk,
+            en      => ibReadyFb,
             -- Data and tap coefficient Interface
-            datain  => datain,  -- Common data input because Transpose Multiply-Accumulate architecture
+            datain  => din,  -- Common data input because Transpose Multiply-Accumulate architecture
             coeffin => r.coeffin(TAP_SIZE_G-1-i),  -- Reversed order because Transpose Multiply-Accumulate architecture
             -- Cascade Interface
             cascin  => cascin(i),

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -70,8 +70,6 @@ architecture mapping of FirFilterSingleChannel is
 
    type RegType is record
       cnt        : natural range 0 to TAP_SIZE_G-1;
---      datain     : slv(WIDTH_G-1 downto 0);
---      cascin     : CascArray;
       coeffin    : CoeffArray;
       ibReady    : sl;
       tValid     : sl;
@@ -81,8 +79,6 @@ architecture mapping of FirFilterSingleChannel is
    end record RegType;
    constant REG_INIT_C : RegType := (
       cnt        => 0,
---      datain     => (others => '0'),
---      cascin     => (others => (others => '0')),
       coeffin    => COEFFICIENTS_C,
       ibReady    => '0',
       tValid     => '0',
@@ -96,7 +92,6 @@ architecture mapping of FirFilterSingleChannel is
    signal cascin  : CascArray;
    signal cascout : CascArray;
 
---   signal datain    : slv(WIDTH_G-1 downto 0);
    signal tReady    : sl;
    signal ibReadyFb : sl;
 
@@ -128,8 +123,7 @@ begin
          mAxiWriteMaster => writeMaster,
          mAxiWriteSlave  => writeSlave);
 
-   comb : process (cascout, din, ibValid, r, readMaster, rst, tReady,
-                   writeMaster) is
+   comb : process (cascout, ibReadyFb, ibValid, r, readMaster, rst, tReady, writeMaster) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndPointType;
    begin
@@ -159,10 +153,6 @@ begin
          -- Accept the data
          v.ibReady := '1';
 
-         -- Latch the value
---         v.datain := din;
-
-
          -- Truncating the LSBs
          v.tData := cascout(TAP_SIZE_G-1)(2*WIDTH_G-2 downto WIDTH_G-1);
 
@@ -182,8 +172,6 @@ begin
       readSlave  <= r.readSlave;
       ibReadyFb  <= v.ibReady;
       ibReady    <= ibReadyFb;
---      datain     <= v.datain;
-      --cascin     <= v.cascin;
 
       -- Reset
       if (rst = RST_POLARITY_G) then

--- a/dsp/fixed/FirFilterTap.vhd
+++ b/dsp/fixed/FirFilterTap.vhd
@@ -26,6 +26,7 @@ entity FirFilterTap is
    port (
       -- Clock Only (Infer into DSP)
       clk     : in  sl;
+      en      : in  sl := '1';
       -- Data and tap coefficient Interface
       datain  : in  slv(WIDTH_G-1 downto 0);
       coeffin : in  slv(WIDTH_G-1 downto 0);
@@ -79,7 +80,9 @@ begin
    seq : process (clk) is
    begin
       if rising_edge(clk) then
-         r <= rin after TPD_G;
+         if (en = '1') then
+            r <= rin after TPD_G;
+         end if;
       end if;
    end process seq;
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This change makes use the the DSP48 clock enable signal to stall the pipeline on cycles when it should not advance.

Previously, the design was synthesizing a set of stall registers and associated logic between each filter stage. Now it synthesizes a string of DSP48 blocks with no glue logic in between to create the filter. 
