### PR TITLE
Provide register init values for PGP2b

### DIFF
--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
@@ -5,87 +5,6 @@
 -------------------------------------------------------------------------------
 -- Description:
 -- AXI-Lite block to manage the PGP interface.
---
--- Address map (offset from base):
---    0x00 = Read/Write
---       Bits 0 = Count Reset
---    0x04 = Read/Write
---       Bits 0 = Reset Rx
---    0x08 = Read/Write
---       Bits 0 = Flush
---    0x0C = Read/Write
---       Bits 1:0 = Loop Back
---    0x10 = Read/Write
---       Bits 7:0 = Sideband data to transmit
---       Bits 8   = Sideband data enable
---    0x14 = Read/Write
---       Bits 0 = Auto Status Send Enable (PPI)
---    0x18 = Read/Write
---       Bits 0 = Disable Flow Control
---    0x20 = Read Only
---       Bits 0     = Rx Phy Ready
---       Bits 1     = Tx Phy Ready
---       Bits 2     = Local Link Ready
---       Bits 3     = Remote Link Ready
---       Bits 4     = Transmit Ready
---       Bits 9:8   = Receive Link Polarity
---       Bits 15:12 = Remote Pause Status
---       Bits 19:16 = Local Pause Status
---       Bits 23:20 = Remote Overflow Status
---       Bits 27:24 = Local Overflow Status
---    0x24 = Read Only
---       Bits 7:0 = Remote Link Data
---    0x28 = Read Only
---       Bits ?:0 = Cell Error Count
---    0x2C = Read Only
---       Bits ?:0 = Link Down Count
---    0x30 = Read Only
---       Bits ?:0 = Link Error Count
---    0x34 = Read Only
---       Bits ?:0 = Remote Overflow VC 0 Count
---    0x38 = Read Only
---       Bits ?:0 = Remote Overflow VC 1 Count
---    0x3C = Read Only
---       Bits ?:0 = Remote Overflow VC 2 Count
---    0x40 = Read Only
---       Bits ?:0 = Remote Overflow VC 3 Count
---    0x44 = Read Only
---       Bits ?:0 = Receive Frame Error Count
---    0x48 = Read Only
---       Bits ?:0 = Receive Frame Count
---    0x4C = Read Only
---       Bits ?:0 = Local Overflow VC 0 Count
---    0x50 = Read Only
---       Bits ?:0 = Local Overflow VC 1 Count
---    0x54 = Read Only
---       Bits ?:0 = Local Overflow VC 2 Count
---    0x58 = Read Only
---       Bits ?:0 = Local Overflow VC 3 Count
---    0x5C = Read Only
---       Bits ?:0 = Transmit Frame Error Count
---    0x60 = Read Only
---       Bits ?:0 = Transmit Frame Count
---    0x64 = Read Only
---       Bits 31:0 = Receive Clock Frequency
---    0x68 = Read Only
---       Bits 31:0 = Transmit Clock Frequency
---    0x70 = Read Only
---       Bits 7:0 = Last OpCode Transmitted
---    0x74 = Read Only
---       Bits 7:0 = Last OpCode Received
---    0x78 = Read Only
---       Bits ?:0 = OpCode Transmit count
---    0x7C = Read Only
---       Bits ?:0 = OpCode Received count
---
--- Status vector:
---       Bits 31:24 = Rx Link Down Count
---       Bits 23:16 = Rx Frame Error Count
---       Bits 15:8  = Rx Cell Error Count
---       Bits  7:6  = Zeros
---       Bits    5  = Remote Link Ready
---       Bits    4  = Local Link Ready
---       Bits  3:0  = Remote Overflow Status
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -400,7 +319,7 @@ begin
       generic map (
          TPD_G             => TPD_G,
          REF_CLK_FREQ_G    => AXI_CLK_FREQ_G,
-         REFRESH_RATE_G    => 100.0,
+         REFRESH_RATE_G    => 1000.0,
          CLK_LOWER_LIMIT_G => 155.0E+6,
          CLK_UPPER_LIMIT_G => 158.0E+6,
          CNT_WIDTH_G       => 32)
@@ -515,7 +434,7 @@ begin
       generic map (
          TPD_G             => TPD_G,
          REF_CLK_FREQ_G    => AXI_CLK_FREQ_G,
-         REFRESH_RATE_G    => 100.0,
+         REFRESH_RATE_G    => 1000.0,
          CLK_LOWER_LIMIT_G => 155.0E+6,
          CLK_UPPER_LIMIT_G => 158.0E+6,
          CNT_WIDTH_G       => 32)

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bAxi.vhd
@@ -319,7 +319,7 @@ begin
       generic map (
          TPD_G             => TPD_G,
          REF_CLK_FREQ_G    => AXI_CLK_FREQ_G,
-         REFRESH_RATE_G    => 1000.0,
+         REFRESH_RATE_G    => 100.0,
          CLK_LOWER_LIMIT_G => 155.0E+6,
          CLK_UPPER_LIMIT_G => 158.0E+6,
          CNT_WIDTH_G       => 32)
@@ -434,7 +434,7 @@ begin
       generic map (
          TPD_G             => TPD_G,
          REF_CLK_FREQ_G    => AXI_CLK_FREQ_G,
-         REFRESH_RATE_G    => 1000.0,
+         REFRESH_RATE_G    => 100.0,
          CLK_LOWER_LIMIT_G => 155.0E+6,
          CLK_UPPER_LIMIT_G => 158.0E+6,
          CNT_WIDTH_G       => 32)

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bTxCell.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bTxCell.vhd
@@ -41,16 +41,16 @@ entity Pgp2bTxCell is
       pgpTxLinkReady    : in  sl;                               -- Local side has link
 
       -- Phy Transmit Interface
-      cellTxSOC         : out sl;                               -- Cell data start of cell
-      cellTxSOF         : out sl;                               -- Cell data start of frame
-      cellTxEOC         : out sl;                               -- Cell data end of cell
-      cellTxEOF         : out sl;                               -- Cell data end of frame
-      cellTxEOFE        : out sl;                               -- Cell data end of frame error
-      cellTxData        : out slv(TX_LANE_CNT_G*16-1 downto 0); -- Cell data data
+      cellTxSOC         : out sl := '0';                               -- Cell data start of cell
+      cellTxSOF         : out sl := '0';                               -- Cell data start of frame
+      cellTxEOC         : out sl := '0';                               -- Cell data end of cell
+      cellTxEOF         : out sl := '0';                               -- Cell data end of frame
+      cellTxEOFE        : out sl := '0';                               -- Cell data end of frame error
+      cellTxData        : out slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0'); -- Cell data data
 
       -- Transmit Scheduler Interface
-      schTxSOF          : out sl;                               -- Cell contained SOF
-      schTxEOF          : out sl;                               -- Cell contained EOF
+      schTxSOF          : out sl := '0';                               -- Cell contained SOF
+      schTxEOF          : out sl := '0';                               -- Cell contained EOF
       schTxIdle         : in  sl;                               -- Force IDLE transmit
       schTxReq          : in  sl;                               -- Cell transmit request
       schTxAck          : out sl;                               -- Cell transmit acknowledge
@@ -121,12 +121,12 @@ architecture Pgp2bTxCell of Pgp2bTxCell is
    signal muxFrameTxEOFE     : sl;
    signal muxFrameTxData     : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal muxRemAlmostFull   : sl;
-   signal cellCnt            : slv(PAYLOAD_CNT_TOP_G downto 0);
+   signal cellCnt            : slv(PAYLOAD_CNT_TOP_G downto 0) := (others => '0');
    signal cellCntRst         : sl;
    signal nxtFrameTxReady    : sl;
    signal nxtType            : slv(2 downto 0);
    signal nxtTypeLast        : slv(2 downto 0);
-   signal curTypeLast        : slv(2 downto 0);
+   signal curTypeLast        : slv(2 downto 0) := (others => '0');
    signal nxtTxSOF           : sl;
    signal nxtTxEOF           : sl;
    signal nxtTxAck           : sl;
@@ -136,27 +136,27 @@ architecture Pgp2bTxCell of Pgp2bTxCell is
    signal crcWordA           : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal crcWordB           : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal serialCntEn        : sl;
-   signal vc0Serial          : slv(5 downto 0);
-   signal vc1Serial          : slv(5 downto 0);
-   signal vc2Serial          : slv(5 downto 0);
-   signal vc3Serial          : slv(5 downto 0);
+   signal vc0Serial          : slv(5 downto 0) := (others => '0');
+   signal vc1Serial          : slv(5 downto 0) := (others => '0');
+   signal vc2Serial          : slv(5 downto 0) := (others => '0');
+   signal vc3Serial          : slv(5 downto 0) := (others => '0');
    signal muxSerial          : slv(5 downto 0);
-   signal dly0Data           : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dly0Type           : slv(2 downto 0);
-   signal dly1Data           : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dly1Type           : slv(2 downto 0);
-   signal dly2Data           : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dly2Type           : slv(2 downto 0);
-   signal dly3Data           : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dly3Type           : slv(2 downto 0);
-   signal dly4Data           : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dly4Type           : slv(2 downto 0);
-   signal int0FrameTxReady   : sl;
-   signal int1FrameTxReady   : sl;
-   signal int2FrameTxReady   : sl;
-   signal int3FrameTxReady   : sl;
-   signal intTimeout         : sl;
-   signal intOverflow        : slv(3 downto 0);
+   signal dly0Data           : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dly0Type           : slv(2 downto 0) := (others => '0');
+   signal dly1Data           : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dly1Type           : slv(2 downto 0) := (others => '0');
+   signal dly2Data           : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dly2Type           : slv(2 downto 0) := (others => '0');
+   signal dly3Data           : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dly3Type           : slv(2 downto 0) := (others => '0');
+   signal dly4Data           : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dly4Type           : slv(2 downto 0) := (others => '0');
+   signal int0FrameTxReady   : sl := '0';
+   signal int1FrameTxReady   : sl := '0';
+   signal int2FrameTxReady   : sl := '0';
+   signal int3FrameTxReady   : sl := '0';
+   signal intTimeout         : sl := '0';
+   signal intOverflow        : slv(3 downto 0) := (others => '0');
 
    -- Transmit Data Marker
    constant TX_DATA_C   : slv(2 downto 0) := "000";
@@ -169,8 +169,6 @@ architecture Pgp2bTxCell of Pgp2bTxCell is
    constant TX_CRCB_C   : slv(2 downto 0) := "111";
 
    -- Transmit states
-   signal   curState    : slv(2 downto 0);
-   signal   nxtState    : slv(2 downto 0);
    constant ST_IDLE_C   : slv(2 downto 0) := "001";
    constant ST_EMPTY_C  : slv(2 downto 0) := "010";
    constant ST_SOC_C    : slv(2 downto 0) := "011";
@@ -178,6 +176,8 @@ architecture Pgp2bTxCell of Pgp2bTxCell is
    constant ST_CRCA_C   : slv(2 downto 0) := "101";
    constant ST_CRCB_C   : slv(2 downto 0) := "110";
    constant ST_EOC_C    : slv(2 downto 0) := "111";
+   signal   curState    : slv(2 downto 0) := ST_IDLE_C;
+   signal   nxtState    : slv(2 downto 0);
 
 begin
 

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bTxPhy.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bTxPhy.vhd
@@ -68,19 +68,19 @@ end Pgp2bTxPhy;
 architecture Pgp2bTxPhy of Pgp2bTxPhy is
 
    -- Local Signals
-   signal algnCnt        : slv(6 downto 0);
+   signal algnCnt        : slv(6 downto 0) := (others => '0');
    signal algnCntRst     : sl;
-   signal intTxLinkReady : sl;
+   signal intTxLinkReady : sl := '0';
    signal nxtTxLinkReady : sl;
    signal nxtTxData      : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal nxtTxDataK     : slv(TX_LANE_CNT_G*2-1  downto 0);
-   signal dlyTxData      : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal dlyTxDataK     : slv(TX_LANE_CNT_G*2-1  downto 0);
-   signal dlySelect      : sl;
-   signal intTxData      : slv(TX_LANE_CNT_G*16-1 downto 0);
-   signal intTxDataK     : slv(TX_LANE_CNT_G*2-1  downto 0);
-   signal intTxOpCode    : slv(7 downto 0);
-   signal intTxOpCodeEn  : sl;
+   signal dlyTxData      : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal dlyTxDataK     : slv(TX_LANE_CNT_G*2-1  downto 0) := (others => '0');
+   signal dlySelect      : sl := '0';
+   signal intTxData      : slv(TX_LANE_CNT_G*16-1 downto 0) := (others => '0');
+   signal intTxDataK     : slv(TX_LANE_CNT_G*2-1  downto 0) := (others => '0');
+   signal intTxOpCode    : slv(7 downto 0) := (others => '0');
+   signal intTxOpCodeEn  : sl := '0';
    signal skpAData       : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal skpADataK      : slv(TX_LANE_CNT_G*2-1  downto 0);
    signal skpBData       : slv(TX_LANE_CNT_G*16-1 downto 0);
@@ -95,7 +95,7 @@ architecture Pgp2bTxPhy of Pgp2bTxPhy is
    signal ltsBDataK      : slv(TX_LANE_CNT_G*2-1  downto 0);
    signal cellData       : slv(TX_LANE_CNT_G*16-1 downto 0);
    signal cellDataK      : slv(TX_LANE_CNT_G*2-1  downto 0);
-   signal dlyTxEOC       : sl;
+   signal dlyTxEOC       : sl := '0';
 
    -- Physical Link State
    constant ST_LOCK_C  : slv(3 downto 0) := "0000";
@@ -107,7 +107,7 @@ architecture Pgp2bTxPhy of Pgp2bTxPhy is
    constant ST_ALN_B_C : slv(3 downto 0) := "0110";
    constant ST_CELL_C  : slv(3 downto 0) := "0111";
    constant ST_EMPTY_C : slv(3 downto 0) := "1000";
-   signal   curState   : slv(3 downto 0);
+   signal   curState   : slv(3 downto 0) := ST_LOCK_C;
    signal   nxtState   : slv(3 downto 0);
 
 begin

--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bTxSched.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bTxSched.vhd
@@ -73,22 +73,22 @@ architecture Pgp2bTxSched of Pgp2bTxSched is
 
    -- Local Signals
    signal currValid    : sl;
-   signal currVc       : slv(1 downto 0);
+   signal currVc       : slv(1 downto 0) := (others => '0');
    signal nextVc       : slv(1 downto 0);
    signal arbVc        : slv(1 downto 0);
    signal arbValid     : sl;
-   signal vcInFrame    : slv(3 downto 0);
-   signal intTxReq     : sl;
-   signal intTxIdle    : sl;
+   signal vcInFrame    : slv(3 downto 0) := (others => '0');
+   signal intTxReq     : sl := '0';
+   signal intTxIdle    : sl := '0';
    signal nxtTxReq     : sl;
    signal nxtTxIdle    : sl;
    signal nxtTxTimeout : sl;
-   signal intTxTimeout : sl;
-   signal vcTimerA     : slv(23 downto 0);
-   signal vcTimerB     : slv(23 downto 0);
-   signal vcTimerC     : slv(23 downto 0);
-   signal vcTimerD     : slv(23 downto 0);
-   signal vcTimeout    : slv(3 downto 0);
+   signal intTxTimeout : sl := '0';
+   signal vcTimerA     : slv(23 downto 0) := (others => '0');
+   signal vcTimerB     : slv(23 downto 0) := (others => '0');
+   signal vcTimerC     : slv(23 downto 0) := (others => '0');
+   signal vcTimerD     : slv(23 downto 0) := (others => '0');
+   signal vcTimeout    : slv(3 downto 0) := (others => '0');
    signal gateTxValid  : slv(3 downto 0);
 
    -- Schedular state
@@ -98,7 +98,7 @@ architecture Pgp2bTxSched of Pgp2bTxSched is
    constant ST_GAP_A_C : slv(2 downto 0) := "100";
    constant ST_GAP_B_C : slv(2 downto 0) := "101";
    constant ST_GAP_C_C : slv(2 downto 0) := "110";
-   signal   curState   : slv(2 downto 0);
+   signal   curState   : slv(2 downto 0) := ST_ARB_C;
    signal   nxtState   : slv(2 downto 0);
 
 begin


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

PGP2b was coded using the older VHDL style, and so the registers did not have GSR init values. This was causing 'X' values to propagate into the GT during simulation. Once this happens, the 'X' values get stuck even after reseting the GT.

This change adds default values for all TX related registers so that 'X' values do not propagate into a simulated GT.
