### PR TITLE
Pgp4TxLiteWrapper: Bug fix in simulation with ASYNC reset

### DIFF
--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
@@ -56,6 +56,7 @@ architecture mapping of Pgp4TxLiteWrapper is
 
    signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
    signal pgpTxSlave  : AxiStreamSlaveType;
+   signal rstL        : sl;
 
 begin
 
@@ -89,11 +90,13 @@ begin
          remRxFifoCtrl(0)=> AXI_STREAM_CTRL_UNUSED_C,
          remRxLinkReady  => '1',       
          -- PHY interface
-         phyTxActive     => '1',
+         phyTxActive     => rstL,
          phyTxReady      => phyTxReady,
          phyTxValid      => phyTxValid,
          phyTxStart      => open,
          phyTxData       => phyTxData(63 downto 0),
          phyTxHeader     => phyTxData(65 downto 64));
+
+   rstL <= not(rst);
 
 end architecture mapping;


### PR DESCRIPTION
In Pgp4TxLiteWrapper, changed Pgp4TxLite.phyTxActive from '1' to rstL 

### Description
When PhyTxActive = '1', Scrambler was never reset, leading to issues after post-syn simulations in ASIC. This is due to the fact that ASIC synthesizer discard initial values assigned during instantiation.

