### PR TITLE
adding HSkip, HActive, VSkip, VActive to CLINK

### DIFF
--- a/protocols/clink/rtl/ClinkFraming.vhd
+++ b/protocols/clink/rtl/ClinkFraming.vhd
@@ -255,42 +255,24 @@ begin
       -- Check for VALID
       if (v.portData.valid = '1') then
 
-         -- Check of non-lv
-         if (v.portData.lv = '0') then
-            -- Reset the counter
-            v.hCnt := (others => '0');
-         else
-            -- Increment the counter
-            v.hCnt := r.hCnt + 1;
-            -- Check if out of bound
-            if (r.hCnt < chanConfig.hSkip) then
-               -- Reset dv
-               v.portData.dv := '0';
-            end if;
-            -- Check if out of bound
-            if (r.hCnt >= (chanConfig.hSkip+chanConfig.hActive)) then
-               -- Reset dv
-               v.portData.dv := '0';
-            end if;
-         end if;
-
-         -- Keep a delayed copy
-         v.lineValid := v.portData.lv;
-
-         -- Check for a falling edge of LV
-         if (r.lineValid = '1') and (v.lineValid = '0') then
-            -- Increment the counter
-            v.vCnt := r.vCnt + 1;
-         end if;
-
          -- Check of non-fv
          if (v.portData.fv = '0') then
             -- Reset the counter
-            v.vCnt := (others => '0');
+            v.vCnt      := (others => '0');
+            v.lineValid := '0';
          else
 
+            -- Keep a delayed copy
+            v.lineValid := v.portData.lv;
+
+            -- Check for a falling edge of LV
+            if (r.lineValid = '1') and (v.lineValid = '0') then
+               -- Increment the counter
+               v.vCnt := r.vCnt + 1;
+            end if;
+
             -- Check if out of bound
-            if (r.vCnt < chanConfig.vSkip) then
+            if (r.vCnt < chanConfig.vSkip) and (chanConfig.vSkip /= 0) then
                -- Reset dv
                v.portData.dv := '0';
             end if;
@@ -301,6 +283,25 @@ begin
                v.portData.dv := '0';
             end if;
 
+         end if;
+
+         -- Check of non-lv
+         if (v.portData.lv = '0') then
+            -- Reset the counter
+            v.hCnt := (others => '0');
+         else
+            -- Increment the counter
+            v.hCnt := r.hCnt + 1;
+            -- Check if out of bound
+            if (r.hCnt < chanConfig.hSkip) and (chanConfig.hSkip /= 0) then
+               -- Reset lv
+               v.portData.lv := '0';
+            end if;
+            -- Check if out of bound
+            if (r.hCnt >= (chanConfig.hSkip+chanConfig.hActive)) then
+               -- Reset dv
+               v.portData.lv := '0';
+            end if;
          end if;
 
       end if;

--- a/protocols/clink/rtl/ClinkFraming.vhd
+++ b/protocols/clink/rtl/ClinkFraming.vhd
@@ -54,29 +54,35 @@ architecture rtl of ClinkFraming is
    constant MST_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(dataBytes => 16, tDestBits => 0);
 
    type RegType is record
-      byteCnt  : slv(31 downto 0);
-      ready    : sl;
-      portData : ClDataType;
-      byteData : ClDataType;
-      bytes    : integer range 1 to 16;
-      inFrame  : sl;
-      dump     : sl;
-      status   : ClChanStatusType;
-      master   : AxiStreamMasterType;
-      pipeline : AxiStreamMasterArray(1 downto 0);
+      hCnt      : slv(15 downto 0);
+      vCnt      : slv(15 downto 0);
+      byteCnt   : slv(31 downto 0);
+      lineValid : sl;
+      ready     : sl;
+      portData  : ClDataType;
+      byteData  : ClDataType;
+      bytes     : integer range 1 to 16;
+      inFrame   : sl;
+      dump      : sl;
+      status    : ClChanStatusType;
+      master    : AxiStreamMasterType;
+      pipeline  : AxiStreamMasterArray(1 downto 0);
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      byteCnt  => (others => '0'),
-      ready    => '1',
-      portData => CL_DATA_INIT_C,
-      byteData => CL_DATA_INIT_C,
-      bytes    => 1,
-      inFrame  => '0',
-      dump     => '0',
-      status   => CL_CHAN_STATUS_INIT_C,
-      master   => AXI_STREAM_MASTER_INIT_C,
-      pipeline => (others => AXI_STREAM_MASTER_INIT_C));
+      hCnt      => (others => '0'),
+      vCnt      => (others => '0'),
+      byteCnt   => (others => '0'),
+      lineValid => '0',
+      ready     => '1',
+      portData  => CL_DATA_INIT_C,
+      byteData  => CL_DATA_INIT_C,
+      bytes     => 1,
+      inFrame   => '0',
+      dump      => '0',
+      status    => CL_CHAN_STATUS_INIT_C,
+      master    => AXI_STREAM_MASTER_INIT_C,
+      pipeline  => (others => AXI_STREAM_MASTER_INIT_C));
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -245,6 +251,59 @@ begin
 
       -- Drive ready, dump when not running
       v.ready := v.portData.valid or (not r.status.running);
+
+      -- Check for VALID
+      if (v.portData.valid = '1') then
+
+         -- Check of non-lv
+         if (v.portData.lv = '0') then
+            -- Reset the counter
+            v.hCnt := (others => '0');
+         else
+            -- Increment the counter
+            v.hCnt := r.hCnt + 1;
+            -- Check if out of bound
+            if (r.hCnt < chanConfig.hSkip) then
+               -- Reset dv
+               v.portData.dv := '0';
+            end if;
+            -- Check if out of bound
+            if (r.hCnt >= (chanConfig.hSkip+chanConfig.hActive)) then
+               -- Reset dv
+               v.portData.dv := '0';
+            end if;
+         end if;
+
+         -- Keep a delayed copy
+         v.lineValid := v.portData.lv;
+
+         -- Check for a falling edge of LV
+         if (r.lineValid = '1') and (v.lineValid = '0') then
+            -- Increment the counter
+            v.vCnt := r.vCnt + 1;
+         end if;
+
+         -- Check of non-fv
+         if (v.portData.fv = '0') then
+            -- Reset the counter
+            v.vCnt := (others => '0');
+         else
+
+            -- Check if out of bound
+            if (r.vCnt < chanConfig.vSkip) then
+               -- Reset dv
+               v.portData.dv := '0';
+            end if;
+
+            -- Check if out of bound
+            if (r.vCnt >= (chanConfig.vSkip+chanConfig.vActive)) then
+               -- Reset dv
+               v.portData.dv := '0';
+            end if;
+
+         end if;
+
+      end if;
 
       ---------------------------------
       -- Map data bytes

--- a/protocols/clink/rtl/ClinkPkg.vhd
+++ b/protocols/clink/rtl/ClinkPkg.vhd
@@ -92,6 +92,10 @@ package ClinkPkg is
    -- Channel Configuration Record
    ------------------------------------
    type ClChanConfigType is record
+      hSkip       : slv(15 downto 0);
+      hActive     : slv(15 downto 0);
+      vSkip       : slv(15 downto 0);
+      vActive     : slv(15 downto 0);
       swCamCtrl   : slv(3 downto 0);
       swCamCtrlEn : slv(3 downto 0);
       serBaud     : slv(23 downto 0);
@@ -106,6 +110,10 @@ package ClinkPkg is
    end record ClChanConfigType;
 
    constant CL_CHAN_CONFIG_INIT_C : ClChanConfigType := (
+      hSkip       => (others => '0'),
+      hActive     => (others => '1'),
+      vSkip       => (others => '0'),
+      vActive     => (others => '1'),
       swCamCtrl   => (others => '0'),
       swCamCtrlEn => (others => '0'),
       serBaud     => toSlv(9600, 24),   -- Default of 9600 baud

--- a/protocols/clink/rtl/ClinkReg.vhd
+++ b/protocols/clink/rtl/ClinkReg.vhd
@@ -152,6 +152,12 @@ begin
       axiSlaveRegisterR(axilEp, x"128", 0, chanStatus(0).dropCount);
       axiSlaveRegisterR(axilEp, x"12C", 0, chanStatus(0).frameSize);
 
+      -- Channel A ROI
+      axiSlaveRegister (axilEp, x"130", 0, v.chanConfig(0).hSkip);
+      axiSlaveRegister (axilEp, x"134", 0, v.chanConfig(0).hActive);
+      axiSlaveRegister (axilEp, x"138", 0, v.chanConfig(0).vSkip);
+      axiSlaveRegister (axilEp, x"13C", 0, v.chanConfig(0).vActive);
+
       -- Channel B Config
       axiSlaveRegister (axilEp, x"200", 0, v.chanConfig(1).linkMode);
       axiSlaveRegister (axilEp, x"204", 0, v.chanConfig(1).dataMode);
@@ -170,6 +176,12 @@ begin
       axiSlaveRegisterR(axilEp, x"224", 0, chanStatus(1).frameCount);
       axiSlaveRegisterR(axilEp, x"228", 0, chanStatus(1).dropCount);
       axiSlaveRegisterR(axilEp, x"22C", 0, chanStatus(1).frameSize);
+
+      -- Channel B ROI
+      axiSlaveRegister (axilEp, x"230", 0, v.chanConfig(1).hSkip);
+      axiSlaveRegister (axilEp, x"234", 0, v.chanConfig(1).hActive);
+      axiSlaveRegister (axilEp, x"238", 0, v.chanConfig(1).vSkip);
+      axiSlaveRegister (axilEp, x"23C", 0, v.chanConfig(1).vActive);
 
       axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
 

--- a/python/surf/protocols/clink/_ClinkChannel.py
+++ b/python/surf/protocols/clink/_ClinkChannel.py
@@ -198,6 +198,38 @@ class ClinkChannel(pr.Device):
             pollInterval = 1,
         ))
 
+        self.add(pr.RemoteVariable(
+            name         = "HSkip",
+            description  = "# of cycle to skip from the start of CLINK LineValid (LV)",
+            offset       =  0x30,
+            bitSize      =  16,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "HActive",
+            description  = "# of active cycle after HSkip while CLINK LineValid (LV) is active",
+            offset       =  0x34,
+            bitSize      =  16,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "VSkip",
+            description  = "# of lines to skip from the start of CLINK FrameValid (FV)",
+            offset       =  0x38,
+            bitSize      =  16,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "VActive",
+            description  = "# of active lines after VSkip while CLINK FrameValid (FV) is active",
+            offset       =  0x3C,
+            bitSize      =  16,
+            mode         = "RW",
+        ))
+
         ##############################################################################
 
         self._rx = None


### PR DESCRIPTION
### Description
- Required for supporting the U900 camera 
  - Where the raw camera image size (active and inactive pixels) are not the same for all cameras