### PR TITLE
Add Si570 PyRogue Device

### DIFF
--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -100,13 +100,13 @@ class _Regs(pr.Device):
 
                     # Kick off the proxy transaction
                     self.Rnw.setDisp('Write', write=True)
-                    #print(f'Started write transaction: {transaction.id()}')
+                    #print(f'Started write transaction: {tranId}')
 
                 elif (transaction.type() == rogue.interfaces.memory.Read) or (transaction.type() == rogue.interfaces.memory.Verify):
 
                     # Kick off the read proxy txn
                     self.Rnw.setDisp('Read', write=True)
-                    #print(f'Started read transaction: {transaction.id()}')
+                    #print(f'Started read transaction: {tranId}')
 
                 else:
                     # Post transactions not allowed

--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -86,24 +86,25 @@ class _Regs(pr.Device):
                 addr = transaction.address()
                 #print('Writing address')
                 self.Addr.set(addr, write=True)
-                #print(f'Wrote address {addr:x}')
+                print(f'Wrote address {addr:x}')
 
                 if transaction.type() == rogue.interfaces.memory.Write:
                     # Convert data bytes to int and write data to proxy register
-                    transaction.getData(self._dataBa, 0)
-                    data = int.from_bytes(self._dataBa, 'little', signed=False)
+                    dataBa = bytearray(4)
+                    transaction.getData(dataBa, 0)
+                    data = int.from_bytes(dataBa, 'little', signed=False)
                     self.Data.set(data, write=True)
-                    #print(f'Wrote data {data:x}')
+                    print(f'Wrote data {data:x}')
 
                     # Kick off the proxy transaction
                     self.Rnw.setDisp('Write', write=True)
-                    #print(f'Started write transaction: {tranId}')
+                    print(f'Started write transaction: {transaction.id()}')
 
                 elif (transaction.type() == rogue.interfaces.memory.Read) or (transaction.type() == rogue.interfaces.memory.Verify):
 
                     # Kick off the read proxy txn
                     self.Rnw.setDisp('Read', write=True)
-                    #print(f'Started read transaction: {tranId}')
+                    print(f'Started read transaction: {transaction.id()}')
 
                 else:
                     # Post transactions not allowed
@@ -120,7 +121,7 @@ class _Regs(pr.Device):
 
                 # Check for error flags
                 resp = self.Resp.get(read=True)
-                #print(f'Resp: {resp}')
+                print(f'Resp: {resp}')
                 if resp != 0:
                     transaction.error(f'AXIL tranaction failed with RESP: {resp}')
 
@@ -129,7 +130,7 @@ class _Regs(pr.Device):
                     transaction.done()
                 else:
                     data = self.Data.get(read=True)
-                    #print(f'Got read data: {data:x}')
+                    print(f'Got read data: {data:x}')
                     dataBa = bytearray(data.to_bytes(4, 'little', signed=False))
                     #print(dataBa)
                     transaction.setData(dataBa, 0)

--- a/python/surf/axi/_AxiLiteMasterProxy.py
+++ b/python/surf/axi/_AxiLiteMasterProxy.py
@@ -86,7 +86,7 @@ class _Regs(pr.Device):
                 addr = transaction.address()
                 #print('Writing address')
                 self.Addr.set(addr, write=True)
-                print(f'Wrote address {addr:x}')
+                #print(f'Wrote address {addr:x}')
 
                 if transaction.type() == rogue.interfaces.memory.Write:
                     # Convert data bytes to int and write data to proxy register
@@ -94,17 +94,17 @@ class _Regs(pr.Device):
                     transaction.getData(dataBa, 0)
                     data = int.from_bytes(dataBa, 'little', signed=False)
                     self.Data.set(data, write=True)
-                    print(f'Wrote data {data:x}')
+                    #print(f'Wrote data {data:x}')
 
                     # Kick off the proxy transaction
                     self.Rnw.setDisp('Write', write=True)
-                    print(f'Started write transaction: {transaction.id()}')
+                    #print(f'Started write transaction: {transaction.id()}')
 
                 elif (transaction.type() == rogue.interfaces.memory.Read) or (transaction.type() == rogue.interfaces.memory.Verify):
 
                     # Kick off the read proxy txn
                     self.Rnw.setDisp('Read', write=True)
-                    print(f'Started read transaction: {transaction.id()}')
+                    #print(f'Started read transaction: {transaction.id()}')
 
                 else:
                     # Post transactions not allowed
@@ -121,7 +121,7 @@ class _Regs(pr.Device):
 
                 # Check for error flags
                 resp = self.Resp.get(read=True)
-                print(f'Resp: {resp}')
+                #print(f'Resp: {resp}')
                 if resp != 0:
                     transaction.error(f'AXIL tranaction failed with RESP: {resp}')
 
@@ -130,7 +130,7 @@ class _Regs(pr.Device):
                     transaction.done()
                 else:
                     data = self.Data.get(read=True)
-                    print(f'Got read data: {data:x}')
+                    #print(f'Got read data: {data:x}')
                     dataBa = bytearray(data.to_bytes(4, 'little', signed=False))
                     #print(dataBa)
                     transaction.setData(dataBa, 0)

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -205,8 +205,6 @@ class Si570(pr.Device):
                 fdco = value * hs_div * n1
                 rfreq = fdco / self.fxtal.get(read=True)
 
-                #print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
-
                 # Freeze
                 self.FreezeDCO.set(1, write=True)
 

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -64,7 +64,7 @@ class Si570(pr.Device):
         # Enum for HS_DIV
         self.add(pr.RemoteVariable(
             name = 'HS_DIV',
-            description = 'Sets value for high speed divider that takes the DCO output fOSC as its clock input',            
+            description = 'Sets value for high speed divider that takes the DCO output fOSC as its clock input',
             overlapEn = True,
             offset = 7 * ADDR_SIZE,
             bitSize = 3,
@@ -116,7 +116,7 @@ class Si570(pr.Device):
 
         self.add(pr.LinkVariable(
             name = 'RFREQ',
-            description = 'Frequency control input to DCO, formatted from fixed point',            
+            description = 'Frequency control input to DCO, formatted from fixed point',
             dependencies = [self.RFREQ_RAW],
             linkedGet = lambda read: self.RFREQ_RAW.get(read=read) / 2**28,
             linkedSet = lambda value, write: self.RFREQ_RAW.set(int(value*2**28), write=write)))
@@ -124,8 +124,8 @@ class Si570(pr.Device):
         self.add(pr.RemoteCommand(
             name = 'RST_REG',
             description = """
-            Reset of all internal logic. Output tristated during reset. 
-            Automatically returns to 0 after reset completion. 
+            Reset of all internal logic. Output tristated during reset.
+            Automatically returns to 0 after reset completion.
             Interrupts I2C state machine. Not recommended to use""",
             offset = 135 * ADDR_SIZE,
             bitOffset = 7,
@@ -135,7 +135,7 @@ class Si570(pr.Device):
 
         self.add(pr.RemoteCommand(
             name = 'NewFreq',
-            description = 'Alerts the DSPLL that a new frequency configuration has been applied',            
+            description = 'Alerts the DSPLL that a new frequency configuration has been applied',
             offset = 135 * ADDR_SIZE,
             bitOffset = 6,
             bitSize = 1,

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -1,0 +1,149 @@
+#-----------------------------------------------------------------------------
+# This file is part of 'SLAC Firmware Standard Library'.
+# It is subject to the license terms in the LICENSE.txt file found in the
+# top-level directory of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of 'SLAC Firmware Standard Library', including this file,
+# may be copied, modified, propagated, or distributed except according to
+# the terms contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class Si570(pr.Device):
+    def __init__(self, factory_freq):
+        super().__init__(**kwargs)
+        self.factory_freq = factory_freq
+
+        ADDR_SIZE = 4
+
+        self.add(pr.RemoteVariable(
+            name = 'N1_RAW'
+            offset = [7*ADDR_SIZE, 8*ADDR_SIZE],
+            bitSize = [5, 2]
+            bitOffset = [0, 6],
+            base = pr.UIntBE))
+
+        def read_n1(read):
+            n1_raw = self.N1_RAW.get(read=read)
+            if n1_raw == 0:
+                return 1
+            else:
+                return n1_raw << 1
+
+        self.add(pr.LinkVariable(
+            name = 'N1'
+            dependencies = [self.N1_RAW]
+            linkedGet = read_n1,
+            linkedSet = lambda value, write: self.N1_RAW.set(value>>1, write=write)))
+        
+
+        self.add(pr.RemoteVariable(
+            name = 'HS_DIV',
+            offset = 7 * ADDR_SIZE,
+            bitSize = 3,
+            bitOffset = 5,
+            emum = {
+                0: '4',
+                1: '5',
+                2: '6',
+                3: '7',
+                5: '9',
+                7: '11'}))
+
+        self.add(pr.RemoteVariable(
+            name = 'RFREQ_RAW',
+            offset = [8*ADDR_SIZE, 9*ADDR_SIZE, 10*ADDR_SIZE, 11*ADDR_SIZE, 12*ADDR_SIZE],
+            bitSize = [6, 8, 8, 8, 8],
+            bitOffset =[0, 0, 0, 0, 0],
+            base = pr.UIntBE
+        ))
+
+        self.add(pr.LinkVariable(
+            name = 'RFREQ',
+            dependencies = [self.RFREQ_RAW],
+            linkedGet = lambda read: self.RFREQ_RAW.get(read=read) / 2**28,
+            linkedSet = lambda value, write: self.RFREQ_RAW.set(int(value*2**28), write=write)))
+
+        self.add(pr.RemoteCommand(
+            name = 'RST_REG'
+            offset = 135 * ADDR_SIZE,
+            bitOffset = 7,
+            bitSize = 1,
+            function = pr.Command.toggle))
+
+        self.add(pr.RemoteCommand(
+            name = 'NewFreq',
+            offset = 135 * ADDR_SIZE,
+            bitOffset = 6,
+            bitSize = 1,
+            function = pr.Command.touchOne))
+
+        self.add(pr.RemoteVariable(
+            name = 'FreezeM',
+            offset = 135 * ADDR_SIZE,
+            bitOffset = 5,
+            bitSize = 1,
+            base = pr.UInt))
+
+        self.add(pr.RemoteVariable(
+            name = 'RECALL',
+            offset = 135 * ADDR_SIZE,
+            bitOffset = 0,
+            bitSize = 1,
+            function = pr.Command.touchOne))
+
+        self.add(pr.RemoteVariable(
+            name = 'FreezeDCO',
+            offset = 137 * ADDR_SIZE,
+            bitSize = 1,
+            bitOffset = 4))
+
+        self.add(pr.LinkVariable(
+            name = 'fxtal',
+            dependencies = [self.RFREQ, self.HS_DIV, self.N1],
+            linkedGet = lambda read: factory_freq * self.HS_DIV.get(read=read) * self.N1.get(read=read) / self.RFREQ.get(read=read)))
+
+
+        n1_array = [1] + [x for x in range(2, 2**7, 2)]
+        hs_div_array = [11, 9, 7, 6, 5, 4]
+
+        def find_params(f1):
+            # want low N1 and high HS_DIV
+            for n1 in n1_array:
+                for hs_div in hs_div_array:
+                    fdco = f1 * hs_div_array * n1
+                    if 4850 < fdco < 5670:
+                        return n1, hs_div
+        
+        def set_freq(value, write):
+            if write is False:
+                return
+            
+            n1, hs_div = find_params(value)
+            fdco = value * hs_div * n1
+            rfreq = fdco / self.fxtal.get(read=true)
+
+            print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}')
+
+            # Freeze
+            self.FreezeDCO.set(1, write=True)
+
+            # Write new config
+            self.N1.set(n1, write=False)
+            self.HS_DIV.setDisp(str(hs_div), write=False)
+            self.RFREQ.set(rfreq, write=False)
+            self.writeAndVerifyBlocks()
+
+            # Unfreeze
+            self.FreezeDCO.set(0, write=True)
+
+            # NewFreq
+            self.NewFreq()
+            
+
+        
+
+                 
+            
+

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -11,39 +11,61 @@
 import pyrogue as pr
 
 class Si570(pr.Device):
-    def __init__(self, factory_freq):
+    def __init__(self, factory_freq, **kwargs):
         super().__init__(**kwargs)
         self.factory_freq = factory_freq
 
         ADDR_SIZE = 4
 
-        self.add(pr.RemoteVariable(
-            name = 'N1_RAW'
-            offset = [7*ADDR_SIZE, 8*ADDR_SIZE],
-            bitSize = [5, 2]
-            bitOffset = [0, 6],
-            base = pr.UIntBE))
+        for i in range(7, 13):
+            self.add(pr.RemoteVariable(
+                name = f'Config[{i}]',
+                offset = i * ADDR_SIZE,
+                bitOffset = 0,
+                bitSize = 8,
+                overlapEn = True))
 
-        def read_n1(read):
-            n1_raw = self.N1_RAW.get(read=read)
-            if n1_raw == 0:
-                return 1
-            else:
-                return n1_raw << 1
+        # Extract N1 register value
+        def n1_raw_get(read):
+            high = self.Config[7].get(read=read)
+            low = self.Config[8].get(read=read)
+            return ((high & 0x1f) << 2) | ((low & 0xc0) >> 6)
+
+        def n1_raw_set(value, write):
+            high = self.Config[7].value() & 0xe0
+            low = self.Config[8].value() & 0x1f
+
+            high |= (value & 0b01111100) >> 2
+            low |= (value & 0x3) << 6
+
+            self.Config[7].set(high, write=False)
+            self.Config[8].set(low, write=False)
+            self.writeAndVerifyBlocks()
 
         self.add(pr.LinkVariable(
-            name = 'N1'
-            dependencies = [self.N1_RAW]
-            linkedGet = read_n1,
-            linkedSet = lambda value, write: self.N1_RAW.set(value>>1, write=write)))
-        
+            name = 'N1_RAW',
+            dependencies = [self.Config[7], self.Config[8]],
+            linkedGet = n1_raw_get,
+            linkedSet = n1_raw_set))
 
+        # Actual N1 multiplier is x2 what is written in register
+        def read_n1(read):
+            return self.N1_RAW.get(read=read) + 1
+
+        self.add(pr.LinkVariable(
+            name = 'N1',
+            dependencies = [self.N1_RAW],
+            linkedGet = read_n1,
+            linkedSet = lambda value, write: self.N1_RAW.set(value-1, write=write)))
+        
+        # Enum for HS_DIV
         self.add(pr.RemoteVariable(
             name = 'HS_DIV_RAW',
+            overlapEn = True,
             offset = 7 * ADDR_SIZE,
             bitSize = 3,
             bitOffset = 5,
-            emum = {
+            enum = {
                 0: '4',
                 1: '5',
                 2: '6',
@@ -51,19 +73,39 @@ class Si570(pr.Device):
                 5: '9',
                 7: '11'}))
 
+        # Map enum to link variable for setting as int
         self.add(pr.LinkVariable(
-            name 'HS_DIV',
+            name = 'HS_DIV',
             dependencies = [self.HS_DIV_RAW],
-            linkedGet = lambda read: int(self.HS_DIV_RAW.get(read=read))
+            linkedGet = lambda read: int(self.HS_DIV_RAW.getDisp(read=read)),
             linkedSet = lambda value, write: self.HS_DIV_RAW.setDisp(str(value))))
 
-        self.add(pr.RemoteVariable(
+        # Extract RFREQ from registers
+        def rfreq_raw_get(read):
+            ret = 0
+            for i in range(8, 13):
+                ret = ret << 8 | self.Config[i].get(read=read)
+
+            ret &= 0x1fffffffff
+            return ret
+
+        def rfreq_raw_set(value, write):
+            tmp = value
+            for i in reversed(range(8, 13)):
+                if i == 8:
+                    old = self.Config[i].get(read=False)
+                    tmp = (tmp & 0x1f) | (old & 0xc0)
+                self.Config[i].set(tmp&0xFF, write=write)
+                tmp = tmp >> 8
+        
+        self.add(pr.LinkVariable(
             name = 'RFREQ_RAW',
-            offset = [8*ADDR_SIZE, 9*ADDR_SIZE, 10*ADDR_SIZE, 11*ADDR_SIZE, 12*ADDR_SIZE],
-            bitSize = [6, 8, 8, 8, 8],
-            bitOffset =[0, 0, 0, 0, 0],
-            base = pr.UIntBE
-        ))
+            #value = 0x2EBB04CE0,
+            disp = '0x{:x}',
+            dependencies = [self.Config[x] for x in range(8,13)],
+            linkedGet = rfreq_raw_get,
+            linkedSet = rfreq_raw_set))
+        
 
         self.add(pr.LinkVariable(
             name = 'RFREQ',
@@ -71,12 +113,12 @@ class Si570(pr.Device):
             linkedGet = lambda read: self.RFREQ_RAW.get(read=read) / 2**28,
             linkedSet = lambda value, write: self.RFREQ_RAW.set(int(value*2**28), write=write)))
 
-        self.add(pr.RemoteCommand(
-            name = 'RST_REG'
-            offset = 135 * ADDR_SIZE,
-            bitOffset = 7,
-            bitSize = 1,
-            function = pr.Command.toggle))
+#         self.add(pr.RemoteCommand(
+#             name = 'RST_REG',
+#             offset = 135 * ADDR_SIZE,
+#             bitOffset = 7,
+#             bitSize = 1,
+#             function = pr.Command.toggle))
 
         self.add(pr.RemoteCommand(
             name = 'NewFreq',
@@ -85,14 +127,14 @@ class Si570(pr.Device):
             bitSize = 1,
             function = pr.Command.touchOne))
 
-        self.add(pr.RemoteVariable(
-            name = 'FreezeM',
-            offset = 135 * ADDR_SIZE,
-            bitOffset = 5,
-            bitSize = 1,
-            base = pr.UInt))
+#         self.add(pr.RemoteVariable(
+#             name = 'FreezeM',
+#             offset = 135 * ADDR_SIZE,
+#             bitOffset = 5,
+#             bitSize = 1,
+#             base = pr.UInt))
 
-        self.add(pr.RemoteVariable(
+        self.add(pr.RemoteCommand(
             name = 'RECALL',
             offset = 135 * ADDR_SIZE,
             bitOffset = 0,
@@ -105,10 +147,18 @@ class Si570(pr.Device):
             bitSize = 1,
             bitOffset = 4))
 
+        def get_fxtal(read):
+            return 114.2855151335625
+            rfreq =  self.RFREQ.get(read)
+            if rfreq == 0:
+                return 0.0
+            else:
+                return factory_freq * self.HS_DIV.get(read=read) * self.N1.get(read=read) / rfreq
+            
         self.add(pr.LinkVariable(
             name = 'fxtal',
             dependencies = [self.RFREQ, self.HS_DIV, self.N1],
-            linkedGet = lambda read: factory_freq * self.HS_DIV.get(read=read) * self.N1.get(read=read) / self.RFREQ.get(read=read)))
+            linkedGet = get_fxtal))
 
 
         n1_array = [1] + [x for x in range(2, 2**7, 2)]
@@ -118,7 +168,7 @@ class Si570(pr.Device):
             # want low N1 and high HS_DIV
             for n1 in n1_array:
                 for hs_div in hs_div_array:
-                    fdco = f1 * hs_div_array * n1
+                    fdco = f1 * hs_div * n1
                     if 4850 < fdco < 5670:
                         return n1, hs_div
         
@@ -128,10 +178,9 @@ class Si570(pr.Device):
             
             n1, hs_div = find_params(value)
             fdco = value * hs_div * n1
-            rfreq = fdco / self.fxtal.get(read=true)
+            rfreq = fdco / self.fxtal.get(read=True)
 
-            print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fcdo=}')
-            return
+            print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
 
             # Freeze
             self.FreezeDCO.set(1, write=True)

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -181,7 +181,7 @@ class Si570(pr.Device):
                 fdco = value * hs_div * n1
                 rfreq = fdco / self.fxtal.get(read=True)
 
-                print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
+                #print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
 
                 # Freeze
                 self.FreezeDCO.set(1, write=True)

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -175,27 +175,28 @@ class Si570(pr.Device):
         def set_freq(value, write):
             if write is False:
                 return
-            
-            n1, hs_div = find_params(value)
-            fdco = value * hs_div * n1
-            rfreq = fdco / self.fxtal.get(read=True)
 
-            print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
+            with self.root.updateGroup():
+                n1, hs_div = find_params(value)
+                fdco = value * hs_div * n1
+                rfreq = fdco / self.fxtal.get(read=True)
 
-            # Freeze
-            self.FreezeDCO.set(1, write=True)
+                print(f'Si570 setting new params, {n1=}, {hs_div=}, {rfreq=}, {fdco=}')
 
-            # Write new config
-            self.N1.set(n1, write=False)
-            self.HS_DIV.set(hs_div, write=False)
-            self.RFREQ.set(rfreq, write=False)
-            self.writeAndVerifyBlocks()
+                # Freeze
+                self.FreezeDCO.set(1, write=True)
 
-            # Unfreeze
-            self.FreezeDCO.set(0, write=True)
+                # Write new config
+                self.N1.set(n1, write=False)
+                self.HS_DIV.set(hs_div, write=False)
+                self.RFREQ.set(rfreq, write=False)
+                self.writeAndVerifyBlocks()
 
-            # NewFreq
-            self.NewFreq()
+                # Unfreeze
+                self.FreezeDCO.set(0, write=True)
+
+                # NewFreq
+                self.NewFreq()
 
         def get_freq(read):
             n1 = self.N1.get(read=read)

--- a/python/surf/devices/silabs/_Si570.py
+++ b/python/surf/devices/silabs/_Si570.py
@@ -57,7 +57,7 @@ class Si570(pr.Device):
             dependencies = [self.N1_RAW],
             linkedGet = read_n1,
             linkedSet = lambda value, write: self.N1_RAW.set(value-1, write=write)))
-        
+
         # Enum for HS_DIV
         self.add(pr.RemoteVariable(
             name = 'HS_DIV_RAW',
@@ -97,7 +97,7 @@ class Si570(pr.Device):
                     tmp = (tmp & 0x1f) | (old & 0xc0)
                 self.Config[i].set(tmp&0xFF, write=write)
                 tmp = tmp >> 8
-        
+
         self.add(pr.LinkVariable(
             name = 'RFREQ_RAW',
             #value = 0x2EBB04CE0,
@@ -105,7 +105,7 @@ class Si570(pr.Device):
             dependencies = [self.Config[x] for x in range(8,13)],
             linkedGet = rfreq_raw_get,
             linkedSet = rfreq_raw_set))
-        
+
 
         self.add(pr.LinkVariable(
             name = 'RFREQ',
@@ -154,7 +154,7 @@ class Si570(pr.Device):
                 return 0.0
             else:
                 return factory_freq * self.HS_DIV.get(read=read) * self.N1.get(read=read) / rfreq
-            
+
         self.add(pr.LinkVariable(
             name = 'fxtal',
             dependencies = [self.RFREQ, self.HS_DIV, self.N1],
@@ -171,7 +171,7 @@ class Si570(pr.Device):
                     fdco = f1 * hs_div * n1
                     if 4850 < fdco < 5670:
                         return n1, hs_div
-        
+
         def set_freq(value, write):
             if write is False:
                 return
@@ -205,7 +205,7 @@ class Si570(pr.Device):
             fxtal = self.fxtal.get(read=read)
 
             return (fxtal * rfreq)/(hs_div * n1)
-        
+
 
         self.add(pr.LinkVariable(
             name = 'Frequency',

--- a/python/surf/devices/silabs/__init__.py
+++ b/python/surf/devices/silabs/__init__.py
@@ -15,3 +15,5 @@ from surf.devices.silabs._Si5345      import *
 
 from surf.devices.silabs._Si5394Lite  import *
 from surf.devices.silabs._Si5394      import *
+
+from surf.devices.silabs._Si570       import *


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
Add a PyRogue Device class for the Si570 programmable clock chip found on the Alveo PCIe card and others.
