### PR TITLE
Adding line-code encode/decode modules to cocoTB CI regression testing

### DIFF
--- a/protocols/line-codes/rtl/Code10b12bPkg.vhd
+++ b/protocols/line-codes/rtl/Code10b12bPkg.vhd
@@ -34,7 +34,7 @@ package Code10b12bPkg is
    constant K_28_19_C : slv(9 downto 0) := b"10011_11100";  -- 0x27C -> 0x4FC, 0xB03
 
    -- These symbols are not commas but can be used for control sequences
-   -- Technically any K.28.x character is a valid k-char but these are preffered
+   -- Technically any K.28.x character is a valid k-char but these are preferred
    constant K_28_5_C  : slv(9 downto 0) := b"00101_11100";  -- 0x0BC -> 0x683, 0x97C
    constant K_28_6_C  : slv(9 downto 0) := b"00110_11100";  -- 0x0DC -> 0x643, 0x9BC
    constant K_28_9_C  : slv(9 downto 0) := b"01001_11100";  -- 0x13C -> 0x583, 0xA7C

--- a/protocols/line-codes/rtl/Decoder12b14b.vhd
+++ b/protocols/line-codes/rtl/Decoder12b14b.vhd
@@ -57,7 +57,7 @@ architecture rtl of Decoder12b14b is
 
    constant REG_INIT_C : RegType := (
       validOut  => '0',
-      dispOut   => "01",
+      dispOut   => "00",
       dataOut   => (others => '0'),
       dataKOut  => '0',
       codeError => '0',

--- a/protocols/line-codes/rtl/Encoder12b14b.vhd
+++ b/protocols/line-codes/rtl/Encoder12b14b.vhd
@@ -67,7 +67,7 @@ architecture rtl of Encoder12b14b is
 
 begin
 
-   comb : process (dataIn, dataKIn, dispIn, r, rst, validIn) is
+   comb : process (dataIn, dataKIn, dispIn, r, readyOut, rst, validIn) is
       variable v         : RegType;
       variable dispInTmp : slv(1 downto 0);
       variable invalidK  : sl;

--- a/protocols/line-codes/tb/LineCode10b12bTb.vhd
+++ b/protocols/line-codes/tb/LineCode10b12bTb.vhd
@@ -1,0 +1,87 @@
+-------------------------------------------------------------------------------
+-- Title      : Line Code 10B12B: https://confluence.slac.stanford.edu/x/QndODQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: 10B12B Line Code Test bed for cocoTB
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+entity LineCode10b12bTb is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      -- Clock and Reset
+      clk      : in  sl;
+      rst      : in  sl;
+      -- Encoder Interface
+      validIn  : in  sl;
+      dataIn   : in  slv(9 downto 0);
+      dataKIn  : in  sl;
+      -- Decoder Interface
+      validOut : out sl;
+      dataOut  : out slv(9 downto 0);
+      dataKOut : out sl;
+      codeErr  : out sl;
+      dispErr  : out sl);
+end entity LineCode10b12bTb;
+
+architecture mapping of LineCode10b12bTb is
+
+   signal validEncode : sl;
+   signal dataEncode  : slv(11 downto 0);
+
+begin
+
+   U_Encoder : entity surf.Encoder10b12b
+      generic map (
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false,
+         USE_CLK_EN_G   => false,
+         FLOW_CTRL_EN_G => true)
+      port map (
+         clk      => clk,
+         clkEn    => '1',
+         rst      => rst,
+         validIn  => validIn,
+         readyIn  => open,
+         dataIn   => dataIn,
+         dataKIn  => dataKIn,
+         validOut => validEncode,
+         readyOut => validEncode,
+         dataOut  => dataEncode,
+         dispOut  => open);
+
+   U_Decoder : entity surf.Decoder10b12b
+      generic map (
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false,
+         USE_CLK_EN_G   => false)
+      port map (
+         clk       => clk,
+         clkEn     => '1',
+         rst       => rst,
+         validIn   => validEncode,
+         dataIn    => dataEncode,
+         validOut  => validOut,
+         dataOut   => dataOut,
+         dataKOut  => dataKOut,
+         codeError => codeErr,
+         dispError => dispErr);
+
+end mapping;

--- a/protocols/line-codes/tb/LineCode12b14bTb.vhd
+++ b/protocols/line-codes/tb/LineCode12b14bTb.vhd
@@ -1,0 +1,90 @@
+-------------------------------------------------------------------------------
+-- Title      : Line Code 12B14B: https://confluence.slac.stanford.edu/x/6AJODQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: 12B14B Line Code Test bed for cocoTB
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+entity LineCode12b14bTb is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      -- Clock and Reset
+      clk      : in  sl;
+      rst      : in  sl;
+      -- Encoder Interface
+      validIn  : in  sl;
+      dataIn   : in  slv(11 downto 0);
+      dataKIn  : in  sl;
+      -- Decoder Interface
+      validOut : out sl;
+      dataOut  : out slv(11 downto 0);
+      dataKOut : out sl;
+      codeErr  : out sl;
+      dispErr  : out sl);
+end entity LineCode12b14bTb;
+
+architecture mapping of LineCode12b14bTb is
+
+   signal validEncode : sl;
+   signal dataEncode  : slv(13 downto 0);
+
+begin
+
+   U_Encoder : entity surf.Encoder12b14b
+      generic map (
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false,
+         DEBUG_DISP_G   => false,
+         FLOW_CTRL_EN_G => true)
+      port map (
+         clk      => clk,
+         clkEn    => '1',
+         rst      => rst,
+         validIn  => validIn,
+         readyIn  => open,
+         dataIn   => dataIn,
+         dispIn   => "00",              -- Used if DEBUG_DISP_G=true
+         dataKIn  => dataKIn,
+         validOut => validEncode,
+         readyOut => validEncode,
+         dataOut  => dataEncode,
+         dispOut  => open);
+
+   U_Decoder : entity surf.Decoder12b14b
+      generic map (
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false,
+         DEBUG_DISP_G   => false)
+      port map (
+         clk       => clk,
+         clkEn     => '1',
+         rst       => rst,
+         validIn   => validEncode,
+         dataIn    => dataEncode,
+         dispIn    => "00",             -- Used if DEBUG_DISP_G=true
+         validOut  => validOut,
+         dataOut   => dataOut,
+         dataKOut  => dataKOut,
+         codeError => codeErr,
+         dispError => dispErr,
+         dispOut   => open);
+
+end mapping;

--- a/protocols/line-codes/tb/LineCode8b10bTb.vhd
+++ b/protocols/line-codes/tb/LineCode8b10bTb.vhd
@@ -1,0 +1,87 @@
+-------------------------------------------------------------------------------
+-- Title      : Line Code 8B10B: https://en.wikipedia.org/wiki/8b/10b_encoding
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: 8B10B Line Code Test bed for cocoTB
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+entity LineCode8b10bTb is
+   generic (
+      TPD_G       : time     := 1 ns;
+      NUM_BYTES_G : positive := 1);
+   port (
+      -- Clock and Reset
+      clk      : in  sl;
+      rst      : in  sl;
+      -- Encoder Interface
+      validIn  : in  sl;
+      dataIn   : in  slv(NUM_BYTES_G*8-1 downto 0);
+      dataKIn  : in  slv(NUM_BYTES_G-1 downto 0);
+      -- Decoder Interface
+      validOut : out sl;
+      dataOut  : out slv(NUM_BYTES_G*8-1 downto 0);
+      dataKOut : out slv(NUM_BYTES_G-1 downto 0);
+      codeErr  : out slv(NUM_BYTES_G-1 downto 0);
+      dispErr  : out slv(NUM_BYTES_G-1 downto 0));
+end entity LineCode8b10bTb;
+
+architecture mapping of LineCode8b10bTb is
+
+   signal validEncode : sl;
+   signal dataEncode  : slv(NUM_BYTES_G*10-1 downto 0);
+
+begin
+
+   U_Encoder : entity surf.Encoder8b10b
+      generic map (
+         TPD_G          => TPD_G,
+         NUM_BYTES_G    => NUM_BYTES_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false,
+         FLOW_CTRL_EN_G => true)
+      port map (
+         clk      => clk,
+         clkEn    => '1',
+         rst      => rst,
+         validIn  => validIn,
+         readyIn  => open,
+         dataIn   => dataIn,
+         dataKIn  => dataKIn,
+         validOut => validEncode,
+         readyOut => validEncode,
+         dataOut  => dataEncode);
+
+   U_Decoder : entity surf.Decoder8b10b
+      generic map (
+         TPD_G          => TPD_G,
+         NUM_BYTES_G    => NUM_BYTES_G,
+         RST_POLARITY_G => '1',
+         RST_ASYNC_G    => false)
+      port map (
+         clk      => clk,
+         clkEn    => '1',
+         rst      => rst,
+         validIn  => validEncode,
+         dataIn   => dataEncode,
+         validOut => validOut,
+         dataOut  => dataOut,
+         dataKOut => dataKOut,
+         codeErr  => codeErr,
+         dispErr  => dispErr);
+
+end mapping;

--- a/protocols/sugoi/ruckus.tcl
+++ b/protocols/sugoi/ruckus.tcl
@@ -4,13 +4,12 @@ source $::env(RUCKUS_PROC_TCL)
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
 
-# Load Simulation
-loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
-
 # Check for non-zero Vivado version (in-case non-Vivado project)
 if {  $::env(VIVADO_VERSION) > 0.0} {
    loadSource -lib surf -dir "$::DIR_PATH/rtl/7Series"
    loadSource -lib surf -dir "$::DIR_PATH/rtl/UltraScale"
+   # Load Simulation (includes library UNISIM)
+   loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
 } else {
    loadSource -lib surf -dir "$::DIR_PATH/rtl/dummy"
 }

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -3,7 +3,7 @@ source $::env(RUCKUS_PROC_TCL)
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus} {4.8.2} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus} {4.8.4} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"

--- a/tests/test_LineCode10b12bTb.py
+++ b/tests/test_LineCode10b12bTb.py
@@ -1,0 +1,171 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# dut_tb
+import cocotb
+from cocotb.clock    import Clock
+from cocotb.triggers import RisingEdge
+
+# test_DspComparator
+from cocotb_test.simulator import run
+import pytest
+import glob
+import os
+
+@cocotb.coroutine
+def dut_init(dut):
+
+    # Initialize the inputs
+    dut.rst.value     = 1
+    dut.validIn.value = 0
+    dut.dataIn.value  = 0
+    dut.dataKIn.value = 0
+
+    # Start clock (200 MHz) in a separate thread
+    cocotb.start_soon(Clock(dut.clk, 5.0, units='ns').start())
+
+    # Wait 5 clock cycle
+    for i in range(5):
+        yield RisingEdge(dut.clk)
+
+    # De-assert the reset
+    dut.rst.value = 0
+
+    # Wait 1 clock cycle
+    yield RisingEdge(dut.clk)
+
+@cocotb.coroutine
+def load_value(dut, dataIn, dataKIn):
+
+    # Load the values
+    dut.dataIn.value  = dataIn
+    dut.dataKIn.value = dataKIn
+
+    # Assert valid flag
+    dut.validIn.value = 1
+
+    # Wait 1 clock cycle
+    yield RisingEdge(dut.clk)
+
+    # De-assert valid flag
+    dut.validIn.value = 0
+
+    # Wait for the result
+    while ( dut.validOut.value != 1 ):
+        yield RisingEdge(dut.clk)
+
+
+def check_result(dut, dataIn, dataKIn):
+    # Check (dataIn = dataOut) or (dataKIn = dataKOut) result
+    if (dataIn != dut.dataOut.value) or (dataKIn != dut.dataKOut.value):
+        dut._log.error( f'dataIn={hex(dataIn)},dataKIn={hex(dataKIn)} but got dataOut={hex(dut.dataOut.value)},dataKOut={hex(dut.dataKOut.value)}')
+        assert False
+
+    # Check (codeErr = 0) or (dispErr = 0) result
+    if (dut.codeErr.value != 0) or (dut.dispErr.value != 0):
+        dut._log.error( f'ERROR: codeErr={hex(dut.codeErr.value)},dispErr={hex(dut.dispErr.value)}')
+        assert False
+
+@cocotb.test()
+def dut_tb(dut):
+
+    # Initialize the DUT
+    yield dut_init(dut)
+
+    # Sweep through all possible combinations of data codes
+    dataKIn = 0
+    for dataIn in range(2**10):
+
+        # Load the values
+        yield load_value(dut, dataIn, dataKIn)
+
+        # Check the results for errors
+        check_result(dut, dataIn, dataKIn)
+
+    # Sweep through the defined Control Code Constants
+    dataKIn = 1
+    controlCodes = [
+        # These symbols are commas, sequences that can be used for word alignment
+        0x07C, # 0x07C -> 0x8FC, 0x703
+        0x17C, # 0x17C -> 0x2FC, 0xD03
+        0x27C, # 0x27C -> 0x4FC, 0xB03
+        # These symbols are not commas but can be used for control sequences
+        # Technically any K.28.x character is a valid k-char but these are preferred
+        0x0BC, # 0x0BC -> 0x683, 0x97C
+        0x0DC, # 0x0DC -> 0x643, 0x9BC
+        0x13C, # 0x13C -> 0x583, 0xA7C
+        0x15C, # 0x15C -> 0xABC, 0x543
+        0x19C, # 0x19C -> 0x4C3, 0xB3C
+        0x1BC, # 0x1BC -> 0x37C, 0xC83
+        0x1DC, # 0x1DC -> 0x3BC, 0xC43
+        0x23C, # 0x23C -> 0x383, 0xC7C
+        0x25C, # 0x25C -> 0x343, 0xCBC
+        0x29C, # 0x29C -> 0x2C3, 0xD3C
+        0x2BC, # 0x2BC -> 0x57C, 0xA83
+        0x2DC, # 0x2DC -> 0x5BC, 0xA43
+        0x33C, # 0x33C -> 0x67C, 0x983
+        0x35C, # 0x35C -> 0x6BC, 0x943
+    ]
+    for dataIn in controlCodes:
+
+        # Load the values
+        yield load_value(dut, dataIn, dataKIn)
+
+        # Check the results for errors
+        check_result(dut, dataIn, dataKIn)
+
+    dut._log.info("DUT: Passed")
+
+tests_dir = os.path.dirname(__file__)
+tests_module = 'LineCode10b12bTb'
+
+@pytest.mark.parametrize(
+    "parameters", [
+        None
+    ])
+def test_LineCode10b12bTb(parameters):
+
+    # https://github.com/themperek/cocotb-test#arguments-for-simulatorrun
+    # https://github.com/themperek/cocotb-test/blob/master/cocotb_test/simulator.py
+    run(
+        # top level HDL
+        toplevel = f'surf.{tests_module}'.lower(),
+
+        # name of the file that contains @cocotb.test() -- this file
+        # https://docs.cocotb.org/en/stable/building.html?#envvar-MODULE
+        module = f'test_{tests_module}',
+
+        # https://docs.cocotb.org/en/stable/building.html?#var-TOPLEVEL_LANG
+        toplevel_lang = 'vhdl',
+
+        # VHDL source files to include.
+        # Can be specified as a list or as a dict of lists with the library name as key,
+        # if the simulator supports named libraries.
+        vhdl_sources = {
+            'surf'   : glob.glob(f'{tests_dir}/../build/SRC_VHDL/surf/*'),
+            'ruckus' : glob.glob(f'{tests_dir}/../build/SRC_VHDL/ruckus/*'),
+        },
+
+        # A dictionary of top-level parameters/generics.
+        parameters = parameters,
+
+        # The directory used to compile the tests. (default: sim_build)
+        sim_build = f'{tests_dir}/sim_build/{tests_module}.',
+
+        # A dictionary of extra environment variables set in simulator process.
+        extra_env=parameters,
+
+        # Select a simulator
+        simulator="ghdl",
+
+        # use of synopsys package "std_logic_arith" needs the -fsynopsys option
+        # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
+        vhdl_compile_args = ['-fsynopsys', '-fexplicit'],
+    )

--- a/tests/test_LineCode10b12bTb.py
+++ b/tests/test_LineCode10b12bTb.py
@@ -70,7 +70,7 @@ def check_result(dut, dataIn, dataKIn):
 
     # Check (codeErr = 0) or (dispErr = 0) result
     if (dut.codeErr.value != 0) or (dut.dispErr.value != 0):
-        dut._log.error( f'ERROR: codeErr={hex(dut.codeErr.value)},dispErr={hex(dut.dispErr.value)}')
+        dut._log.error( f'ERROR - dataIn={hex(dataIn)},dataKIn={hex(dataKIn)}: codeErr={hex(dut.codeErr.value)},dispErr={hex(dut.dispErr.value)}')
         assert False
 
 @cocotb.test()
@@ -168,4 +168,7 @@ def test_LineCode10b12bTb(parameters):
         # use of synopsys package "std_logic_arith" needs the -fsynopsys option
         # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
         vhdl_compile_args = ['-fsynopsys', '-fexplicit'],
+
+        # Dump waveform to file ($ gtkwave sim_build/LineCode12b14bTb./LineCode12b14bTb.vcd)
+        sim_args =[f'--vcd={tests_module}.vcd'],
     )

--- a/tests/test_LineCode12b14bTb.py
+++ b/tests/test_LineCode12b14bTb.py
@@ -127,6 +127,64 @@ def dut_tb(dut):
         # Check the results for errors
         check_result(dut, dataIn, dataKIn)
 
+    testPattern = [
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x078,1],
+       [0x5F8,1],
+       [0xEAD,0],
+       [0x0BD,0],
+       [0xEAD,0],
+       [0x1BD,0],
+       [0xEAD,0],
+       [0x2BD,0],
+       [0xEAD,0],
+       [0x3BD,0],
+       [0xEAD,0],
+       [0x4BD,0],
+       [0xEAD,0],
+       [0x5BD,0],
+       [0xEAD,0],
+       [0x6BD,0],
+       [0xEAD,0],
+       [0x7BD,0],
+       [0xEAD,0],
+       [0x8BD,0],
+       [0xEAD,0],
+       [0x9BD,0],
+       [0xEAD,0],
+       [0xABD,0],
+       [0xEAD,0],
+       [0xBBD,0],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+       [0x5F8,1],
+    ]
+    for dataIn,dataKIn in testPattern:
+
+        # Load the values
+        yield load_value(dut, dataIn, dataKIn)
+
+        # Check the results for errors
+        check_result(dut, dataIn, dataKIn)
+
     dut._log.info("DUT: Passed")
 
 tests_dir = os.path.dirname(__file__)

--- a/tests/test_LineCode8b10bTb.py
+++ b/tests/test_LineCode8b10bTb.py
@@ -1,0 +1,167 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# dut_tb
+import cocotb
+from cocotb.clock    import Clock
+from cocotb.triggers import RisingEdge
+
+# test_DspComparator
+from cocotb_test.simulator import run
+import pytest
+import glob
+import os
+
+@cocotb.coroutine
+def dut_init(dut):
+
+    # Initialize the inputs
+    dut.rst.value     = 1
+    dut.validIn.value = 0
+    dut.dataIn.value  = 0
+    dut.dataKIn.value = 0
+
+    # Start clock (200 MHz) in a separate thread
+    cocotb.start_soon(Clock(dut.clk, 5.0, units='ns').start())
+
+    # Wait 5 clock cycle
+    for i in range(5):
+        yield RisingEdge(dut.clk)
+
+    # De-assert the reset
+    dut.rst.value = 0
+
+    # Wait 1 clock cycle
+    yield RisingEdge(dut.clk)
+
+@cocotb.coroutine
+def load_value(dut, dataIn, dataKIn):
+
+    # Load the values
+    dut.dataIn.value  = dataIn
+    dut.dataKIn.value = dataKIn
+
+    # Assert valid flag
+    dut.validIn.value = 1
+
+    # Wait 1 clock cycle
+    yield RisingEdge(dut.clk)
+
+    # De-assert valid flag
+    dut.validIn.value = 0
+
+    # Wait for the result
+    while ( dut.validOut.value != 1 ):
+        yield RisingEdge(dut.clk)
+
+
+def check_result(dut, dataIn, dataKIn):
+    # Check (dataIn = dataOut) or (dataKIn = dataKOut) result
+    if (dataIn != dut.dataOut.value) or (dataKIn != dut.dataKOut.value):
+        dut._log.error( f'dataIn={hex(dataIn)},dataKIn={hex(dataKIn)} but got dataOut={hex(dut.dataOut.value)},dataKOut={hex(dut.dataKOut.value)}')
+        assert False
+
+    # Check (codeErr = 0) or (dispErr = 0) result
+    if (dut.codeErr.value != 0) or (dut.dispErr.value != 0):
+        dut._log.error( f'ERROR: codeErr={hex(dut.codeErr.value)},dispErr={hex(dut.dispErr.value)}')
+        assert False
+
+@cocotb.test()
+def dut_tb(dut):
+
+    # Initialize the DUT
+    yield dut_init(dut)
+
+    # Read the parameters back from the DUT to set up our model
+    width = dut.NUM_BYTES_G.value.integer
+    dut._log.info( f'Found NUM_BYTES_G={width}' )
+
+    # Sweep through all possible combinations of data codes
+    dataKIn = 0
+    for dataIn in range(2**(8*width)):
+
+        # Load the values
+        yield load_value(dut, dataIn, dataKIn)
+
+        # Check the results for errors
+        check_result(dut, dataIn, dataKIn)
+
+    # Sweep through the defined Control Code Constants
+    dataKIn = 1
+    controlCodes = [
+        0x1C, # K28.0, 0x1C
+        0x3C, # K28.1, 0x3C (Comma)
+        0x5C, # K28.2, 0x5C
+        0x7C, # K28.3, 0x7C
+        0x9C, # K28.4, 0x9C
+        0xBC, # K28.5, 0xBC (Comma)
+        0xDC, # K28.6, 0xDC
+        0xFC, # K28.7, 0xFC (Comma)
+        0xF7, # K23.7, 0xF7
+        0xFB, # K27.7, 0xFB
+        0xFD, # K29.7, 0xFD
+        0xFE, # K30.7, 0xFE
+    ]
+    for dataIn in controlCodes:
+
+        # Load the values
+        yield load_value(dut, dataIn, dataKIn)
+
+        # Check the results for errors
+        check_result(dut, dataIn, dataKIn)
+
+    dut._log.info("DUT: Passed")
+
+tests_dir = os.path.dirname(__file__)
+tests_module = 'LineCode8b10bTb'
+
+@pytest.mark.parametrize(
+    "parameters", [
+        {'NUM_BYTES_G': '1'},  # Test 1 byte interface
+        {'NUM_BYTES_G': '2'},  # Test 2 byte interface
+    ])
+def test_LineCode8b10bTb(parameters):
+
+    # https://github.com/themperek/cocotb-test#arguments-for-simulatorrun
+    # https://github.com/themperek/cocotb-test/blob/master/cocotb_test/simulator.py
+    run(
+        # top level HDL
+        toplevel = f'surf.{tests_module}'.lower(),
+
+        # name of the file that contains @cocotb.test() -- this file
+        # https://docs.cocotb.org/en/stable/building.html?#envvar-MODULE
+        module = f'test_{tests_module}',
+
+        # https://docs.cocotb.org/en/stable/building.html?#var-TOPLEVEL_LANG
+        toplevel_lang = 'vhdl',
+
+        # VHDL source files to include.
+        # Can be specified as a list or as a dict of lists with the library name as key,
+        # if the simulator supports named libraries.
+        vhdl_sources = {
+            'surf'   : glob.glob(f'{tests_dir}/../build/SRC_VHDL/surf/*'),
+            'ruckus' : glob.glob(f'{tests_dir}/../build/SRC_VHDL/ruckus/*'),
+        },
+
+        # A dictionary of top-level parameters/generics.
+        parameters = parameters,
+
+        # The directory used to compile the tests. (default: sim_build)
+        sim_build = f'{tests_dir}/sim_build/{tests_module}.' + ",".join((f"{key}={value}" for key, value in parameters.items())),
+
+        # A dictionary of extra environment variables set in simulator process.
+        extra_env=parameters,
+
+        # Select a simulator
+        simulator="ghdl",
+
+        # Dump waveform to file ($ gtkwave sim_build/LineCode8b10bTb.NUM_BYTES_G\=1/LineCode8b10bTb.vcd)
+        sim_args =[f'--vcd={tests_module}.vcd'],
+    )


### PR DESCRIPTION
### Description
- [adding test_LineCode8b10bTb.py](https://github.com/slaclab/surf/commit/f92629ad47d18670e9e3277d4dfd48327383fd5a)
- [adding test_LineCode10b12bTb.py](https://github.com/slaclab/surf/pull/1091/commits/64b0510ed063933d0b37a8f1e6a4affedcf99d8f)
- [Encoder12b14b.vhd bug fix: missing readyOut in sensitivity list](https://github.com/slaclab/surf/pull/1091/commits/0f83a8e580944cccc80f76da1a6c84afe0754e3f)
- [adding adding test_LineCode12b14bTb.py](https://github.com/slaclab/surf/pull/1091/commits/ea775c4769801f9b4cf6a448b29170a9b2c1c6c0)