### PR TITLE
updating microblaze/ruckus.tcl for Vivado 2023.2

### DIFF
--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -3,7 +3,7 @@ source $::env(RUCKUS_PROC_TCL)
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus} {4.8.4} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus} {4.9.0} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"

--- a/xilinx/general/microblaze/ruckus.tcl
+++ b/xilinx/general/microblaze/ruckus.tcl
@@ -19,7 +19,8 @@ if { [info exists ::env(VITIS_SRC_PATH)] != 1 }  {
       loadSource -lib surf -path "$::DIR_PATH/generate/MicroblazeBasicCoreWrapper.vhd"
 
       # Load the .bd file
-      if { $::env(VIVADO_VERSION) == 2023.1 ||
+      if { $::env(VIVADO_VERSION) == 2023.2 ||
+           $::env(VIVADO_VERSION) == 2023.1 ||
            $::env(VIVADO_VERSION) == 2022.2 } {
          puts "\nVivado v$::env(VIVADO_VERSION) not supported for general/microblaze\n"
          exit -1


### PR DESCRIPTION
### Description
- Vivado bug for .bd not resolved yet
- Updating submodule lock for Vivado 2023.2 support