### PR TITLE
SSP Bug Fix - Allow exit from DATA_S state for auto frame mode

### DIFF
--- a/protocols/ssp/rtl/SspFramer.vhd
+++ b/protocols/ssp/rtl/SspFramer.vhd
@@ -145,6 +145,11 @@ begin
 
                end if;
             end if;
+
+            -- Allow exit to EOF_S for auto frame mode
+            if (AUTO_FRAME_G and validIn = '0') then
+               v.state := EOF_S;
+            end if;
          ----------------------------------------------------------------------
          when EOF_S =>
             -- Check if we are ready to move data


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This module was rewritten in #828. This change left a bug, where the `DATA_S` state never exits when running with `AUTO_FRAME_G=true`. This bug has been fixed.
