### PR TITLE
Fix Asynchronous Resets found by Vivado DRC

### DIFF
--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -189,7 +189,7 @@ begin
    sAxisCtrl <= sCtrl;
    sRstTmp   <= rst or sAxisRst;
 
-   Sync_Rst : entity surf.RstSync
+   Sync_Rst_1 : entity surf.RstSync
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -197,11 +197,11 @@ begin
          asyncRst => sRstTmp,
          syncRst  => sRst);
 
-   Sync_Rst : entity surf.RstSync
+   Sync_Rst_2 : entity surf.RstSync
       generic map (
          TPD_G => TPD_G)
       port map (
-         clk      => mAxisClk,
+         clk      => axilClk,
          asyncRst => rxRstTmp,
          syncRst  => rxRst);
 

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -201,7 +201,7 @@ begin
       generic map (
          TPD_G => TPD_G)
       port map (
-         clk      => MAxisClk,
+         clk      => mAxisClk,
          asyncRst => rxRstTmp,
          syncRst  => rxRst);
 

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -165,7 +165,9 @@ architecture rtl of SrpV3AxiLite is
    signal rxTLastTUser : slv(7 downto 0);
    signal txSlave      : AxiStreamSlaveType;
    signal rst          : sl;
+   signal sRstTmp      : sl;
    signal sRst         : sl;
+   signal rxRstTmp     : sl;
    signal rxRst        : sl;
 
    -- attribute dont_touch                 : string;
@@ -185,7 +187,24 @@ architecture rtl of SrpV3AxiLite is
 begin
 
    sAxisCtrl <= sCtrl;
-   sRst      <= rst or sAxisRst;
+   sRstTmp   <= rst or sAxisRst;
+
+   Sync_Rst : entity surf.RstSync
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk      => sAxisClk,
+         asyncRst => sRstTmp,
+         syncRst  => sRst);
+
+   Sync_Rst : entity surf.RstSync
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk      => MAxisClk,
+         asyncRst => rxRstTmp,
+         syncRst  => rxRst);
+
 
    U_Limiter : entity surf.SsiFrameLimiter
       generic map (
@@ -773,7 +792,7 @@ begin
       -- Registered Outputs
       mAxilWriteMaster <= r.mAxilWriteMaster;
       mAxilReadMaster  <= r.mAxilReadMaster;
-      rxRst            <= r.rxRst or axilRst;
+      rxRstTmp         <= r.rxRst or axilRst;
 
    end process comb;
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
There were a couple resets in SrpV3AxiLite that Vivado DRC complained about.

Whenever a reset is created by `OR`ing together signals, the resulting combinatorial signal should be run through a `RstSync` block. This should be done even if the signals being `OR`ed belong to the same clock domain, as was the case here.

__We should probably discuss this a bit.__ Maybe it's not that big a problem. I wonder how many other instances of this there are in SURF. It seems Vivado DRC still complains despite this change.