### PR TITLE
Fix 24LC64FT for rogue v6 compatibility

### DIFF
--- a/python/surf/devices/microchip/_Axi24LC64FT.py
+++ b/python/surf/devices/microchip/_Axi24LC64FT.py
@@ -36,5 +36,5 @@ class Axi24LC64FT(pr.Device):
                 valueBits   = 32,
                 valueStride = 32,
                 bitSize     = 32 * nelms,
-                # mode      = "RO",
+                bulkOpEn    = False, # FALSE for large variables,
             ))

--- a/python/surf/devices/microchip/_Axi24LC64FT.py
+++ b/python/surf/devices/microchip/_Axi24LC64FT.py
@@ -31,7 +31,7 @@ class Axi24LC64FT(pr.Device):
             self.add(pr.RemoteVariable(
                 name        = "Mem",
                 description = "Memory Array",
-                size        = (4*nelms),
+                offset      = 0x0000,
                 numValues   = nelms,
                 valueBits   = 32,
                 valueStride = 32,


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Add offset param to 24LC64FT I2C PROM chip Rogue Device. Offset is now required by rogue for RemoteVariables.

