### PR TITLE
CXPoF Updates and Whitespace removal

### DIFF
--- a/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
@@ -247,7 +247,7 @@ architecture rtl of AxiStreamDmaRingWrite is
    signal statusWe     : sl;
    signal statusAddr   : slv(RAM_ADDR_WIDTH_C-1 downto 0);
    signal statusDin    : slv(31 downto 0);
-   
+
 begin
 
    -- Assert that stream config has enough tdest bits for the number of buffers being tracked
@@ -430,7 +430,7 @@ begin
    statusWe   <= r.statusClearEn or r.ramWe;
    statusAddr <= r.statusClearAddr when (r.statusClearEn = '1' and r.ramWe = '0') else r.wrRamAddr;
    statusDin  <= statusRamClear    when (r.statusClearEn = '1' and r.ramWe = '0') else r.status;
-  
+
    -- DMA Write block
    U_AxiStreamDmaWrite_1 : entity surf.AxiStreamDmaWrite
       generic map (
@@ -529,7 +529,7 @@ begin
       if (r.statusClearEn = '1' and r.ramWe = '1') then
          v.statusClearEn := '1';
       end if;
-        
+
 
       case (r.state) is
          when WAIT_TVALID_S =>
@@ -548,7 +548,7 @@ begin
             if r.statusClearEn = '0' then
                v.state     := LATCH_POINTERS_S;
             end if;
-            
+
          when LATCH_POINTERS_S =>
             -- Latch pointers
             v.startAddr := startRamDout;   -- Address of start of buffer

--- a/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
@@ -31,7 +31,8 @@ entity CoaXPressCore is
       RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIL_CLK_FREQ_G    : real                   := 156.25E+6;  -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real                   := 156.25E+6;  -- dataClk frequency (units of Hz)
-      AXIS_CONFIG_G      : AxiStreamConfigType);
+      DATA_AXIS_CONFIG_G : AxiStreamConfigType;
+      CFG_AXIS_CONFIG_G  : AxiStreamConfigType);
    port (
       -- Data Interface (dataClk domain)
       dataClk         : in  sl;
@@ -112,7 +113,7 @@ begin
    U_Config : entity surf.CoaXPressConfig
       generic map (
          TPD_G         => TPD_G,
-         AXIS_CONFIG_G => AXIS_CONFIG_G)
+         AXIS_CONFIG_G => CFG_AXIS_CONFIG_G)
       port map (
          -- Clock and Reset
          cfgClk          => cfgClk,
@@ -162,7 +163,7 @@ begin
          TPD_G              => TPD_G,
          NUM_LANES_G        => NUM_LANES_G,
          RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
-         AXIS_CONFIG_G      => AXIS_CONFIG_G)
+         AXIS_CONFIG_G      => DATA_AXIS_CONFIG_G)
       port map (
          -- Data Interface (dataClk domain)
          dataClk        => dataClk,
@@ -201,7 +202,7 @@ begin
          RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
          AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G,
          AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,
-         AXIS_CONFIG_G      => AXIS_CONFIG_G)
+         AXIS_CONFIG_G      => DATA_AXIS_CONFIG_G)
       port map (
          -- Tx Interface (txClk domain)
          txClk           => txClk,

--- a/protocols/coaxpress/gthUs/rtl/CoaxpressOverFiberGthUs.vhd
+++ b/protocols/coaxpress/gthUs/rtl/CoaxpressOverFiberGthUs.vhd
@@ -34,7 +34,8 @@ entity CoaxpressOverFiberGthUs is
       AXIL_BASE_ADDR_G   : slv(31 downto 0);
       AXIL_CLK_FREQ_G    : real;        -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real;        -- dataClk frequency (units of Hz)
-      AXIS_CONFIG_G      : AxiStreamConfigType);
+      DATA_AXIS_CONFIG_G : AxiStreamConfigType;
+      CFG_AXIS_CONFIG_G  : AxiStreamConfigType);
    port (
       -- QPLL Interface
       qpllLock        : in  Slv2Array(NUM_LANES_G-1 downto 0);
@@ -132,7 +133,9 @@ begin
          NUM_LANES_G        => NUM_LANES_G,
          STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
          RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
-         AXIS_CONFIG_G      => AXIS_CONFIG_G,
+         DATA_AXIS_CONFIG_G => DATA_AXIS_CONFIG_G,
+         CFG_AXIS_CONFIG_G  => CFG_AXIS_CONFIG_G,
+         AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,
          AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G)
       port map (
          -- Data Interface (dataClk domain)
@@ -180,45 +183,45 @@ begin
    --------------------------
    GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
 
-         U_CXPoF : entity surf.CoaXPressOverFiberGthUsIpWrapper
-            generic map (
-               TPD_G   => TPD_G,
-               LANE0_G => (i = 0))
-            port map (
-               -- QPLL Interface
-               qpllLock        => qpllLock(i),
-               qpllclk         => qpllclk(i),
-               qpllrefclk      => qpllrefclk(i),
-               qpllRst         => qpllRst(i),
-               -- GT Ports
-               gtRxP           => gtRxP(i),
-               gtRxN           => gtRxN(i),
-               gtTxP           => gtTxP(i),
-               gtTxN           => gtTxN(i),
-               -- Tx Interface (txClk domain)
-               txClk           => txClk(i),
-               txRst           => txRst(i),
-               txLsValid       => txLsValid(i),
-               txLsData        => txLsData(i),
-               txLsDataK       => txLsDataK(i),
-               txLsRate        => txLsRate(i),
-               txLsLaneEn      => txLsLaneEn(i),
-               txLinkUp        => txLinkUp(i),
-               -- Rx Interface (rxClk domain)
-               rxClk           => rxClk(i),
-               rxRst           => rxRst(i),
-               rxData          => rxData(i),
-               rxDataK         => rxDataK(i),
-               rxDispErr       => rxDispErr(i),
-               rxDecErr        => rxDecErr(i),
-               rxLinkUp        => rxLinkUp(i),
-               -- AXI-Lite Register Interface (axilClk domain)
-               axilClk         => axilClk,
-               axilRst         => axilRst,
-               axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C+i),
-               axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C+i),
-               axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C+i),
-               axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C+i));
+      U_CXPoF : entity surf.CoaXPressOverFiberGthUsIpWrapper
+         generic map (
+            TPD_G   => TPD_G,
+            LANE0_G => (i = 0))
+         port map (
+            -- QPLL Interface
+            qpllLock        => qpllLock(i),
+            qpllclk         => qpllclk(i),
+            qpllrefclk      => qpllrefclk(i),
+            qpllRst         => qpllRst(i),
+            -- GT Ports
+            gtRxP           => gtRxP(i),
+            gtRxN           => gtRxN(i),
+            gtTxP           => gtTxP(i),
+            gtTxN           => gtTxN(i),
+            -- Tx Interface (txClk domain)
+            txClk           => txClk(i),
+            txRst           => txRst(i),
+            txLsValid       => txLsValid(i),
+            txLsData        => txLsData(i),
+            txLsDataK       => txLsDataK(i),
+            txLsRate        => txLsRate(i),
+            txLsLaneEn      => txLsLaneEn(i),
+            txLinkUp        => txLinkUp(i),
+            -- Rx Interface (rxClk domain)
+            rxClk           => rxClk(i),
+            rxRst           => rxRst(i),
+            rxData          => rxData(i),
+            rxDataK         => rxDataK(i),
+            rxDispErr       => rxDispErr(i),
+            rxDecErr        => rxDecErr(i),
+            rxLinkUp        => rxLinkUp(i),
+            -- AXI-Lite Register Interface (axilClk domain)
+            axilClk         => axilClk,
+            axilRst         => axilRst,
+            axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C+i),
+            axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C+i),
+            axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C+i),
+            axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C+i));
 
    end generate GEN_LANE;
 

--- a/protocols/coaxpress/gtyUs+/rtl/CoaxpressOverFiberGtyUs.vhd
+++ b/protocols/coaxpress/gtyUs+/rtl/CoaxpressOverFiberGtyUs.vhd
@@ -34,7 +34,8 @@ entity CoaxpressOverFiberGtyUs is
       AXIL_BASE_ADDR_G   : slv(31 downto 0);
       AXIL_CLK_FREQ_G    : real;        -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real;        -- dataClk frequency (units of Hz)
-      AXIS_CONFIG_G      : AxiStreamConfigType);
+      DATA_AXIS_CONFIG_G : AxiStreamConfigType;
+      CFG_AXIS_CONFIG_G  : AxiStreamConfigType);
    port (
       -- QPLL Interface
       qpllLock        : in  Slv2Array(NUM_LANES_G-1 downto 0);
@@ -132,7 +133,9 @@ begin
          NUM_LANES_G        => NUM_LANES_G,
          STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
          RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
-         AXIS_CONFIG_G      => AXIS_CONFIG_G,
+         DATA_AXIS_CONFIG_G => DATA_AXIS_CONFIG_G,
+         CFG_AXIS_CONFIG_G  => CFG_AXIS_CONFIG_G,
+         AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,
          AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G)
       port map (
          -- Data Interface (dataClk domain)
@@ -180,45 +183,45 @@ begin
    --------------------------
    GEN_LANE : for i in NUM_LANES_G-1 downto 0 generate
 
-         U_CXPoF : entity surf.CoaXPressOverFiberGtyUsIpWrapper
-            generic map (
-               TPD_G   => TPD_G,
-               LANE0_G => (i = 0))
-            port map (
-               -- QPLL Interface
-               qpllLock        => qpllLock(i),
-               qpllclk         => qpllclk(i),
-               qpllrefclk      => qpllrefclk(i),
-               qpllRst         => qpllRst(i),
-               -- GT Ports
-               gtRxP           => gtRxP(i),
-               gtRxN           => gtRxN(i),
-               gtTxP           => gtTxP(i),
-               gtTxN           => gtTxN(i),
-               -- Tx Interface (txClk domain)
-               txClk           => txClk(i),
-               txRst           => txRst(i),
-               txLsValid       => txLsValid(i),
-               txLsData        => txLsData(i),
-               txLsDataK       => txLsDataK(i),
-               txLsRate        => txLsRate(i),
-               txLsLaneEn      => txLsLaneEn(i),
-               txLinkUp        => txLinkUp(i),
-               -- Rx Interface (rxClk domain)
-               rxClk           => rxClk(i),
-               rxRst           => rxRst(i),
-               rxData          => rxData(i),
-               rxDataK         => rxDataK(i),
-               rxDispErr       => rxDispErr(i),
-               rxDecErr        => rxDecErr(i),
-               rxLinkUp        => rxLinkUp(i),
-               -- AXI-Lite Register Interface (axilClk domain)
-               axilClk         => axilClk,
-               axilRst         => axilRst,
-               axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C+i),
-               axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C+i),
-               axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C+i),
-               axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C+i));
+      U_CXPoF : entity surf.CoaXPressOverFiberGtyUsIpWrapper
+         generic map (
+            TPD_G   => TPD_G,
+            LANE0_G => (i = 0))
+         port map (
+            -- QPLL Interface
+            qpllLock        => qpllLock(i),
+            qpllclk         => qpllclk(i),
+            qpllrefclk      => qpllrefclk(i),
+            qpllRst         => qpllRst(i),
+            -- GT Ports
+            gtRxP           => gtRxP(i),
+            gtRxN           => gtRxN(i),
+            gtTxP           => gtTxP(i),
+            gtTxN           => gtTxN(i),
+            -- Tx Interface (txClk domain)
+            txClk           => txClk(i),
+            txRst           => txRst(i),
+            txLsValid       => txLsValid(i),
+            txLsData        => txLsData(i),
+            txLsDataK       => txLsDataK(i),
+            txLsRate        => txLsRate(i),
+            txLsLaneEn      => txLsLaneEn(i),
+            txLinkUp        => txLinkUp(i),
+            -- Rx Interface (rxClk domain)
+            rxClk           => rxClk(i),
+            rxRst           => rxRst(i),
+            rxData          => rxData(i),
+            rxDataK         => rxDataK(i),
+            rxDispErr       => rxDispErr(i),
+            rxDecErr        => rxDecErr(i),
+            rxLinkUp        => rxLinkUp(i),
+            -- AXI-Lite Register Interface (axilClk domain)
+            axilClk         => axilClk,
+            axilRst         => axilRst,
+            axilReadMaster  => axilReadMasters(DRP_AXIL_INDEX_C+i),
+            axilReadSlave   => axilReadSlaves(DRP_AXIL_INDEX_C+i),
+            axilWriteMaster => axilWriteMasters(DRP_AXIL_INDEX_C+i),
+            axilWriteSlave  => axilWriteSlaves(DRP_AXIL_INDEX_C+i));
 
    end generate GEN_LANE;
 


### PR DESCRIPTION
### Description
- [CoaXPressRxLaneMux.vhd syntax error fix when NUM_LANES_G=1](https://github.com/slaclab/surf/commit/c548dc1ddf38ab7ccbe23b56ed8a3d8e54c29db9)
- [AxiStreamDmaRingWrite.vhd whitespace removal](https://github.com/slaclab/surf/commit/705e3ef0d1a7ed2951409d90735d2f642888003f)
- [splitting AXIS_CONFIG_G into seperate generics for data and config paths](https://github.com/slaclab/surf/pull/1047/commits/e0d307c190035cde44773bf219fe205a2a118fd1)