### PR TITLE
Vivado 2022.2 is buggy for general microblaze build

### DIFF
--- a/xilinx/general/microblaze/ruckus.tcl
+++ b/xilinx/general/microblaze/ruckus.tcl
@@ -19,7 +19,10 @@ if { [info exists ::env(VITIS_SRC_PATH)] != 1 }  {
       loadSource -lib surf -path "$::DIR_PATH/generate/MicroblazeBasicCoreWrapper.vhd"
 
       # Load the .bd file
-      if { $::env(VIVADO_VERSION) >= 2021.1 } {
+      if  { $::env(VIVADO_VERSION) == 2022.2 } {
+         puts "\nVivado v$::env(VIVADO_VERSION) not supported for general/microblaze\n"
+         exit -1
+      } elseif  { $::env(VIVADO_VERSION) >= 2021.1 } {
          loadBlockDesign -path "$::DIR_PATH/bd/2021.1/MicroblazeBasicCore.bd"
       } else {
          loadBlockDesign -path "$::DIR_PATH/bd/2020.1/MicroblazeBasicCore.bd"


### PR DESCRIPTION
### Description
- Not able to resolve the broken "AXI GPIO" and "Processor Reset" modules
  - Vivado says the IP version needs upgrading but recommends the same version?!?
- Decided not to support this version of Vivado for general microblaze build and just abort if user tries to build in this particular version  