### PR TITLE
Enhancements to Pgp2bGtx7FixedLat

### DIFF
--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -229,9 +229,9 @@ begin
          OUT_POLARITY_G => '1',
          PULSE_WIDTH_G  => 100)
       port map (
-         clk     => stableClk,           -- [in]
-         dataIn  => phyRxInit,           -- [in]
-         dataOut => gtRxUserReset);      -- [out]
+         clk     => stableClk,          -- [in]
+         dataIn  => phyRxInit,          -- [in]
+         dataOut => gtRxUserReset);     -- [out]
 
    --------------------------------------------------------------------------------------------------
    -- Rx Data Path
@@ -359,7 +359,7 @@ begin
          rxMmcmLockedIn   => pgpRxMmcmLocked,
          rxUserResetIn    => gtRxUserReset,
          rxResetDoneOut   => gtRxResetDone,                -- Use for rxRecClkReset???
-         rxDataValidIn    => '1',       -- From 8b10b
+         rxDataValidIn    => dataValid,   -- From 8b10b
          rxSlideIn        => '0',       -- Slide is controlled internally
          rxDataOut        => gtRxData,
          rxCharIsKOut     => open,      -- Not using gt rx 8b10b

--- a/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtp7/rtl/Pgp2bGtp7FixedLat.vhd
@@ -359,7 +359,7 @@ begin
          rxMmcmLockedIn   => pgpRxMmcmLocked,
          rxUserResetIn    => gtRxUserReset,
          rxResetDoneOut   => gtRxResetDone,                -- Use for rxRecClkReset???
-         rxDataValidIn    => dataValid,   -- From 8b10b
+         rxDataValidIn    => '1',   -- From 8b10b
          rxSlideIn        => '0',       -- Slide is controlled internally
          rxDataOut        => gtRxData,
          rxCharIsKOut     => open,      -- Not using gt rx 8b10b

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLat.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLat.vhd
@@ -29,8 +29,8 @@ use UNISIM.VCOMPONENTS.all;
 
 entity Pgp2bGtx7Fixedlat is
    generic (
-      TPD_G : time := 1 ns;
-
+      TPD_G                 : time       := 1 ns;
+      COMMON_CLK_G          : boolean    := false;  -- set true if (stableClk = axilClk)
       ----------------------------------------------------------------------------------------------
       -- GT Settings
       ----------------------------------------------------------------------------------------------
@@ -52,9 +52,9 @@ entity Pgp2bGtx7Fixedlat is
       PMA_RSV_G             : bit_vector := x"00018480";
       RX_OS_CFG_G           : bit_vector := "0000010000000";        -- Set by wizard
       RXCDR_CFG_G           : bit_vector := x"03000023ff40200020";  -- Set by wizard
-      RXDFEXYDEN_G          : sl         := '0';                    -- Set by wizard
+      RXDFEXYDEN_G          : sl         := '0';    -- Set by wizard
       RX_DFE_KL_CFG2_G      : bit_vector := x"3008E56A";            -- Set by wizard
-      RX_EQUALIZER_G        : string     := "DFE";        -- Or "LPM"
+      RX_EQUALIZER_G        : string     := "DFE";  -- Or "LPM"
       -- Allow TX to run in var lat mode by altering these generics
       TX_BUF_EN_G           : boolean    := false;
       TX_OUTCLK_SRC_G       : string     := "PLLREFCLK";
@@ -93,8 +93,10 @@ entity Pgp2bGtx7Fixedlat is
       gtTxP : out sl;                   -- GT Serial Transmit Positive
 
       -- Tx Clocking
-      pgpTxReset : in sl;
-      pgpTxClk   : in sl;
+      pgpTxReset      : in  sl;
+      pgpTxClk        : in  sl;
+      pgpTxMmcmReset  : out sl := '0';
+      pgpTxMmcmLocked : in  sl := '1';
 
       -- Rx clocking
       pgpRxReset      : in  sl;
@@ -154,6 +156,7 @@ architecture rtl of Pgp2bGtx7Fixedlat is
    -- PgpRx Signals
    signal gtRxData      : slv(19 downto 0);                -- Feed to 8B10B decoder
    signal dataValid     : sl;                              -- no decode or disparity errors
+   signal dataValidTmp  : sl;                              -- no decode or disparity errors      
    signal phyRxLanesIn  : Pgp2bRxPhyLaneInArray(0 to 0);   -- Output from decoder
    signal phyRxLanesOut : Pgp2bRxPhyLaneOutArray(0 to 0);  -- Polarity to GT
    signal phyRxReady    : sl;                              -- To RxRst
@@ -170,12 +173,13 @@ architecture rtl of Pgp2bGtx7Fixedlat is
    signal phyTxLanesOut : Pgp2bTxPhyLaneOutArray(0 to 0);
    signal phyTxReady    : sl;
 
-   signal drpRdy  : sl;
-   signal drpEn   : sl;
-   signal drpWe   : sl;
-   signal drpAddr : slv(8 downto 0);
-   signal drpDi   : slv(15 downto 0);
-   signal drpDo   : slv(15 downto 0);
+   signal stableRst : sl;
+   signal drpRdy    : sl;
+   signal drpEn     : sl;
+   signal drpWe     : sl;
+   signal drpAddr   : slv(8 downto 0);
+   signal drpDi     : slv(15 downto 0);
+   signal drpDo     : slv(15 downto 0);
 
 begin
 
@@ -213,8 +217,22 @@ begin
          phyRxLanesOut    => phyRxLanesOut,
          phyRxLanesIn     => phyRxLanesIn,
          phyRxReady       => gtRxResetDone,
-         phyRxInit        => gtRxUserReset   -- Ignore phyRxInit, rx will reset on its own
+         phyRxInit        => phyRxInit       -- Ignore phyRxInit, rx will reset on its own
          );
+
+   -------------------------------------------------------------------------------------------------
+   -- Oneshot the phy init because clock may drop out and leave it stuck high
+   -------------------------------------------------------------------------------------------------
+   U_gtRxUserReset : entity surf.SynchronizerOneShot
+      generic map (
+         TPD_G          => TPD_G,
+         IN_POLARITY_G  => '1',
+         OUT_POLARITY_G => '1',
+         PULSE_WIDTH_G  => 100)
+      port map (
+         clk     => stableClk,          -- [in]
+         dataIn  => phyRxInit,          -- [in]
+         dataOut => gtRxUserReset);     -- [out]
 
    --------------------------------------------------------------------------------------------------
    -- Rx Data Path
@@ -235,7 +253,25 @@ begin
          codeErr  => phyRxLanesIn(0).decErr,
          dispErr  => phyRxLanesIn(0).dispErr);
 
-   dataValid <= not (uOr(phyRxLanesIn(0).decErr) or uOr(phyRxLanesIn(0).dispErr));
+   dataValidTmp <= not (uOr(phyRxLanesIn(0).decErr) or uOr(phyRxLanesIn(0).dispErr));
+
+   -------------------------------------------------------------------------------------------------
+   -- Filter on dataValid so that it doesn't drop immediately on errors
+   -- Not currently hooked up but leaving it in so we can try it someday.
+   -------------------------------------------------------------------------------------------------
+   U_Pgp3RxGearboxAligner_1 : entity surf.Pgp3RxGearboxAligner
+      generic map (
+         TPD_G       => TPD_G,
+         SLIP_WAIT_G => 1)
+      port map (
+         clk           => pgpRxClk,        -- [in]
+         rst           => gtRxResetDoneL,  -- [in]
+         rxHeader(0)   => dataValidTmp,    -- [in]
+         rxHeader(1)   => '0',             -- [in]
+         rxHeaderValid => '1',             -- [in]
+         slip          => open,            -- [out]
+         locked        => dataValid);      -- [out]
+
 
    pgpRxRecClkRst <= gtRxResetDoneL;
 
@@ -328,7 +364,7 @@ begin
          rxMmcmLockedIn   => pgpRxMmcmLocked,
          rxUserResetIn    => gtRxUserReset,
          rxResetDoneOut   => gtRxResetDone,                -- Use for rxRecClkReset???
-         rxDataValidIn    => dataValid,   -- From 8b10b
+         rxDataValidIn    => '1',       -- From 8b10b
          rxSlideIn        => '0',       -- Slide is controlled internally
          rxDataOut        => gtRxData,
          rxCharIsKOut     => open,      -- Not using gt rx 8b10b
@@ -340,8 +376,8 @@ begin
          txUsrClkIn       => gtTxUsrClk,
          txUsrClk2In      => gtTxUsrClk,
          txUserRdyOut     => open,      -- Not sure what to do with this
-         txMmcmResetOut   => open,      -- No Tx MMCM in Fixed Latency mode
-         txMmcmLockedIn   => '1',
+         txMmcmResetOut   => pgpTxMmcmReset,               -- No Tx MMCM in Fixed Latency mode
+         txMmcmLockedIn   => pgpTxMmcmLocked,
          txUserResetIn    => pgpTxReset,
          txResetDoneOut   => gtTxResetDone,
          txDataIn         => phyTxLanesOut(0).data,
@@ -352,7 +388,7 @@ begin
          txPreCursor      => txPreCursor,
          txPostCursor     => txPostCursor,
          txDiffCtrl       => txDiffCtrl,
-         drpClk           => axilClk,
+         drpClk           => stableClk,
          drpRdy           => drpRdy,
          drpEn            => drpEn,
          drpWe            => drpWe,
@@ -363,8 +399,8 @@ begin
    U_AxiLiteToDrp : entity surf.AxiLiteToDrp
       generic map (
          TPD_G            => TPD_G,
-         COMMON_CLK_G     => true,
-         EN_ARBITRATION_G => false,
+         COMMON_CLK_G     => COMMON_CLK_G,
+         EN_ARBITRATION_G => true,
          TIMEOUT_G        => 4096,
          ADDR_WIDTH_G     => 9,
          DATA_WIDTH_G     => 16)
@@ -377,13 +413,27 @@ begin
          axilWriteMaster => axilWriteMaster,
          axilWriteSlave  => axilWriteSlave,
          -- DRP Interface
-         drpClk          => axilClk,
-         drpRst          => axilRst,
+         drpClk          => stableClk,
+         drpRst          => stableRst,
          drpRdy          => drpRdy,
          drpEn           => drpEn,
          drpWe           => drpWe,
          drpAddr         => drpAddr,
          drpDi           => drpDi,
          drpDo           => drpDo);
+
+   GEN_RST : if (COMMON_CLK_G = false) generate
+      U_RstSync : entity surf.RstSync
+         generic map (
+            TPD_G => TPD_G)
+         port map (
+            clk      => stableClk,
+            asyncRst => axilRst,
+            syncRst  => stableRst);
+   end generate;
+
+   BYP_RST_SYNC : if (COMMON_CLK_G = true) generate
+      stableRst <= axilRst;
+   end generate;
 
 end rtl;

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -252,11 +252,11 @@ begin
 
    -- pgpTxClk and stable clock might be the same
    pgpTxClkBase <= txOutClk when TX_USER_CLK_SRC_G = "txOutClk" else
+                   stableClk when STABLE_CLK_SRC_G = TX_USER_CLK_SRC_G else                   
                    gtClk0 when TX_USER_CLK_SRC_G = "gtClk0" else
                    gtClk0Div2 when TX_USER_CLK_SRC_G = "gtClk0Div2" else
                    gtClk1 when TX_USER_CLK_SRC_G = "gtClk1" else
                    gtClk1Div2 when TX_USER_CLK_SRC_G = "gtClk1Div2" else                   
-                   stableClk when STABLE_CLK_SRC_G = TX_REFCLK_SRC_G else
                    txRefClk;
 
    TX_CM_GEN : if (TX_CM_EN_G) generate
@@ -290,7 +290,7 @@ begin
    NO_TX_CM_GEN : if (not TX_CM_EN_G) generate
       pgpTxMmcmLocked <= '1';
       
-      PGP_TX_CLK_BUFG : if (TX_USER_CLK_SRC_G = "txOutClk") or (TX_REFCLK_SRC_G /= STABLE_CLK_SRC_G) generate
+      PGP_TX_CLK_BUFG : if (TX_USER_CLK_SRC_G = "txOutClk") generate
          BUFG_pgpTxClk : BUFG
             port map (
                i => pgpTxClkBase,
@@ -307,7 +307,7 @@ begin
                syncRst  => pgpTxReset);  -- [out]
 
       end generate PGP_TX_CLK_BUFG;
-      NO_PGP_TX_CLK_BUFG : if (TX_USER_CLK_SRC_G /= "txOutClk") and (TX_REFCLK_SRC_G = STABLE_CLK_SRC_G) generate
+      NO_PGP_TX_CLK_BUFG : if (TX_USER_CLK_SRC_G /= "txOutClk") generate
          pgpTxClk   <= pgpTxClkBase;
          pgpTxReset <= stableRst;
       end generate;

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -252,11 +252,11 @@ begin
 
    -- pgpTxClk and stable clock might be the same
    pgpTxClkBase <= txOutClk when TX_USER_CLK_SRC_G = "txOutClk" else
-                   stableClk when STABLE_CLK_SRC_G = TX_USER_CLK_SRC_G else                   
-                   gtClk0 when TX_USER_CLK_SRC_G = "gtClk0" else
+                   stableClk  when STABLE_CLK_SRC_G = TX_USER_CLK_SRC_G else
+                   gtClk0     when TX_USER_CLK_SRC_G = "gtClk0" else
                    gtClk0Div2 when TX_USER_CLK_SRC_G = "gtClk0Div2" else
-                   gtClk1 when TX_USER_CLK_SRC_G = "gtClk1" else
-                   gtClk1Div2 when TX_USER_CLK_SRC_G = "gtClk1Div2" else                   
+                   gtClk1     when TX_USER_CLK_SRC_G = "gtClk1" else
+                   gtClk1Div2 when TX_USER_CLK_SRC_G = "gtClk1Div2" else
                    txRefClk;
 
    TX_CM_GEN : if (TX_CM_EN_G) generate
@@ -289,7 +289,7 @@ begin
 
    NO_TX_CM_GEN : if (not TX_CM_EN_G) generate
       pgpTxMmcmLocked <= '1';
-      
+
       PGP_TX_CLK_BUFG : if (TX_USER_CLK_SRC_G = "txOutClk") generate
          BUFG_pgpTxClk : BUFG
             port map (

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -79,13 +79,13 @@ entity Pgp2bGtx7FixedLatWrapper is
    port (
       -- Manual Reset
       stableClkIn      : in  sl                               := '0';
-      extRst           : in  sl := '0';;
+      extRst           : in  sl                               := '0';
       -- Status and Clock Signals
       txPllLock        : out sl;
       rxPllLock        : out sl;
       -- Output internally configured clocks
       pgpTxClkOut      : out sl;
-      pgpTxRstOut      : out sl;      
+      pgpTxRstOut      : out sl;
       pgpRxClkOut      : out sl;
       pgpRxRstOut      : out sl;
       stableClkOut     : out sl;
@@ -101,7 +101,7 @@ entity Pgp2bGtx7FixedLatWrapper is
       -- Frame Receive Interface - 1 Lane, Array of 4 VCs
       pgpRxMasters     : out AxiStreamMasterArray(3 downto 0);
       pgpRxMasterMuxed : out AxiStreamMasterType;
-      pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
+      pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0)   := (others => AXI_STREAM_CTRL_UNUSED_C);
       -- GT Pins
       gtgClk           : in  sl                               := '0';
       gtClk0P          : in  sl                               := '0';

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -31,54 +31,61 @@ use unisim.vcomponents.all;
 
 entity Pgp2bGtx7FixedLatWrapper is
    generic (
-      TPD_G                   : time                 := 1 ns;
-      SIM_GTRESET_SPEEDUP_G   : string               := "FALSE";
-      SIM_VERSION_G           : string               := "4.0";
-      SIMULATION_G            : boolean              := false;
+      TPD_G                   : time                   := 1 ns;
+      SIM_GTRESET_SPEEDUP_G   : string                 := "FALSE";
+      SIM_VERSION_G           : string                 := "4.0";
+      SIMULATION_G            : boolean                := false;
       -- PGP Settings
-      VC_INTERLEAVE_G         : integer              := 0;         -- No interleave Frames
-      PAYLOAD_CNT_TOP_G       : integer              := 7;         -- Top bit for payload counter
-      NUM_VC_EN_G             : integer range 1 to 4 := 4;
-      TX_POLARITY_G           : sl                   := '0';
-      RX_POLARITY_G           : sl                   := '0';
-      TX_ENABLE_G             : boolean              := true;      -- Enable TX direction
-      RX_ENABLE_G             : boolean              := true;      -- Enable RX direction
+      VC_INTERLEAVE_G         : integer                := 0;         -- No interleave Frames
+      PAYLOAD_CNT_TOP_G       : integer                := 7;         -- Top bit for payload counter
+      NUM_VC_EN_G             : integer range 1 to 4   := 4;
+      TX_POLARITY_G           : sl                     := '0';
+      RX_POLARITY_G           : sl                     := '0';
+      TX_ENABLE_G             : boolean                := true;      -- Enable TX direction
+      RX_ENABLE_G             : boolean                := true;      -- Enable RX direction
       -- CM Configurations
-      TX_CM_EN_G              : boolean              := false;
-      TX_CM_TYPE_G            : string               := "MMCM";
-      TX_CM_CLKIN_PERIOD_G    : real                 := 8.000;
-      TX_CM_DIVCLK_DIVIDE_G   : natural              := 8;
-      TX_CM_CLKFBOUT_MULT_F_G : real                 := 8.000;
-      TX_CM_CLKOUT_DIVIDE_F_G : real                 := 8.000;
-      RX_CM_EN_G              : boolean              := false;
-      RX_CM_TYPE_G            : string               := "MMCM";
-      RX_CM_CLKIN_PERIOD_G    : real                 := 8.000;
-      RX_CM_DIVCLK_DIVIDE_G   : natural              := 8;
-      RX_CM_CLKFBOUT_MULT_F_G : real                 := 8.000;
-      RX_CM_CLKOUT_DIVIDE_F_G : real                 := 8.000;
+      TX_CM_EN_G              : boolean                := false;
+      TX_CM_TYPE_G            : string                 := "MMCM";
+      TX_CM_BANDWIDTH_G       : string                 := "OPTIMIZED";
+      TX_CM_CLKIN_PERIOD_G    : real                   := 8.000;
+      TX_CM_DIVCLK_DIVIDE_G   : natural                := 8;
+      TX_CM_CLKFBOUT_MULT_F_G : real                   := 8.000;
+      TX_CM_CLKFBOUT_MULT_G   : integer range 2 to 64  := 8;
+      TX_CM_CLKOUT_DIVIDE_F_G : real                   := 8.000;
+      TX_CM_CLKOUT_DIVIDE_G   : integer range 1 to 128 := 8;
+      RX_CM_EN_G              : boolean                := false;
+      RX_CM_TYPE_G            : string                 := "MMCM";
+      RX_CM_BANDWIDTH_G       : string                 := "OPTIMIZED";
+      RX_CM_CLKIN_PERIOD_G    : real                   := 8.000;
+      RX_CM_DIVCLK_DIVIDE_G   : natural                := 8;
+      RX_CM_CLKFBOUT_MULT_F_G : real                   := 8.000;
+      RX_CM_CLKFBOUT_MULT_G   : integer range 2 to 64  := 8;
+      RX_CM_CLKOUT_DIVIDE_F_G : real                   := 8.000;
+      RX_CM_CLKOUT_DIVIDE_G   : integer range 1 to 128 := 8;
       -- MGT Configurations
-      PMA_RSV_G               : bit_vector           := x"00018480";
-      RX_OS_CFG_G             : bit_vector           := "0000010000000";        -- Set by wizard
-      RXCDR_CFG_G             : bit_vector           := x"03000023ff40200020";  -- Set by wizard
-      RXDFEXYDEN_G            : sl                   := '0';       -- Set by wizard
-      RX_DFE_KL_CFG2_G        : bit_vector           := x"3008E56A";
+      PMA_RSV_G               : bit_vector             := x"00018480";
+      RX_OS_CFG_G             : bit_vector             := "0000010000000";        -- Set by wizard
+      RXCDR_CFG_G             : bit_vector             := x"03000023ff40200020";  -- Set by wizard
+      RXDFEXYDEN_G            : sl                     := '0';       -- Set by wizard
+      RX_DFE_KL_CFG2_G        : bit_vector             := x"3008E56A";
       -- PLL and clock configurations
-      STABLE_CLK_SRC_G        : string               := "gtClk0";  -- or "gtClk0" or "gtClk1"
-      TX_REFCLK_SRC_G         : string               := "gtClk0";
-      RX_REFCLK_SRC_G         : string               := "gtClk1";
-      CPLL_CFG_G              : Gtx7CPllCfgType      := getGtx7CPllCfg(250.0E6, 3.125E9);
-      QPLL_CFG_G              : Gtx7QPllCfgType      := getGtx7QPllCfg(156.25e6, 3.125e9);
-      TX_PLL_G                : string               := "QPLL";
-      RX_PLL_G                : string               := "CPLL");
+      STABLE_CLK_SRC_G        : string                 := "gtClk0";  -- or "gtClk0" or "gtClk1"
+      TX_REFCLK_SRC_G         : string                 := "gtClk0";
+      RX_REFCLK_SRC_G         : string                 := "gtClk1";
+      CPLL_CFG_G              : Gtx7CPllCfgType        := getGtx7CPllCfg(250.0E6, 3.125E9);
+      QPLL_CFG_G              : Gtx7QPllCfgType        := getGtx7QPllCfg(156.25e6, 3.125e9);
+      TX_PLL_G                : string                 := "QPLL";
+      RX_PLL_G                : string                 := "CPLL");
    port (
       -- Manual Reset
       stableClkIn      : in  sl                               := '0';
-      extRst           : in  sl;
+      extRst           : in  sl := '0';;
       -- Status and Clock Signals
       txPllLock        : out sl;
       rxPllLock        : out sl;
       -- Output internally configured clocks
       pgpTxClkOut      : out sl;
+      pgpTxRstOut      : out sl;      
       pgpRxClkOut      : out sl;
       pgpRxRstOut      : out sl;
       stableClkOut     : out sl;
@@ -94,7 +101,7 @@ entity Pgp2bGtx7FixedLatWrapper is
       -- Frame Receive Interface - 1 Lane, Array of 4 VCs
       pgpRxMasters     : out AxiStreamMasterArray(3 downto 0);
       pgpRxMasterMuxed : out AxiStreamMasterType;
-      pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0);
+      pgpRxCtrl        : in  AxiStreamCtrlArray(3 downto 0) := (others => AXI_STREAM_CTRL_UNUSED_C);
       -- GT Pins
       gtgClk           : in  sl                               := '0';
       gtClk0P          : in  sl                               := '0';
@@ -245,7 +252,7 @@ begin
             RST_IN_POLARITY_G  => '1',
             NUM_CLOCKS_G       => 1,
             -- MMCM attributes
-            BANDWIDTH_G        => "OPTIMIZED",
+            BANDWIDTH_G        => TX_CM_BANDWIDTH_G,
             CLKIN_PERIOD_G     => TX_CM_CLKIN_PERIOD_G,
             DIVCLK_DIVIDE_G    => TX_CM_DIVCLK_DIVIDE_G,
             CLKFBOUT_MULT_F_G  => TX_CM_CLKFBOUT_MULT_F_G,
@@ -282,7 +289,7 @@ begin
    end generate NO_TX_CM_GEN;
 
    -- PGP RX Reset
-   RstSync_pgpTxRst : entity surf.RstSync
+   RstSync_pgpRxRst : entity surf.RstSync
       generic map (
          TPD_G           => TPD_G,
          RELEASE_DELAY_G => 16,
@@ -421,7 +428,7 @@ begin
             INPUT_BUFG_G       => false,
             FB_BUFG_G          => true,
             NUM_CLOCKS_G       => 1,
-            BANDWIDTH_G        => "OPTIMIZED",
+            BANDWIDTH_G        => RX_CM_BANDWIDTH_G,
             CLKIN_PERIOD_G     => RX_CM_CLKIN_PERIOD_G,
             DIVCLK_DIVIDE_G    => RX_CM_DIVCLK_DIVIDE_G,
             CLKFBOUT_MULT_F_G  => RX_CM_CLKFBOUT_MULT_F_G,
@@ -450,6 +457,8 @@ begin
    end generate RxClkNoMmcmGen;
 
    pgpRxClkOut <= pgpRxClkLoc;
+   pgpTxClkOut <= pgpTxClk;
+   pgpTxRstOut <= pgpTxReset;
 
    stableClkOut <= stableClk;
 

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -256,7 +256,9 @@ begin
             CLKIN_PERIOD_G     => TX_CM_CLKIN_PERIOD_G,
             DIVCLK_DIVIDE_G    => TX_CM_DIVCLK_DIVIDE_G,
             CLKFBOUT_MULT_F_G  => TX_CM_CLKFBOUT_MULT_F_G,
+            CLKFBOUT_MULT_G    => TX_CM_CLKFBOUT_MULT_G,
             CLKOUT0_DIVIDE_F_G => TX_CM_CLKOUT_DIVIDE_F_G,
+            CLKOUT0_DIVIDE_G   => TX_CM_CLKOUT_DIVIDE_G,
             CLKOUT0_RST_HOLD_G => 16)
          port map(
             clkIn     => pgpTxClkBase,
@@ -432,7 +434,9 @@ begin
             CLKIN_PERIOD_G     => RX_CM_CLKIN_PERIOD_G,
             DIVCLK_DIVIDE_G    => RX_CM_DIVCLK_DIVIDE_G,
             CLKFBOUT_MULT_F_G  => RX_CM_CLKFBOUT_MULT_F_G,
+            CLKFBOUT_MULT_G    => RX_CM_CLKFBOUT_MULT_G,
             CLKOUT0_DIVIDE_F_G => RX_CM_CLKOUT_DIVIDE_F_G,
+            CLKOUT0_DIVIDE_G   => RX_CM_CLKOUT_DIVIDE_G,
             CLKOUT0_RST_HOLD_G => 16)
          port map (
             clkIn     => pgpRxRecClk,

--- a/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
+++ b/protocols/pgp/pgp2b/gtx7/rtl/Pgp2bGtx7FixedLatWrapper.vhd
@@ -252,6 +252,10 @@ begin
 
    -- pgpTxClk and stable clock might be the same
    pgpTxClkBase <= txOutClk when TX_USER_CLK_SRC_G = "txOutClk" else
+                   gtClk0 when TX_USER_CLK_SRC_G = "gtClk0" else
+                   gtClk0Div2 when TX_USER_CLK_SRC_G = "gtClk0Div2" else
+                   gtClk1 when TX_USER_CLK_SRC_G = "gtClk1" else
+                   gtClk1Div2 when TX_USER_CLK_SRC_G = "gtClk1Div2" else                   
                    stableClk when STABLE_CLK_SRC_G = TX_REFCLK_SRC_G else
                    txRefClk;
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
These changes make the GTX7 fixed-latency PGP more like the (working) GTP7 fixed-latency PGP.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
 - Add IO for TX clock PLL/MMCM.
 - Add generics to allow PLL or MMCM in Wrapper.
 - Add generics and logic for more flexible clock configurations.

