### PR TITLE
Update TenGigEthGthUltraScaleClk.vhd

### DIFF
--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleClk.vhd
@@ -51,6 +51,8 @@ architecture mapping of TenGigEthGthUltraScaleClk is
    signal coreClock  : sl;
    signal qpllReset  : sl;
 
+   signal dummyBits  : slv(2 downto 0);
+
 begin
 
    gtClk <= refClock;
@@ -115,11 +117,11 @@ begin
          qPllRefClk(0)     => refClock,
          qPllRefClk(1)     => '0',
          qPllOutClk(0)     => qPllOutClk,
-         qPllOutClk(1)     => open,
+         qPllOutClk(1)     => dummyBits(0),
          qPllOutRefClk(0)  => qPllOutRefClk,
-         qPllOutRefClk(1)  => open,
+         qPllOutRefClk(1)  => dummyBits(1),
          qPllLock(0)       => qPllLock,
-         qPllLock(1)       => open,
+         qPllLock(1)       => dummyBits(2),
          qPllLockDetClk(0) => '0',   -- IP Core ties this to GND (see note below)
          qPllLockDetClk(1) => '0',   -- IP Core ties this to GND (see note below)
          qPllPowerDown(0)  => '0',


### PR DESCRIPTION
### Description
- Mapping the`open` output ports to signals to get rid of `ERROR: [VRFC 10-3628] partially associated formal` error messages in simulation
