### PR TITLE
fix Delay3PatchFSM: init issue (JIRA ESSURF-24)

### DIFF
--- a/xilinx/UltraScale/general/rtl/Delaye3PatchFsm.vhd
+++ b/xilinx/UltraScale/general/rtl/Delaye3PatchFsm.vhd
@@ -49,6 +49,7 @@ architecture rtl of Delaye3PatchFsm is
 
    type StateType is (
       IDLE_S,
+      CHECK_CNT_S,
       LOAD_S,
       WAIT_S);
 
@@ -84,15 +85,17 @@ begin
          v.Load := '0';
 
          -- Check for load request
-         if (LOAD = '1') then
-            -- Update the target delay value
-            v.dlyTarget := CNTVALUEIN;
-         end if;
-
          -- Main state machine
          case r.state is
             ----------------------------------------------------------------------
             when IDLE_S =>
+               if (LOAD = '1') then
+                  -- Update the target delay value on load request
+                  v.dlyTarget := CNTVALUEIN;
+                  v.state     := CHECK_CNT_S;
+               end if;
+               
+            when CHECK_CNT_S =>
                -- Check if load target different from current output
                if (v.dlyTarget /= CNTVALUEOUT) then
                   -- Check if we should increment the value
@@ -104,6 +107,10 @@ begin
                   end if;
                   -- Next state
                   v.state := LOAD_S;
+                  
+               else
+                  v.state := IDLE_S;
+                  
                end if;
             ----------------------------------------------------------------------
             when LOAD_S =>
@@ -121,7 +128,7 @@ begin
                   -- Reset the counter
                   v.waitCnt := (others => '0');
                   -- Next state
-                  v.state   := IDLE_S;
+                  v.state   := CHECK_CNT_S;
                end if;
          ----------------------------------------------------------------------
          end case;

--- a/xilinx/UltraScale/general/rtl/Delaye3PatchFsm.vhd
+++ b/xilinx/UltraScale/general/rtl/Delaye3PatchFsm.vhd
@@ -94,12 +94,12 @@ begin
                   v.dlyTarget := CNTVALUEIN;
                   v.state     := CHECK_CNT_S;
                end if;
-               
+            ----------------------------------------------------------------------
             when CHECK_CNT_S =>
                -- Check if load target different from current output
-               if (v.dlyTarget /= CNTVALUEOUT) then
+               if (r.dlyTarget /= CNTVALUEOUT) then
                   -- Check if we should increment the value
-                  if (v.dlyTarget > CNTVALUEOUT) then
+                  if (r.dlyTarget > CNTVALUEOUT) then
                      v.dlyValue := CNTVALUEOUT + 1;
                   -- Else decrement the value
                   else
@@ -107,10 +107,8 @@ begin
                   end if;
                   -- Next state
                   v.state := LOAD_S;
-                  
                else
                   v.state := IDLE_S;
-                  
                end if;
             ----------------------------------------------------------------------
             when LOAD_S =>


### PR DESCRIPTION
Fixing init bug of the delay3PatchFSM

### Description
 I added an additional step named CHECK_CNT_S. IT handles the logic previously located in the IDLE_S state. Then, the IDLE_S has been changed to wait for a load command. The FSM goes to CHECK_CNT_S after loading where the logic check if the CNTINVALUE has to be inc/dec. Finally, if the FSM has reached the expect value, it goes back to IDLE_S and wait for a new LOAD_S.

### Details
Side effect: no new value can be load until busy signal goes back to low.

### JIRA
[ESSURF-24](https://jira.slac.stanford.edu/browse/ESSURF-24)
