### PR TITLE
Updates to Ad9249ReadoutGroup[UltraScale]

### DIFF
--- a/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249Deserializer.vhd
+++ b/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249Deserializer.vhd
@@ -33,6 +33,7 @@ use surf.Ad9249Pkg.all;
 entity Ad9249Deserializer is
    generic (
       TPD_G             : time                 := 1 ns;
+      SIM_DEVICE_G      : string               := "ULTRASCALE";
       IODELAY_GROUP_G   : string               := "DEFAULT_GROUP";
       IDELAY_CASCADE_G  : boolean              := false;
       IDELAYCTRL_FREQ_G : real                 := 300.0;
@@ -118,7 +119,7 @@ begin
          IS_CLK_INVERTED  => '0',       -- Optional inversion for CLK
          IS_RST_INVERTED  => '0',       -- Optional inversion for RST
          REFCLK_FREQUENCY => IDELAYCTRL_FREQ_G,  -- IDELAYCTRL clock input frequency in MHz (200.0-2667.0)
-         SIM_DEVICE       => "ULTRASCALE",  -- Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
+         SIM_DEVICE       => SIM_DEVICE_G,  -- Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
          -- ULTRASCALE_PLUS_ES2)
          UPDATE_MODE      => "ASYNC"  -- Determines when updates to the delay will take effect (ASYNC, MANUAL,
        -- SYNC)
@@ -190,7 +191,7 @@ begin
          IS_CLK_B_INVERTED => '1',      -- Optional inversion for CLK_B
          IS_CLK_INVERTED   => '0',      -- Optional inversion for CLK
          IS_RST_INVERTED   => '0',      -- Optional inversion for RST
-         SIM_DEVICE        => "ULTRASCALE"  -- Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
+         SIM_DEVICE        => SIM_DEVICE_G  -- Set the device version (ULTRASCALE, ULTRASCALE_PLUS, ULTRASCALE_PLUS_ES1,
       )
       port map (
          FIFO_EMPTY      => open,       -- 1-bit output: FIFO empty flag

--- a/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
+++ b/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
@@ -35,6 +35,7 @@ entity Ad9249ReadoutGroup is
       TPD_G             : time                 := 1 ns;
       NUM_CHANNELS_G    : natural range 1 to 8 := 8;
       IODELAY_GROUP_G   : string               := "DEFAULT_GROUP";
+      SIM_DEVICE_G      : string               := "ULTRASCALE";
       D_DELAY_CASCADE_G : boolean              := false;
       F_DELAY_CASCADE_G : boolean              := false;
       IDELAYCTRL_FREQ_G : real                 := 200.0;
@@ -377,6 +378,7 @@ begin
    U_FRAME_DESERIALIZER : entity surf.Ad9249Deserializer
       generic map (
          TPD_G             => TPD_G,
+         SIM_DEVICE_G      => SIM_DEVICE_G,
          IODELAY_GROUP_G   => "DEFAULT_GROUP",
          IDELAY_CASCADE_G  => F_DELAY_CASCADE_G,
          IDELAYCTRL_FREQ_G => 350.0,
@@ -426,6 +428,7 @@ begin
       U_DATA_DESERIALIZER : entity surf.Ad9249Deserializer
          generic map (
             TPD_G             => TPD_G,
+            SIM_DEVICE_G      => SIM_DEVICE_G,
             IODELAY_GROUP_G   => "DEFAULT_GROUP",
             IDELAY_CASCADE_G  => D_DELAY_CASCADE_G,
             IDELAYCTRL_FREQ_G => 350.0,

--- a/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
+++ b/devices/AnalogDevices/ad9249/UltraScale/rtl/Ad9249ReadoutGroup.vhd
@@ -174,11 +174,6 @@ architecture rtl of Ad9249ReadoutGroup is
 
    signal invertSync    : sl;
 
-   attribute KEEP_HIERARCHY                     : string;
-   attribute KEEP_HIERARCHY of AdcClk_I_Ibufds  : label is "TRUE";
-   attribute dont_touch                         : string;
-   attribute dont_touch of adcDclk              : signal is "TRUE";
-
 begin
    -------------------------------------------------------------------------------------------------
    -- Synchronize adcR.locked across to axil clock domain and count falling edges on it
@@ -315,23 +310,21 @@ begin
       end if;
    end process axilSeq;
 
-
-   AdcClk_I_Ibufds : IBUFDS
-   generic map (
-      DQS_BIAS => "FALSE"
-   )
-   port map (
-      I  => adcSerial.dClkP,
-      IB => adcSerial.dClkN,
-      O  => adcDclk
-   );
-
    -------------------------------------------------------------------------------------------------
    -- Create Clocks
    -------------------------------------------------------------------------------------------------
 
    G_MMCM : if USE_MMCME_G = true generate
 
+      AdcClk_I_Ibufds : IBUFDS
+      generic map (
+         DQS_BIAS => "FALSE"
+      )
+      port map (
+         I  => adcSerial.dClkP,
+         IB => adcSerial.dClkN,
+         O  => adcDclk
+      );
 
       ------------------------------------------
       -- Generate clocks from ADC incoming clock


### PR DESCRIPTION
### Description
- bug fix for Ad9249ReadoutGroup[UltraScale] when USE_MMCME_G=false
  - Required to prevent `PLIOBUF #1` DRC error
```
Inputs of IBUF/BUFGP instance DIFFINBUF_INST (in AdcClk_I_Ibufds macro) is not driven by port. This might lead to unplaceable/unroutable situation
```
- [exposing SIM_DEVICE_G to prevent DRC error when 'ULTRASCALE_PLUS'](https://github.com/slaclab/surf/pull/994/commits/059217dfe8bdeb267cbe5a3815fc0096ae05d7d4)
```
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell U_App/GEN_REAL.U_AdcMon/GEN_FAST_ADC[1].U_MonAdcReadout/U_FRAME_DESERIALIZER/U_ISERDESE3_master was changed from 'ULTRASCALE' to 'ULTRASCALE_PLUS' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be changed in the source netlist.
```