### PR TITLE
SelectIoRxGearboxAligner: Expose the measured eyeWidth to userspace

### DIFF
--- a/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder10b12bWrapper.vhd
@@ -67,6 +67,7 @@ architecture mapping of SspLowSpeedDecoder10b12bWrapper is
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
+   signal eyeWidth       : Slv9Array(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
    signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
@@ -103,6 +104,7 @@ begin
             lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
+            eyeWidth       => eyeWidth(i),
             locked         => locked(i),
             idleCode       => idleCode(i),
             -- SSP Frame Output
@@ -128,6 +130,7 @@ begin
          dlyConfig       => dlyConfig,
          errorDet        => errorDet,
          bitSlip         => bitSlip,
+         eyeWidth        => eyeWidth,
          locked          => locked,
          idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder12b14bWrapper.vhd
@@ -67,6 +67,7 @@ architecture mapping of SspLowSpeedDecoder12b14bWrapper is
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
+   signal eyeWidth       : Slv9Array(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
    signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
@@ -103,6 +104,7 @@ begin
             lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
+            eyeWidth       => eyeWidth(i),
             locked         => locked(i),
             idleCode       => idleCode(i),
             -- SSP Frame Output
@@ -128,6 +130,7 @@ begin
          dlyConfig       => dlyConfig,
          errorDet        => errorDet,
          bitSlip         => bitSlip,
+         eyeWidth        => eyeWidth,
          locked          => locked,
          idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,

--- a/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoder8b10bWrapper.vhd
@@ -67,6 +67,7 @@ architecture mapping of SspLowSpeedDecoder8b10bWrapper is
    signal polarity       : slv(NUM_LANE_G-1 downto 0);
    signal errorDet       : slv(NUM_LANE_G-1 downto 0);
    signal bitSlip        : slv(NUM_LANE_G-1 downto 0);
+   signal eyeWidth       : Slv9Array(NUM_LANE_G-1 downto 0);
    signal locked         : slv(NUM_LANE_G-1 downto 0);
    signal idleCode       : slv(NUM_LANE_G-1 downto 0);
 
@@ -103,6 +104,7 @@ begin
             lockOnIdle     => lockOnIdle,
             errorDet       => errorDet(i),
             bitSlip        => bitSlip(i),
+            eyeWidth       => eyeWidth(i),
             locked         => locked(i),
             idleCode       => idleCode(i),
             -- SSP Frame Output
@@ -128,6 +130,7 @@ begin
          dlyConfig       => dlyConfig,
          errorDet        => errorDet,
          bitSlip         => bitSlip,
+         eyeWidth        => eyeWidth,
          locked          => locked,
          idleCode        => idleCode,
          enUsrDlyCfg     => enUsrDlyCfg,

--- a/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderLane.vhd
@@ -46,6 +46,7 @@ entity SspLowSpeedDecoderLane is
       lockOnIdle     : in  sl;
       errorDet       : out sl;
       bitSlip        : out sl;
+      eyeWidth       : out slv(8 downto 0);
       locked         : out sl;
       idleCode       : out sl;
       -- SSP Frame Output
@@ -158,6 +159,7 @@ begin
          lockingCntCfg   => lockingCntCfg,
          -- Status Interface
          errorDet        => errorDet,
+         eyeWidth        => eyeWidth,
          locked          => gearboxAligned);
 
    lineCodeErr     <= codeError and not(errorMask(0));

--- a/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
@@ -34,6 +34,7 @@ entity SspLowSpeedDecoderReg is
       dlyConfig       : in  Slv9Array(NUM_LANE_G-1 downto 0);
       errorDet        : in  slv(NUM_LANE_G-1 downto 0);
       bitSlip         : in  slv(NUM_LANE_G-1 downto 0);
+      eyeWidth        : in  Slv9Array(NUM_LANE_G-1 downto 0);
       locked          : in  slv(NUM_LANE_G-1 downto 0);
       idleCode        : in  slv(NUM_LANE_G-1 downto 0);
       enUsrDlyCfg     : out sl;
@@ -124,8 +125,8 @@ begin
          mAxiWriteMaster => writeMaster,
          mAxiWriteSlave  => writeSlave);
 
-   comb : process (deserRst, dlyConfig, idleCode, r, readMaster, statusCnt,
-                   statusOut, writeMaster) is
+   comb : process (deserRst, dlyConfig, eyeWidth, idleCode, r, readMaster,
+                   statusCnt, statusOut, writeMaster) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndPointType;
    begin
@@ -146,12 +147,14 @@ begin
 
       for i in NUM_LANE_G-1 downto 0 loop
 
+         -- Address starts at 0x200
+         axiSlaveRegisterR(axilEp, toSlv(512+4*i, 12), 0, eyeWidth(i));
+
          -- Address starts at 0x500
          axiSlaveRegister (axilEp, toSlv(1280+4*i, 12), 0, v.usrDlyCfg(i));
 
          -- Address starts at 0x600
          axiSlaveRegisterR(axilEp, toSlv(1536+4*i, 12), 0, dlyConfig(i));
-
 
       end loop;
 

--- a/protocols/sugoi/rtl/SugoiManagerCore.vhd
+++ b/protocols/sugoi/rtl/SugoiManagerCore.vhd
@@ -78,6 +78,7 @@ architecture mapping of SugoiManagerCore is
 
    signal enUsrDlyCfg    : sl;
    signal usrDlyCfg      : slv(8 downto 0);
+   signal eyeWidth       : slv(8 downto 0);
    signal bypFirstBerDet : sl;
    signal minEyeWidth    : slv(7 downto 0);
    signal lockingCntCfg  : slv(23 downto 0);
@@ -185,6 +186,7 @@ begin
          lockingCntCfg   => lockingCntCfg,
          -- Status Interface
          errorDet        => errorDet,
+         eyeWidth        => eyeWidth,
          locked          => gearboxAligned);
 
    ---------------
@@ -267,6 +269,7 @@ begin
          minEyeWidth     => minEyeWidth,
          lockingCntCfg   => lockingCntCfg,
          errorDet        => errorDet,
+         eyeWidth        => eyeWidth,
          gearboxAligned  => gearboxAligned,
          -- AXI-Lite Master Interface
          axilReadMaster  => readMaster,

--- a/protocols/sugoi/rtl/SugoiManagerFsm.vhd
+++ b/protocols/sugoi/rtl/SugoiManagerFsm.vhd
@@ -57,6 +57,7 @@ entity SugoiManagerFsm is
       minEyeWidth     : out slv(7 downto 0);
       lockingCntCfg   : out slv(23 downto 0);
       errorDet        : in  sl;
+      eyeWidth        : in  slv(8 downto 0);
       gearboxAligned  : in  sl;
       -- AXI-Lite Master Interface
       axilReadMaster  : in  AxiLiteReadMasterType;
@@ -163,8 +164,9 @@ architecture rtl of SugoiManagerFsm is
 
 begin
 
-   comb : process (axilReadMaster, axilWriteMaster, errorDet, gearboxAligned,
-                   globalRst, opCode, r, rst, rxData, rxDataK, rxValid) is
+   comb : process (axilReadMaster, axilWriteMaster, errorDet, eyeWidth,
+                   gearboxAligned, globalRst, opCode, r, rst, rxData, rxDataK,
+                   rxValid) is
       variable v        : RegType;
       variable i        : natural;
       variable RnW      : sl;
@@ -431,6 +433,7 @@ begin
                axiSlaveRegisterR(axilEp, x"A0", 0, r.errorDetCnt);
                axiSlaveRegisterR(axilEp, x"A4", 0, r.linkUpCnt);
                axiSlaveRegisterR(axilEp, x"A8", 0, r.latency);  -- Round trip SOF latency
+               axiSlaveRegisterR(axilEp, x"AC", 0, eyeWidth);
 
                axiSlaveRegister(axilEp, x"FC", 0, v.rstCnt);
 
@@ -451,8 +454,8 @@ begin
                v.txMsg(7)  := axilWriteMaster.wData(23 downto 16);
                v.txMsg(8)  := axilWriteMaster.wData(15 downto 8);
                v.txMsg(9)  := axilWriteMaster.wData(7 downto 0);
-               v.txMsg(10) := x"00";                           -- Footer
-               v.txMsg(11) := x"00";                           -- checksum
+               v.txMsg(10) := x"00";    -- Footer
+               v.txMsg(11) := x"00";    -- checksum
                v.txMsg(12) := CODE_EOF_C;
 
                -- Reset the counter

--- a/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
+++ b/python/surf/protocols/ssp/_SspLowSpeedDecoderReg.py
@@ -44,6 +44,17 @@ class SspLowSpeedDecoderReg(pr.Device):
             pollInterval = 1,
         )
 
+        self.addRemoteVariables(
+            name         = 'EyeWidth',
+            description  = 'Measured eye width after locking completed',
+            offset       = 0x200,
+            bitSize      = 9,
+            mode         = 'RO',
+            number       = numberLanes,
+            stride       = 4,
+            pollInterval = 1,
+        )
+
         self.add(pr.RemoteVariable(
             name         = 'Locked',
             offset       = 0x400,

--- a/python/surf/protocols/sugoi/_SugoiAxiL.py
+++ b/python/surf/protocols/sugoi/_SugoiAxiL.py
@@ -145,6 +145,15 @@ class SugoiAxiL(pr.Device):
             pollInterval = 1,
         ))
 
+        self.add(pr.RemoteVariable(
+            name         = 'EyeWidth',
+            description  = 'Measured eye width after locking completed',
+            offset       = 0xAC,
+            bitSize      = 9,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
         self.add(pr.RemoteCommand(
             name         = 'CountReset',
             description  = 'Status counter reset',


### PR DESCRIPTION
### Description
- [adding measured eyeWidth status port](https://github.com/slaclab/surf/commit/101cdd395963631b94b372e8154836e51dec9dbb)
- [adding EyeWidth status register to sugoi](https://github.com/slaclab/surf/commit/dbdea1f1829dc96d104c5c6029f101c8716040ee)
- [adding EyeWidth status register to ssp](https://github.com/slaclab/surf/commit/02aea9510fffa691c2ae42a1943eafa4e81a4cc9)