### PR TITLE
Enhancements to PRBS modules

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamMon.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMon.vhd
@@ -89,7 +89,7 @@ architecture rtl of AxiStreamMon is
    signal bwMax : slv(39 downto 0);
    signal bwMin : slv(39 downto 0);
 
-   signal frameRateRst     : sl;
+   signal frameRateReset   : sl;
    signal frameRateUpdate  : sl;
    signal frameRateSync    : slv(31 downto 0);
    signal frameRateMaxSync : slv(31 downto 0);

--- a/axi/axi-stream/rtl/AxiStreamMon.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMon.vhd
@@ -89,6 +89,7 @@ architecture rtl of AxiStreamMon is
    signal bwMax : slv(39 downto 0);
    signal bwMin : slv(39 downto 0);
 
+   signal frameRateRst     : sl;
    signal frameRateUpdate  : sl;
    signal frameRateSync    : slv(31 downto 0);
    signal frameRateMaxSync : slv(31 downto 0);
@@ -98,6 +99,15 @@ architecture rtl of AxiStreamMon is
    -- attribute dont_touch of r     : signal is "true";
 
 begin
+
+  
+   U_RstSync : entity surf.RstSync
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk      => axisClk,
+         asyncRst => statusRst,
+         syncRst  => frameRateReset);
 
    U_packetRate : entity surf.SyncTrigRate
       generic map (
@@ -116,7 +126,7 @@ begin
          trigRateOutMin  => frameRateMinSync,
          -- Clocks
          locClk          => axisClk,
-         locRst          => axisRst,
+         locRst          => frameRateReset,
          refClk          => axisClk,
          refRst          => axisRst);
 

--- a/axi/axi-stream/rtl/AxiStreamMon.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMon.vhd
@@ -265,7 +265,7 @@ begin
          WIDTH_G      => 32)
       port map (
          -- ASYNC statistics reset
-         rstStat => axisRst,
+         rstStat => statusRst,
          -- Write Interface (wrClk domain)
          wrClk   => axisClk,
          wrEn    => r.sizeValid,
@@ -283,7 +283,7 @@ begin
          WIDTH_G      => 40)
       port map (
          -- ASYNC statistics reset
-         rstStat => axisRst,
+         rstStat => statusRst,
          -- Write Interface (wrClk domain)
          wrClk   => axisClk,
          wrEn    => r.updated,

--- a/protocols/ssi/rtl/SsiPrbsRateGen.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRateGen.vhd
@@ -36,6 +36,7 @@ entity SsiPrbsRateGen is
       MEMORY_TYPE_G              : string                     := "block";
       CASCADE_SIZE_G             : natural range 1 to (2**24) := 1;
       FIFO_ADDR_WIDTH_G          : natural range 4 to 48      := 9;
+      PRBS_SEED_SIZE_G           : natural range 32 to 512    := 32;
       -- AXI Stream Configurations
       AXIS_CLK_FREQ_G            : real                       := 156.25E+6;  -- units of Hz
       AXIS_CONFIG_G              : AxiStreamConfigType;
@@ -118,6 +119,7 @@ begin
          GEN_SYNC_FIFO_G            => not USE_AXIL_CLK_G,
          CASCADE_SIZE_G             => CASCADE_SIZE_G,
          FIFO_ADDR_WIDTH_G          => FIFO_ADDR_WIDTH_G,
+         PRBS_SEED_SIZE_G          => PRBS_SEED_SIZE_G,
          MASTER_AXI_STREAM_CONFIG_G => AXIS_CONFIG_G)
       port map (
          mAxisClk        => mAxisClk,

--- a/protocols/ssi/rtl/SsiPrbsRateGen.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRateGen.vhd
@@ -160,21 +160,21 @@ begin
       axiSlaveWaitTxn(axilEp, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
 
       -- Map the registers
-      axiSlaveRegister(axilEp, x"000", 0, v.statReset);
-      axiSlaveRegister(axilEp, x"004", 0, v.packetLength);
-      axiSlaveRegister(axilEp, x"008", 0, v.genPeriod);
-      axiSlaveRegister(axilEp, x"00C", 0, v.genEnable);
-      axiSlaveRegister(axilEp, x"00C", 1, v.genOne);
+      axiSlaveRegister(axilEp, x"00", 0, v.statReset);
+      axiSlaveRegister(axilEp, x"04", 0, v.packetLength);
+      axiSlaveRegister(axilEp, x"08", 0, v.genPeriod);
+      axiSlaveRegister(axilEp, x"0C", 0, v.genEnable);
+      axiSlaveRegister(axilEp, x"0C", 1, v.genOne);
 
-      axiSlaveRegisterR(axilEp, x"010", 0, r.genMissed);
-      axiSlaveRegisterR(axilEp, x"014", 0, frameRate);
-      axiSlaveRegisterR(axilEp, x"018", 0, frameRateMax);
-      axiSlaveRegisterR(axilEp, x"01C", 0, frameRateMin);
-      axiSlaveRegisterR(axilEp, x"020", 0, bandwidth);
-      axiSlaveRegisterR(axilEp, x"028", 0, bandwidthMax);
-      axiSlaveRegisterR(axilEp, x"030", 0, bandwidthMin);
+      axiSlaveRegisterR(axilEp, x"10", 0, r.genMissed);
+      axiSlaveRegisterR(axilEp, x"14", 0, frameRate);
+      axiSlaveRegisterR(axilEp, x"18", 0, frameRateMax);
+      axiSlaveRegisterR(axilEp, x"1C", 0, frameRateMin);
+      axiSlaveRegisterR(axilEp, x"20", 0, bandwidth);
+      axiSlaveRegisterR(axilEp, x"28", 0, bandwidthMax);
+      axiSlaveRegisterR(axilEp, x"30", 0, bandwidthMin);
 
-      axiSlaveRegisterR(axilEp, x"040", 0, r.frameCount);
+      axiSlaveRegisterR(axilEp, x"40", 0, r.frameCount);
 
       -- End transaction block
       axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_OK_C);

--- a/protocols/ssi/rtl/SsiPrbsRx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsRx.vhd
@@ -30,22 +30,22 @@ use surf.SsiPkg.all;
 entity SsiPrbsRx is
    generic (
       -- General Configurations
-      TPD_G                      : time                     := 1 ns;
-      STATUS_CNT_WIDTH_G         : natural range 1 to 32    := 32;
+      TPD_G                     : time                     := 1 ns;
+      STATUS_CNT_WIDTH_G        : natural range 1 to 32    := 32;
       -- FIFO configurations
-      SLAVE_READY_EN_G           : boolean                  := true;
-      GEN_SYNC_FIFO_G            : boolean                  := false;
-      CASCADE_SIZE_G             : positive                 := 1;
-      FIFO_ADDR_WIDTH_G          : positive                 := 9;
-      FIFO_PAUSE_THRESH_G        : positive                 := 2**8;
-      SYNTH_MODE_G               : string                   := "inferred";
-      MEMORY_TYPE_G              : string                   := "block";
+      SLAVE_READY_EN_G          : boolean                  := true;
+      GEN_SYNC_FIFO_G           : boolean                  := false;
+      CASCADE_SIZE_G            : positive                 := 1;
+      FIFO_ADDR_WIDTH_G         : positive                 := 9;
+      FIFO_PAUSE_THRESH_G       : positive                 := 2**8;
+      SYNTH_MODE_G              : string                   := "inferred";
+      MEMORY_TYPE_G             : string                   := "block";
       -- PRBS Config
-      PRBS_SEED_SIZE_G           : positive range 32 to 512 := 32;
-      PRBS_TAPS_G                : NaturalArray             := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
+      PRBS_SEED_SIZE_G          : positive range 32 to 512 := 32;
+      PRBS_TAPS_G               : NaturalArray             := (0 => 31, 1 => 6, 2 => 2, 3 => 1);
       -- AXI Stream IO Config
-      SLAVE_AXI_STREAM_CONFIG_G  : AxiStreamConfigType;
-      SLAVE_AXI_PIPE_STAGES_G    : natural                  := 0);
+      SLAVE_AXI_STREAM_CONFIG_G : AxiStreamConfigType;
+      SLAVE_AXI_PIPE_STAGES_G   : natural                  := 0);
    port (
       -- Streaming RX Data Interface (sAxisClk domain)
       sAxisClk        : in  sl;
@@ -590,98 +590,49 @@ begin
                           errWordStrbSync, overflow, overflow0Cnt,
                           overflow1Cnt, packetLengthSync, packetRateSync,
                           pause, pause0Cnt, pause1Cnt, rAxiLite) is
-      variable v            : LocRegType;
-      variable axiStatus    : AxiLiteStatusType;
-      variable axiWriteResp : slv(1 downto 0);
-      variable axiReadResp  : slv(1 downto 0);
+      variable v      : LocRegType;
+      variable axilEp : AxiLiteEndpointType;
    begin
       -- Latch the current value
       v := rAxiLite;
 
-      -- Determine the transaction type
-      axiSlaveWaitTxn(axiWriteMaster, axiReadMaster, v.axiWriteSlave, v.axiReadSlave, axiStatus);
-
       -- Reset strobe signals
       v.cntRst := '0';
 
-      if (axiStatus.writeEnable = '1') then
-         -- Check for an out of 32 bit aligned address
-         axiWriteResp := ite(axiWriteMaster.awaddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
-         -- Decode address and perform write
-         case (axiWriteMaster.awaddr(9 downto 2)) is
-            when X"0A" =>
-               v.dummy := axiWriteMaster.wdata;
-            when x"F0" =>
-               v.rollOverEn := axiWriteMaster.wdata(STATUS_SIZE_C-1 downto 0);
-            when x"FE" =>
-               v.bypCheck := axiWriteMaster.wdata(0);
-            when x"FF" =>
-               v.cntRst := '1';
-            when others =>
-               axiWriteResp := AXI_RESP_DECERR_C;
-         end case;
-         -- Send AXI response
-         axiSlaveWriteResponse(v.axiWriteSlave, axiWriteResp);
-      end if;
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilEp, axiWriteMaster, axiReadMaster, v.axiWriteSlave, v.axiReadSlave);
 
-      if (axiStatus.readEnable = '1') then
-         -- Check for an out of 32 bit aligned address
-         axiReadResp          := ite(axiReadMaster.araddr(1 downto 0) = "00", AXI_RESP_OK_C, AXI_RESP_DECERR_C);
-         -- Decode address and assign read data
-         case (axiReadMaster.araddr(9 downto 2)) is
-            when x"00" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := errMissedPacketCnt;
-            when x"01" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := errLengthCnt;
-            when x"02" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := errEofeCnt;
-            when x"03" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := errDataBusCnt;
-            when x"04" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := errWordStrbCnt;
-            when x"05" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := (others => '0');  -- Legacy errBitStrbCnt
-            when x"06" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := overflow0Cnt;
-            when x"07" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := pause0Cnt;
-            when x"08" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := overflow1Cnt;
-            when x"09" =>
-               v.axiReadSlave.rdata(STATUS_CNT_WIDTH_G-1 downto 0) := pause1Cnt;
-            when X"0A" =>
-               v.axiReadSlave.rdata := rAxiLite.dummy;
-            when x"70" =>
-               v.axiReadSlave.rdata(0) := errMissedPacketSync;
-               v.axiReadSlave.rdata(1) := errLengthSync;
-               v.axiReadSlave.rdata(2) := errEofeSync;
-               v.axiReadSlave.rdata(3) := errDataBusSync;
-               v.axiReadSlave.rdata(4) := errWordStrbSync;
-               v.axiReadSlave.rdata(5) := '0';  -- Legacy errBitStrbSync
-               v.axiReadSlave.rdata(6) := overflow(0);
-               v.axiReadSlave.rdata(7) := pause(0);
-               v.axiReadSlave.rdata(8) := overflow(1);
-               v.axiReadSlave.rdata(9) := pause(1);
-            when x"71" =>
-               v.axiReadSlave.rdata := packetLengthSync;
-            when x"72" =>
-               v.axiReadSlave.rdata := packetRateSync;
-            when x"73" =>
-               v.axiReadSlave.rdata := (others => '0');  -- Legacy errbitCntSync
-            when x"74" =>
-               v.axiReadSlave.rdata := errWordCntSync;
-            when x"F0" =>
-               v.axiReadSlave.rdata(STATUS_SIZE_C-1 downto 0) := rAxiLite.rollOverEn;
-            when X"F1" =>
-               v.axiReadSlave.rdata := toSlv(PRBS_SEED_SIZE_G, 32);
-            when x"FE" =>
-               v.axiReadSlave.rdata(0) := rAxiLite.bypCheck;
-            when others =>
-               axiReadResp := AXI_RESP_DECERR_C;
-         end case;
-         -- Send Axi Response
-         axiSlaveReadResponse(v.axiReadSlave, axiReadResp);
-      end if;
+      axiSlaveRegisterR(axilEp, X"00", 0, errMissedPacketCnt);
+      axiSlaveRegisterR(axilEp, X"04", 0, errLengthCnt);
+      axiSlaveRegisterR(axilEp, X"08", 0, errEofeCnt);
+      axiSlaveRegisterR(axilEp, X"0C", 0, errDataBusCnt);
+      axiSlaveRegisterR(axilEp, X"10", 0, errWordStrbCnt);
+      axiSlaveRegisterR(axilEp, X"14", 0, X"00000000");  -- legacy errBitStrbCnt
+      axiSlaveRegisterR(axilEp, X"18", 0, overflow0Cnt);
+      axiSlaveRegisterR(axilEp, X"1C", 0, pause0Cnt);
+      axiSlaveRegisterR(axilEp, X"20", 0, overflow1Cnt);
+      axiSlaveRegisterR(axilEp, X"24", 0, pause1Cnt);
+      axiSlaveRegister(axilEp, X"28", 0, v.dummy);      
+      axiSlaveRegisterR(axilEp, X"70", 0, errMissedPacketSync);
+      axiSlaveRegisterR(axilEp, X"70", 1, errLengthSync);
+      axiSlaveRegisterR(axilEp, X"70", 2, errEofeSync);
+      axiSlaveRegisterR(axilEp, X"70", 3, errDataBusSync);
+      axiSlaveRegisterR(axilEp, X"70", 4, errWordStrbSync);
+      axiSlaveRegisterR(axilEp, X"70", 5, '0');          -- legacy errBitStrbSync
+      axiSlaveRegisterR(axilEp, X"70", 6, overflow(0));
+      axiSlaveRegisterR(axilEp, X"70", 7, pause(0));
+      axiSlaveRegisterR(axilEp, X"70", 8, overflow(1));
+      axiSlaveRegisterR(axilEp, X"70", 9, pause(1));
+      axiSlaveRegisterR(axilEp, X"74", 0, packetLengthSync);
+      axiSlaveRegisterR(axilEp, X"78", 0, packetRateSync);
+      axiSlaveRegisterR(axilEp, X"7C", 0, X"00000000");  -- legacy errBitCntSync
+      axiSlaveRegisterR(axilEp, X"80", 0, errWordCntSync);
+      axiSlaveRegister(axilEp, X"F0", 0, v.rollOverEn);
+      axiSlaveRegister(axilEp, X"F4", 0, v.bypCheck);      
+      axiSlaveRegisterR(axilEp, X"F8", 0,  toSlv(PRBS_SEED_SIZE_G, 32));
+      axiWrDetect(axilEp, X"FC", v.cntRst);      
+
+      axiSlaveDefault(axilEp, v.axiWriteSlave, v.axiReadSlave, AXI_RESP_DECERR_C);      
 
       -- Synchronous Reset
       if axiRst = '1' then

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -167,6 +167,7 @@ begin
       axiSlaveRegister(axilEp, X"04", 0, v.packetLength);
       axiSlaveRegister(axilEp, X"08", 0, v.tDest);
       axiSlaveRegister(axilEp, X"08", 8, v.tId);
+      axiSlaveRegister(axilEp, X"0C", 0, v.dataCnt);
       axiSlaveRegister(axilEp, X"18", 0, v.oneShot);
       axiSlaveRegister(axilEp, X"1C", 0, v.trigDly);
 

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -126,7 +126,7 @@ architecture rtl of SsiPrbsTx is
       trigDlyCnt     => (others => '0'),
       eventCnt       => toSlv(1, EVENT_CNT_SIZE_C),
       randomData     => (others => '0'),
-      txAxisMaster   => AXI_STREAM_MASTER_INIT_C,
+      txAxisMaster   => axiStreamMasterInit(PRBS_SSI_CONFIG_C),
       state          => IDLE_S,
       axiEn          => AXI_EN_G,
       oneShot        => '0',
@@ -211,7 +211,6 @@ begin
          v.txAxisMaster.tValid := '0';
          v.txAxisMaster.tLast  := '0';
          v.txAxisMaster.tUser  := (others => '0');
-         v.txAxisMaster.tKeep  := (others => '1');
       end if;
 
       -- State Machine

--- a/protocols/ssi/rtl/SsiPrbsTx.vhd
+++ b/protocols/ssi/rtl/SsiPrbsTx.vhd
@@ -252,6 +252,7 @@ begin
             if v.txAxisMaster.tvalid = '0' then
                -- Send the random seed word
                v.txAxisMaster.tvalid                             := '1';
+               v.txAxisMaster.tData(PRBS_SEED_SIZE_G-1 downto 0) := (others => '0');
                v.txAxisMaster.tData(EVENT_CNT_SIZE_C-1 downto 0) := r.eventCnt;
                -- Generate the next random data word
 --               for i in 0 to PRBS_SEED_SIZE_G-1 loop

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -17,6 +17,31 @@ class SsiPrbsRateGen(pr.Device):
     def __init__(self, clock_freq=125.0e6, **kwargs):
         super().__init__(**kwargs)
 
+
+        ##############################
+        # Functions
+        ##############################
+        def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
+                    self.add(pr.RemoteVariable(
+                        name         = ("Raw"+name),
+                        offset       = offset,
+                        bitSize      = bitSize,
+                        bitOffset    = bitOffset,
+                        base         = pr.UInt,
+                        mode         = 'RO',
+                        description  = description,
+                        pollInterval = pollInterval,
+                        hidden       = True,
+                    ))
+                    self.add(pr.LinkVariable(
+                        name         = name,
+                        mode         = 'RO',
+                        units        = units,
+                        linkedGet    = function,
+                        disp         = '{:1.1f}',
+                        dependencies = [self.variables["Raw"+name]],
+                    ))
+
         ##############################
         # Variables
         ##############################
@@ -189,28 +214,6 @@ class SsiPrbsRateGen(pr.Device):
             pollInterval = 1,
             mode         = "RO",
         ))
-
-
-        def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
-                    self.add(pr.RemoteVariable(
-                        name         = ("Raw"+name),
-                        offset       = offset,
-                        bitSize      = bitSize,
-                        bitOffset    = bitOffset,
-                        base         = pr.UInt,
-                        mode         = 'RO',
-                        description  = description,
-                        pollInterval = pollInterval,
-                        hidden       = True,
-                    ))
-                    self.add(pr.LinkVariable(
-                        name         = name,
-                        mode         = 'RO',
-                        units        = units,
-                        linkedGet    = function,
-                        disp         = '{:1.1f}',
-                        dependencies = [self.variables["Raw"+name]],
-                    ))
 
         @staticmethod
         def convMbps(var):

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -53,7 +53,7 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 1,
             bitOffset    = 0,
             base         = pr.UInt,
-            function     = lambda cmd: cmd.toggle,
+            function     = pr.Command.toggle,
             hidden       = False,
         ))
 

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -114,8 +114,8 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
-            units = 'Hz',
-            disp = '{:d}',
+            units        = 'Hz',
+            disp         = '{:d}',
             pollInterval = 1,
             mode         = "RO",
         ))
@@ -127,7 +127,8 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
-            disp = '{:d}',            
+            units        = 'Hz',
+            disp         = '{:d}',            
             pollInterval = 1,
             mode         = "RO",
         ))
@@ -139,44 +140,45 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
-            disp = '{:d}',            
+            units        = 'Hz',
+            disp         = '{:d}',            
             pollInterval = 1,
             mode         = "RO",
         ))
 
-        self.add(pr.RemoteVariable(
-            name         = "BandWidth",
-            description  = "",
+        addPair(
+            name         = 'Bandwidth',
+            description  = "Current Bandwidth",
             offset       = 0x20,
             bitSize      = 64,
             bitOffset    = 0,
-            base         = pr.UInt,
+            function     = self.convMbps,
+            units        = 'Mbps',
             pollInterval = 1,
-            mode         = "RO",
-        ))
+        )
 
-        self.add(pr.RemoteVariable(
-            name         = "BandWidthMax",
-            description  = "",
+        addPair(
+            name         = 'BandwidthMax',
+            description  = "Max Bandwidth",
             offset       = 0x28,
             bitSize      = 64,
             bitOffset    = 0,
-            base         = pr.UInt,
+            function     = self.convMbps,
+            units        = 'Mbps',
             pollInterval = 1,
-            mode         = "RO",
-        ))
+        )
 
-        self.add(pr.RemoteVariable(
-            name         = "BandWidthMin",
-            description  = "",
+        addPair(
+            name         = 'BandwidthMin',
+            description  = "Min Bandwidth",
             offset       = 0x30,
             bitSize      = 64,
             bitOffset    = 0,
-            base         = pr.UInt,
+            function     = self.convMbps,
+            units        = 'Mbps',
             pollInterval = 1,
-            mode         = "RO",
-        ))
-
+        )
+        
         self.add(pr.RemoteVariable(
             name         = "FrameCount",
             description  = "",
@@ -187,3 +189,29 @@ class SsiPrbsRateGen(pr.Device):
             pollInterval = 1,
             mode         = "RO",
         ))
+
+
+        def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
+                    self.add(pr.RemoteVariable(
+                        name         = ("Raw"+name),
+                        offset       = offset,
+                        bitSize      = bitSize,
+                        bitOffset    = bitOffset,
+                        base         = pr.UInt,
+                        mode         = 'RO',
+                        description  = description,
+                        pollInterval = pollInterval,
+                        hidden       = True,
+                    ))
+                    self.add(pr.LinkVariable(
+                        name         = name,
+                        mode         = 'RO',
+                        units        = units,
+                        linkedGet    = function,
+                        disp         = '{:1.1f}',
+                        dependencies = [self.variables["Raw"+name]],
+                    ))
+
+        @staticmethod
+        def convMbps(var):
+            return var.dependencies[0].value() * 8e-6

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -215,6 +215,6 @@ class SsiPrbsRateGen(pr.Device):
             mode         = "RO",
         ))
 
-        @staticmethod
-        def convMbps(var):
-            return var.dependencies[0].value() * 8e-6
+    @staticmethod
+    def convMbps(var):
+        return var.dependencies[0].value() * 8e-6

--- a/python/surf/protocols/ssi/_SsiPrbsRateGen.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRateGen.py
@@ -14,7 +14,7 @@
 import pyrogue as pr
 
 class SsiPrbsRateGen(pr.Device):
-    def __init__(self, **kwargs):
+    def __init__(self, clock_freq=125.0e6, **kwargs):
         super().__init__(**kwargs)
 
         ##############################
@@ -43,7 +43,7 @@ class SsiPrbsRateGen(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = "Period",
+            name         = "RawPeriod",
             description  = "",
             offset       = 0x08,
             bitSize      = 32,
@@ -51,6 +51,28 @@ class SsiPrbsRateGen(pr.Device):
             base         = pr.UInt,
             mode         = "RW",
         ))
+
+        def get_conv(var):
+            return clock_freq / (self.RawPeriod.value()+1)
+
+        def set_conv(value, write):
+            if value <= 0:
+                self.RawPeriod.set(0xFFFFFFFF, write=write)
+            else:
+                v = int(clock_freq / value)-1
+                if v > 0xFFFFFFFF:
+                    v = 0xFFFFFFFF
+                self.RawPeriod.set(v, write=write)
+
+        self.add(pr.LinkVariable(
+            name = 'TxRate',
+            dependencies = [self.RawPeriod],
+            units = 'Hz',
+            disp = '{:0.3f}',
+            linkedGet = get_conv,
+            linkedSet = set_conv))
+
+
 
         self.add(pr.RemoteVariable(
             name         = "TxEn",
@@ -80,6 +102,7 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
+            disp = '{:d}',            
             pollInterval = 1,
             mode         = "RO",
         ))
@@ -91,6 +114,8 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
+            units = 'Hz',
+            disp = '{:d}',
             pollInterval = 1,
             mode         = "RO",
         ))
@@ -102,6 +127,7 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
+            disp = '{:d}',            
             pollInterval = 1,
             mode         = "RO",
         ))
@@ -113,6 +139,7 @@ class SsiPrbsRateGen(pr.Device):
             bitSize      = 32,
             bitOffset    = 0,
             base         = pr.UInt,
+            disp = '{:d}',            
             pollInterval = 1,
             mode         = "RO",
         ))

--- a/python/surf/protocols/ssi/_SsiPrbsRx.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRx.py
@@ -80,7 +80,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "RxFifoOverflowCnt",
-            description  = "",
+            description  = "Number of times the RX FIFO has overflowed",
             offset       =  0x18,
             bitSize      =  32,
             mode         = "RO",
@@ -89,7 +89,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "RxFifoPauseCnt",
-            description  = "",
+            description  = "Number of times the RX FIFO has paused",
             offset       =  0x1C,
             bitSize      =  32,
             mode         = "RO",
@@ -98,7 +98,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "TxFifoOverflowCnt",
-            description  = "",
+            description  = "Number of times the TX FIFO has overflowed",
             offset       =  0x20,
             bitSize      =  32,
             mode         = "RO",
@@ -107,7 +107,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "TxFifoPauseCnt",
-            description  = "",
+            description  = "Number of times the TX FIFO has paused",
             offset       =  0x24,
             bitSize      =  32,
             mode         = "RO",
@@ -116,7 +116,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "Dummy",
-            description  = "",
+            description  = "Writable register that does nothing",
             offset       =  0x28,
             bitSize      =  32,
             mode         = "RW",
@@ -124,8 +124,8 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = "Status",
-            description  = "",
-            offset       =  0x1C0,
+            description  = "Current status of several internal values",
+            offset       =  0x70,
             bitSize      =  32,
             mode         = "RO",
             pollInterval = 1,
@@ -134,7 +134,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "PacketLength",
             description  = "",
-            offset       =  0x1C4,
+            offset       =  0x74,
             bitSize      =  32,
             mode         = "RO",
             pollInterval = 1,
@@ -142,7 +142,7 @@ class SsiPrbsRx(pr.Device):
 
         self.add(pr.RemoteVariable(
             name = 'WordSize',
-            offset = 0xF1 << 2,
+            offset = 0xF8,
             mode = 'RO',
             disp = '{:d}',
             hidden = False))
@@ -150,7 +150,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "PacketRateRaw",
             description  = "",
-            offset       =  0x1C8,
+            offset       =  0x78,
             bitSize      =  32,
             mode         = "RO",
             pollInterval = 1,
@@ -189,7 +189,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "WordErrCnt",
             description  = "",
-            offset       =  0x1D0,
+            offset       =  0x80,
             bitSize      =  32,
             mode         = "RO",
             pollInterval = 1,
@@ -198,7 +198,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "RolloverEnable",
             description  = "",
-            offset       =  0x3C0,
+            offset       =  0xF0,
             bitSize      =  32,
             mode         = "RW",
         ))
@@ -206,7 +206,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "BypassErrorChecking",
             description  = "Used to bypass the error checking",
-            offset       =  0x3F8,
+            offset       =  0xF4,
             bitSize      =  1,
             mode         = "RW",
         ))
@@ -214,7 +214,7 @@ class SsiPrbsRx(pr.Device):
         self.add(pr.RemoteCommand(
             name         = "CountReset",
             description  = "Status counter reset",
-            offset       =  0x3FC,
+            offset       =  0xFC,
             bitSize      =  1,
             function     = pr.BaseCommand.touchOne
         ))

--- a/python/surf/protocols/ssi/_SsiPrbsTx.py
+++ b/python/surf/protocols/ssi/_SsiPrbsTx.py
@@ -14,7 +14,7 @@
 import pyrogue as pr
 
 class SsiPrbsTx(pr.Device):
-    def __init__(self, **kwargs):
+    def __init__(self, clock_freq=125e6, **kwargs):
         super().__init__(**kwargs)
 
         ##############################
@@ -152,3 +152,22 @@ class SsiPrbsTx(pr.Device):
             bitSize      =  32,
             mode         = "RW",
         ))
+
+        def get_conv(read):
+            return clock_freq / (self.TrigDly.get(read=read)+1)
+
+        def set_conv(value, write):
+            if value <= 0:
+                self.TrigDly.set(0xFFFFFFFF, write=write)
+            else:
+                v = int(clock_freq / value)-1
+                if v > 0xFFFFFFFF:
+                    v = 0xFFFFFFFF
+                self.TrigDly.set(v, write=write)
+        
+        self.add(pr.LinkVariable(
+            name = 'TrigRate',
+            dependencies = [self.TrigDly],
+            mode = 'RW',
+            linkedGet = get_conv,
+            linkedSet = set_conv))


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

 - `AxiStreamMon`
   - Use `statusRst` to reset the min and max statistics.
   - Previously used `axisRst`.
   - Previously could not reset packet rate statistics.
 - `SsiPrbsRateGen`
   - Allow an asynchronous `localClk` input that runs internal logic.
   - Use only 8 bits of AXI-Lite address space instead of 12.
 - `SsiPrbsRx`/`SsiPrbsTx`
   - Remap AXI-Lite register space to use 8 address bits instead of 10.
   - Use "new" style AXI-Lite procedures from `AxiLitePkg`.
 - Software
   - Update with new register mappings for `SsiPrbsRx` and `SsiPrbsTx`.
   - Add useful `LinkedVariables` to `SsiPrbsRateGen`.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

We will need to discuss the changes in `SsiPrbsRx` and `SsiPrbsTx`. It should be fine as long as projects distribute software properly with their firmware. But it could happen that someone tries to use new SURF software to access PRBS modules on legacy firmware and then it wont work.

The extra address bits in the PRBS modules were becoming a problem in a project where many of these modules were instantiated. It was cumbersome to fit them all in the available address space on a PCIe project where you don't have the full 32 bits of address space for the firmware application.