### PR TITLE
Corrected a register offset in ads54j60.py

### DIFF
--- a/python/surf/devices/ti/_Ads54J60.py
+++ b/python/surf/devices/ti/_Ads54J60.py
@@ -80,7 +80,7 @@ class Ads54J60(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = "PDN_ADC_CHB",
+            name         = "PDN_ADC_CHB_0",
             description  = "",
             offset       = (masterPage + (4*0x20)),
             bitSize      = 4,
@@ -92,7 +92,7 @@ class Ads54J60(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "PDN_BUFFER_CHB_0",
             description  = "",
-            offset       = (masterPage + (4*0x20)),
+            offset       = (masterPage + (4*0x21)),
             bitSize      = 2,
             bitOffset    = 6,
             base         = pr.UInt,
@@ -102,7 +102,7 @@ class Ads54J60(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "PDN_BUFFER_CHA_0",
             description  = "",
-            offset       = (masterPage + (4*0x20)),
+            offset       = (masterPage + (4*0x21)),
             bitSize      = 2,
             bitOffset    = 4,
             base         = pr.UInt,


### PR DESCRIPTION
Corrected a register offset in ads54j60.py

### Description
-Changed the offset of registers "PDN_BUFFER_CHB_0" and "PDN_BUFFER_CHA_0".
The offset of both register was changed from "(masterPage + (4*0x20))" to "(masterPage + (4*0x21))"
This was done because both register were pointing at the same memory space of 2 other registers "PDN_ADC_CHA_0" and "PDN_ADC_CHB"

-Changed the name of the register "PDN_ADC_CHB" to "PDN_ADC_CHB_0". 
This was done to uniform the register names.





