### PR TITLE
updates to SugoiManager

### DIFF
--- a/protocols/sugoi/rtl/SugoiManagerFsm.vhd
+++ b/protocols/sugoi/rtl/SugoiManagerFsm.vhd
@@ -150,7 +150,7 @@ architecture rtl of SugoiManagerFsm is
       dropTrigCnt    => (others => (others => '0')),
       errorDetCnt    => (others => '0'),
       linkUpCnt      => (others => '0'),
-      timerConfig    => (others => '1'),
+      timerConfig    => toSlv(1024, 24),
       timer          => (others => '0'),
       enLatencyCnt   => '0',
       latencyCnt     => (others => '0'),

--- a/python/surf/protocols/sugoi/_SugoiAxiL.py
+++ b/python/surf/protocols/sugoi/_SugoiAxiL.py
@@ -154,6 +154,15 @@ class SugoiAxiL(pr.Device):
             pollInterval = 1,
         ))
 
+        self.add(pr.RemoteVariable(
+            name         = 'LinkUp',
+            description  = 'High when the gearbox alignment is completed',
+            offset       = 0xB0,
+            bitSize      = 1,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
         self.add(pr.RemoteCommand(
             name         = 'CountReset',
             description  = 'Status counter reset',


### PR DESCRIPTION
### Description
- Set bypFirstBerDet default to 0x1
- Reduced the lockingCntCfg default
- Set TXN to 0x0 when gearboxAligned=0x0
- Map the gearboxAligned (A.K.A. "Linkup") to software
- [updating timerConfig default](https://github.com/slaclab/surf/pull/996/commits/028d0b9a7b9d8aa58f662b93f3273312275806d6)