### PR TITLE
Allow custom TDEST and TID on Packetizer output stream

### DIFF
--- a/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamPacketizer2.vhd
@@ -37,6 +37,8 @@ entity AxiStreamPacketizer2 is
       MAX_PACKET_BYTES_G   : positive               := 256*8;   -- Must be a multiple of 8
       SEQ_CNT_SIZE_G       : positive range 4 to 16 := 16;
       TDEST_BITS_G         : natural                := 8;
+      OUTPUT_TDEST_G       : slv(7 downto 0)        := (others => '0');
+      OUTPUT_TID_G         : slv(7 downto 0)        := (others => '0');
       INPUT_PIPE_STAGES_G  : natural                := 0;
       OUTPUT_PIPE_STAGES_G : natural                := 0);
    port (
@@ -384,8 +386,8 @@ begin
                -- Send data through
                v.outputAxisMaster       := inputAxisMaster;
                v.outputAxisMaster.tUser := (others => '0');
-               v.outputAxisMaster.tDest := (others => '0');
-               v.outputAxisMaster.tId   := (others => '0');
+               v.outputAxisMaster.tDest := OUTPUT_TDEST_G;
+               v.outputAxisMaster.tId   := OUTPUT_TID_G;
 
                -- Increment word count with each txn
                v.wordCount := r.wordCount + 1;

--- a/protocols/packetizer/rtl/AxiStreamPacketizer2Pkg.vhd
+++ b/protocols/packetizer/rtl/AxiStreamPacketizer2Pkg.vhd
@@ -60,8 +60,8 @@ package AxiStreamPacketizer2Pkg is
    constant PACKETIZER2_AXIS_CFG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => 8,
-      TDEST_BITS_C  => 0,
-      TID_BITS_C    => 0,
+      TDEST_BITS_C  => 8,
+      TID_BITS_C    => 8,
       TKEEP_MODE_C  => TKEEP_NORMAL_C,
       TUSER_BITS_C  => 2,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Generics have been added to allow the `TDEST` and `TID` of the packetized output stream to be set to a non-zero value. This is useful if multiple packetizes streams will be later muxed, and you want to assign a custom TDEST or TID to each. 

This change should be backward compatible, so TDEST and TID default to zero from the generic.