### PR TITLE
update to UartUp900cl12b.py

### DIFF
--- a/python/surf/protocols/clink/_UartUp900cl12b.py
+++ b/python/surf/protocols/clink/_UartUp900cl12b.py
@@ -26,13 +26,13 @@ class UartUp900cl12bRx(clink.ClinkSerialRx):
 
         for i in range(0,len(ba),4):
             c = chr(ba[i])
-            # print (ba[i])
+            print (c)
 
-            if (c == '\r'):
-                print(self._path+": Got Response: {}".format(''.join(self._cur)))
-                self._cur = []
-            elif (c != '') and (ba[i] != 1):
-                self._cur.append(c)
+            # if (c == '\r'):
+                # print(self._path+": Got Response: {}".format(''.join(self._cur)))
+                # self._cur = []
+            # elif (c != '') and (ba[i] != 1):
+                # self._cur.append(c)
 
 class UartUp900cl12b(pr.Device):
     def __init__(self, serial=None, **kwargs):

--- a/python/surf/protocols/clink/_UartUp900cl12b.py
+++ b/python/surf/protocols/clink/_UartUp900cl12b.py
@@ -25,14 +25,14 @@ class UartUp900cl12bRx(clink.ClinkSerialRx):
         frame.read(ba,0)
 
         for i in range(0,len(ba),4):
-            c = chr(ba[i])
-            print (c)
+            # print (ba[i])
 
-            # if (c == '\r'):
-                # print(self._path+": Got Response: {}".format(''.join(self._cur)))
-                # self._cur = []
-            # elif (c != '') and (ba[i] != 1):
-                # self._cur.append(c)
+            if (ba[i] == 1) or (ba[i] == 0x3F):
+                self._cur.append(hex(ba[i]))
+                print(self._path+": Got Response: {}".format(''.join(self._cur)))
+                self._cur = []
+            elif (ba[i] != 1) and (ba[i] != 0x3F):
+                self._cur.append(hex(ba[i]) + ' ')
 
 class UartUp900cl12b(pr.Device):
     def __init__(self, serial=None, **kwargs):


### PR DESCRIPTION
### Description
- Much easier to debug the response if each byte is printed out at a time

### Example Printout
```bash
$ python scripts/devGui --pgp4 1 --laneConfig 0=Up900cl12b --standAloneMode 1
Rogue/pyrogue version v5.10.0. https://github.com/slaclab/rogue
laneConfig={0: 'Up900cl12b'}
Start: Started zmqServer on ports 9099-9101
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: SendString: am
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: SendString: smf
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: SendString: rp
ConfigureTpgMiniStream()
ConfigLclsTimingV1()
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: Got Response: 0xd 0x1
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: Got Response: 0xd 0x1
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: Got Response: 0x87 0x40 0x60 0x72 0xc6 0x40 0xb2 0x40 0x70 0x61 0xc4 0x40 0xa3 0x9d 0x40 0xc6 0x40 0x8e 0xb3 0x40 0xa0 0x83 0x40 0x81 0x9d 0xd 0xd 0x1
Loading ['config/defaults_LCLS-I.yml', 'config/Up900cl12b/lane0.yml'] Configuration File...
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: SendString: smf
ClinkDevRoot.ClinkPcie.AxiPcieCore.AxiVersion initialize called
ClinkDevRoot.ClinkFeb[0].AxiVersion initialize called
ClinkDevRoot.ClinkFeb[0].ClinkTop.Ch[0].UartUp900cl12b: Got Response: 0xd 0x1
ClinkDev.StopRun() executed
ClinkDevRoot.ClinkPcie.AxiPcieCore.AxiVersion count reset called
ClinkDevRoot.ClinkFeb[0].AxiVersion count reset called
ZmqClient::setTimeout: Setting timeout to 1000 msecs, waitRetry = 1
Connected to ClinkDevRoot at localhost:9099
Running GUI. Close window, hit cntrl-c or send SIGTERM to 1893033 to exit.
```