### PR TITLE
FIR Filter Revamp

### DIFF
--- a/dsp/fixed/FirFilterMultiChannel.vhd
+++ b/dsp/fixed/FirFilterMultiChannel.vhd
@@ -307,7 +307,9 @@ begin
          U_Tap : entity surf.FirFilterTap
             generic map (
                TPD_G   => TPD_G,
-               WIDTH_G => WIDTH_G)
+               DIN_WIDTH_G => WIDTH_G,
+               COEFF_WIDTH_G => WIDTH_G,
+               CASC_WIDTH_G => 2*WIDTH_G+1)
             port map (
                -- Clock Only (Infer into DSP)
                clk     => axisClk,

--- a/dsp/fixed/FirFilterMultiChannel.vhd
+++ b/dsp/fixed/FirFilterMultiChannel.vhd
@@ -24,12 +24,12 @@ use surf.AxiStreamPkg.all;
 entity FirFilterMultiChannel is
    generic (
       TPD_G          : time         := 1 ns;
-      COMMON_CLOCK_G : boolean      := false;     -- True if axisClk and axiClk are the same
+      COMMON_CLK_G   : boolean      := false;     -- True if axisClk and axiClk are the same
       NUM_TAPS_G     : positive;                  -- Number of filter taps
       NUM_CHANNELS_G : positive;                  -- Number of data channels
       PARALLEL_G     : positive;                  -- Number of parallel channel processing
       DATA_WIDTH_G   : positive;                  -- Number of bits per data word
-      COEFF_WIDTH_G  : positive range 1 to 32;                  -- Number of bits per coefficient
+      COEFF_WIDTH_G  : positive range 1 to 32;    -- Number of bits per coefficient
       COEFFICIENTS_G : IntegerArray := (0 => 0);  -- Initial coefficients
       MEMORY_TYPE_G  : string       := "distributed";
       SYNTH_MODE_G   : string       := "inferred");

--- a/dsp/fixed/FirFilterMultiChannel.vhd
+++ b/dsp/fixed/FirFilterMultiChannel.vhd
@@ -201,7 +201,7 @@ begin
 
    end generate;
 
-   comb : process (axisRst, cascCache, cascout, mAxisSlave, r, sAxisMaster) is
+   comb : process (axiWrAddr, axiWrData, axiWrValid, axisRst, cascout, mAxisSlave, r, sAxisMaster) is
       variable v : RegType;
    begin
       -- Latch the current value

--- a/dsp/fixed/FirFilterMultiChannel.vhd
+++ b/dsp/fixed/FirFilterMultiChannel.vhd
@@ -14,8 +14,7 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
-use ieee.std_logic_arith.all;
+use ieee.numeric_std.all;
 
 library surf;
 use surf.StdRtlPkg.all;
@@ -24,14 +23,17 @@ use surf.AxiStreamPkg.all;
 
 entity FirFilterMultiChannel is
    generic (
-      TPD_G              : time     := 1 ns;
-      TAP_SIZE_G         : positive := 21;      -- Number of programmable taps
-      CH_SIZE_G          : positive := 128;     -- Number of data channels
-      PARALLEL_G         : positive := 4;  -- Number of parallel channel processing
-      WIDTH_G            : positive := 12;      -- Number of bits per data word
-      MEMORY_INIT_FILE_G : string   := "none";  -- Used to load tap coefficients into RAM at boot up
-      MEMORY_TYPE_G      : string   := "distributed";
-      SYNTH_MODE_G       : string   := "inferred");
+      TPD_G              : time         := 1 ns;
+      NUM_TAPS_G         : positive;    -- Number of programmable taps
+      NUM_CHANNELS_G     : positive;    -- Number of data channels
+      PARALLEL_G         : positive;    -- Number of parallel channel processing
+      DATA_WIDTH_G       : positive;    -- Number of bits per data word
+      COEFF_WIDTH_G      : positive;
+      SHARED_COEFF_G     : boolean      := true;    -- Coefficients are shared between channels
+      COEFFICIENTS_G     : IntegerArray := (0 => 0);  -- Only valid when SHARED_COEFF_G=true
+      MEMORY_INIT_FILE_G : string       := "none";  -- Used to load tap coefficients into RAM at boot up
+      MEMORY_TYPE_G      : string       := "distributed";
+      SYNTH_MODE_G       : string       := "inferred");
    port (
       -- AXI Stream Interface (axilClk domain)
       axisClk         : in  sl;
@@ -51,18 +53,43 @@ end FirFilterMultiChannel;
 
 architecture mapping of FirFilterMultiChannel is
 
-   constant WORD_PER_FRAME   : positive := CH_SIZE_G/PARALLEL_G;
-   constant RAM_ADDR_WIDTH_C : positive := bitSize(WORD_PER_FRAME-1);
+   constant WORDS_PER_FRAME_C : positive := NUM_CHANNELS_G/PARALLEL_G;
+   constant RAM_ADDR_WIDTH_C  : positive := bitSize(WORDS_PER_FRAME_C-1);
 
-   type DataArray is array (PARALLEL_G-1 downto 0) of slv(WIDTH_G-1 downto 0);
-   type CoeffArray is array (TAP_SIZE_G-1 downto 0, PARALLEL_G-1 downto 0) of slv(WIDTH_G-1 downto 0);
-   type CascArray is array (TAP_SIZE_G-1 downto 0, PARALLEL_G-1 downto 0) of slv(2*WIDTH_G downto 0);
+   constant CASC_WIDTH_C : integer := COEFF_WIDTH_G + DATA_WIDTH_G + log2(NUM_TAPS_G);
+
+   constant CASC_RAM_DATA_WIDTH_C : integer := CASC_WIDTH_C*NUM_TAPS_G*PARALLEL_G;
+   constant COEF_RAM_DATA_WIDTH_C : integer := COEFF_WIDTH_G*NUM_TAPS_G*ite(SHARED_COEFF_G, 1, PARALLEL_G);
+
+   type DataArray is array (PARALLEL_G-1 downto 0) of slv(DATA_WIDTH_G-1 downto 0);
+   type CoeffArray is array (NUM_TAPS_G-1 downto 0, PARALLEL_G-1 downto 0) of slv(COEFF_WIDTH_G-1 downto 0);
+   type CascArray is array (NUM_TAPS_G-1 downto 0, PARALLEL_G-1 downto 0) of slv(CASC_WIDTH_C-1 downto 0);
+
+   -------------------------------------------------------------------------------------------------
+   -- Special stuff for shared coefficients
+   -------------------------------------------------------------------------------------------------
+   constant SHARED_COEFF_RAM_ADDR_WIDTH_G : integer := bitSize(NUM_TAPS_G-1);
+
+   type SharedCoeffArray is array (NUM_TAPS_G-1 downto 0) of slv(COEFF_WIDTH_G-1 downto 0);
+
+   impure function initSharedCoeffArray return SharedCoeffArray is
+      variable retValue : SharedCoeffArray := (others => (others => '0'));
+   begin
+      for i in COEFFICIENTS_G'range loop
+         retValue(i) := std_logic_vector(to_signed(COEFFICIENTS_G(i), COEFF_WIDTH_G));
+      end loop;
+      return(retValue);
+   end function;
+
+   constant COEFFICIENTS_C : SharedCoeffArray := initSharedCoeffArray;
+   -------------------------------------------------------------------------------------------------
+
 
    function toSlv (din : CascArray) return slv is
-      variable retValue : slv((2*WIDTH_G+1)*TAP_SIZE_G*PARALLEL_G-1 downto 0) := (others => '0');
-      variable idx      : integer                                             := 0;
+      variable retValue : slv(CASC_RAM_DATA_WIDTH_C-1 downto 0) := (others => '0');
+      variable idx      : integer                               := 0;
    begin
-      for i in 0 to TAP_SIZE_G-1 loop
+      for i in 0 to NUM_TAPS_G-1 loop
          for j in 0 to PARALLEL_G-1 loop
             assignSlv(idx, retValue, din(i, j));
          end loop;
@@ -74,7 +101,7 @@ architecture mapping of FirFilterMultiChannel is
       variable retValue : CascArray := (others => (others => (others => '0')));
       variable idx      : integer   := 0;
    begin
-      for i in 0 to TAP_SIZE_G-1 loop
+      for i in 0 to NUM_TAPS_G-1 loop
          for j in 0 to PARALLEL_G-1 loop
             assignRecord(idx, din, retValue(i, j));
          end loop;
@@ -87,7 +114,7 @@ architecture mapping of FirFilterMultiChannel is
       variable idx      : integer    := 0;
    begin
       for j in 0 to PARALLEL_G-1 loop
-         for i in 0 to TAP_SIZE_G-1 loop
+         for i in 0 to NUM_TAPS_G-1 loop
             assignRecord(idx, din, retValue(i, j));
          end loop;
       end loop;
@@ -97,17 +124,16 @@ architecture mapping of FirFilterMultiChannel is
    type RegType is record
       ramWe       : sl;
       addr        : slv(RAM_ADDR_WIDTH_C-1 downto 0);
-      datain      : DataArray;
-      cascin      : CascArray;
+      coeffin     : SharedCoeffArray;
       sAxisSlave  : AxiStreamSlaveType;
       axisMeta    : AxiStreamMasterType;
       mAxisMaster : AxiStreamMasterType;
    end record RegType;
+
    constant REG_INIT_C : RegType := (
       ramWe       => '0',
       addr        => (others => '0'),
-      datain      => (others => (others => '0')),
-      cascin      => (others => (others => (others => '0'))),
+      coeffin     => COEFFICIENTS_C,
       sAxisSlave  => AXI_STREAM_SLAVE_INIT_C,
       axisMeta    => AXI_STREAM_MASTER_INIT_C,
       mAxisMaster => AXI_STREAM_MASTER_INIT_C);
@@ -118,6 +144,7 @@ architecture mapping of FirFilterMultiChannel is
    signal datain  : DataArray;
    signal coeffin : CoeffArray;
 
+   signal cascEn    : sl;
    signal cascin    : CascArray;
    signal cascout   : CascArray;
    signal cascCache : CascArray;
@@ -125,50 +152,92 @@ architecture mapping of FirFilterMultiChannel is
    signal ramWe      : sl;
    signal raddr      : slv(RAM_ADDR_WIDTH_C-1 downto 0);
    signal waddr      : slv(RAM_ADDR_WIDTH_C-1 downto 0);
-   signal coeffinSlv : slv(WIDTH_G*TAP_SIZE_G*PARALLEL_G-1 downto 0);
-   signal ramDin     : slv((2*WIDTH_G+1)*TAP_SIZE_G*PARALLEL_G-1 downto 0);
-   signal ramDout    : slv((2*WIDTH_G+1)*TAP_SIZE_G*PARALLEL_G-1 downto 0);
+   signal coeffinSlv : slv(COEF_RAM_DATA_WIDTH_C-1 downto 0);
+   signal ramDin     : slv(CASC_RAM_DATA_WIDTH_C-1 downto 0);
+   signal ramDout    : slv(CASC_RAM_DATA_WIDTH_C-1 downto 0);
+
+   signal axiWrValid : sl;
+   signal axiWrAddr  : slv(SHARED_COEFF_RAM_ADDR_WIDTH_G-1 downto 0);
+   signal axiWrData  : slv(31 downto 0);
+
 
 begin
 
-   assert (CH_SIZE_G mod PARALLEL_G = 0)
-      report "PARALLEL_G must be even number multiples of CH_SIZE_G" severity failure;
+   assert (NUM_CHANNELS_G mod PARALLEL_G = 0)
+      report "PARALLEL_G must be even number multiples of NUM_CHANNELS_G" severity failure;
 
-   assert (CH_SIZE_G >= PARALLEL_G)
-      report "CH_SIZE_G must be >= PARALLEL_G" severity failure;
+   assert (NUM_CHANNELS_G >= PARALLEL_G)
+      report "NUM_CHANNELS_G must be >= PARALLEL_G" severity failure;
 
-   U_TapCoeff : entity surf.AxiDualPortRam
-      generic map (
-         TPD_G              => TPD_G,
-         SYNTH_MODE_G       => ite(MEMORY_INIT_FILE_G /= "none", "xpm", SYNTH_MODE_G),
-         MEMORY_INIT_FILE_G => MEMORY_INIT_FILE_G,
-         MEMORY_TYPE_G      => MEMORY_TYPE_G,
-         READ_LATENCY_G     => 1,
-         ADDR_WIDTH_G       => RAM_ADDR_WIDTH_C,
-         DATA_WIDTH_G       => WIDTH_G*TAP_SIZE_G*PARALLEL_G)
-      port map (
-         -- Axi Port
-         axiClk         => axilClk,
-         axiRst         => axilRst,
-         axiReadMaster  => axilReadMaster,
-         axiReadSlave   => axilReadSlave,
-         axiWriteMaster => axilWriteMaster,
-         axiWriteSlave  => axilWriteSlave,
-         -- Standard Port
-         clk            => axisClk,
-         addr           => raddr,
-         dout           => coeffinSlv);
 
-   coeffin <= toCoeffArray(coeffinSlv);
+   SHARED_COEFF_RAM_GEN : if (SHARED_COEFF_G) generate
+      U_AxiDualPortRam_1 : entity surf.AxiDualPortRam
+         generic map (
+            TPD_G            => TPD_G,
+            SYNTH_MODE_G     => "inferred",
+            MEMORY_TYPE_G    => "distributed",
+            READ_LATENCY_G   => 0,
+            AXI_WR_EN_G      => true,
+            SYS_WR_EN_G      => false,
+            SYS_BYTE_WR_EN_G => false,
+            COMMON_CLK_G     => false,
+            ADDR_WIDTH_G     => SHARED_COEFF_RAM_ADDR_WIDTH_G,
+            DATA_WIDTH_G     => 32)
+         port map (
+            axiClk         => axilClk,          -- [in]
+            axiRst         => axilRst,          -- [in]
+            axiReadMaster  => axilReadMaster,   -- [in]
+            axiReadSlave   => axilReadSlave,    -- [out]
+            axiWriteMaster => axilWriteMaster,  -- [in]
+            axiWriteSlave  => axilWriteSlave,   -- [out]
+            clk            => axisClk,          -- [in]
+            rst            => axisRst,          -- [in]
+            axiWrValid     => axiWrValid,       -- [out]
+            axiWrAddr      => axiWrAddr,        -- [out]
+            axiWrData      => axiWrData);       -- [out]
 
-   GEN_CACHE : if (WORD_PER_FRAME > 1) generate
+      GEN_COEFFIN_TAP : for i in NUM_TAPS_G-1 downto 0 generate
+         GEN_COEFFIN_PARALLEL : for j in PARALLEL_G-1 downto 0 generate
+            coeffin(i, j) <= r.coeffin(i);
+         end generate GEN_COEFFIN_PARALLEL;
+      end generate GEN_COEFFIN_TAP;
+
+   end generate SHARED_COEFF_RAM_GEN;
+
+   NOT_SHARED_COEFF_RAM_GEN : if (not SHARED_COEFF_G) generate
+      U_TapCoeff : entity surf.AxiDualPortRam
+         generic map (
+            TPD_G              => TPD_G,
+            SYNTH_MODE_G       => ite(MEMORY_INIT_FILE_G /= "none", "xpm", SYNTH_MODE_G),
+            MEMORY_INIT_FILE_G => MEMORY_INIT_FILE_G,
+            MEMORY_TYPE_G      => MEMORY_TYPE_G,
+            READ_LATENCY_G     => 1,
+            ADDR_WIDTH_G       => RAM_ADDR_WIDTH_C,
+            DATA_WIDTH_G       => COEF_RAM_DATA_WIDTH_C)
+         port map (
+            -- Axi Port
+            axiClk         => axilClk,
+            axiRst         => axilRst,
+            axiReadMaster  => axilReadMaster,
+            axiReadSlave   => axilReadSlave,
+            axiWriteMaster => axilWriteMaster,
+            axiWriteSlave  => axilWriteSlave,
+            -- Standard Port
+            clk            => axisClk,
+            addr           => raddr,
+            dout           => coeffinSlv);
+
+      coeffin <= toCoeffArray(coeffinSlv);
+   end generate NOT_SHARED_COEFF_RAM_GEN;
+
+   GEN_CACHE : if (WORDS_PER_FRAME_C > 1) generate
 
       U_Cache : entity surf.DualPortRam
          generic map (
             TPD_G         => TPD_G,
             MEMORY_TYPE_G => MEMORY_TYPE_G,
             ADDR_WIDTH_G  => RAM_ADDR_WIDTH_C,
-            DATA_WIDTH_G  => (2*WIDTH_G+1)*TAP_SIZE_G*PARALLEL_G)
+            DATA_WIDTH_G  => CASC_RAM_DATA_WIDTH_C)
          port map (
             -- Port A
             clka  => axisClk,
@@ -191,6 +260,12 @@ begin
       -- Latch the current value
       v := r;
 
+      -- Capture coefficient shadow registers
+      if (axiWrValid = '1') then
+         v.coeffin(to_integer(unsigned(axiWrAddr))) := axiWrData(COEFF_WIDTH_G-1 downto 0);
+      end if;
+
+
       -- Reset strobes
       v.ramWe := '0';
 
@@ -205,36 +280,6 @@ begin
 
          -- Accept the data
          v.sAxisSlave.tReady := '1';
-
-         for j in PARALLEL_G-1 downto 0 loop
-
-            -- Map to the TAPs' data inputs
-            v.datain(j) := sAxisMaster.tData(j*WIDTH_G+WIDTH_G-1 downto j*WIDTH_G);
-
-            -- Load zero into the 1st tap's cascaded input
-            v.cascin(0, j) := (others => '0');
-
-         end loop;
-
-         -- Map to the cascaded input
-         for i in TAP_SIZE_G-2 downto 0 loop
-            for j in PARALLEL_G-1 downto 0 loop
-
-               -- Check for 1 word per frame
-               if (WORD_PER_FRAME = 1) then
-
-                  -- Use the previous cascade out values
-                  v.cascin(i+1, j) := cascout(i, j);
-
-               else
-
-                  -- Use the cached values
-                  v.cascin(i+1, j) := cascCache(i, j);
-
-               end if;
-
-            end loop;
-         end loop;
 
          -- Cache the AXI stream meta data
          v.axisMeta := sAxisMaster;
@@ -253,7 +298,7 @@ begin
          for j in PARALLEL_G-1 downto 0 loop
 
             -- Truncating the LSBs
-            v.mAxisMaster.tData(j*WIDTH_G+WIDTH_G-1 downto j*WIDTH_G) := cascout(TAP_SIZE_G-1, j)(2*WIDTH_G-2 downto WIDTH_G-1);
+            v.mAxisMaster.tData(j*DATA_WIDTH_G+DATA_WIDTH_G-1 downto j*DATA_WIDTH_G) := cascout(NUM_TAPS_G-1, j)(DATA_WIDTH_G-1+COEFF_WIDTH_G-1 downto COEFF_WIDTH_G-1);
 
          end loop;
 
@@ -263,7 +308,7 @@ begin
             v.addr := (others => '0');
          else
             -- Increment the counter
-            v.addr := r.addr + 1;
+            v.addr := slv(unsigned(r.addr) + 1);
          end if;
 
       end if;
@@ -277,9 +322,8 @@ begin
       waddr <= r.addr;
       raddr <= v.addr;                  -- Comb output
 
-      -- FIR TAP Outputs
-      datain <= v.datain;               -- Comb output
-      cascin <= v.cascin;               -- Comb output
+      -- FIR TAP Enable
+      cascEn <= v.sAxisSlave.tReady;    -- Comb output
 
       -- Reset
       if (axisRst = '1') then
@@ -291,6 +335,32 @@ begin
 
    end process comb;
 
+   GLUE : process (cascCache, cascout, sAxisMaster) is
+   begin
+      for j in PARALLEL_G-1 downto 0 loop
+         -- Map to the TAPs' data inputs
+         datain(j)    <= sAxisMaster.tData(j*DATA_WIDTH_G+DATA_WIDTH_G-1 downto j*DATA_WIDTH_G);
+         -- Load zero into the 1st tap's cascaded input
+         cascin(0, j) <= (others => '0');
+      end loop;
+
+      -- Map to the cascaded input
+      for i in NUM_TAPS_G-2 downto 0 loop
+         for j in PARALLEL_G-1 downto 0 loop
+            -- Check for 1 word per frame
+            if (WORDS_PER_FRAME_C = 1) then
+               -- Use the previous cascade out values
+               cascin(i+1, j) <= cascout(i, j);
+            else
+               -- Use the cached values
+               cascin(i+1, j) <= cascCache(i, j);
+            end if;
+         end loop;
+      end loop;
+
+   end process GLUE;
+
+
    seq : process (axisClk) is
    begin
       if rising_edge(axisClk) then
@@ -299,23 +369,24 @@ begin
    end process seq;
 
    GEN_TAP :
-   for i in TAP_SIZE_G-1 downto 0 generate
+   for i in NUM_TAPS_G-1 downto 0 generate
 
       GEN_PARALLEL :
       for j in PARALLEL_G-1 downto 0 generate
 
          U_Tap : entity surf.FirFilterTap
             generic map (
-               TPD_G   => TPD_G,
-               DIN_WIDTH_G => WIDTH_G,
-               COEFF_WIDTH_G => WIDTH_G,
-               CASC_WIDTH_G => 2*WIDTH_G+1)
+               TPD_G         => TPD_G,
+               DATA_WIDTH_G  => DATA_WIDTH_G,
+               COEFF_WIDTH_G => COEFF_WIDTH_G,
+               CASC_WIDTH_G  => CASC_WIDTH_C)
             port map (
                -- Clock Only (Infer into DSP)
                clk     => axisClk,
+               en      => cascEn,
                -- Data and tap coefficient Interface
                datain  => datain(j),  -- Common data input because Transpose Multiply-Accumulate architecture
-               coeffin => coeffin(TAP_SIZE_G-1-i, j),  -- Reversed order because Transpose Multiply-Accumulate architecture
+               coeffin => coeffin(NUM_TAPS_G-1-i, j),  -- Reversed order because Transpose Multiply-Accumulate architecture
                -- Cascade Interface
                cascin  => cascin(i, j),
                cascout => cascout(i, j));

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -22,32 +22,30 @@ use surf.AxiLitePkg.all;
 
 entity FirFilterSingleChannel is
    generic (
-      TPD_G          : time    := 1 ns;
-      RST_POLARITY_G : sl      := '1';  -- '1' for active high rst, '0' for active low
-      PIPE_STAGES_G  : natural := 0;
-      COMMON_CLK_G   : boolean := false;
-      NUM_TAPS_G     : positive;        -- Number of programmable taps
-      DATA_WIDTH_G   : positive;        -- Number of bits per data word
-      COEFF_WIDTH_G  : positive;
-      COEFFICIENTS_G : IntegerArray);   -- Tap Coefficients Init Constants
+      TPD_G          : time         := 1 ns;
+      COMMON_CLK_G   : boolean      := false;
+      NUM_TAPS_G     : positive;                   -- Number of filter taps
+      DATA_WIDTH_G   : positive;                   -- Number of bits per data word
+      COEFF_WIDTH_G  : positive range 1 to 32;     -- Number of bits per coefficient word
+      COEFFICIENTS_G : IntegerArray := (0 => 0));  -- Tap Coefficients Init Constants
    port (
       -- Clock and Reset
       clk             : in  sl;
-      rst             : in  sl := not(RST_POLARITY_G);
+      rst             : in  sl                     := '0';
       -- Inbound Interface
-      ibValid         : in  sl := '1';
+      ibValid         : in  sl                     := '1';
       ibReady         : out sl;
       din             : in  slv(DATA_WIDTH_G-1 downto 0);
       -- Outbound Interface
       obValid         : out sl;
-      obReady         : in  sl := '1';
+      obReady         : in  sl                     := '1';
       dout            : out slv(DATA_WIDTH_G-1 downto 0);
       -- AXI-Lite Interface (axilClk domain)
       axilClk         : in  sl;
       axilRst         : in  sl;
-      axilReadMaster  : in  AxiLiteReadMasterType;
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
       axilReadSlave   : out AxiLiteReadSlaveType;
-      axilWriteMaster : in  AxiLiteWriteMasterType;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
       axilWriteSlave  : out AxiLiteWriteSlaveType);
 end FirFilterSingleChannel;
 
@@ -58,16 +56,16 @@ architecture mapping of FirFilterSingleChannel is
    type CoeffArray is array (NUM_TAPS_G-1 downto 0) of slv(COEFF_WIDTH_G-1 downto 0);
    type CascArray is array (NUM_TAPS_G-1 downto 0) of slv(CASC_WIDTH_C-1 downto 0);
 
-   impure function InitCoeffArray return CoeffArray is
+   impure function initCoeffArray return CoeffArray is
       variable retValue : CoeffArray := (others => (others => '0'));
    begin
-      for i in 0 to NUM_TAPS_G-1 loop
+      for i in 0 to COEFFICIENTS_G'range loop
          retValue(i) := std_logic_vector(to_signed(COEFFICIENTS_G(i), COEFF_WIDTH_G));
       end loop;
       return(retValue);
    end function;
 
-   constant COEFFICIENTS_C : CoeffArray := InitCoeffArray;
+   constant COEFFICIENTS_C : CoeffArray := initCoeffArray;
 
    constant NUM_ADDR_BITS_C : positive := bitSize(NUM_TAPS_G-1);
 
@@ -92,15 +90,13 @@ architecture mapping of FirFilterSingleChannel is
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
 
-   signal cascin  : CascArray;
-   signal cascout : CascArray;
+   signal cascin    : CascArray;
+   signal cascout   : CascArray;
+   signal cascTapEn : sl;
 
-   signal tReady    : sl;
-   signal ibReadyFb : sl;
-
-   signal axiWrValid : sl;
-   signal axiWrAddr  : slv(NUM_ADDR_BITS_C-1 downto 0);
-   signal axiWrData  : slv(31 downto 0);
+   signal axiWrValid : sl                              := '0';
+   signal axiWrAddr  : slv(NUM_ADDR_BITS_C-1 downto 0) := (others => '0');
+   signal axiWrData  : slv(31 downto 0)                := (others => '0');
 
 begin
 
@@ -129,20 +125,21 @@ begin
          axiWrAddr      => axiWrAddr,        -- [out]
          axiWrData      => axiWrData);       -- [out]
 
-   comb : process (axiWrAddr, axiWrData, axiWrValid, cascout, ibReadyFb, ibValid, r, rst, tReady) is
+   comb : process (axiWrAddr, axiWrData, axiWrValid, cascTapEn, cascout, ibValid, obReady, r, rst) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndPointType;
    begin
       -- Latch the current value
       v := r;
 
+      -- Capture coefficients in shadow registers when updated in AxiDualPortRam      
       if (axiWrValid = '1') then
          v.coeffin(to_integer(unsigned(axiWrAddr))) := axiWrData(COEFF_WIDTH_G-1 downto 0);
       end if;
 
       -- Flow Control
       v.ibReady := '0';
-      if (tReady = '1') then
+      if (obReady = '1') then
          v.tValid := '0';
       end if;
 
@@ -167,10 +164,10 @@ begin
       end if;
 
       -- Outputs
---       writeSlave <= r.writeSlave;
---       readSlave  <= r.readSlave;
-      ibReadyFb <= v.ibReady;
-      ibReady   <= ibReadyFb;
+      cascTapEn <= v.ibReady;
+      ibReady   <= v.ibReady;
+      dout      <= r.tdata;
+      obValid   <= r.tValid;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -182,6 +179,16 @@ begin
 
    end process comb;
 
+   seq : process (clk) is
+   begin
+      if rising_edge(clk) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   -------------------------------------------------------------------------------------------------
+   -- Cascade glue Logic
+   -------------------------------------------------------------------------------------------------
    -- Load zero into the 1st tap's cascaded input
    cascin(0) <= (others => '0');
    -- Map to the cascaded input
@@ -191,16 +198,8 @@ begin
    end generate;
 
 
-   seq : process (clk) is
-   begin
-      if rising_edge(clk) then
-         r <= rin after TPD_G;
-      end if;
-   end process seq;
 
-   GEN_TAP :
-   for i in NUM_TAPS_G-1 downto 0 generate
-
+   GEN_TAP : for i in NUM_TAPS_G-1 downto 0 generate
       U_Tap : entity surf.FirFilterTap
          generic map (
             TPD_G         => TPD_G,
@@ -210,7 +209,7 @@ begin
          port map (
             -- Clock Only (Infer into DSP)
             clk     => clk,
-            en      => ibReadyFb,
+            en      => cascTapEn,
             -- Data and tap coefficient Interface
             datain  => din,  -- Common data input because Transpose Multiply-Accumulate architecture
             coeffin => r.coeffin(NUM_TAPS_G-1-i),  -- Reversed order because Transpose Multiply-Accumulate architecture
@@ -219,24 +218,5 @@ begin
             cascout => cascout(i));
 
    end generate GEN_TAP;
-
-   U_Pipe : entity surf.FifoOutputPipeline
-      generic map (
-         TPD_G          => TPD_G,
-         RST_POLARITY_G => RST_POLARITY_G,
-         DATA_WIDTH_G   => DATA_WIDTH_G,
-         PIPE_STAGES_G  => PIPE_STAGES_G)
-      port map (
-         -- Slave Port
-         sData  => r.tdata,
-         sValid => r.tValid,
-         sRdEn  => tReady,
-         -- Master Port
-         mData  => dout,
-         mValid => obValid,
-         mRdEn  => obReady,
-         -- Clock and Reset
-         clk    => clk,
-         rst    => rst);
 
 end mapping;

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -132,14 +132,14 @@ begin
          axiWrAddr      => axiWrAddr,        -- [out]
          axiWrData      => axiWrData);       -- [out]
 
-   comb : process (axiWrAddr, axiWrData, axiWrValid, cascTapEn, cascout, ibValid, obReady, r, rst) is
+   comb : process (axiWrAddr, axiWrData, axiWrValid, cascout, ibValid, obReady, r, rst, sbIn) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndPointType;
    begin
       -- Latch the current value
       v := r;
 
-      -- Capture coefficients in shadow registers when updated in AxiDualPortRam      
+      -- Capture coefficients in shadow registers when updated in AxiDualPortRam
       if (axiWrValid = '1') then
          v.coeffin(to_integer(unsigned(axiWrAddr))) := axiWrData(COEFF_WIDTH_G-1 downto 0);
       end if;
@@ -151,7 +151,7 @@ begin
       end if;
 
       -- Check for new data
-      if (ibValid = '1') and (v.tValid = '0') then
+      if (ibValid = '1') and (v.tValid(0) = '0') then
 
          -- Accept the data
          v.ibReady := '1';
@@ -176,7 +176,7 @@ begin
       sbOut     <= r.sideband(FILTER_DELAY_C-1);
 
       -- Reset
-      if (rst = RST_POLARITY_G) then
+      if (rst = '1') then
          v          := REG_INIT_C;
          -- Allow sidebind to use SRL
          v.sideband := r.sideband;

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -62,7 +62,7 @@ architecture mapping of FirFilterSingleChannel is
    impure function initCoeffArray return CoeffArray is
       variable retValue : CoeffArray := (others => (others => '0'));
    begin
-      for i in 0 to COEFFICIENTS_G'range loop
+      for i in COEFFICIENTS_G'range loop
          retValue(i) := std_logic_vector(to_signed(COEFFICIENTS_G(i), COEFF_WIDTH_G));
       end loop;
       return(retValue);

--- a/dsp/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/fixed/FirFilterSingleChannel.vhd
@@ -27,7 +27,7 @@ entity FirFilterSingleChannel is
       PIPE_STAGES_G  : natural := 0;
       COMMON_CLK_G   : boolean := false;
       NUM_TAPS_G     : positive;        -- Number of programmable taps
-      DIN_WIDTH_G    : positive;        -- Number of bits per data word
+      DATA_WIDTH_G   : positive;        -- Number of bits per data word
       COEFF_WIDTH_G  : positive;
       COEFFICIENTS_G : IntegerArray);   -- Tap Coefficients Init Constants
    port (
@@ -37,11 +37,11 @@ entity FirFilterSingleChannel is
       -- Inbound Interface
       ibValid         : in  sl := '1';
       ibReady         : out sl;
-      din             : in  slv(DIN_WIDTH_G-1 downto 0);
+      din             : in  slv(DATA_WIDTH_G-1 downto 0);
       -- Outbound Interface
       obValid         : out sl;
       obReady         : in  sl := '1';
-      dout            : out slv(DIN_WIDTH_G-1 downto 0);
+      dout            : out slv(DATA_WIDTH_G-1 downto 0);
       -- AXI-Lite Interface (axilClk domain)
       axilClk         : in  sl;
       axilRst         : in  sl;
@@ -53,7 +53,7 @@ end FirFilterSingleChannel;
 
 architecture mapping of FirFilterSingleChannel is
 
-   constant CASC_WIDTH_C : integer := COEFF_WIDTH_G + DIN_WIDTH_G + log2(NUM_TAPS_G);
+   constant CASC_WIDTH_C : integer := COEFF_WIDTH_G + DATA_WIDTH_G + log2(NUM_TAPS_G);
 
    type CoeffArray is array (NUM_TAPS_G-1 downto 0) of slv(COEFF_WIDTH_G-1 downto 0);
    type CascArray is array (NUM_TAPS_G-1 downto 0) of slv(CASC_WIDTH_C-1 downto 0);
@@ -76,7 +76,7 @@ architecture mapping of FirFilterSingleChannel is
       coeffin    : CoeffArray;
       ibReady    : sl;
       tValid     : sl;
-      tdata      : slv(DIN_WIDTH_G-1 downto 0);
+      tdata      : slv(DATA_WIDTH_G-1 downto 0);
       readSlave  : AxiLiteReadSlaveType;
       writeSlave : AxiLiteWriteSlaveType;
    end record RegType;
@@ -103,27 +103,6 @@ architecture mapping of FirFilterSingleChannel is
    signal axiWrData  : slv(31 downto 0);
 
 begin
-
---    U_AxiLiteAsync : entity surf.AxiLiteAsync
---       generic map (
---          TPD_G           => TPD_G,
---          COMMON_CLK_G    => COMMON_CLK_G,
---          NUM_ADDR_BITS_G => NUM_ADDR_BITS_C)
---       port map (
---          -- Slave Interface
---          sAxiClk         => axilClk,
---          sAxiClkRst      => axilRst,
---          sAxiReadMaster  => axilReadMaster,
---          sAxiReadSlave   => axilReadSlave,
---          sAxiWriteMaster => axilWriteMaster,
---          sAxiWriteSlave  => axilWriteSlave,
---          -- Master Interface
---          mAxiClk         => clk,
---          mAxiClkRst      => rst,
---          mAxiReadMaster  => readMaster,
---          mAxiReadSlave   => readSlave,
---          mAxiWriteMaster => writeMaster,
---          mAxiWriteSlave  => writeSlave);
 
    U_AxiDualPortRam_1 : entity surf.AxiDualPortRam
       generic map (
@@ -174,7 +153,7 @@ begin
          v.ibReady := '1';
 
          -- Truncate the fractional bits (COEFF_WIDTH_G-1) and overflow bits
-         v.tData := cascout(NUM_TAPS_G-1)(DIN_WIDTH_G-1+COEFF_WIDTH_G-1 downto COEFF_WIDTH_G-1);
+         v.tData := cascout(NUM_TAPS_G-1)(DATA_WIDTH_G-1+COEFF_WIDTH_G-1 downto COEFF_WIDTH_G-1);
 
          -- Check the latency init counter
          if (r.cnt = NUM_TAPS_G-1) then
@@ -190,8 +169,8 @@ begin
       -- Outputs
 --       writeSlave <= r.writeSlave;
 --       readSlave  <= r.readSlave;
-      ibReadyFb  <= v.ibReady;
-      ibReady    <= ibReadyFb;
+      ibReadyFb <= v.ibReady;
+      ibReady   <= ibReadyFb;
 
       -- Reset
       if (rst = RST_POLARITY_G) then
@@ -225,7 +204,7 @@ begin
       U_Tap : entity surf.FirFilterTap
          generic map (
             TPD_G         => TPD_G,
-            DIN_WIDTH_G   => DIN_WIDTH_G,
+            DATA_WIDTH_G  => DATA_WIDTH_G,
             COEFF_WIDTH_G => COEFF_WIDTH_G,
             CASC_WIDTH_G  => CASC_WIDTH_C)
          port map (
@@ -245,7 +224,7 @@ begin
       generic map (
          TPD_G          => TPD_G,
          RST_POLARITY_G => RST_POLARITY_G,
-         DATA_WIDTH_G   => DIN_WIDTH_G,
+         DATA_WIDTH_G   => DATA_WIDTH_G,
          PIPE_STAGES_G  => PIPE_STAGES_G)
       port map (
          -- Slave Port

--- a/dsp/fixed/FirFilterTap.vhd
+++ b/dsp/fixed/FirFilterTap.vhd
@@ -22,7 +22,7 @@ use surf.StdRtlPkg.all;
 entity FirFilterTap is
    generic (
       TPD_G         : time     := 1 ns;
-      DIN_WIDTH_G   : positive := 12;
+      DATA_WIDTH_G   : positive := 12;
       COEFF_WIDTH_G : positive := 12;
       CASC_WIDTH_G  : positive := 25);
    port (
@@ -30,7 +30,7 @@ entity FirFilterTap is
       clk     : in  sl;
       en      : in  sl := '1';
       -- Data and tap coefficient Interface
-      datain  : in  slv(DIN_WIDTH_G-1 downto 0);
+      datain  : in  slv(DATA_WIDTH_G-1 downto 0);
       coeffin : in  slv(COEFF_WIDTH_G-1 downto 0);
       -- Cascade Interface
       cascin  : in  slv(CASC_WIDTH_G-1 downto 0);
@@ -39,7 +39,7 @@ end FirFilterTap;
 
 architecture rtl of FirFilterTap is
 
-   constant PROD_WIDTH_C : integer := DIN_WIDTH_G + COEFF_WIDTH_G;
+   constant PROD_WIDTH_C : integer := DATA_WIDTH_G + COEFF_WIDTH_G;
 
    type RegType is record
       accum : signed(CASC_WIDTH_G-1 downto 0);
@@ -54,7 +54,7 @@ begin
 
    comb : process (cascin, coeffin, datain, r) is
       variable v       : RegType;
-      variable din     : signed(DIN_WIDTH_G-1 downto 0);
+      variable din     : signed(DATA_WIDTH_G-1 downto 0);
       variable coeff   : signed(COEFF_WIDTH_G-1 downto 0);
       variable product : signed(PROD_WIDTH_C-1 downto 0);
       variable cascade : signed(CASC_WIDTH_G-1 downto 0);

--- a/dsp/fixed/FirFilterTap.vhd
+++ b/dsp/fixed/FirFilterTap.vhd
@@ -21,24 +21,28 @@ use surf.StdRtlPkg.all;
 
 entity FirFilterTap is
    generic (
-      TPD_G   : time     := 1 ns;
-      WIDTH_G : positive := 12);
+      TPD_G         : time     := 1 ns;
+      DIN_WIDTH_G   : positive := 12;
+      COEFF_WIDTH_G : positive := 12;
+      CASC_WIDTH_G  : positive := 25);
    port (
       -- Clock Only (Infer into DSP)
       clk     : in  sl;
       en      : in  sl := '1';
       -- Data and tap coefficient Interface
-      datain  : in  slv(WIDTH_G-1 downto 0);
-      coeffin : in  slv(WIDTH_G-1 downto 0);
+      datain  : in  slv(DIN_WIDTH_G-1 downto 0);
+      coeffin : in  slv(COEFF_WIDTH_G-1 downto 0);
       -- Cascade Interface
-      cascin  : in  slv(2*WIDTH_G downto 0);
-      cascout : out slv(2*WIDTH_G downto 0));
+      cascin  : in  slv(CASC_WIDTH_G-1 downto 0);
+      cascout : out slv(CASC_WIDTH_G-1 downto 0));
 end FirFilterTap;
 
 architecture rtl of FirFilterTap is
 
+   constant PROD_WIDTH_C : integer := DIN_WIDTH_G + COEFF_WIDTH_G;
+
    type RegType is record
-      accum : signed(2*WIDTH_G downto 0);
+      accum : signed(CASC_WIDTH_G-1 downto 0);
    end record RegType;
    constant REG_INIT_C : RegType := (
       accum => (others => '0'));
@@ -50,10 +54,10 @@ begin
 
    comb : process (cascin, coeffin, datain, r) is
       variable v       : RegType;
-      variable din     : signed(WIDTH_G-1 downto 0);
-      variable coeff   : signed(WIDTH_G-1 downto 0);
-      variable product : signed(2*WIDTH_G-1 downto 0);
-      variable cascade : signed(2*WIDTH_G downto 0);
+      variable din     : signed(DIN_WIDTH_G-1 downto 0);
+      variable coeff   : signed(COEFF_WIDTH_G-1 downto 0);
+      variable product : signed(PROD_WIDTH_C-1 downto 0);
+      variable cascade : signed(CASC_WIDTH_G-1 downto 0);
    begin
       -- Latch the current value
       v := r;
@@ -67,7 +71,7 @@ begin
       product := din * coeff;
 
       -- Accumulator
-      v.accum := resize(product, 2*WIDTH_G) + cascade;
+      v.accum := resize(product, PROD_WIDTH_C) + cascade;
 
       -- Register the variable for next clock cycle
       rin <= v;

--- a/python/surf/dsp/fixed/_FirFilterMultiChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterMultiChannel.py
@@ -13,45 +13,19 @@ import pyrogue as pr
 class FirFilterMultiChannel(pr.Device):
     def __init__(
             self,
-            numberTaps      = None, # TAP_SIZE_G
-            numberChannels  = None, # CH_SIZE_G
-            dataWordBitSize = None, # WIDTH_G
+            numberTaps, # NUM_TAPS_G
+            coeffWordBitSize, # COEFF_WIDTH_G
             **kwargs):
         super().__init__(**kwargs)
 
-        if numberTaps is None:
-            raise ValueError( f'{self.path}: numberTaps is undefined' )
+        self.add(pr.RemoteVariable(
+            name = f'Taps',
+            offset = 0,
+            disp = '{:0.04f}',
+            bitSize = 32*numberTaps,
+            valueBits = coeffWordBitSize,
+            numValues = numberTaps,
+            valueStride = 32,
+            base = pr.Fixed(coeffWordBitSize, coeffWordBitSize-1)))
 
-        if numberChannels is None:
-            raise ValueError( f'{self.path}: numberChannels is undefined' )
 
-        if dataWordBitSize is None:
-            raise ValueError( f'{self.path}: dataWordBitSize is undefined' )
-
-        def addBoolPair(ch,tap):
-            self.add(pr.RemoteVariable(
-                name         = f'RawCh{ch}Tap[{tap}]',
-                description  = f'Tap[{tap}] Fixed Point Coefficient',
-                offset       = 0x0,
-                bitSize      = dataWordBitSize,
-                bitOffset    = (ch*numberTaps+tap)*dataWordBitSize,
-                base         = pr.Int,
-                mode         = 'RW',
-                hidden       = True,
-            ))
-
-            var = self.variables[ f'RawCh{ch}Tap[{tap}]' ]
-
-            self.add(pr.LinkVariable(
-                name         = f'Ch{ch}Tap[{tap}]',
-                description  = f'Tap[{tap}] Floating Point Coefficient',
-                mode         = 'RW',
-                linkedGet    = lambda: var.value()/2**dataWordBitSize,
-                linkedSet    = lambda value, write: var.set(int(value*2**dataWordBitSize)),
-                dependencies = [var],
-                disp         = '{:1.3f}',
-            ))
-
-        for ch in range(numberChannels):
-            for tap in range(numberTaps):
-                addBoolPair(ch=ch,tap=tap)

--- a/python/surf/dsp/fixed/_FirFilterMultiChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterMultiChannel.py
@@ -27,5 +27,3 @@ class FirFilterMultiChannel(pr.Device):
             numValues = numberTaps,
             valueStride = 32,
             base = pr.Fixed(coeffWordBitSize, coeffWordBitSize-1)))
-
-

--- a/python/surf/dsp/fixed/_FirFilterMultiChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterMultiChannel.py
@@ -19,7 +19,7 @@ class FirFilterMultiChannel(pr.Device):
         super().__init__(**kwargs)
 
         self.add(pr.RemoteVariable(
-            name = f'Taps',
+            name = 'Taps',
             offset = 0,
             disp = '{:0.04f}',
             bitSize = 32*numberTaps,

--- a/python/surf/dsp/fixed/_FirFilterSingleChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterSingleChannel.py
@@ -7,7 +7,7 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-
+import scipy
 import pyrogue as pr
 
 class FirFilterSingleChannel(pr.Device):
@@ -24,28 +24,14 @@ class FirFilterSingleChannel(pr.Device):
         if dataWordBitSize is None:
             raise ValueError( f'{self.path}: dataWordBitSize is undefined' )
 
-        def addBoolPair(tap):
-            self.add(pr.RemoteVariable(
-                name         = f'RawTap[{tap}]',
-                description  = f'Tap[{tap}] Fixed Point Coefficient',
-                offset       = 4*tap,
-                bitSize      = dataWordBitSize,
-                base         = pr.Int,
-                mode         = 'RW',
-                hidden       = True,
-            ))
+        self.add(pr.RemoteVariable(
+            name = f'Taps',
+            offset = 0,
+            disp = '{:0.04f}',
+            bitSize = 32*numberTaps,
+            valueBits = dataWordBitSize,
+            numValues = numberTaps,
+            valueStride = 32,
+            base = pr.Fixed(dataWordBitSize, dataWordBitSize-1)))
 
-            var = self.variables[ f'RawTap[{tap}]' ]
-
-            self.add(pr.LinkVariable(
-                name         = f'Tap[{tap}]',
-                description  = f'Tap[{tap}] Floating Point Coefficient',
-                mode         = 'RW',
-                linkedGet    = lambda: var.value()/2**dataWordBitSize,
-                linkedSet    = lambda value, write: var.set(int(value*2**dataWordBitSize)),
-                dependencies = [var],
-                disp         = '{:1.3f}',
-            ))
-
-        for tap in range(numberTaps):
-            addBoolPair(tap=tap)
+            

--- a/python/surf/dsp/fixed/_FirFilterSingleChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterSingleChannel.py
@@ -18,7 +18,7 @@ class FirFilterSingleChannel(pr.Device):
         super().__init__(**kwargs)
 
         self.add(pr.RemoteVariable(
-            name = f'Taps',
+            name = 'Taps',
             offset = 0,
             disp = '{:0.04f}',
             bitSize = 32*numberTaps,

--- a/python/surf/dsp/fixed/_FirFilterSingleChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterSingleChannel.py
@@ -26,5 +26,3 @@ class FirFilterSingleChannel(pr.Device):
             numValues = numberTaps,
             valueStride = 32,
             base = pr.Fixed(coeffWordBitSize, coeffWordBitSize-1)))
-
-            

--- a/python/surf/dsp/fixed/_FirFilterSingleChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterSingleChannel.py
@@ -13,25 +13,19 @@ import pyrogue as pr
 class FirFilterSingleChannel(pr.Device):
     def __init__(
             self,
-            numberTaps      = None, # TAP_SIZE_G
-            dataWordBitSize = None, # WIDTH_G
+            numberTaps, # NUM_TAPS_G
+            coeffWordBitSize, # COEFF_WIDTH_G
             **kwargs):
         super().__init__(**kwargs)
-
-        if numberTaps is None:
-            raise ValueError( f'{self.path}: numberTaps is undefined' )
-
-        if dataWordBitSize is None:
-            raise ValueError( f'{self.path}: dataWordBitSize is undefined' )
 
         self.add(pr.RemoteVariable(
             name = f'Taps',
             offset = 0,
             disp = '{:0.04f}',
             bitSize = 32*numberTaps,
-            valueBits = dataWordBitSize,
+            valueBits = coeffWordBitSize,
             numValues = numberTaps,
             valueStride = 32,
-            base = pr.Fixed(dataWordBitSize, dataWordBitSize-1)))
+            base = pr.Fixed(coeffWordBitSize, coeffWordBitSize-1)))
 
             

--- a/python/surf/dsp/fixed/_FirFilterSingleChannel.py
+++ b/python/surf/dsp/fixed/_FirFilterSingleChannel.py
@@ -7,7 +7,6 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import scipy
 import pyrogue as pr
 
 class FirFilterSingleChannel(pr.Device):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This PR makes several changes to the FIR Filter modules.

 - The DSP48 internal register and enable are used for pipeline stalls, rather than external registers and logic.
 - Different coefficient and data widths are now allowed.
 - `MultiChannelFirFilter` now only allows one set of coefficients to be applied to all channels.
   - The logic allowing different coefficients per channel was broken.
   - Fixing it would require extensive changes to `AxiDualPortRam`
 - Coefficients now held in `AxiDualPortRam` with shadow registers for parallel read.
   - Seems counterintuitive, but ends up saving resources.
   - Use `AxiDualPortRam` to handle AXI address decode and read muxing.
   - Shadow registers allow all coefficients to be accessed in parallel for filter application.
   - Also allows for easy synchronization between AXI-Lite clock and data clock.
 - FirFilterSingleChannel now has sideband interface.
   - Allows sideband data to get same pipeline delay as the filter.
 - Some generic names have been updated for clarity.
   - OK since nothing was using these modules yet.
 - Software
   - Use Fixed type variables
     - Automatically converts floats to internal fixed point representation.
   - Use array variables
     - Allows all coefficients to be accessed in a single SRP transaction.

