### PR TITLE
updating the ruckus.tcl to use non-symbolic link of proc.tcl

### DIFF
--- a/axi/axi-lite/ruckus.tcl
+++ b/axi/axi-lite/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/axi/axi-stream/ruckus.tcl
+++ b/axi/axi-stream/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/axi/axi4/ruckus.tcl
+++ b/axi/axi4/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/axi/bridge/ruckus.tcl
+++ b/axi/bridge/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/axi/dma/ruckus.tcl
+++ b/axi/dma/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/axi/ruckus.tcl
+++ b/axi/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadRuckusTcl "$::DIR_PATH/axi4"

--- a/base/crc/ruckus.tcl
+++ b/base/crc/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/base/delay/ruckus.tcl
+++ b/base/delay/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/base/fifo/ruckus.tcl
+++ b/base/fifo/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/base/general/ruckus.tcl
+++ b/base/general/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/base/ram/ruckus.tcl
+++ b/base/ram/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/inferred"

--- a/base/ruckus.tcl
+++ b/base/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/delay"

--- a/base/sync/ruckus.tcl
+++ b/base/sync/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad5780/ruckus.tcl
+++ b/devices/AnalogDevices/ad5780/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad9249/7Series/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/7Series/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad9249/UltraScale/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/UltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad9249/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/core"

--- a/devices/AnalogDevices/ad9467/ruckus.tcl
+++ b/devices/AnalogDevices/ad9467/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad9681/7Series/ruckus.tcl
+++ b/devices/AnalogDevices/ad9681/7Series/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ad9681/ruckus.tcl
+++ b/devices/AnalogDevices/ad9681/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/core"

--- a/devices/AnalogDevices/general/ruckus.tcl
+++ b/devices/AnalogDevices/general/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/AnalogDevices/ruckus.tcl
+++ b/devices/AnalogDevices/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/ad5780"

--- a/devices/Linear/lct2270/ruckus.tcl
+++ b/devices/Linear/lct2270/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Linear/ruckus.tcl
+++ b/devices/Linear/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/lct2270"

--- a/devices/Marvell/Sgmii88E1111/ruckus.tcl
+++ b/devices/Marvell/Sgmii88E1111/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the source code
 loadSource -lib surf -dir "$::DIR_PATH/core"

--- a/devices/Marvell/ruckus.tcl
+++ b/devices/Marvell/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/Sgmii88E1111"

--- a/devices/Maxim/ruckus.tcl
+++ b/devices/Maxim/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the source code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Microchip/ruckus.tcl
+++ b/devices/Microchip/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/sy56040"

--- a/devices/Microchip/sy56040/ruckus.tcl
+++ b/devices/Microchip/sy56040/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Micron/ddr3/ruckus.tcl
+++ b/devices/Micron/ddr3/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load target's source code and constraints
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/devices/Micron/ddr4/ruckus.tcl
+++ b/devices/Micron/ddr4/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load target's source code and constraints
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/devices/Micron/mt28ew/ruckus.tcl
+++ b/devices/Micron/mt28ew/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Micron/n25q/ruckus.tcl
+++ b/devices/Micron/n25q/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Micron/p30/ruckus.tcl
+++ b/devices/Micron/p30/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Micron/ruckus.tcl
+++ b/devices/Micron/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/ddr3"

--- a/devices/Nxp/Sc18Is602/ruckus.tcl
+++ b/devices/Nxp/Sc18Is602/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Nxp/ruckus.tcl
+++ b/devices/Nxp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/Sc18Is602"

--- a/devices/Silabs/ruckus.tcl
+++ b/devices/Silabs/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/si5324"

--- a/devices/Silabs/si5324/ruckus.tcl
+++ b/devices/Silabs/si5324/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Silabs/si5345/ruckus.tcl
+++ b/devices/Silabs/si5345/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/Lmk048Base/ruckus.tcl
+++ b/devices/Ti/Lmk048Base/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/adc32rf45/ruckus.tcl
+++ b/devices/Ti/adc32rf45/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/ads42lb69/ruckus.tcl
+++ b/devices/Ti/ads42lb69/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/ads54j60/ruckus.tcl
+++ b/devices/Ti/ads54j60/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/dac7654/ruckus.tcl
+++ b/devices/Ti/dac7654/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/Ti/dp83867/ruckus.tcl
+++ b/devices/Ti/dp83867/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the source code
 loadSource -lib surf -dir "$::DIR_PATH/core"

--- a/devices/Ti/ruckus.tcl
+++ b/devices/Ti/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/adc32rf45"

--- a/devices/Xilinx/ruckus.tcl
+++ b/devices/Xilinx/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/xcf128"

--- a/devices/Xilinx/xcf128/ruckus.tcl
+++ b/devices/Xilinx/xcf128/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/devices/ruckus.tcl
+++ b/devices/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/AnalogDevices"

--- a/devices/transceivers/ruckus.tcl
+++ b/devices/transceivers/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/dsp/ruckus.tcl
+++ b/dsp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/core"   -fileType "VHDL 2008"

--- a/ethernet/Caui4Core/gtyUltraScale+/ruckus.tcl
+++ b/ethernet/Caui4Core/gtyUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2021.1 } {

--- a/ethernet/Caui4Core/ruckus.tcl
+++ b/ethernet/Caui4Core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Get the family type
 set family [getFpgaArch]

--- a/ethernet/EthMacCore/ruckus.tcl
+++ b/ethernet/EthMacCore/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/ethernet/GigEthCore/core/ruckus.tcl
+++ b/ethernet/GigEthCore/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/ethernet/GigEthCore/gth7/ruckus.tcl
+++ b/ethernet/GigEthCore/gth7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/ethernet/GigEthCore/gthUltraScale+/ruckus.tcl
+++ b/ethernet/GigEthCore/gthUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2017.3 } {

--- a/ethernet/GigEthCore/gthUltraScale/ruckus.tcl
+++ b/ethernet/GigEthCore/gthUltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/ethernet/GigEthCore/gtp7/ruckus.tcl
+++ b/ethernet/GigEthCore/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/ethernet/GigEthCore/gtx7/ruckus.tcl
+++ b/ethernet/GigEthCore/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/ethernet/GigEthCore/gtyUltraScale+/ruckus.tcl
+++ b/ethernet/GigEthCore/gtyUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2017.3 } {

--- a/ethernet/GigEthCore/lvdsUltraScale/ruckus.tcl
+++ b/ethernet/GigEthCore/lvdsUltraScale/ruckus.tcl
@@ -1,4 +1,4 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/ethernet/GigEthCore/ruckus.tcl
+++ b/ethernet/GigEthCore/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/ethernet/IpV4Engine/ruckus.tcl
+++ b/ethernet/IpV4Engine/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/ethernet/RawEthFramer/ruckus.tcl
+++ b/ethernet/RawEthFramer/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/ethernet/TenGigEthCore/core/ruckus.tcl
+++ b/ethernet/TenGigEthCore/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/ethernet/TenGigEthCore/gth7/ruckus.tcl
+++ b/ethernet/TenGigEthCore/gth7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2015.3 } {

--- a/ethernet/TenGigEthCore/gthUltraScale+/ruckus.tcl
+++ b/ethernet/TenGigEthCore/gthUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2018.3 } {

--- a/ethernet/TenGigEthCore/gthUltraScale/ruckus.tcl
+++ b/ethernet/TenGigEthCore/gthUltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2015.4 } {

--- a/ethernet/TenGigEthCore/gtx7/ruckus.tcl
+++ b/ethernet/TenGigEthCore/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/ethernet/TenGigEthCore/gtyUltraScale+/ruckus.tcl
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2018.3 } {

--- a/ethernet/TenGigEthCore/ruckus.tcl
+++ b/ethernet/TenGigEthCore/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/ethernet/UdpEngine/ruckus.tcl
+++ b/ethernet/UdpEngine/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/ethernet/XauiCore/core/ruckus.tcl
+++ b/ethernet/XauiCore/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/ethernet/XauiCore/gth7/ruckus.tcl
+++ b/ethernet/XauiCore/gth7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2014.4 } {

--- a/ethernet/XauiCore/gthUltraScale+/ruckus.tcl
+++ b/ethernet/XauiCore/gthUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2017.3 } {

--- a/ethernet/XauiCore/gthUltraScale/ruckus.tcl
+++ b/ethernet/XauiCore/gthUltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2015.4 } {

--- a/ethernet/XauiCore/gtx7/ruckus.tcl
+++ b/ethernet/XauiCore/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2014.4 } {

--- a/ethernet/XauiCore/gtyUltraScale+/ruckus.tcl
+++ b/ethernet/XauiCore/gtyUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2017.4 } {

--- a/ethernet/XauiCore/ruckus.tcl
+++ b/ethernet/XauiCore/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/ethernet/XlauiCore/core/ruckus.tcl
+++ b/ethernet/XlauiCore/core/ruckus.tcl
@@ -1,2 +1,2 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl

--- a/ethernet/XlauiCore/gth7/ruckus.tcl
+++ b/ethernet/XlauiCore/gth7/ruckus.tcl
@@ -1,2 +1,2 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl

--- a/ethernet/XlauiCore/gthUltraScale+/ruckus.tcl
+++ b/ethernet/XlauiCore/gthUltraScale+/ruckus.tcl
@@ -1,2 +1,2 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl

--- a/ethernet/XlauiCore/gthUltraScale/ruckus.tcl
+++ b/ethernet/XlauiCore/gthUltraScale/ruckus.tcl
@@ -1,2 +1,2 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl

--- a/ethernet/XlauiCore/gtx7/ruckus.tcl
+++ b/ethernet/XlauiCore/gtx7/ruckus.tcl
@@ -1,2 +1,2 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl

--- a/ethernet/XlauiCore/ruckus.tcl
+++ b/ethernet/XlauiCore/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/ethernet/ruckus.tcl
+++ b/ethernet/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/EthMacCore"

--- a/protocols/batcher/ruckus.tcl
+++ b/protocols/batcher/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/clink/ruckus.tcl
+++ b/protocols/clink/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Get the family type
 set family [getFpgaArch]

--- a/protocols/glink/core/ruckus.tcl
+++ b/protocols/glink/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/glink/gtp7/ruckus.tcl
+++ b/protocols/glink/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/glink/gtx7/ruckus.tcl
+++ b/protocols/glink/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/glink/ruckus.tcl
+++ b/protocols/glink/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/protocols/hamming-ecc/ruckus.tcl
+++ b/protocols/hamming-ecc/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/htsp/core/ruckus.tcl
+++ b/protocols/htsp/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/htsp/gtyUs+/ruckus.tcl
+++ b/protocols/htsp/gtyUs+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/htsp/ruckus.tcl
+++ b/protocols/htsp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/protocols/i2c/ruckus.tcl
+++ b/protocols/i2c/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/jesd204b/ruckus.tcl
+++ b/protocols/jesd204b/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/jtag/ruckus.tcl
+++ b/protocols/jtag/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 if { ($::env(VIVADO_VERSION) >= 2016.4) && ([isVersal] != true) } {
 

--- a/protocols/line-codes/ruckus.tcl
+++ b/protocols/line-codes/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/mdio/ruckus.tcl
+++ b/protocols/mdio/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/packetizer/ruckus.tcl
+++ b/protocols/packetizer/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2b/core/ruckus.tcl
+++ b/protocols/pgp/pgp2b/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2b/gth7/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gth7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2b/gthUltraScale+/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gthUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load local source Code and constraints
 if { $::env(VIVADO_VERSION) >= 2018.3 } {

--- a/protocols/pgp/pgp2b/gthUltraScale/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gthUltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load local source Code and constraints
 if { $::env(VIVADO_VERSION) >= 2017.3 } {

--- a/protocols/pgp/pgp2b/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2b/gtx7/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2b/gtyUltraScale+/ruckus.tcl
+++ b/protocols/pgp/pgp2b/gtyUltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load local source Code and constraints
 if { $::env(VIVADO_VERSION) >= 2020.1 } {

--- a/protocols/pgp/pgp2b/ruckus.tcl
+++ b/protocols/pgp/pgp2b/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/protocols/pgp/pgp3/core/ruckus.tcl
+++ b/protocols/pgp/pgp3/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp3/gthUs+/ruckus.tcl
+++ b/protocols/pgp/pgp3/gthUs+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2020.1 } {

--- a/protocols/pgp/pgp3/gthUs/ruckus.tcl
+++ b/protocols/pgp/pgp3/gthUs/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2020.1 } {

--- a/protocols/pgp/pgp3/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp3/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2018.2 } {

--- a/protocols/pgp/pgp3/gtx7/ruckus.tcl
+++ b/protocols/pgp/pgp3/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2018.1 } {

--- a/protocols/pgp/pgp3/gtyUs+/ruckus.tcl
+++ b/protocols/pgp/pgp3/gtyUs+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2020.1 } {

--- a/protocols/pgp/pgp3/ruckus.tcl
+++ b/protocols/pgp/pgp3/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/protocols/pgp/pgp4/asic/ruckus.tcl
+++ b/protocols/pgp/pgp4/asic/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/core/ruckus.tcl
+++ b/protocols/pgp/pgp4/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gthUs+/ruckus.tcl
+++ b/protocols/pgp/pgp4/gthUs+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gthUs/ruckus.tcl
+++ b/protocols/pgp/pgp4/gthUs/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtx7/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/gtyUs+/ruckus.tcl
+++ b/protocols/pgp/pgp4/gtyUs+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"

--- a/protocols/pgp/ruckus.tcl
+++ b/protocols/pgp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/pgp2b"

--- a/protocols/pmbus/ruckus.tcl
+++ b/protocols/pmbus/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/rssi/ruckus.tcl
+++ b/protocols/rssi/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 loadRuckusTcl "$::DIR_PATH/v1"
 loadRuckusTcl "$::DIR_PATH/v1b"

--- a/protocols/rssi/v1/ruckus.tcl
+++ b/protocols/rssi/v1/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/rssi/v1b/ruckus.tcl
+++ b/protocols/rssi/v1b/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/ruckus.tcl
+++ b/protocols/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/batcher"

--- a/protocols/saci/ruckus.tcl
+++ b/protocols/saci/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/salt/ruckus.tcl
+++ b/protocols/salt/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Get the family type
 set family [getFpgaArch]

--- a/protocols/spi/ruckus.tcl
+++ b/protocols/spi/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/srp/ruckus.tcl
+++ b/protocols/srp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/ssi/ruckus.tcl
+++ b/protocols/ssi/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/ssp/ruckus.tcl
+++ b/protocols/ssp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/sugoi/ruckus.tcl
+++ b/protocols/sugoi/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/uart/ruckus.tcl
+++ b/protocols/uart/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/xvc-udp/dcp/7Series/ruckus.tcl
+++ b/protocols/xvc-udp/dcp/7Series/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load submodules' code and constraints
 loadRuckusTcl $::env(MODULES)/surf

--- a/protocols/xvc-udp/dcp/UltraScale/ruckus.tcl
+++ b/protocols/xvc-udp/dcp/UltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load submodules' code and constraints
 loadRuckusTcl $::env(MODULES)/surf

--- a/protocols/xvc-udp/ruckus.tcl
+++ b/protocols/xvc-udp/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 if { [isVersal] == true } {
    set versalType true

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS environment and library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {

--- a/xilinx/7Series/general/ruckus.tcl
+++ b/xilinx/7Series/general/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/7Series/gth7/ruckus.tcl
+++ b/xilinx/7Series/gth7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/7Series/gtp7/ruckus.tcl
+++ b/xilinx/7Series/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/7Series/gtx7/ruckus.tcl
+++ b/xilinx/7Series/gtx7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/7Series/ruckus.tcl
+++ b/xilinx/7Series/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/general"

--- a/xilinx/7Series/sem/ruckus.tcl
+++ b/xilinx/7Series/sem/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2016.4 } {

--- a/xilinx/7Series/xadc/ruckus.tcl
+++ b/xilinx/7Series/xadc/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 if { $::env(VIVADO_VERSION) >= 2015.2 } {

--- a/xilinx/UltraScale+/clocking/ruckus.tcl
+++ b/xilinx/UltraScale+/clocking/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/UltraScale+/gthUs/ruckus.tcl
+++ b/xilinx/UltraScale+/gthUs/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/UltraScale+/ruckus.tcl
+++ b/xilinx/UltraScale+/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/../UltraScale/general"

--- a/xilinx/UltraScale/clocking/ruckus.tcl
+++ b/xilinx/UltraScale/clocking/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/UltraScale/general/ruckus.tcl
+++ b/xilinx/UltraScale/general/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/UltraScale/gthUs/ruckus.tcl
+++ b/xilinx/UltraScale/gthUs/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/xilinx/UltraScale/ruckus.tcl
+++ b/xilinx/UltraScale/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/general"

--- a/xilinx/general/microblaze/ruckus.tcl
+++ b/xilinx/general/microblaze/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Check if Microblaze source code path defined
 if { [info exists ::env(VITIS_SRC_PATH)] != 1 }  {

--- a/xilinx/general/ruckus.tcl
+++ b/xilinx/general/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/microblaze"

--- a/xilinx/ruckus.tcl
+++ b/xilinx/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/general"


### PR DESCRIPTION
### Description
- In a future release of ruckus, I would like to get rid of this symbolic link to clean things up in that repo