### PR TITLE
Properly exit poll thread when stopping AxiLiteMasterProxy.py

### DIFF
--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -78,6 +78,8 @@ class _Regs(pr.Device):
         while True:
             #print('Main thread loop start')
             transaction = self._queue.get()
+            if transaction is None:
+                return
             with self._memLock, transaction.lock():
                 #tranId = transaction.id()
                 #print(f'Woke the pollWorker with id: {tranId}')
@@ -134,6 +136,12 @@ class _Regs(pr.Device):
                     #print(dataBa)
                     transaction.setData(dataBa, 0)
                     transaction.done()
+
+
+    def _stop(self):
+        self._queue.put(None)
+        self._pollThread.join()
+
 
 class _ProxySlave(rogue.interfaces.memory.Slave):
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
`AxiLiteMasterProxy` spins up a thread to handle its transactions. This thread was not being stopped when the `Root` was stopped, leading the applications hanging open. This has been fixed.

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESROGUE-515

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
