### PR TITLE
Adding AxiStreamFifoV2 to cocoTB CI regression testing

### DIFF
--- a/axi/axi-stream/ip_integrator/AxiStreamFifoV2IpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/AxiStreamFifoV2IpIntegrator.vhd
@@ -96,13 +96,13 @@ entity AxiStreamFifoV2IpIntegrator is
       M_AXIS_ACLK     : in  std_logic                                          := '0';
       M_AXIS_ARESETN  : in  std_logic                                          := '0';
       M_AXIS_TVALID   : out std_logic;
-      M_AXIS_TDATA    : out std_logic_vector((8*S_TDATA_NUM_BYTES)-1 downto 0);
-      M_AXIS_TSTRB    : out std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0);
-      M_AXIS_TKEEP    : out std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TDATA    : out std_logic_vector((8*M_TDATA_NUM_BYTES)-1 downto 0);
+      M_AXIS_TSTRB    : out std_logic_vector(M_TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TKEEP    : out std_logic_vector(M_TDATA_NUM_BYTES-1 downto 0);
       M_AXIS_TLAST    : out std_logic;
-      M_AXIS_TDEST    : out std_logic_vector(S_TDEST_WIDTH-1 downto 0);
-      M_AXIS_TID      : out std_logic_vector(S_TID_WIDTH-1 downto 0);
-      M_AXIS_TUSER    : out std_logic_vector(S_TUSER_WIDTH-1 downto 0);
+      M_AXIS_TDEST    : out std_logic_vector(M_TDEST_WIDTH-1 downto 0);
+      M_AXIS_TID      : out std_logic_vector(M_TID_WIDTH-1 downto 0);
+      M_AXIS_TUSER    : out std_logic_vector(M_TUSER_WIDTH-1 downto 0);
       M_AXIS_TREADY   : in  std_logic                                          := '1';
       -- Misc. Interfaces
       fifoPauseThresh : in  std_logic_vector(FIFO_ADDR_WIDTH-1 downto 0)       := (others => '1');

--- a/axi/axi-stream/ip_integrator/AxiStreamFifoV2IpIntegrator.vhd
+++ b/axi/axi-stream/ip_integrator/AxiStreamFifoV2IpIntegrator.vhd
@@ -1,0 +1,253 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: IP Integrator Wrapper for surf.AxiStreamFifoV2
+-------------------------------------------------------------------------------
+-- TCL Command: create_bd_cell -type module -reference AxiStreamFifoV2IpIntegrator AxiStreamFifoV2_0
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity AxiStreamFifoV2IpIntegrator is
+   generic (
+      -- IP Integrator Slave AXI Stream Configuration
+      S_INTERFACENAME   : string                 := "S_AXIS";
+      S_HAS_TLAST       : natural range 0 to 1   := 1;
+      S_HAS_TKEEP       : natural range 0 to 1   := 1;
+      S_HAS_TSTRB       : natural range 0 to 1   := 0;
+      S_HAS_TREADY      : natural range 0 to 1   := 1;
+      S_TUSER_WIDTH     : natural range 1 to 8   := 2;
+      S_TID_WIDTH       : natural range 1 to 8   := 1;
+      S_TDEST_WIDTH     : natural range 1 to 8   := 1;
+      S_TDATA_NUM_BYTES : natural range 1 to 128 := 1;
+
+      -- IP Integrator Master AXI Stream Configuration
+      M_INTERFACENAME   : string                 := "M_AXIS";
+      M_HAS_TLAST       : natural range 0 to 1   := 1;
+      M_HAS_TKEEP       : natural range 0 to 1   := 1;
+      M_HAS_TSTRB       : natural range 0 to 1   := 0;
+      M_HAS_TREADY      : natural range 0 to 1   := 1;
+      M_TUSER_WIDTH     : natural range 1 to 8   := 2;
+      M_TID_WIDTH       : natural range 1 to 8   := 1;
+      M_TDEST_WIDTH     : natural range 1 to 8   := 1;
+      M_TDATA_NUM_BYTES : natural range 1 to 128 := 1;
+
+      -- General Configurations
+      RST_ASYNC        : boolean                    := false;
+      INT_PIPE_STAGES  : natural range 0 to 16      := 0;  -- Internal FIFO setting
+      PIPE_STAGES      : natural range 0 to 16      := 1;
+      VALID_BURST_MODE : boolean                    := false;  -- only used in VALID_THOLD_G>1
+      VALID_THOLD      : integer range 0 to (2**24) := 1;  -- =1 = normal operation
+                                        -- =0 = only when frame ready
+                                                           -- >1 = only when frame ready or # entries
+
+      -- FIFO configurations
+      GEN_SYNC_FIFO     : boolean                    := false;
+      FIFO_ADDR_WIDTH   : integer range 4 to 48      := 9;
+      FIFO_FIXED_THRESH : boolean                    := true;
+      FIFO_PAUSE_THRESH : integer range 1 to (2**24) := 1;
+      SYNTH_MODE        : string                     := "inferred";
+      MEMORY_TYPE       : string                     := "block";
+
+      -- Internal FIFO width select, "WIDE", "NARROW" or "CUSTOM"
+      -- WIDE uses wider of slave / master. NARROW  uses narrower.
+      -- CUSOTM uses passed FIFO_DATA_WIDTH_G
+      INT_WIDTH_SELECT : string                := "WIDE";
+      INT_DATA_WIDTH   : natural range 1 to 16 := 16;
+
+      -- If VALID_THOLD_G /=1, FIFO that stores on tLast txns can be smaller.
+      -- Set to 0 for same size as primary fifo (default)
+      -- Set >4 for custom size.
+      -- Use at own risk. Overflow of tLast fifo is not checked
+      LAST_FIFO_ADDR_WIDTH : integer range 0 to 48 := 0;
+
+      -- Index = 0 is output, index = n is input
+      CASCADE_PAUSE_SEL : integer range 0 to (2**24) := 0;
+      CASCADE_SIZE      : integer range 1 to (2**24) := 1);
+   port (
+      -- IP Integrator Slave AXI Stream Interface
+      S_AXIS_ACLK     : in  std_logic                                          := '0';
+      S_AXIS_ARESETN  : in  std_logic                                          := '0';
+      S_AXIS_TVALID   : in  std_logic                                          := '0';
+      S_AXIS_TDATA    : in  std_logic_vector((8*S_TDATA_NUM_BYTES)-1 downto 0) := (others => '0');
+      S_AXIS_TSTRB    : in  std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TKEEP    : in  std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0)     := (others => '0');
+      S_AXIS_TLAST    : in  std_logic                                          := '0';
+      S_AXIS_TDEST    : in  std_logic_vector(S_TDEST_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TID      : in  std_logic_vector(S_TID_WIDTH-1 downto 0)           := (others => '0');
+      S_AXIS_TUSER    : in  std_logic_vector(S_TUSER_WIDTH-1 downto 0)         := (others => '0');
+      S_AXIS_TREADY   : out std_logic;
+      -- IP Integrator Master AXI Stream Interface
+      M_AXIS_ACLK     : in  std_logic                                          := '0';
+      M_AXIS_ARESETN  : in  std_logic                                          := '0';
+      M_AXIS_TVALID   : out std_logic;
+      M_AXIS_TDATA    : out std_logic_vector((8*S_TDATA_NUM_BYTES)-1 downto 0);
+      M_AXIS_TSTRB    : out std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TKEEP    : out std_logic_vector(S_TDATA_NUM_BYTES-1 downto 0);
+      M_AXIS_TLAST    : out std_logic;
+      M_AXIS_TDEST    : out std_logic_vector(S_TDEST_WIDTH-1 downto 0);
+      M_AXIS_TID      : out std_logic_vector(S_TID_WIDTH-1 downto 0);
+      M_AXIS_TUSER    : out std_logic_vector(S_TUSER_WIDTH-1 downto 0);
+      M_AXIS_TREADY   : in  std_logic                                          := '1';
+      -- Misc. Interfaces
+      fifoPauseThresh : in  std_logic_vector(FIFO_ADDR_WIDTH-1 downto 0)       := (others => '1');
+      fifoWrCnt       : out std_logic_vector(FIFO_ADDR_WIDTH-1 downto 0);
+      fifoFull        : out std_logic;
+      sAxisPause      : out std_logic;
+      sAxisOverflow   : out std_logic;
+      sAxisIdle       : out std_logic;
+      mTLastTUser     : out std_logic_vector(7 downto 0));
+end AxiStreamFifoV2IpIntegrator;
+
+architecture mapping of AxiStreamFifoV2IpIntegrator is
+
+   constant S_AXI_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => ite(S_HAS_TSTRB = 1, true, false),
+      TDATA_BYTES_C => S_TDATA_NUM_BYTES,
+      TDEST_BITS_C  => S_TDEST_WIDTH,
+      TID_BITS_C    => S_TID_WIDTH,
+      TKEEP_MODE_C  => ite(S_HAS_TKEEP = 1, TKEEP_NORMAL_C, TKEEP_FIXED_C),
+      TUSER_BITS_C  => S_TUSER_WIDTH,
+      TUSER_MODE_C  => TUSER_NORMAL_C);
+
+   constant M_AXI_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => ite(M_HAS_TSTRB = 1, true, false),
+      TDATA_BYTES_C => M_TDATA_NUM_BYTES,
+      TDEST_BITS_C  => M_TDEST_WIDTH,
+      TID_BITS_C    => M_TID_WIDTH,
+      TKEEP_MODE_C  => ite(M_HAS_TKEEP = 1, TKEEP_NORMAL_C, TKEEP_FIXED_C),
+      TUSER_BITS_C  => M_TUSER_WIDTH,
+      TUSER_MODE_C  => TUSER_NORMAL_C);
+
+   signal sAxisClk    : sl                  := '0';
+   signal sAxisRst    : sl                  := '0';
+   signal sAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal sAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal sAxisCtrl   : AxiStreamCtrlType   := AXI_STREAM_CTRL_UNUSED_C;
+
+   signal mAxisClk    : sl                  := '0';
+   signal mAxisRst    : sl                  := '0';
+   signal mAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+
+begin
+
+   U_ShimLayerSlave : entity surf.SlaveAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => S_INTERFACENAME,
+         HAS_TLAST       => S_HAS_TLAST,
+         HAS_TKEEP       => S_HAS_TKEEP,
+         HAS_TSTRB       => S_HAS_TSTRB,
+         HAS_TREADY      => S_HAS_TREADY,
+         TUSER_WIDTH     => S_TUSER_WIDTH,
+         TID_WIDTH       => S_TID_WIDTH,
+         TDEST_WIDTH     => S_TDEST_WIDTH,
+         TDATA_NUM_BYTES => S_TDATA_NUM_BYTES)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         S_AXIS_ACLK    => S_AXIS_ACLK,
+         S_AXIS_ARESETN => S_AXIS_ARESETN,
+         S_AXIS_TVALID  => S_AXIS_TVALID,
+         S_AXIS_TDATA   => S_AXIS_TDATA,
+         S_AXIS_TSTRB   => S_AXIS_TSTRB,
+         S_AXIS_TKEEP   => S_AXIS_TKEEP,
+         S_AXIS_TLAST   => S_AXIS_TLAST,
+         S_AXIS_TDEST   => S_AXIS_TDEST,
+         S_AXIS_TID     => S_AXIS_TID,
+         S_AXIS_TUSER   => S_AXIS_TUSER,
+         S_AXIS_TREADY  => S_AXIS_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => sAxisClk,
+         axisRst        => sAxisRst,
+         axisMaster     => sAxisMaster,
+         axisSlave      => sAxisSlave);
+
+   U_AxiStreamFifoV2 : entity surf.AxiStreamFifoV2
+      generic map (
+         RST_ASYNC_G            => RST_ASYNC,
+         INT_PIPE_STAGES_G      => INT_PIPE_STAGES,
+         PIPE_STAGES_G          => PIPE_STAGES,
+         SLAVE_READY_EN_G       => ite(S_HAS_TREADY = 1, true, false),
+         VALID_THOLD_G          => VALID_THOLD,
+         VALID_BURST_MODE_G     => VALID_BURST_MODE,
+         GEN_SYNC_FIFO_G        => GEN_SYNC_FIFO,
+         FIFO_ADDR_WIDTH_G      => FIFO_ADDR_WIDTH,
+         FIFO_FIXED_THRESH_G    => FIFO_FIXED_THRESH,
+         FIFO_PAUSE_THRESH_G    => FIFO_PAUSE_THRESH,
+         SYNTH_MODE_G           => SYNTH_MODE,
+         MEMORY_TYPE_G          => MEMORY_TYPE,
+         INT_WIDTH_SELECT_G     => INT_WIDTH_SELECT,
+         INT_DATA_WIDTH_G       => INT_DATA_WIDTH,
+         LAST_FIFO_ADDR_WIDTH_G => LAST_FIFO_ADDR_WIDTH,
+         CASCADE_PAUSE_SEL_G    => CASCADE_PAUSE_SEL,
+         CASCADE_SIZE_G         => CASCADE_SIZE,
+         SLAVE_AXI_CONFIG_G     => S_AXI_CONFIG_C,
+         MASTER_AXI_CONFIG_G    => M_AXI_CONFIG_C)
+      port map (
+         -- Slave Port
+         sAxisClk        => sAxisClk,
+         sAxisRst        => sAxisRst,
+         sAxisMaster     => sAxisMaster,
+         sAxisSlave      => sAxisSlave,
+         sAxisCtrl       => sAxisCtrl,
+         -- FIFO status & config
+         fifoPauseThresh => fifoPauseThresh,
+         fifoWrCnt       => fifoWrCnt,
+         fifoFull        => fifoFull,
+         -- Master Port
+         mAxisClk        => mAxisClk,
+         mAxisRst        => mAxisRst,
+         mAxisMaster     => mAxisMaster,
+         mAxisSlave      => mAxisSlave,
+         mTLastTUser     => mTLastTUser);
+
+   sAxisPause    <= sAxisCtrl.pause;
+   sAxisOverflow <= sAxisCtrl.overflow;
+   sAxisIdle     <= sAxisCtrl.idle;
+
+   U_ShimLayerMaster : entity surf.MasterAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => M_INTERFACENAME,
+         HAS_TLAST       => M_HAS_TLAST,
+         HAS_TKEEP       => M_HAS_TKEEP,
+         HAS_TSTRB       => M_HAS_TSTRB,
+         HAS_TREADY      => M_HAS_TREADY,
+         TUSER_WIDTH     => M_TUSER_WIDTH,
+         TID_WIDTH       => M_TID_WIDTH,
+         TDEST_WIDTH     => M_TDEST_WIDTH,
+         TDATA_NUM_BYTES => M_TDATA_NUM_BYTES)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         M_AXIS_ACLK    => M_AXIS_ACLK,
+         M_AXIS_ARESETN => M_AXIS_ARESETN,
+         M_AXIS_TVALID  => M_AXIS_TVALID,
+         M_AXIS_TDATA   => M_AXIS_TDATA,
+         M_AXIS_TSTRB   => M_AXIS_TSTRB,
+         M_AXIS_TKEEP   => M_AXIS_TKEEP,
+         M_AXIS_TLAST   => M_AXIS_TLAST,
+         M_AXIS_TDEST   => M_AXIS_TDEST,
+         M_AXIS_TID     => M_AXIS_TID,
+         M_AXIS_TUSER   => M_AXIS_TUSER,
+         M_AXIS_TREADY  => M_AXIS_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => mAxisClk,
+         axisRst        => mAxisRst,
+         axisMaster     => mAxisMaster,
+         axisSlave      => mAxisSlave);
+
+end mapping;

--- a/axi/axi-stream/ruckus.tcl
+++ b/axi/axi-stream/ruckus.tcl
@@ -3,11 +3,7 @@ source $::env(RUCKUS_PROC_TCL)
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
-
-# Check for non-zero Vivado version (in-case non-Vivado project)
-if {  $::env(VIVADO_VERSION) > 0.0} {
-   loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
-}
+loadSource -lib surf -dir "$::DIR_PATH/ip_integrator"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/protocols/sugoi/ruckus.tcl
+++ b/protocols/sugoi/ruckus.tcl
@@ -4,13 +4,12 @@ source $::env(RUCKUS_PROC_TCL)
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
 
-# Load Simulation
-loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
-
 # Check for non-zero Vivado version (in-case non-Vivado project)
 if {  $::env(VIVADO_VERSION) > 0.0} {
    loadSource -lib surf -dir "$::DIR_PATH/rtl/7Series"
    loadSource -lib surf -dir "$::DIR_PATH/rtl/UltraScale"
+   # Load Simulation (includes library UNISIM)
+   loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
 } else {
    loadSource -lib surf -dir "$::DIR_PATH/rtl/dummy"
 }

--- a/tests/test_AxiStreamFifoV2IpIntegrator.py
+++ b/tests/test_AxiStreamFifoV2IpIntegrator.py
@@ -9,14 +9,14 @@
 ##############################################################################
 
 # dut_tb
+import itertools
 import logging
-import random
 import cocotb
 from cocotb.clock      import Clock
 from cocotb.triggers   import RisingEdge
 from cocotb.regression import TestFactory
 
-from cocotbext.axi import AxiStreamFrame, AxiStreamBus, AxiStreamSource, AxiStreamSink, AxiStreamMonitor
+from cocotbext.axi import AxiStreamFrame, AxiStreamBus, AxiStreamSource, AxiStreamSink
 
 # test_AxiStreamFifoV2IpIntegrator
 from cocotb_test.simulator import run
@@ -35,25 +35,25 @@ class TB:
 
         # Start S_AXIS_ACLK clock (200 MHz) in a separate thread
         cocotb.start_soon(Clock(dut.S_AXIS_ACLK, 5.0, units='ns').start())
-        
+
         # Start M_AXIS_ACLK clock (200 MHz) in a separate thread
-        cocotb.start_soon(Clock(dut.M_AXIS_ACLK, 5.0, units='ns').start())        
+        cocotb.start_soon(Clock(dut.M_AXIS_ACLK, 5.0, units='ns').start())
 
         # Setup the AXI stream source
         self.source = AxiStreamSource(
-            bus   = AxiStreamBus.from_prefix(dut, "S_AXIS"), 
-            clock = dut.S_AXIS_ACLK, 
+            bus   = AxiStreamBus.from_prefix(dut, "S_AXIS"),
+            clock = dut.S_AXIS_ACLK,
             reset = dut.S_AXIS_ARESETN,
             reset_active_level = False,
         )
-        
+
         # Setup the AXI stream sink
         self.sink = AxiStreamSink(
-            bus   = AxiStreamBus.from_prefix(dut, "M_AXIS"), 
-            clock = dut.M_AXIS_ACLK, 
+            bus   = AxiStreamBus.from_prefix(dut, "M_AXIS"),
+            clock = dut.M_AXIS_ACLK,
             reset = dut.M_AXIS_ARESETN,
             reset_active_level = False,
-        )        
+        )
 
     def set_idle_generator(self, generator=None):
         if generator:
@@ -73,7 +73,7 @@ class TB:
         self.dut.S_AXIS_ARESETN.value = 1
         await RisingEdge(self.dut.S_AXIS_ACLK)
         await RisingEdge(self.dut.S_AXIS_ACLK)
-        
+
     async def m_cycle_reset(self):
         self.dut.M_AXIS_ARESETN.setimmediatevalue(0)
         await RisingEdge(self.dut.M_AXIS_ACLK)
@@ -83,28 +83,78 @@ class TB:
         await RisingEdge(self.dut.M_AXIS_ACLK)
         self.dut.M_AXIS_ARESETN.value = 1
         await RisingEdge(self.dut.M_AXIS_ACLK)
-        await RisingEdge(self.dut.M_AXIS_ACLK)        
+        await RisingEdge(self.dut.M_AXIS_ACLK)
 
-async def dut_tb(dut):
+async def run_test(dut, payload_lengths=None, payload_data=None, idle_inserter=None, backpressure_inserter=None):
 
-    # Initialize the DUT
     tb = TB(dut)
 
-    # Reset DUT
+    id_count = 2**len(tb.source.bus.tid)
+
+    cur_id = 1
+
     await tb.s_cycle_reset()
     await tb.m_cycle_reset()
 
+    tb.set_idle_generator(idle_inserter)
+    tb.set_backpressure_generator(backpressure_inserter)
+
+    test_frames = []
+
+    for test_data in [payload_data(x) for x in payload_lengths()]:
+        test_frame = AxiStreamFrame(test_data)
+        test_frame.tid = cur_id
+        test_frame.tdest = cur_id
+        await tb.source.send(test_frame)
+
+        test_frames.append(test_frame)
+
+        cur_id = (cur_id + 1) % id_count
+
+    for test_frame in test_frames:
+        rx_frame = await tb.sink.recv()
+
+        assert rx_frame.tdata == test_frame.tdata
+        assert rx_frame.tid == test_frame.tid
+        assert rx_frame.tdest == test_frame.tdest
+        assert not rx_frame.tuser
+
+    assert tb.sink.empty()
+
+def cycle_pause():
+    return itertools.cycle([1, 1, 1, 0])
+
+def size_list():
+    return list(range(1, 32+1))
+
+def incrementing_payload(length):
+    return bytearray(itertools.islice(itertools.cycle(range(256)), length))
+
 if cocotb.SIM_NAME:
-    factory = TestFactory(dut_tb)
+    factory = TestFactory(run_test)
+    factory.add_option("payload_lengths", [size_list])
+    factory.add_option("payload_data", [incrementing_payload])
+    factory.add_option("idle_inserter", [None, cycle_pause])
+    factory.add_option("backpressure_inserter", [None, cycle_pause])
     factory.generate_tests()
 
 tests_dir = os.path.dirname(__file__)
 tests_module = 'AxiStreamFifoV2IpIntegrator'
 
-@pytest.mark.parametrize(
-    "parameters", [
-        {'S_TDATA_NUM_BYTES': '1', },
-    ])
+##############################################################################
+
+paramSweep = []
+for sTdataByte in ['2','6']:
+    for mTdataByte in ['2','6']:
+        tmpDict = {
+          "M_TDATA_NUM_BYTES": mTdataByte,
+          "S_TDATA_NUM_BYTES": sTdataByte,
+        }
+        paramSweep.append(tmpDict)
+
+##############################################################################
+
+@pytest.mark.parametrize("parameters", paramSweep)
 def test_AxiStreamFifoV2IpIntegrator(parameters):
 
     # https://github.com/themperek/cocotb-test#arguments-for-simulatorrun
@@ -132,19 +182,19 @@ def test_AxiStreamFifoV2IpIntegrator(parameters):
         parameters = parameters,
 
         # The directory used to compile the tests. (default: sim_build)
-        sim_build = f'{tests_dir}/sim_build/{tests_module}',
+        sim_build = f'{tests_dir}/sim_build/{tests_module}.' + ",".join((f"{key}={value}" for key, value in parameters.items())),
 
         # A dictionary of extra environment variables set in simulator process.
         extra_env=parameters,
+
+        # Select a simulator
+        simulator="ghdl",
 
         # use of synopsys package "std_logic_arith" needs the -fsynopsys option
         # -frelaxed-rules option to allow IP integrator attributes
         # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
         vhdl_compile_args = ['-fsynopsys','-frelaxed-rules', '-fexplicit'],
 
-        # Select a simulator
-        simulator="ghdl",
-
-        # # Dump waveform to file ($ gtkwave sim_build/AxiStreamFifoV2IpIntegrator/AxiStreamFifoV2IpIntegrator.vcd)
-        # sim_args =[f'--vcd={tests_module}.vcd'],
+        # Dump waveform to file ($ gtkwave sim_build/AxiStreamFifoV2IpIntegrator/AxiStreamFifoV2IpIntegrator.vcd)
+        sim_args =[f'--vcd={tests_module}.vcd'],
     )

--- a/tests/test_AxiStreamFifoV2IpIntegrator.py
+++ b/tests/test_AxiStreamFifoV2IpIntegrator.py
@@ -1,0 +1,150 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# dut_tb
+import logging
+import random
+import cocotb
+from cocotb.clock      import Clock
+from cocotb.triggers   import RisingEdge
+from cocotb.regression import TestFactory
+
+from cocotbext.axi import AxiStreamFrame, AxiStreamBus, AxiStreamSource, AxiStreamSink, AxiStreamMonitor
+
+# test_AxiStreamFifoV2IpIntegrator
+from cocotb_test.simulator import run
+import pytest
+import glob
+import os
+
+class TB:
+    def __init__(self, dut):
+
+        # Pointer to DUT object
+        self.dut = dut
+
+        self.log = logging.getLogger("cocotb.tb")
+        self.log.setLevel(logging.DEBUG)
+
+        # Start S_AXIS_ACLK clock (200 MHz) in a separate thread
+        cocotb.start_soon(Clock(dut.S_AXIS_ACLK, 5.0, units='ns').start())
+        
+        # Start M_AXIS_ACLK clock (200 MHz) in a separate thread
+        cocotb.start_soon(Clock(dut.M_AXIS_ACLK, 5.0, units='ns').start())        
+
+        # Setup the AXI stream source
+        self.source = AxiStreamSource(
+            bus   = AxiStreamBus.from_prefix(dut, "S_AXIS"), 
+            clock = dut.S_AXIS_ACLK, 
+            reset = dut.S_AXIS_ARESETN,
+            reset_active_level = False,
+        )
+        
+        # Setup the AXI stream sink
+        self.sink = AxiStreamSink(
+            bus   = AxiStreamBus.from_prefix(dut, "M_AXIS"), 
+            clock = dut.M_AXIS_ACLK, 
+            reset = dut.M_AXIS_ARESETN,
+            reset_active_level = False,
+        )        
+
+    def set_idle_generator(self, generator=None):
+        if generator:
+            self.source.set_pause_generator(generator())
+
+    def set_backpressure_generator(self, generator=None):
+        if generator:
+            self.sink.set_pause_generator(generator())
+
+    async def s_cycle_reset(self):
+        self.dut.S_AXIS_ARESETN.setimmediatevalue(0)
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        self.dut.S_AXIS_ARESETN.value = 0
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        self.dut.S_AXIS_ARESETN.value = 1
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        await RisingEdge(self.dut.S_AXIS_ACLK)
+        
+    async def m_cycle_reset(self):
+        self.dut.M_AXIS_ARESETN.setimmediatevalue(0)
+        await RisingEdge(self.dut.M_AXIS_ACLK)
+        await RisingEdge(self.dut.M_AXIS_ACLK)
+        self.dut.M_AXIS_ARESETN.value = 0
+        await RisingEdge(self.dut.M_AXIS_ACLK)
+        await RisingEdge(self.dut.M_AXIS_ACLK)
+        self.dut.M_AXIS_ARESETN.value = 1
+        await RisingEdge(self.dut.M_AXIS_ACLK)
+        await RisingEdge(self.dut.M_AXIS_ACLK)        
+
+async def dut_tb(dut):
+
+    # Initialize the DUT
+    tb = TB(dut)
+
+    # Reset DUT
+    await tb.s_cycle_reset()
+    await tb.m_cycle_reset()
+
+if cocotb.SIM_NAME:
+    factory = TestFactory(dut_tb)
+    factory.generate_tests()
+
+tests_dir = os.path.dirname(__file__)
+tests_module = 'AxiStreamFifoV2IpIntegrator'
+
+@pytest.mark.parametrize(
+    "parameters", [
+        {'S_TDATA_NUM_BYTES': '1', },
+    ])
+def test_AxiStreamFifoV2IpIntegrator(parameters):
+
+    # https://github.com/themperek/cocotb-test#arguments-for-simulatorrun
+    # https://github.com/themperek/cocotb-test/blob/master/cocotb_test/simulator.py
+    run(
+        # top level HDL
+        toplevel = f'surf.{tests_module}'.lower(),
+
+        # name of the file that contains @cocotb.test() -- this file
+        # https://docs.cocotb.org/en/stable/building.html?#envvar-MODULE
+        module = f'test_{tests_module}',
+
+        # https://docs.cocotb.org/en/stable/building.html?#var-TOPLEVEL_LANG
+        toplevel_lang = 'vhdl',
+
+        # VHDL source files to include.
+        # Can be specified as a list or as a dict of lists with the library name as key,
+        # if the simulator supports named libraries.
+        vhdl_sources = {
+            'surf'   : glob.glob(f'{tests_dir}/../build/SRC_VHDL/surf/*'),
+            'ruckus' : glob.glob(f'{tests_dir}/../build/SRC_VHDL/ruckus/*'),
+        },
+
+        # A dictionary of top-level parameters/generics.
+        parameters = parameters,
+
+        # The directory used to compile the tests. (default: sim_build)
+        sim_build = f'{tests_dir}/sim_build/{tests_module}',
+
+        # A dictionary of extra environment variables set in simulator process.
+        extra_env=parameters,
+
+        # use of synopsys package "std_logic_arith" needs the -fsynopsys option
+        # -frelaxed-rules option to allow IP integrator attributes
+        # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
+        vhdl_compile_args = ['-fsynopsys','-frelaxed-rules', '-fexplicit'],
+
+        # Select a simulator
+        simulator="ghdl",
+
+        # # Dump waveform to file ($ gtkwave sim_build/AxiStreamFifoV2IpIntegrator/AxiStreamFifoV2IpIntegrator.vcd)
+        # sim_args =[f'--vcd={tests_module}.vcd'],
+    )

--- a/tests/test_AxiVersionIpIntegrator.py
+++ b/tests/test_AxiVersionIpIntegrator.py
@@ -123,12 +123,12 @@ def test_AxiVersionIpIntegrator(parameters):
         # A dictionary of extra environment variables set in simulator process.
         extra_env=parameters,
 
+        # Select a simulator
+        simulator="ghdl",
+
         # use of synopsys package "std_logic_arith" needs the -fsynopsys option
         # -frelaxed-rules option to allow IP integrator attributes
         vhdl_compile_args = ['-fsynopsys','-frelaxed-rules'],
-
-        # Select a simulator
-        simulator="ghdl",
 
         # Dump waveform to file ($ gtkwave sim_build/AxiVersionIpIntegrator/AxiVersionIpIntegrator.vcd)
         sim_args =[f'--vcd={tests_module}.vcd'],


### PR DESCRIPTION
### Description
- [SUGOI sim includes library UNISIM](https://github.com/slaclab/surf/commit/2044adc8c20e37d0c62a223e0008b2cb86ed914f)
- [adding AxiStreamFifoV2IpIntegrator.vhd](https://github.com/slaclab/surf/commit/cb03b3567635b4fe897a35673eb1828497e09e12)
- Added test_AxiStreamFifoV2IpIntegrator.py