### PR TITLE
updating microblaze/ruckus.tcl

### DIFF
--- a/xilinx/general/microblaze/ruckus.tcl
+++ b/xilinx/general/microblaze/ruckus.tcl
@@ -19,7 +19,8 @@ if { [info exists ::env(VITIS_SRC_PATH)] != 1 }  {
       loadSource -lib surf -path "$::DIR_PATH/generate/MicroblazeBasicCoreWrapper.vhd"
 
       # Load the .bd file
-      if  { $::env(VIVADO_VERSION) == 2022.2 } {
+      if { $::env(VIVADO_VERSION) == 2023.1 ||
+           $::env(VIVADO_VERSION) == 2022.2 } {
          puts "\nVivado v$::env(VIVADO_VERSION) not supported for general/microblaze\n"
          exit -1
       } elseif  { $::env(VIVADO_VERSION) >= 2021.1 } {


### PR DESCRIPTION
### Description
- Vivado 2023.1 did `NOT` fixed the bug with AXI GPIO and system processor reset IP core blocks
- This issue started in Vivado 2022.2 release
