### PR TITLE
Changed getTKeep to return the number of bits set rather than the MSB+1

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -387,7 +387,7 @@ package body AxiStreamPkg is
             -- .....................................
             ----------------------------------------------------
             if (tKeepFull(i) = '1') then
-               retVar := (i+1);
+               retVar := (retVar+1);
             end if;
          end loop;
       end if;


### PR DESCRIPTION
The function getTKeep in AxiStreamPkg.vhd contains two branches based on the value of TKEEP_MODE. 

When TKEEP_COUNT_C, then the function returns the largest number of bits that can be held by tKeep.

Otherwise, it returned the most significant set bit position +1. In other words a count of set bits that assumes that all bits below the MSB are also 1.

When the AxiStreamDmaWrite block counts the number of bytes transmitted, and tKeep violates this assumption data words are not written to memory. In my case, this can happen when the incoming PGP stream has transactions unaligned to 64-bit boundaries and tKeep can assume values like 0xC0, 0xF0, or 0xFC. Note when the alignment is in the other direction, tKeep of 0x03, 0x0F, and 0x3F will work with the current code.

AxiStreamDmaWrite is currently overriding the system TKEEP_MODE and setting it to TKEEP_NORMAL. It is unclear to me if some of the TKEEP_MODEs might actually want the current behavior of getTKeep. 

Testing with this addition did not seem to adversely affect any of the LSST RCE uses of getTKeep, including the Ethernet PPI implementation. I suspect that in those cases, the assumption that the lower bits turns out to be true when actually counted.