### PR TITLE
Update Pgp4TxLiteWrapper.vhd

### DIFF
--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
@@ -83,6 +83,11 @@ begin
          pgpTxActive     => '1',
          pgpTxMasters(0) => pgpTxMaster,
          pgpTxSlaves(0)  => pgpTxSlave,
+         -- Status of receive and remote FIFOs (Asynchronous)
+         locRxFifoCtrl(0)=> AXI_STREAM_CTRL_UNUSED_C,
+         locRxLinkReady  => '1',
+         remRxFifoCtrl(0)=> AXI_STREAM_CTRL_UNUSED_C,
+         remRxLinkReady  => '1',       
          -- PHY interface
          phyTxActive     => '1',
          phyTxReady      => phyTxReady,


### PR DESCRIPTION
### Description
- Cadence Genus will give an error if the port has a default value on the entity definition but not connected at the component instantiation. 
- This PR resolves this error
