### PR TITLE
adding IGMPv2 support to surf.ethernet library

### DIFF
--- a/ethernet/EthMacCore/rtl/EthMacPkg.vhd
+++ b/ethernet/EthMacCore/rtl/EthMacPkg.vhd
@@ -36,6 +36,7 @@ package EthMacPkg is
    constant UDP_C  : slv(7 downto 0) := x"11";  -- Protocol = UDP  = 0x11
    constant TCP_C  : slv(7 downto 0) := x"06";  -- Protocol = TCP  = 0x06
    constant ICMP_C : slv(7 downto 0) := x"01";  -- Protocol = ICMP = 0x01
+   constant IGMP_C : slv(7 downto 0) := x"02";  -- Protocol = IGMP = 0x02
 
    -- DHCP Constants
    constant DHCP_CPORT : slv(15 downto 0) := x"4400";  -- Port = 68 = 0x0044

--- a/ethernet/IpV4Engine/rtl/IgmpV2Engine.vhd
+++ b/ethernet/IpV4Engine/rtl/IgmpV2Engine.vhd
@@ -1,0 +1,285 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Igmp Engine (A.K.A. "ping" protocol)
+-------------------------------------------------------------------------------
+-- TODO: Add Leave Group messaging (Message Type = 0x17) support
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+use surf.EthMacPkg.all;
+
+entity IgmpV2Engine is
+   generic (
+      TPD_G         : time     := 1 ns;
+      IGMP_GRP_SIZE : positive := 1;
+      CLK_FREQ_G    : real     := 156.25E+06);  -- In units of Hz
+   port (
+      -- Local Configurations
+      localIp      : in  slv(31 downto 0);      --  big-Endian configuration
+      igmpIp       : in  Slv32Array(IGMP_GRP_SIZE-1 downto 0);  --  big-Endian configuration
+      -- Interface to Igmp Engine
+      ibIgmpMaster : in  AxiStreamMasterType;
+      ibIgmpSlave  : out AxiStreamSlaveType;
+      obIgmpMaster : out AxiStreamMasterType;
+      obIgmpSlave  : in  AxiStreamSlaveType;
+      -- Clock and Reset
+      clk          : in  sl;
+      rst          : in  sl);
+end IgmpV2Engine;
+
+architecture rtl of IgmpV2Engine is
+
+   constant TIMER_100MS_C : natural := getTimeRatio(CLK_FREQ_G, 10.0);  -- units of 0.1 second
+
+   type RxStateType is (
+      RX_IDLE_S,
+      RX_MSG_S);
+
+   type TxStateType is (
+      TX_IDLE_S,
+      TX_MSG_S);
+
+   type RegType is record
+      txCnt        : natural range 0 to IGMP_GRP_SIZE-1;
+      cnt          : natural range 0 to TIMER_100MS_C;
+      sendReport   : slv(IGMP_GRP_SIZE-1 downto 0);
+      rndCnt       : slv(7 downto 0);
+      timer        : slv(7 downto 0);
+      obIgmpMaster : AxiStreamMasterType;
+      rxState      : RxStateType;
+      txState      : TxStateType;
+   end record RegType;
+   constant REG_INIT_C : RegType := (
+      txCnt        => 0,
+      cnt          => 0,
+      sendReport   => (others => '1'),  -- Send report message at power up
+      rndCnt       => (others => '0'),
+      timer        => (others => '1'),  -- Power up delay before sending report messages
+      obIgmpMaster => AXI_STREAM_MASTER_INIT_C,
+      rxState      => RX_IDLE_S,
+      txState      => TX_IDLE_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   -- attribute dont_touch      : string;
+   -- attribute dont_touch of r : signal is "TRUE";
+
+begin
+
+   comb : process (ibIgmpMaster, igmpIp, localIp, obIgmpSlave, r, rst) is
+      variable v      : RegType;
+      variable rxXsum : slv(17 downto 0);
+      variable txXsum : slv(17 downto 0);
+   begin
+      -- Latch the current value
+      v := r;
+
+      ------------------------------------------------
+      -- Notes: Non-Standard IPv4 Pseudo Header Format
+      ------------------------------------------------
+      -- tData[0][47:0]   = Remote MAC Address
+      -- tData[0][63:48]  = zeros
+      -- tData[0][95:64]  = Remote IP Address
+      -- tData[0][127:96] = Local IP address
+      -- tData[1][7:0]    = zeros
+      -- tData[1][15:8]   = Protocol Type = Igmp
+      -- tData[1][31:16]  = IPv4 Pseudo header length
+      -- tData[1][39:32]  = Type of message
+      -- tData[1][47:40]  = Max Resp Time
+      -- tData[1][63:48]  = Checksum
+      -- tData[1][95:64]  = Group Address
+      ------------------------------------------------
+
+      -- Calculate the RX checksum
+      rxXsum := resize(ibIgmpMaster.tData(39 downto 32) & ibIgmpMaster.tData(47 downto 40), 18);
+      rxXsum := resize(ibIgmpMaster.tData(71 downto 64) & ibIgmpMaster.tData(79 downto 72), 18) + rxXsum;
+      rxXsum := resize(ibIgmpMaster.tData(87 downto 80) & ibIgmpMaster.tData(95 downto 88), 18) + rxXsum;
+      rxXsum := resize(rxXsum(17 downto 16), 18) + resize(rxXsum(15 downto 0), 18);
+      rxXsum := not(rxXsum);
+
+      -- Increment the "random" timer
+      v.rndCnt := r.rndCnt + 1;
+
+      -- RX State Machine
+      case r.rxState is
+         ----------------------------------------------------------------------
+         when RX_IDLE_S =>
+            -- Check for data with SOF and no EOF
+            if (ibIgmpMaster.tValid = '1') and (ssiGetUserSof(EMAC_AXIS_CONFIG_C, ibIgmpMaster) = '1') and (ibIgmpMaster.tLast = '0') then
+               -- Next state
+               v.rxState := RX_MSG_S;
+            end if;
+         ----------------------------------------------------------------------
+         when RX_MSG_S =>
+            -- Check for data
+            if (ibIgmpMaster.tValid = '1') then
+
+               -- Next state
+               v.rxState := RX_IDLE_S;
+
+               -- Check for valid checksum
+               if (rxXsum(15 downto 8) = ibIgmpMaster.tData(55 downto 48)) and (rxXsum(7 downto 0) = ibIgmpMaster.tData(63 downto 56)) then
+
+                  -- Check for Membership Query message
+                  if (ibIgmpMaster.tData(39 downto 32) = x"11") and (ibIgmpMaster.tData(95 downto 64) = 0) then
+                     -- Loop through the group addresses
+                     for i in IGMP_GRP_SIZE-1 downto 0 loop
+                        -- Check if matches group address
+                        if (igmpIp(i) /= 0) then
+                           -- Reset the flag
+                           v.sendReport(i) := '1';
+                        end if;
+                        -- Set the "random" timer
+                        v.timer := ibIgmpMaster.tData(47 downto 40);
+                        if resize(r.rndCnt(7 downto i), 8) < ibIgmpMaster.tData(47 downto 40) then
+                           v.timer := resize(r.rndCnt(7 downto i), 8);
+                        end if;
+                     end loop;
+                  end if;
+
+                  -- Check for Membership Report message
+                  if (ibIgmpMaster.tData(39 downto 32) = x"16") then
+                     -- Loop through the group addresses
+                     for i in IGMP_GRP_SIZE-1 downto 0 loop
+                        -- Check if matches group address
+                        if (igmpIp(i) = ibIgmpMaster.tData(95 downto 64)) then
+                           -- Reset the flag
+                           v.sendReport(i) := '0';
+                        end if;
+                     end loop;
+                  end if;
+
+               end if;
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Check for timeout
+      if (r.cnt = (TIMER_100MS_C-1)) then
+         -- Reset the counter
+         v.cnt := 0;
+         -- Check if need to decrement timer
+         if (r.timer /= 0) then
+            v.timer := r.timer - 1;
+         end if;
+      else
+         -- Increment the timer
+         v.cnt := r.cnt + 1;
+      end if;
+
+      -- Reset the flags
+      if obIgmpSlave.tReady = '1' then
+         v.obIgmpMaster.tValid := '0';
+         v.obIgmpMaster.tLast  := '0';
+         v.obIgmpMaster.tUser  := (others => '0');
+         v.obIgmpMaster.tKeep  := (others => '1');
+      end if;
+
+      -- Calculate the TX checksum
+      txXsum := resize(x"16" & x"00", 18);
+      txXsum := resize(r.obIgmpMaster.tData(103 downto 96) & r.obIgmpMaster.tData(111 downto 104), 18) + txXsum;
+      txXsum := resize(r.obIgmpMaster.tData(119 downto 112) & r.obIgmpMaster.tData(127 downto 120), 18) + txXsum;
+      txXsum := resize(txXsum(17 downto 16), 18) + resize(txXsum(15 downto 0), 18);
+      txXsum := not(txXsum);
+
+      -- TX State Machine
+      case r.txState is
+         ----------------------------------------------------------------------
+         when TX_IDLE_S =>
+            -- Check for timeout
+            if (r.timer = 0) then
+
+               -- Check if ready to move data
+               if (v.obIgmpMaster.tValid = '0') then
+
+                  -- Setup the IPv4 base header
+                  ssiSetUserSof(EMAC_AXIS_CONFIG_C, v.obIgmpMaster, '1');
+                  v.obIgmpMaster.tData(47 downto 0)   := igmpIp(r.txCnt)(31 downto 8) & x"5E_00_01";  -- IPv4mcast
+                  v.obIgmpMaster.tData(95 downto 64)  := localIp;  -- SRC IP
+                  v.obIgmpMaster.tData(127 downto 96) := igmpIp(r.txCnt);  -- DST IP
+
+                  -- Check if need to send report and non-zero group IP
+                  if (r.sendReport(r.txCnt) = '1') and (igmpIp(r.txCnt) /= 0) then
+
+                     -- Clear the flag
+                     v.sendReport(r.txCnt) := '0';
+
+                     -- Send the IPv4 base header
+                     v.obIgmpMaster.tValid := '1';
+
+                     -- Next state
+                     v.txState := TX_MSG_S;
+
+                  end if;
+
+                  -- Increment counter
+                  if (r.txCnt = IGMP_GRP_SIZE-1) then
+                     v.txCnt := 0;
+                  else
+                     v.txCnt := r.txCnt + 1;
+                  end if;
+
+               end if;
+            end if;
+         ----------------------------------------------------------------------
+         when TX_MSG_S =>
+            -- Check if ready to move data
+            if (v.obIgmpMaster.tValid = '0') then
+
+               -- Next state
+               v.txState := TX_IDLE_S;
+
+               -- Send the Membership Report message
+               v.obIgmpMaster.tValid              := '1';
+               v.obIgmpMaster.tLast               := '1';
+               v.obIgmpMaster.tKeep               := resize(x"FFF", AXI_STREAM_MAX_TKEEP_WIDTH_C);  -- 96-bit word
+               v.obIgmpMaster.tData(39 downto 32) := x"16";  -- IGMPv2 Membership Report
+               v.obIgmpMaster.tData(47 downto 40) := x"00";  -- Max Resp Time
+               v.obIgmpMaster.tData(55 downto 48) := txXsum(15 downto 8);  -- Checksum[15:8]
+               v.obIgmpMaster.tData(63 downto 56) := txXsum(7 downto 0);  -- Checksum[7:0]
+               v.obIgmpMaster.tData(95 downto 64) := r.obIgmpMaster.tData(127 downto 96);  -- DST IP = Group Address
+
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Outputs
+      ibIgmpSlave  <= AXI_STREAM_SLAVE_FORCE_C;
+      obIgmpMaster <= r.obIgmpMaster;
+
+      -- Reset
+      if (rst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (clk) is
+   begin
+      if rising_edge(clk) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end rtl;

--- a/ethernet/IpV4Engine/rtl/IpV4Engine.vhd
+++ b/ethernet/IpV4Engine/rtl/IpV4Engine.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -29,13 +28,14 @@ entity IpV4Engine is
       CLIENT_SIZE_G   : positive        := 1;  -- Sets the number of attached client engines
       CLK_FREQ_G      : real            := 156.25E+06;    -- In units of Hz
       TTL_G           : slv(7 downto 0) := x"20";
-      ICMP_G          : boolean         := true;
-      ARP_G           : boolean         := true;
+      IGMP_G          : boolean         := false;
+      IGMP_GRP_SIZE   : positive        := 1;
       VLAN_G          : boolean         := false);  -- true = VLAN support
    port (
       -- Local Configurations
       localMac          : in  slv(47 downto 0);   --  big-Endian configuration
       localIp           : in  slv(31 downto 0);   --  big-Endian configuration
+      igmpIp            : in  Slv32Array(IGMP_GRP_SIZE-1 downto 0);  --  big-Endian configuration
       -- Interface to Ethernet Media Access Controller (MAC)
       obMacMaster       : in  AxiStreamMasterType;
       obMacSlave        : out AxiStreamSlaveType;
@@ -58,17 +58,22 @@ end IpV4Engine;
 
 architecture mapping of IpV4Engine is
 
+   constant PROTOCOL_SIZE_C : positive := ite(IGMP_G, PROTOCOL_SIZE_G+2, PROTOCOL_SIZE_G+1);
+
    function GenIPv4List (foo : Slv8Array(PROTOCOL_SIZE_G-1 downto 0)) return Slv8Array is
-      variable retVar : Slv8Array(PROTOCOL_SIZE_G downto 0);
+      variable retVar : Slv8Array(PROTOCOL_SIZE_C-1 downto 0);
       variable i      : natural;
    begin
       for i in PROTOCOL_SIZE_G-1 downto 0 loop
          retVar(i) := foo(i);
       end loop;
       retVar(PROTOCOL_SIZE_G) := ICMP_C;
+      if IGMP_G then
+         retVar(PROTOCOL_SIZE_G+1) := IGMP_C;
+      end if;
       return retVar;
    end function;
-   constant PROTOCOL_C : Slv8Array(PROTOCOL_SIZE_G downto 0) := GenIPv4List(PROTOCOL_G);
+   constant PROTOCOL_C : Slv8Array(PROTOCOL_SIZE_C-1 downto 0) := GenIPv4List(PROTOCOL_G);
 
    signal ibArpMaster : AxiStreamMasterType;
    signal ibArpSlave  : AxiStreamSlaveType;
@@ -83,10 +88,10 @@ architecture mapping of IpV4Engine is
    signal localhostMaster : AxiStreamMasterType;
    signal localhostSlave  : AxiStreamSlaveType;
 
-   signal ibMasters : AxiStreamMasterArray(PROTOCOL_SIZE_G downto 0);
-   signal ibSlaves  : AxiStreamSlaveArray(PROTOCOL_SIZE_G downto 0);
-   signal obMasters : AxiStreamMasterArray(PROTOCOL_SIZE_G downto 0);
-   signal obSlaves  : AxiStreamSlaveArray(PROTOCOL_SIZE_G downto 0);
+   signal ibMasters : AxiStreamMasterArray(PROTOCOL_SIZE_C-1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal ibSlaves  : AxiStreamSlaveArray(PROTOCOL_SIZE_C-1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
+   signal obMasters : AxiStreamMasterArray(PROTOCOL_SIZE_C-1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal obSlaves  : AxiStreamSlaveArray(PROTOCOL_SIZE_C-1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
 
 begin
 
@@ -126,44 +131,34 @@ begin
          mAxisMaster     => ibMacMaster,
          mAxisSlave      => ibMacSlave);
 
-   GEN_ARP : if (ARP_G = true) generate
-      U_ArpEngine : entity surf.ArpEngine
-         generic map (
-            TPD_G         => TPD_G,
-            CLIENT_SIZE_G => CLIENT_SIZE_G,
-            CLK_FREQ_G    => CLK_FREQ_G,
-            VLAN_G        => VLAN_G)
-         port map (
-            -- Local Configurations
-            localMac      => localMac,
-            localIp       => localIp,
-            -- Interface to Client Engine(s)
-            arpReqMasters => arpReqMasters,
-            arpReqSlaves  => arpReqSlaves,
-            arpAckMasters => arpAckMasters,
-            arpAckSlaves  => arpAckSlaves,
-            -- Interface to Ethernet Frame MUX/DEMUX
-            ibArpMaster   => ibArpMaster,
-            ibArpSlave    => ibArpSlave,
-            obArpMaster   => obArpMaster,
-            obArpSlave    => obArpSlave,
-            -- Clock and Reset
-            clk           => clk,
-            rst           => rst);
-   end generate;
-
-   BYPASS_ARP : if (ARP_G = false) generate
-      -- Terminate Unused buses
-      arpReqSlaves  <= (others => AXI_STREAM_SLAVE_FORCE_C);
-      arpAckMasters <= (others => AXI_STREAM_MASTER_INIT_C);
-      ibArpSlave    <= AXI_STREAM_SLAVE_FORCE_C;
-      obArpMaster   <= AXI_STREAM_MASTER_INIT_C;
-   end generate;
+   U_ArpEngine : entity surf.ArpEngine
+      generic map (
+         TPD_G         => TPD_G,
+         CLIENT_SIZE_G => CLIENT_SIZE_G,
+         CLK_FREQ_G    => CLK_FREQ_G,
+         VLAN_G        => VLAN_G)
+      port map (
+         -- Local Configurations
+         localMac      => localMac,
+         localIp       => localIp,
+         -- Interface to Client Engine(s)
+         arpReqMasters => arpReqMasters,
+         arpReqSlaves  => arpReqSlaves,
+         arpAckMasters => arpAckMasters,
+         arpAckSlaves  => arpAckSlaves,
+         -- Interface to Ethernet Frame MUX/DEMUX
+         ibArpMaster   => ibArpMaster,
+         ibArpSlave    => ibArpSlave,
+         obArpMaster   => obArpMaster,
+         obArpSlave    => obArpSlave,
+         -- Clock and Reset
+         clk           => clk,
+         rst           => rst);
 
    U_IpV4EngineRx : entity surf.IpV4EngineRx
       generic map (
          TPD_G           => TPD_G,
-         PROTOCOL_SIZE_G => (PROTOCOL_SIZE_G+1),
+         PROTOCOL_SIZE_G => PROTOCOL_SIZE_C,
          PROTOCOL_G      => PROTOCOL_C,
          VLAN_G          => VLAN_G)
       port map (
@@ -182,7 +177,7 @@ begin
    U_IpV4EngineTx : entity surf.IpV4EngineTx
       generic map (
          TPD_G           => TPD_G,
-         PROTOCOL_SIZE_G => (PROTOCOL_SIZE_G+1),
+         PROTOCOL_SIZE_G => PROTOCOL_SIZE_C,
          PROTOCOL_G      => PROTOCOL_C,
          TTL_G           => TTL_G,
          VLAN_G          => VLAN_G)
@@ -201,27 +196,39 @@ begin
          clk               => clk,
          rst               => rst);
 
-   GEN_ICMP : if (ICMP_G = true) generate
-      U_IcmpEngine : entity surf.IcmpEngine
+   U_IcmpEngine : entity surf.IcmpEngine
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         -- Local Configurations
+         localIp      => localIp,
+         -- Interface to ICMP Engine
+         ibIcmpMaster => ibMasters(PROTOCOL_SIZE_G+0),
+         ibIcmpSlave  => ibSlaves(PROTOCOL_SIZE_G+0),
+         obIcmpMaster => obMasters(PROTOCOL_SIZE_G+0),
+         obIcmpSlave  => obSlaves(PROTOCOL_SIZE_G+0),
+         -- Clock and Reset
+         clk          => clk,
+         rst          => rst);
+
+   GEN_IGMP : if (IGMP_G = true) generate
+      U_IgmpV2Engine : entity surf.IgmpV2Engine
          generic map (
-            TPD_G => TPD_G)
+            TPD_G         => TPD_G,
+            IGMP_GRP_SIZE => IGMP_GRP_SIZE,
+            CLK_FREQ_G    => CLK_FREQ_G)
          port map (
             -- Local Configurations
             localIp      => localIp,
+            igmpIp       => igmpIp,
             -- Interface to ICMP Engine
-            ibIcmpMaster => ibMasters(PROTOCOL_SIZE_G),
-            ibIcmpSlave  => ibSlaves(PROTOCOL_SIZE_G),
-            obIcmpMaster => obMasters(PROTOCOL_SIZE_G),
-            obIcmpSlave  => obSlaves(PROTOCOL_SIZE_G),
+            ibIgmpMaster => ibMasters(PROTOCOL_SIZE_G+1),
+            ibIgmpSlave  => ibSlaves(PROTOCOL_SIZE_G+1),
+            obIgmpMaster => obMasters(PROTOCOL_SIZE_G+1),
+            obIgmpSlave  => obSlaves(PROTOCOL_SIZE_G+1),
             -- Clock and Reset
             clk          => clk,
             rst          => rst);
-   end generate;
-
-   BYPASS_ICMP : if (ICMP_G = false) generate
-      -- Terminate Unused buses
-      ibSlaves(PROTOCOL_SIZE_G)  <= AXI_STREAM_SLAVE_FORCE_C;
-      obMasters(PROTOCOL_SIZE_G) <= AXI_STREAM_MASTER_INIT_C;
    end generate;
 
    GEN_VEC :

--- a/ethernet/UdpEngine/rtl/UdpEngine.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngine.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -32,18 +31,21 @@ entity UdpEngine is
       CLIENT_EN_G    : boolean       := true;
       CLIENT_SIZE_G  : positive      := 1;
       CLIENT_PORTS_G : PositiveArray := (0 => 8193);
-      -- General UDP/ARP/DHCP Generics
+      -- General UDP/IGMP/ARP/DHCP Generics
       TX_FLOW_CTRL_G : boolean       := true;  -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
       DHCP_G         : boolean       := false;
+      IGMP_G         : boolean       := false;
+      IGMP_GRP_SIZE  : positive      := 1;
       CLK_FREQ_G     : real          := 156.25E+06;   -- In units of Hz
       COMM_TIMEOUT_G : positive      := 30;  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
       SYNTH_MODE_G   : string        := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Local Configurations
-      localMac         : in  slv(47 downto 0);        --  big-Endian configuration
-      broadcastIp      : in  slv(31 downto 0);        --  big-Endian configuration
-      localIpIn        : in  slv(31 downto 0);        --  big-Endian configuration
-      dhcpIpOut        : out slv(31 downto 0);        --  big-Endian configuration
+      localMac         : in  slv(47 downto 0);  --  big-Endian configuration
+      broadcastIp      : in  slv(31 downto 0);  --  big-Endian configuration
+      igmpIp           : in  Slv32Array(IGMP_GRP_SIZE-1 downto 0);  --  big-Endian configuration
+      localIpIn        : in  slv(31 downto 0);  --  big-Endian configuration
+      dhcpIpOut        : out slv(31 downto 0);  --  big-Endian configuration
       -- Interface to IPV4 Engine
       obUdpMaster      : out AxiStreamMasterType;
       obUdpSlave       : in  AxiStreamSlaveType;
@@ -106,6 +108,8 @@ begin
       generic map (
          TPD_G          => TPD_G,
          DHCP_G         => DHCP_G,
+         IGMP_G         => IGMP_G,
+         IGMP_GRP_SIZE  => IGMP_GRP_SIZE,
          SERVER_EN_G    => SERVER_EN_G,
          SERVER_SIZE_G  => SERVER_SIZE_G,
          SERVER_PORTS_G => SERVER_PORTS_G,
@@ -116,6 +120,7 @@ begin
          -- Local Configurations
          localIp          => localIp,
          broadcastIp      => broadcastIp,
+         igmpIp           => igmpIp,
          -- Interface to IPV4 Engine
          ibUdpMaster      => ibUdpMaster,
          ibUdpSlave       => ibUdpSlave,

--- a/ethernet/UdpEngine/rtl/UdpEngineWrapper.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineWrapper.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
@@ -27,30 +26,31 @@ use surf.EthMacPkg.all;
 entity UdpEngineWrapper is
    generic (
       -- Simulation Generics
-      TPD_G               : time            := 1 ns;
+      TPD_G               : time                  := 1 ns;
       -- UDP Server Generics
-      SERVER_EN_G         : boolean         := true;
-      SERVER_SIZE_G       : positive        := 1;
-      SERVER_PORTS_G      : PositiveArray   := (0 => 8192);
+      SERVER_EN_G         : boolean               := true;
+      SERVER_SIZE_G       : positive              := 1;
+      SERVER_PORTS_G      : PositiveArray         := (0 => 8192);
       -- UDP Client Generics
-      CLIENT_EN_G         : boolean         := true;
-      CLIENT_SIZE_G       : positive        := 1;
-      CLIENT_PORTS_G      : PositiveArray   := (0 => 8193);
-      CLIENT_EXT_CONFIG_G : boolean         := false;
-      -- General IPv4/ICMP/ARP/DHCP Generics
-      TX_FLOW_CTRL_G      : boolean         := true;  -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
-      DHCP_G              : boolean         := false;
-      ICMP_G              : boolean         := true;
-      ARP_G               : boolean         := true;
-      CLK_FREQ_G          : real            := 156.25E+06;   -- In units of Hz
-      COMM_TIMEOUT_G      : positive        := 30;  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
-      TTL_G               : slv(7 downto 0) := x"20";        -- IPv4's Time-To-Live (TTL)
-      VLAN_G              : boolean         := false;        -- true = VLAN support
-      SYNTH_MODE_G        : string          := "inferred");  -- Synthesis mode for internal RAMs
+      CLIENT_EN_G         : boolean               := true;
+      CLIENT_SIZE_G       : positive              := 1;
+      CLIENT_PORTS_G      : PositiveArray         := (0 => 8193);
+      CLIENT_EXT_CONFIG_G : boolean               := false;
+      -- General IPv4/IGMP/ICMP/ARP/DHCP Generics
+      TX_FLOW_CTRL_G      : boolean               := true;  -- True: Blow off the UDP TX data if link down, False: Backpressure until TX link is up
+      DHCP_G              : boolean               := false;
+      IGMP_G              : boolean               := false;
+      IGMP_GRP_SIZE       : positive range 1 to 8 := 1;
+      IGMP_INIT_G         : Slv32Array            := (0 => x"0000_0000");
+      CLK_FREQ_G          : real                  := 156.25E+06;  -- In units of Hz
+      COMM_TIMEOUT_G      : positive              := 30;  -- In units of seconds, Client's Communication timeout before re-ARPing or DHCP discover/request
+      TTL_G               : slv(7 downto 0)       := x"20";  -- IPv4's Time-To-Live (TTL)
+      VLAN_G              : boolean               := false;  -- true = VLAN support
+      SYNTH_MODE_G        : string                := "inferred");  -- Synthesis mode for internal RAMs
    port (
       -- Local Configurations
-      localMac         : in  slv(47 downto 0);      --  big-Endian configuration
-      localIp          : in  slv(31 downto 0);      --  big-Endian configuration
+      localMac         : in  slv(47 downto 0);  --  big-Endian configuration
+      localIp          : in  slv(31 downto 0);  --  big-Endian configuration
       -- Remote Configurations
       clientRemotePort : in  Slv16Array(CLIENT_SIZE_G-1 downto 0)           := (others => x"0000");
       clientRemoteIp   : in  Slv32Array(CLIENT_SIZE_G-1 downto 0)           := (others => x"00000000");
@@ -83,6 +83,7 @@ architecture rtl of UdpEngineWrapper is
 
    type RegType is record
       broadcastIp      : slv(31 downto 0);
+      igmpIp           : Slv32Array(IGMP_GRP_SIZE-1 downto 0);
       clientRemotePort : Slv16Array(CLIENT_SIZE_G-1 downto 0);
       clientRemoteIp   : Slv32Array(CLIENT_SIZE_G-1 downto 0);
       axilReadSlave    : AxiLiteReadSlaveType;
@@ -91,6 +92,7 @@ architecture rtl of UdpEngineWrapper is
 
    constant REG_INIT_C : RegType := (
       broadcastIp      => (others => '0'),
+      igmpIp           => IGMP_INIT_G,
       clientRemotePort => (others => (others => '0')),
       clientRemoteIp   => (others => (others => '0')),
       axilReadSlave    => AXI_LITE_READ_SLAVE_INIT_C,
@@ -125,13 +127,14 @@ begin
          PROTOCOL_G      => (0 => UDP_C),
          CLIENT_SIZE_G   => CLIENT_SIZE_G,
          CLK_FREQ_G      => CLK_FREQ_G,
-         ICMP_G          => ICMP_G,
-         ARP_G           => ARP_G,
+         IGMP_G          => IGMP_G,
+         IGMP_GRP_SIZE   => IGMP_GRP_SIZE,
          VLAN_G          => VLAN_G)
       port map (
          -- Local Configurations
          localMac             => localMac,
          localIp              => dhcpIp,
+         igmpIp               => r.igmpIp,
          -- Interface to Ethernet Media Access Controller (MAC)
          obMacMaster          => obMacMaster,
          obMacSlave           => obMacSlave,
@@ -158,6 +161,8 @@ begin
       generic map (
          -- Simulation Generics
          TPD_G          => TPD_G,
+         IGMP_G         => IGMP_G,
+         IGMP_GRP_SIZE  => IGMP_GRP_SIZE,
          -- UDP Server Generics
          SERVER_EN_G    => SERVER_EN_G,
          SERVER_SIZE_G  => SERVER_SIZE_G,
@@ -176,6 +181,7 @@ begin
          -- Local Configurations
          localMac         => localMac,
          broadcastIp      => r.broadcastIp,
+         igmpIp           => r.igmpIp,
          localIpIn        => localIp,
          dhcpIpOut        => dhcpIp,
          -- Interface to IPV4 Engine
@@ -230,7 +236,11 @@ begin
          axiSlaveRegisterR(regCon, toSlv((8*i)+4+2048, 12), 0, serverRemoteIp(i));  --  big-Endian configuration
       end loop;
 
-      axiSlaveRegister(regCon, x"FF0", 0, v.broadcastIp);
+      -- igmpIp[7:0] maps to address space = 0xFD0:0xFEF
+      for i in IGMP_GRP_SIZE-1 downto 0 loop
+         axiSlaveRegister(regCon, toSlv((4*i)+4048, 12), 0, v.igmpIp(i));  --  big-Endian configuration
+      end loop;
+      axiSlaveRegister (regCon, x"FF0", 0, v.broadcastIp);
       axiSlaveRegisterR(regCon, x"FF4", 0, dhcpIp);
       axiSlaveRegisterR(regCon, x"FF8", 0, localMac);
 

--- a/python/surf/ethernet/udp/_UdpEngine.py
+++ b/python/surf/ethernet/udp/_UdpEngine.py
@@ -16,6 +16,7 @@ class UdpEngine(pr.Device):
             self,
             numSrv = 0,
             numClt = 0,
+            numIgmp = 0,
             **kwargs):
         super().__init__(**kwargs)
 
@@ -99,6 +100,30 @@ class UdpEngine(pr.Device):
                 mode         = 'RO',
                 linkedGet    = udp.getIpValue,
                 dependencies = [self.variables[f'ServerRemoteIpRaw[{i}]']],
+            ))
+
+        ######################
+        # IGMP Group Addresses
+        ######################
+
+        for i in range(numIgmp):
+
+            self.add(pr.RemoteVariable(
+                name         = f'IgmpIpRaw[{i}]',
+                description  = 'IgmpIp (big-Endian configuration)',
+                offset       = (0xFD0+4*i),
+                bitSize      = 32,
+                mode         = 'RW',
+                hidden       = True,
+            ))
+
+            self.add(pr.LinkVariable(
+                name         = f'IgmpIp[{i}]',
+                description  = 'IgmpIp (human readable)',
+                mode         = 'RW',
+                linkedGet    = udp.getIpValue,
+                linkedSet    = udp.setIpValue,
+                dependencies = [self.variables[f'IgmpIpRaw[{i}]']],
             ))
 
         ##############


### PR DESCRIPTION
### Description
- IGMP_G default is false to keep the FPGA resources the same for older projects
- Support up to 8 Group Addresses

### Traffic Example
- IGMP Membership Query Message from CPU to FPGA 
```
Frame 4: 42 bytes on wire (336 bits), 42 bytes captured (336 bits) on interface eth2, id 0
Ethernet II, Src: Solarfla_51:76:41 (00:0f:53:51:76:41), Dst: Stanford_00:00:00 (08:00:56:00:00:00)
Internet Protocol Version 4, Src: 192.168.2.1, Dst: 192.168.2.10
    0100 .... = Version: 4
    .... 0101 = Header Length: 20 bytes (5)
    Differentiated Services Field: 0x00 (DSCP: CS0, ECN: Not-ECT)
    Total Length: 28
    Identification: 0x0001 (1)
    Flags: 0x0000
    Fragment offset: 0
    Time to live: 1
    Protocol: IGMP (2)
    Header checksum: 0x3484 [validation disabled]
    [Header checksum status: Unverified]
    Source: 192.168.2.1
    Destination: 192.168.2.10
Internet Group Management Protocol
    [IGMP Version: 2]
    Type: Membership Query (0x11)
    Max Resp Time: 2.0 sec (0x14)
    Checksum: 0xeeeb [correct]
    [Checksum Status: Good]
    Multicast Address: 0.0.0.0
```
- IGMPv2 Membership Report from FPGA to CPU
```
Frame 7: 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on interface eth2, id 0
Ethernet II, Src: Stanford_00:00:00 (08:00:56:00:00:00), Dst: IPv4mcast_07:07:07 (01:00:5e:07:07:07)
Internet Protocol Version 4, Src: 192.168.2.10, Dst: 224.7.7.7
    0100 .... = Version: 4
    .... 0101 = Header Length: 20 bytes (5)
    Differentiated Services Field: 0x00 (DSCP: CS0, ECN: Not-ECT)
    Total Length: 28
    Identification: 0x7d50 (32080)
    Flags: 0x4000, Don't fragment
    Fragment offset: 0
    Time to live: 32
    Protocol: IGMP (2)
    Header checksum: 0x33cf [validation disabled]
    [Header checksum status: Unverified]
    Source: 192.168.2.10
    Destination: 224.7.7.7
Internet Group Management Protocol
    [IGMP Version: 2]
    Type: Membership Report (0x16)
    Max Resp Time: 0.0 sec (0x00)
    Checksum: 0x02f1 [correct]
    [Checksum Status: Good]
    Multicast Address: 224.7.7.7
```