### PR TITLE
exposing JUMBO_G generic to high level ETH wrapper level

### DIFF
--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7.vhd
@@ -26,6 +26,7 @@ use surf.GigEthPkg.all;
 entity GigEthGth7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -170,6 +171,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",

--- a/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
+++ b/ethernet/GigEthCore/gth7/rtl/GigEthGth7Wrapper.vhd
@@ -31,6 +31,7 @@ entity GigEthGth7Wrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      JUMBO_G            : boolean                          := true;
       PAUSE_EN_G         : boolean                          := true;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -166,6 +167,7 @@ begin
       U_GigEthGth7 : entity surf.GigEthGth7
          generic map (
             TPD_G           => TPD_G,
+            JUMBO_G         => JUMBO_G,
             PAUSE_EN_G      => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScale.vhd
@@ -26,6 +26,7 @@ use surf.GigEthPkg.all;
 entity GigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -182,6 +183,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",

--- a/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gthUltraScale/rtl/GigEthGthUltraScaleWrapper.vhd
@@ -31,6 +31,7 @@ entity GigEthGthUltraScaleWrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      JUMBO_G            : boolean                          := true;
       PAUSE_EN_G         : boolean                          := true;
       -- Clocking Configurations
       EXT_PLL_G          : boolean                          := false;
@@ -193,6 +194,7 @@ begin
       U_GigEthGthUltraScale : entity surf.GigEthGthUltraScale
          generic map (
             TPD_G         => TPD_G,
+            JUMBO_G       => JUMBO_G,
             PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7.vhd
@@ -26,6 +26,7 @@ use surf.GigEthPkg.all;
 entity GigEthGtp7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -224,6 +225,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",

--- a/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtp7/rtl/GigEthGtp7Wrapper.vhd
@@ -31,6 +31,7 @@ entity GigEthGtp7Wrapper is
       TPD_G              : time                 := 1 ns;
       SIMULATION_G       : boolean              := false;
       NUM_LANE_G         : natural range 1 to 4 := 1;
+      JUMBO_G            : boolean              := true;
       PAUSE_EN_G         : boolean              := true;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean              := false;
@@ -221,6 +222,7 @@ begin
          U_GigEthGtp7 : entity surf.GigEthGtp7
             generic map (
                TPD_G           => TPD_G,
+               JUMBO_G         => JUMBO_G,
                PAUSE_EN_G      => PAUSE_EN_G,
                -- AXI-Lite Configurations
                EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7.vhd
@@ -27,6 +27,7 @@ use surf.GigEthPkg.all;
 entity GigEthGtx7 is
    generic (
       TPD_G                   : time                := 1 ns;
+      JUMBO_G                 : boolean             := true;
       PAUSE_EN_G              : boolean             := true;
       SYNTH_MODE_G            : string              := "inferred";
       -- AXI-Lite Configurations
@@ -235,6 +236,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",

--- a/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
+++ b/ethernet/GigEthCore/gtx7/rtl/GigEthGtx7Wrapper.vhd
@@ -31,6 +31,7 @@ entity GigEthGtx7Wrapper is
    generic (
       TPD_G              : time                             := 1 ns;
       NUM_LANE_G         : natural range 1 to 4             := 1;
+      JUMBO_G            : boolean                          := true;
       PAUSE_EN_G         : boolean                          := true;
       -- Clocking Configurations
       USE_GTREFCLK_G     : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -166,6 +167,7 @@ begin
       U_GigEthGtx7 : entity surf.GigEthGtx7
          generic map (
             TPD_G           => TPD_G,
+            JUMBO_G         => JUMBO_G,
             PAUSE_EN_G      => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
+++ b/ethernet/GigEthCore/lvdsUltraScale/rtl/GigEthLvdsUltraScale.vhd
@@ -25,6 +25,7 @@ use surf.GigEthPkg.all;
 entity GigEthLvdsUltraScale is
    generic (
       TPD_G         : time                := 1 ns;
+      JUMBO_G       : boolean             := true;
       PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXIL_REG_G : boolean             := false;
@@ -156,6 +157,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PAUSE_512BITS_G => PAUSE_512BITS_C,
          PHY_TYPE_G      => "GMII",

--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
@@ -26,6 +26,7 @@ use surf.EthMacPkg.all;
 entity TenGigEthGth7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -208,6 +209,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7Wrapper.vhd
@@ -28,6 +28,7 @@ entity TenGigEthGth7Wrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      JUMBO_G           : boolean                          := true;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -126,6 +127,7 @@ begin
       TenGigEthGth7_Inst : entity surf.TenGigEthGth7
          generic map (
             TPD_G           => TPD_G,
+            JUMBO_G         => JUMBO_G,
             PAUSE_EN_G      => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScale.vhd
@@ -25,6 +25,7 @@ use surf.EthMacPkg.all;
 entity TenGigEthGthUltraScale is
    generic (
       TPD_G         : time                := 1 ns;
+      JUMBO_G       : boolean             := true;
       PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G  : boolean             := false;
@@ -234,6 +235,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G             => TPD_G,
+         JUMBO_G           => JUMBO_G,
          PAUSE_EN_G        => PAUSE_EN_G,
          FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
          SYNTH_MODE_G      => "xpm",

--- a/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale+/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -28,6 +28,7 @@ entity TenGigEthGthUltraScaleWrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      JUMBO_G           : boolean                          := true;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
       EXT_REF_G         : boolean                          := false;
@@ -143,6 +144,7 @@ begin
       TenGigEthGthUltraScale_Inst : entity surf.TenGigEthGthUltraScale
          generic map (
             TPD_G         => TPD_G,
+            JUMBO_G       => JUMBO_G,
             PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
@@ -26,6 +26,7 @@ use surf.EthMacPkg.all;
 entity TenGigEthGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -254,6 +255,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScaleWrapper.vhd
@@ -28,6 +28,7 @@ entity TenGigEthGthUltraScaleWrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      JUMBO_G           : boolean                          := true;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
       EXT_REF_G         : boolean                          := false;
@@ -146,6 +147,7 @@ begin
       TenGigEthGthUltraScale_Inst : entity surf.TenGigEthGthUltraScale
          generic map (
             TPD_G         => TPD_G,
+            JUMBO_G       => JUMBO_G,
             PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
@@ -26,6 +26,7 @@ use surf.EthMacPkg.all;
 entity TenGigEthGtx7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -234,6 +235,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7Wrapper.vhd
@@ -28,6 +28,7 @@ entity TenGigEthGtx7Wrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      JUMBO_G           : boolean                          := true;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G    : boolean                          := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -134,6 +135,7 @@ begin
       TenGigEthGtx7_Inst : entity surf.TenGigEthGtx7
          generic map (
             TPD_G           => TPD_G,
+            JUMBO_G         => JUMBO_G,
             PAUSE_EN_G      => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScale.vhd
@@ -25,6 +25,7 @@ use surf.EthMacPkg.all;
 entity TenGigEthGtyUltraScale is
    generic (
       TPD_G         : time                := 1 ns;
+      JUMBO_G       : boolean             := true;
       PAUSE_EN_G    : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G  : boolean             := false;
@@ -234,6 +235,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G             => TPD_G,
+         JUMBO_G           => JUMBO_G,
          PAUSE_EN_G        => PAUSE_EN_G,
          FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
          SYNTH_MODE_G      => "xpm",

--- a/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/TenGigEthCore/gtyUltraScale+/rtl/TenGigEthGtyUltraScaleWrapper.vhd
@@ -29,6 +29,7 @@ entity TenGigEthGtyUltraScaleWrapper is
    generic (
       TPD_G             : time                             := 1 ns;
       NUM_LANE_G        : natural range 1 to 4             := 1;
+      JUMBO_G           : boolean                          := true;
       PAUSE_EN_G        : boolean                          := true;
       -- QUAD PLL Configurations
       QPLL_REFCLK_SEL_G : slv(2 downto 0)                  := "001";
@@ -140,6 +141,7 @@ begin
       TenGigEthGtyUltraScale_Inst : entity surf.TenGigEthGtyUltraScale
          generic map (
             TPD_G         => TPD_G,
+            JUMBO_G       => JUMBO_G,
             PAUSE_EN_G    => PAUSE_EN_G,
             -- AXI-Lite Configurations
             EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7.vhd
@@ -26,6 +26,7 @@ use surf.EthMacPkg.all;
 entity XauiGth7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -92,6 +93,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
+++ b/ethernet/XauiCore/gth7/rtl/XauiGth7Wrapper.vhd
@@ -29,6 +29,7 @@ use unisim.vcomponents.all;
 entity XauiGth7Wrapper is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -95,6 +96,7 @@ begin
    XauiGth7_Inst : entity surf.XauiGth7
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScale.vhd
@@ -28,6 +28,7 @@ use unisim.vcomponents.all;
 entity XauiGthUltraScale is
    generic (
       TPD_G          : time                := 1 ns;
+      JUMBO_G        : boolean             := true;
       PAUSE_EN_G     : boolean             := true;
       -- XAUI Configurations
       REF_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
@@ -202,6 +203,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G             => TPD_G,
+         JUMBO_G           => JUMBO_G,
          PAUSE_EN_G        => PAUSE_EN_G,
          FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
          SYNTH_MODE_G      => "xpm",

--- a/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale+/rtl/XauiGthUltraScaleWrapper.vhd
@@ -29,6 +29,7 @@ use unisim.vcomponents.all;
 entity XauiGthUltraScaleWrapper is
    generic (
       TPD_G             : time                := 1 ns;
+      JUMBO_G           : boolean             := true;
       PAUSE_EN_G        : boolean             := true;
       EN_WDT_G          : boolean             := false;
       EXT_REF_G         : boolean             := false;
@@ -139,6 +140,7 @@ begin
    XauiGthUltraScale_Inst : entity surf.XauiGthUltraScale
       generic map (
          TPD_G         => TPD_G,
+         JUMBO_G       => JUMBO_G,
          PAUSE_EN_G    => PAUSE_EN_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScale.vhd
@@ -29,6 +29,7 @@ use unisim.vcomponents.all;
 entity XauiGthUltraScale is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -195,6 +196,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gthUltraScale/rtl/XauiGthUltraScaleWrapper.vhd
@@ -29,6 +29,7 @@ use unisim.vcomponents.all;
 entity XauiGthUltraScaleWrapper is
    generic (
       TPD_G             : time                := 1 ns;
+      JUMBO_G           : boolean             := true;
       PAUSE_EN_G        : boolean             := true;
       EN_WDT_G          : boolean             := false;
       EXT_REF_G         : boolean             := false;
@@ -139,6 +140,7 @@ begin
    XauiGthUltraScale_Inst : entity surf.XauiGthUltraScale
       generic map (
          TPD_G         => TPD_G,
+         JUMBO_G       => JUMBO_G,
          PAUSE_EN_G    => PAUSE_EN_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G  => EN_AXI_REG_G,

--- a/ethernet/XauiCore/gtx7/rtl/XauiGtx7.vhd
+++ b/ethernet/XauiCore/gtx7/rtl/XauiGtx7.vhd
@@ -26,6 +26,7 @@ use surf.EthMacPkg.all;
 entity XauiGtx7 is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G    : boolean             := false;
@@ -92,6 +93,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          PHY_TYPE_G      => "XGMII",
          PRIM_CONFIG_G   => AXIS_CONFIG_G)

--- a/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
+++ b/ethernet/XauiCore/gtx7/rtl/XauiGtx7Wrapper.vhd
@@ -29,6 +29,7 @@ use unisim.vcomponents.all;
 entity XauiGtx7Wrapper is
    generic (
       TPD_G           : time                := 1 ns;
+      JUMBO_G         : boolean             := true;
       PAUSE_EN_G      : boolean             := true;
       -- QUAD PLL Configurations
       USE_GTREFCLK_G  : boolean             := false;  --  FALSE: gtClkP/N,  TRUE: gtRefClk
@@ -95,6 +96,7 @@ begin
    XauiGtx7_Inst : entity surf.XauiGtx7
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScale.vhd
@@ -28,6 +28,7 @@ use unisim.vcomponents.all;
 entity XauiGtyUltraScale is
    generic (
       TPD_G          : time                := 1 ns;
+      JUMBO_G        : boolean             := true;
       PAUSE_EN_G     : boolean             := true;
       -- XAUI Configurations
       REF_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
@@ -202,6 +203,7 @@ begin
    U_MAC : entity surf.EthMacTop
       generic map (
          TPD_G             => TPD_G,
+         JUMBO_G           => JUMBO_G,
          PAUSE_EN_G        => PAUSE_EN_G,
          FIFO_ADDR_WIDTH_G => 12,       -- single 4K UltraRAM
          SYNTH_MODE_G      => "xpm",

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
@@ -31,6 +31,7 @@ entity XauiGtyUltraScaleWrapper is
       TPD_G             : time                := 1 ns;
       EN_WDT_G          : boolean             := false;
       STABLE_CLK_FREQ_G : real                := 156.25E+6;  -- Support 156.25MHz or 312.5MHz
+      JUMBO_G           : boolean             := true;
       PAUSE_EN_G        : boolean             := true;
       -- AXI-Lite Configurations
       EN_AXI_REG_G      : boolean             := false;
@@ -134,6 +135,7 @@ begin
    XauiGtyUltraScale_Inst : entity surf.XauiGtyUltraScale
       generic map (
          TPD_G           => TPD_G,
+         JUMBO_G         => JUMBO_G,
          PAUSE_EN_G      => PAUSE_EN_G,
          -- AXI-Lite Configurations
          EN_AXI_REG_G    => EN_AXI_REG_G,


### PR DESCRIPTION
### Description
- Useful to be able to set `JUMBO_G=false` at application layer if not using jumbo frame and trying to optimize resources