### PR TITLE
Sugoi Post-Synthesis Simulation Reset Support

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
+++ b/axi/axi-lite/rtl/AxiLiteCrossbar.vhd
@@ -27,6 +27,7 @@ entity AxiLiteCrossbar is
 
    generic (
       TPD_G              : time                             := 1 ns;
+      RST_ASYNC_G        : boolean                          := false;
       NUM_SLAVE_SLOTS_G  : natural range 1 to 16            := 4;
       NUM_MASTER_SLOTS_G : natural range 1 to 64            := 4;
       DEC_ERROR_RESP_G   : slv(1 downto 0)                  := AXI_RESP_DECERR_C;
@@ -437,7 +438,7 @@ begin
 
       end loop;
 
-      if (axiClkRst = '1') then
+      if (RST_ASYNC_G = false and axiClkRst = '1') then
          v := REG_INIT_C;
       end if;
 
@@ -450,9 +451,11 @@ begin
 
    end process comb;
 
-   seq : process (axiClk) is
+   seq : process (axiClk, axiClkRst) is
    begin
-      if (rising_edge(axiClk)) then
+      if (RST_ASYNC_G and axiClkRst = '1') then
+         r <= REG_INIT_C after TPD_G;
+      elsif rising_edge(axiClk) then
          r <= rin after TPD_G;
       end if;
    end process seq;

--- a/axi/axi-lite/rtl/AxiVersion.vhd
+++ b/axi/axi-lite/rtl/AxiVersion.vhd
@@ -18,7 +18,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
@@ -26,6 +25,7 @@ use surf.AxiLitePkg.all;
 entity AxiVersion is
    generic (
       TPD_G              : time             := 1 ns;
+      RST_ASYNC_G        : boolean          := false;
       BUILD_INFO_G       : BuildInfoType;
       SIM_DNA_VALUE_G    : slv              := X"000000000000000000000000";
       DEVICE_ID_G        : slv(31 downto 0) := (others => '0');
@@ -223,7 +223,7 @@ begin
       --------
       -- Reset
       --------
-      if (axiRst = '1') then
+      if (RST_ASYNC_G = false and axiRst = '1') then
          v := REG_INIT_C;
       end if;
 
@@ -240,9 +240,11 @@ begin
 
    end process comb;
 
-   seq : process (axiClk) is
+   seq : process (axiClk, axiRst) is
    begin
-      if (rising_edge(axiClk)) then
+      if (RST_ASYNC_G and axiRst = '1') then
+         r <= REG_INIT_C after TPD_G;
+      elsif rising_edge(axiClk) then
          r <= rin after TPD_G;
       end if;
    end process seq;

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -25,6 +25,7 @@ use surf.StdRtlPkg.all;
 entity Gearbox is
    generic (
       TPD_G                : time    := 1 ns;
+      RST_ASYNC_G          : boolean := false;
       SLAVE_BIT_REVERSE_G  : boolean := false;
       SLAVE_WIDTH_G        : positive;
       MASTER_BIT_REVERSE_G : boolean := false;
@@ -147,7 +148,7 @@ begin
 
       slaveReady <= v.slaveReady;
 
-      if (rst = '1') then
+      if (RST_ASYNC_G = false and rst = '1') then
          v := REG_INIT_C;
       end if;
 
@@ -162,11 +163,13 @@ begin
 
    end process comb;
 
-   sync : process (clk) is
+   seq : process (clk, rst) is
    begin
-      if (rising_edge(clk)) then
+      if (RST_ASYNC_G and rst = '1') then
+         r <= REG_INIT_C after TPD_G;
+      elsif rising_edge(clk) then
          r <= rin after TPD_G;
       end if;
-   end process sync;
+   end process seq;
 
 end rtl;

--- a/protocols/sugoi/rtl/SugoiSubordinateCore.vhd
+++ b/protocols/sugoi/rtl/SugoiSubordinateCore.vhd
@@ -25,8 +25,10 @@ use surf.AxiLitePkg.all;
 
 entity SugoiSubordinateCore is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G       : time    := 1 ns;
+      RST_ASYNC_G : boolean := true);
    port (
+      simRst          : in  sl := '0';        -- Simulation reset only
       -- Clock and Reset
       clk             : in  sl;
       rst             : out sl;               -- Active HIGH global reset
@@ -73,12 +75,13 @@ begin
    U_Deserializer : entity surf.Gearbox
       generic map (
          TPD_G          => TPD_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
          SLAVE_WIDTH_G  => 1,
          MASTER_WIDTH_G => 10)
       port map (
          -- Clock and Reset
          clk            => clk,
-         rst            => '0',         -- Never reset on global reset command
+         rst            => simRst,      -- Simulation reset only
          -- Slip Interface
          slip           => rxSlip,
          -- Slave Interface
@@ -96,13 +99,12 @@ begin
       generic map (
          TPD_G          => TPD_G,
          RST_POLARITY_G => '1',         -- active HIGH reset
-         -- FLOW_CTRL_EN_G => true, -- placeholder incase FLOW_CTRL_EN_G is added in the future
-         RST_ASYNC_G    => false,
+         RST_ASYNC_G    => RST_ASYNC_G,
          NUM_BYTES_G    => 1)
       port map (
          -- Clock and Reset
          clk         => clk,
-         rst         => '0',            -- Never reset on global reset command
+         rst         => simRst,         -- Simulation reset only
          -- Encoded Interface
          validIn     => rxEncodeValid,
          dataIn      => rxEncodeData,
@@ -120,8 +122,10 @@ begin
    -------------
    U_Fsm : entity surf.SugoiSubordinateFsm
       generic map (
-         TPD_G => TPD_G)
+         TPD_G       => TPD_G,
+         RST_ASYNC_G => RST_ASYNC_G)
       port map (
+         simRst          => simRst,
          -- Clock and Reset
          clk             => clk,
          rst             => rst,
@@ -154,12 +158,12 @@ begin
          TPD_G          => TPD_G,
          RST_POLARITY_G => '1',         -- active HIGH reset
          FLOW_CTRL_EN_G => true,
-         RST_ASYNC_G    => false,
+         RST_ASYNC_G    => RST_ASYNC_G,
          NUM_BYTES_G    => 1)
       port map (
          -- Clock and Reset
          clk        => clk,
-         rst        => '0',             -- Never reset on global reset command
+         rst        => simRst,          -- Simulation reset only
          -- Decoded Interface
          validIn    => txDecodeValid,
          dataIn     => txDecodeData,
@@ -174,12 +178,13 @@ begin
    U_Serializer : entity surf.Gearbox
       generic map (
          TPD_G          => TPD_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
          SLAVE_WIDTH_G  => 10,
          MASTER_WIDTH_G => 1)
       port map (
          -- Clock and Reset
          clk            => clk,
-         rst            => '0',         -- Never reset on global reset command
+         rst            => simRst,      -- Simulation reset only
          -- Slave Interface
          slaveValid     => txEncodeValid,
          slaveData      => txEncodeData,


### PR DESCRIPTION
### Description
- adding RST_ASYNC_G support to these modules so we can do a ASYNC reset at power up after ASIC post-synthsis.
- This removes the 'X' signals such that '+vcs+initreg+0' is nolonger required