### PR TITLE
Fix clkFbIn drive when no BUFG

### DIFF
--- a/xilinx/7Series/general/rtl/ClockManager7.vhd
+++ b/xilinx/7Series/general/rtl/ClockManager7.vhd
@@ -366,7 +366,7 @@ begin
    end generate;
 
    FbNoBufg : if (not FB_BUFG_G) generate
-      clkFbOut <= clkFbIn;
+      clkFbIn <= clkFbOut;
    end generate;
 
    OutBufgGen : if (OUTPUT_BUFG_G) generate

--- a/xilinx/UltraScale/clocking/rtl/ClockManagerUltraScale.vhd
+++ b/xilinx/UltraScale/clocking/rtl/ClockManagerUltraScale.vhd
@@ -332,7 +332,7 @@ begin
    end generate;
 
    FbNoBufg : if (not FB_BUFG_G) generate
-      clkFbOut <= clkFbIn;
+      clkFbIn <= clkFbOut;
    end generate;
 
    ClkOutGen : for i in NUM_CLOCKS_G-1 downto 0 generate


### PR DESCRIPTION
### Description
- Found that the clkFbIn pin was not being driven when generic FB_BUFG_G is False.  Change:
```
    FbNoBufg : if (not FB_BUFG_G) generate
-      clkFbOut <= clkFbIn;
+      clkFbIn <= clkFbOut;
    end generate;
```