### PR TITLE
Renamed 'context' to 'ctx' due to VHDL2008 conflict

### DIFF
--- a/protocols/saci/sim/FrontEndSaciPkg.vhd
+++ b/protocols/saci/sim/FrontEndSaciPkg.vhd
@@ -41,7 +41,7 @@ package FrontEndSaciPkg is
   type FrontEndSaciCmdCntlOutType is record
     cmdEn     : sl;                     -- Command available
     cmdOpCode : slv(7 downto 0);        -- Command Op Code
-    cmdCtxOut : slv(23 downto 0);       -- Command payload
+    cmdCtxOut : slv(23 downto 0);       -- Command Context
   end record;
 
   -- Upstream Data Buffer Interface

--- a/protocols/saci/sim/FrontEndSaciPkg.vhd
+++ b/protocols/saci/sim/FrontEndSaciPkg.vhd
@@ -41,7 +41,7 @@ package FrontEndSaciPkg is
   type FrontEndSaciCmdCntlOutType is record
     cmdEn     : sl;                     -- Command available
     cmdOpCode : slv(7 downto 0);        -- Command Op Code
-    cmdCtxOut : slv(23 downto 0);       -- Command Context
+    cmdCtxOut : slv(23 downto 0);       -- Command payload
   end record;
 
   -- Upstream Data Buffer Interface

--- a/protocols/ssi/rtl/SsiCmdMaster.vhd
+++ b/protocols/ssi/rtl/SsiCmdMaster.vhd
@@ -138,7 +138,7 @@ begin
 
          case r.txnNumber is
             when "000" =>
-               v.cmdMaster.payload := fifoAxisMaster.tData(31 downto 8);
+               v.cmdMaster.ctx := fifoAxisMaster.tData(31 downto 8);
             when "001" =>
                v.cmdMaster.opCode := fifoAxisMaster.tData(7 downto 0);
             when "011" =>

--- a/protocols/ssi/rtl/SsiCmdMaster.vhd
+++ b/protocols/ssi/rtl/SsiCmdMaster.vhd
@@ -138,7 +138,7 @@ begin
 
          case r.txnNumber is
             when "000" =>
-               v.cmdMaster.context := fifoAxisMaster.tData(31 downto 8);
+               v.cmdMaster.payload := fifoAxisMaster.tData(31 downto 8);
             when "001" =>
                v.cmdMaster.opCode := fifoAxisMaster.tData(7 downto 0);
             when "011" =>

--- a/protocols/ssi/rtl/SsiCmdMasterPkg.vhd
+++ b/protocols/ssi/rtl/SsiCmdMasterPkg.vhd
@@ -28,7 +28,7 @@ package SsiCmdMasterPkg is
    type SsiCmdMasterType is record
       valid   : sl;                     -- Command Opcode is valid (formerly cmdEn)
       opCode  : slv(7 downto 0);        -- Command OpCode
-      payload : slv(23 downto 0);       -- Command payload
+      ctx     : slv(23 downto 0);       -- Command Context
    end record;
 
    type SsiCmdMasterArray is array (natural range <>) of SsiCmdMasterType;
@@ -36,6 +36,6 @@ package SsiCmdMasterPkg is
    constant SSI_CMD_MASTER_INIT_C : SsiCmdMasterType := (
       valid   => '0',
       opCode  => (others => '0'),
-      payload => (others => '0'));
+      ctx     => (others => '0'));
 
 end SsiCmdMasterPkg;

--- a/protocols/ssi/rtl/SsiCmdMasterPkg.vhd
+++ b/protocols/ssi/rtl/SsiCmdMasterPkg.vhd
@@ -28,7 +28,7 @@ package SsiCmdMasterPkg is
    type SsiCmdMasterType is record
       valid   : sl;                     -- Command Opcode is valid (formerly cmdEn)
       opCode  : slv(7 downto 0);        -- Command OpCode
-      context : slv(23 downto 0);       -- Command Context
+      payload : slv(23 downto 0);       -- Command payload
    end record;
 
    type SsiCmdMasterArray is array (natural range <>) of SsiCmdMasterType;
@@ -36,6 +36,6 @@ package SsiCmdMasterPkg is
    constant SSI_CMD_MASTER_INIT_C : SsiCmdMasterType := (
       valid   => '0',
       opCode  => (others => '0'),
-      context => (others => '0'));
+      payload => (others => '0'));
 
 end SsiCmdMasterPkg;


### PR DESCRIPTION
### Description
- Breaks the SsiCmdMaster API ... but necessary if we use more VHDL2008 in the future
- This will mostly impact older epix that need to upgrade their surf submodules

### Context (VHDL 2008)
- [A "context" is used to define a set of library and package use clauses into a single unit that can be reused.](https://www.edaplayground.com/x/5ep5)
