### PR TITLE
Remove Python Version Limitation

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 requirements:
    build:
-     - python<3.8
+     - python
      - rogue
      - git
      - gitpython


### PR DESCRIPTION
The previous version had python locked to 3.7 which was making it hard to find solutions. This opens up the python verion.
