### PR TITLE
cocoTB update and Bug fixes for AxiStreamGearbox.vhd

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamGearbox.vhd
+++ b/axi/axi-stream/rtl/AxiStreamGearbox.vhd
@@ -72,7 +72,7 @@ architecture rtl of AxiStreamGearbox is
    constant MAX_C : positive := maximum(MST_BYTES_C, SLV_BYTES_C);
    constant MIN_C : positive := minimum(MST_BYTES_C, SLV_BYTES_C);
 
-   constant SHIFT_WIDTH_C : positive := wordCount(MAX_C, MIN_C) * MIN_C + MIN_C + 1;
+   constant SHIFT_WIDTH_C : positive := wordCount(MAX_C, MIN_C) * MIN_C + MIN_C;
 
    type RegType is record
       writeIndex : natural range 0 to SHIFT_WIDTH_C-1;
@@ -212,8 +212,10 @@ begin
 
                   -- Set the flags
                   v.tValid   := '1';
-                  v.tLast    := r.tLastDly;
-                  v.tLastDly := '0';
+                  if (v.writeIndex <= MST_BYTES_C) then
+                     v.tLast    := r.tLastDly;
+                     v.tLastDly := '0';
+                  end if;
 
                end if;
 

--- a/axi/axi-stream/rtl/AxiStreamGearbox.vhd
+++ b/axi/axi-stream/rtl/AxiStreamGearbox.vhd
@@ -72,7 +72,7 @@ architecture rtl of AxiStreamGearbox is
    constant MAX_C : positive := maximum(MST_BYTES_C, SLV_BYTES_C);
    constant MIN_C : positive := minimum(MST_BYTES_C, SLV_BYTES_C);
 
-   constant SHIFT_WIDTH_C : positive := wordCount(MAX_C, MIN_C) * MIN_C + MIN_C;
+   constant SHIFT_WIDTH_C : positive := wordCount(MAX_C, MIN_C) * MIN_C + MIN_C + 1;
 
    type RegType is record
       writeIndex : natural range 0 to SHIFT_WIDTH_C-1;
@@ -265,7 +265,7 @@ begin
             end if;
 
             -- Increment writeIndex
-            v.writeIndex := v.writeIndex + SLV_BYTES_C;
+            v.writeIndex := v.writeIndex + getTKeep(resize(sAxisMaster.tKeep(1*SLV_BYTES_C-1 downto 0), AXI_STREAM_MAX_TKEEP_WIDTH_C), SLAVE_AXI_CONFIG_G);
 
             -- Assert tValid
             if (v.writeIndex >= MST_BYTES_C) or (sAxisMaster.tLast = '1') then

--- a/tests/test_AxiStreamFifoV2IpIntegrator.py
+++ b/tests/test_AxiStreamFifoV2IpIntegrator.py
@@ -195,6 +195,8 @@ def test_AxiStreamFifoV2IpIntegrator(parameters):
         # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
         vhdl_compile_args = ['-fsynopsys','-frelaxed-rules', '-fexplicit'],
 
-        # Dump waveform to file ($ gtkwave sim_build/AxiStreamFifoV2IpIntegrator/AxiStreamFifoV2IpIntegrator.vcd)
-        sim_args =[f'--vcd={tests_module}.vcd'],
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_AxiStreamFifoV2IpIntegrator.py
+++ b/tests/test_AxiStreamFifoV2IpIntegrator.py
@@ -87,6 +87,10 @@ class TB:
 
 async def run_test(dut, payload_lengths=None, payload_data=None, idle_inserter=None, backpressure_inserter=None):
 
+    # Debug messages in case it fails
+    dut._log.info( f'Found M_TDATA_NUM_BYTES={dut.M_TDATA_NUM_BYTES.value.integer}' )
+    dut._log.info( f'Found S_TDATA_NUM_BYTES={dut.S_TDATA_NUM_BYTES.value.integer}' )
+
     tb = TB(dut)
 
     id_count = 2**len(tb.source.bus.tid)
@@ -144,8 +148,8 @@ tests_module = 'AxiStreamFifoV2IpIntegrator'
 ##############################################################################
 
 paramSweep = []
-for sTdataByte in ['2','6']:
-    for mTdataByte in ['2','6']:
+for sTdataByte in ['2','5','6']:
+    for mTdataByte in ['2','5','6']:
         tmpDict = {
           "M_TDATA_NUM_BYTES": mTdataByte,
           "S_TDATA_NUM_BYTES": sTdataByte,

--- a/tests/test_AxiVersionIpIntegrator.py
+++ b/tests/test_AxiVersionIpIntegrator.py
@@ -130,6 +130,8 @@ def test_AxiVersionIpIntegrator(parameters):
         # -frelaxed-rules option to allow IP integrator attributes
         vhdl_compile_args = ['-fsynopsys','-frelaxed-rules'],
 
-        # Dump waveform to file ($ gtkwave sim_build/AxiVersionIpIntegrator/AxiVersionIpIntegrator.vcd)
-        sim_args =[f'--vcd={tests_module}.vcd'],
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_DspComparator.py
+++ b/tests/test_DspComparator.py
@@ -161,4 +161,9 @@ def test_DspComparator(parameters):
 
         # Select a simulator
         simulator="ghdl",
+
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_LineCode10b12bTb.py
+++ b/tests/test_LineCode10b12bTb.py
@@ -169,6 +169,8 @@ def test_LineCode10b12bTb(parameters):
         # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
         vhdl_compile_args = ['-fsynopsys', '-fexplicit'],
 
-        # Dump waveform to file ($ gtkwave sim_build/LineCode12b14bTb./LineCode12b14bTb.vcd)
-        sim_args =[f'--vcd={tests_module}.vcd'],
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_LineCode12b14bTb.py
+++ b/tests/test_LineCode12b14bTb.py
@@ -233,6 +233,8 @@ def test_LineCode12b14bTb(parameters):
         # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
         vhdl_compile_args = ['-fsynopsys', '-fexplicit'],
 
-        # Dump waveform to file ($ gtkwave sim_build/LineCode12b14bTb./LineCode12b14bTb.vcd)
-        sim_args =[f'--vcd={tests_module}.vcd'],
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_LineCode8b10bTb.py
+++ b/tests/test_LineCode8b10bTb.py
@@ -162,6 +162,8 @@ def test_LineCode8b10bTb(parameters):
         # Select a simulator
         simulator="ghdl",
 
-        # Dump waveform to file ($ gtkwave sim_build/LineCode8b10bTb.NUM_BYTES_G\=1/LineCode8b10bTb.vcd)
-        sim_args =[f'--vcd={tests_module}.vcd'],
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )


### PR DESCRIPTION
### Description
- [migrating from .VCD to .GHW because GHW supports record type dumps](https://github.com/slaclab/surf/commit/53cf2d8e659310de45c1d0262bf2b96da122a1ce)
- [Bug fixes for AxiStreamGearbox.vhd when (SLV_BYTES_C>MST_BYTES_C) and (transfer size < MST_BYTES_C)](https://github.com/slaclab/surf/commit/010b9c44982fa0ab9e6ee2c4634d064ca3b579db)
  - Prevents the tkeep=0 w/ tLast case
- [bug fixes for AxiStreamGearbox.vhd for when (SLV_BYTES_C>2*MST_BYTES_C) and terminating a frame](https://github.com/slaclab/surf/pull/1096/commits/4a90a1e7598f1fd3a5ea90f42cc30050272cd2e9) 
  - Prevent the case there the tLast was getting asserted too early
- [updating paramSweep to include non-word multiple to execise AxiStreamGearbox](https://github.com/slaclab/surf/pull/1096/commits/22f55b66bcceee8722fb07242bed8c100dd4f2ea)