### PR TITLE
ESROGUE-507: Fixed the slow AxiLiteMasterProxy module

### DIFF
--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -15,7 +15,7 @@ import time
 import queue
 
 class _Regs(pr.Device):
-    def __init__(self, pollPeriod=0.1, **kwargs):
+    def __init__(self, pollPeriod=0.0, **kwargs):
         super().__init__(**kwargs)
 
         self._pollPeriod = pollPeriod
@@ -147,8 +147,8 @@ class _ProxySlave(rogue.interfaces.memory.Slave):
 
 class AxiLiteMasterProxy(pr.Device):
 
-    def __init__(self, hidden=True,**kwargs):
-        super().__init__(hidden=hidden, pollPeriod=0.1, **kwargs)
+    def __init__(self, hidden=True, pollPeriod=0.0, **kwargs):
+        super().__init__(hidden=hidden, **kwargs)
 
         self.add(_Regs(
             name    = 'Regs',

--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -15,8 +15,10 @@ import time
 import queue
 
 class _Regs(pr.Device):
-    def __init__(self, **kwargs):
+    def __init__(self, pollPeriod=0.1, **kwargs):
         super().__init__(**kwargs)
+
+        self._pollPeriod = pollPeriod
 
         self._queue = queue.Queue()
         self._pollThread = threading.Thread(target=self._pollWorker)
@@ -114,7 +116,7 @@ class _Regs(pr.Device):
                 while done is False:
                     done = self.Done.get(read=True)
                     #print(f'Polled done: {done}')
-                    time.sleep(.1)
+                    time.sleep(self._pollPeriod)
 
                 # Check for error flags
                 resp = self.Resp.get(read=True)
@@ -146,13 +148,14 @@ class _ProxySlave(rogue.interfaces.memory.Slave):
 class AxiLiteMasterProxy(pr.Device):
 
     def __init__(self, hidden=True,**kwargs):
-        super().__init__(hidden=hidden,**kwargs)
+        super().__init__(hidden=hidden, pollPeriod=0.1, **kwargs)
 
         self.add(_Regs(
             name    = 'Regs',
             memBase = self,
             offset  = 0x0000,
             hidden  = hidden,
+            pollPeriod = pollPeriod,
         ))
         self.proxy = _ProxySlave(self.Regs)
 


### PR DESCRIPTION
### Description
- Add pollPeriod parameter for faster or slower polling for transaction
- Set default pollPeriod to 0

### Details
The AxiLiteMasterProxy kicks off a transaction and then polls a register for it to be done. It was enforcing a 0.1s sleep between each register poll, with at least one 0.1s sleep always happening. This slowed down access by quite a bit. This change allows the poll interval to be set with a parameter, with the default being no sleep at all.

### JIRA
https://jira.slac.stanford.edu/browse/ESROGUE-507