### PR TITLE
Gearbox.vhd: changed the type of the generic parameter RST_POLARITY_G from sl to boolean

### DIFF
--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -25,7 +25,7 @@ use surf.StdRtlPkg.all;
 entity Gearbox is
    generic (
       TPD_G                : time    := 1 ns;
-      RST_POLARITY_G       : sl      := '1';  -- '1' for active high rst, '0' for active low
+      RST_POLARITY_G       : boolean := true;  -- true for active high rst, false for active low
       RST_ASYNC_G          : boolean := false;
       SLAVE_BIT_REVERSE_G  : boolean := false;
       SLAVE_WIDTH_G        : positive;
@@ -52,8 +52,9 @@ end entity Gearbox;
 
 architecture rtl of Gearbox is
 
-   constant MAX_C : positive := maximum(MASTER_WIDTH_G, SLAVE_WIDTH_G);
-   constant MIN_C : positive := minimum(MASTER_WIDTH_G, SLAVE_WIDTH_G);
+   constant MAX_C :           positive := maximum(MASTER_WIDTH_G, SLAVE_WIDTH_G);
+   constant MIN_C :           positive := minimum(MASTER_WIDTH_G, SLAVE_WIDTH_G);
+   constant RST_POLARITY_C :  sl       := ite(RST_POLARITY_G,'1','0');
 
    -- Don't need the +1 if slip is not used.
    constant SHIFT_WIDTH_C : positive := wordCount(MAX_C, MIN_C) * MIN_C + MIN_C + 1;
@@ -152,7 +153,7 @@ begin
 
       slaveReady <= v.slaveReady;
 
-      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
+      if (RST_ASYNC_G = false and rst = RST_POLARITY_C) then
          v := REG_INIT_C;
       end if;
 
@@ -169,7 +170,7 @@ begin
 
    seq : process (clk, rst) is
    begin
-      if (RST_ASYNC_G and rst = RST_POLARITY_G) then
+      if (RST_ASYNC_G and rst = RST_POLARITY_C) then
          r <= REG_INIT_C after TPD_G;
       elsif rising_edge(clk) then
          r <= rin after TPD_G;


### PR DESCRIPTION
Gearbox.vhd: changed the type of the generic parameter RST_POLARITY_G from sl to boolean
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
The type of generic parameter **RST_POLARITY_G** in Gearbox.vhd has been changed from sl to boolean.
**RST_POLARITY_G** now controls a new _constant sl_ called **RST_POLARITY_C**, which acts exactly as the generic acted previously.

### Details
When using a Verilog wrapper around the gearbox, if you tried to set the RST_POLARITY_G generic to either '0' or '1', the simulation would give you a wrong result as its not possible to use sl as parameters in verilog: https://stackoverflow.com/questions/32218950/instantiate-vhdl-in-verilog-with-generics-containing-std-logic
Changing its type to boolean fixes the problem
