### PR TITLE
Update SugoiSubordinateFsm.vhd

### DIFF
--- a/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
+++ b/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
@@ -518,6 +518,21 @@ begin
          v.devSelected := '0';
       end if;
 
+      -- Check for global reset
+      if (r.rst = '1') then
+
+         -- Reset counters
+         v.byteCnt := (others => '0');
+
+         -- Reset the state machine
+         v.state := RX_SOF_S;
+
+         -- Reset the AXI-Lite interface
+         v.axilReadMaster  := AXI_LITE_READ_MASTER_INIT_C;
+         v.axilWriteMaster := AXI_LITE_WRITE_MASTER_INIT_C;
+
+      end if;
+
       -- Outputs
       linkup          <= r.linkup;
       rst             <= r.rst;


### PR DESCRIPTION
### Description
- Need to reset local AXI-Lite signals, state machine and counter during a global reset
- Else the AXI-Lite might get out of "lock step" if the global reset happens during the middle of a AXI-Lite transaction
- It is assumed that the global reset will be connected to all AXI-Lite end points's reset port in the device
