### PR TITLE
Bug fix for base/ram/ruckus.tcl

### DIFF
--- a/base/ram/ruckus.tcl
+++ b/base/ram/ruckus.tcl
@@ -5,7 +5,7 @@ source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_PROC_TCL)
 loadSource -lib surf -dir "$::DIR_PATH/inferred"
 
 # Check for min. Vivado version with XPM support
-if {  $::env(VIVADO_VERSION) > 2019.1} {
+if {  $::env(VIVADO_VERSION) >= 2019.1} {
    loadSource -lib surf  -dir "$::DIR_PATH/xilinx"
    loadSource -lib surf -path "$::DIR_PATH/dummy/SimpleDualPortRamAlteraMfDummy.vhd"
    loadSource -lib surf -path "$::DIR_PATH/dummy/TrueDualPortRamXpmAlteraMfDummy.vhd"


### PR DESCRIPTION
### Description
- Bug fix for XPM true dual port FIFO using Vivado 2019.1
- Addresses issue #997
