### PR TITLE
Rogue Device fix for XADC and SysMon

### DIFF
--- a/python/surf/xilinx/_AxiSysMonUltraScale.py
+++ b/python/surf/xilinx/_AxiSysMonUltraScale.py
@@ -20,7 +20,7 @@ class AxiSysMonUltraScale(pr.Device):
             **kwargs):
         super().__init__(description=description, **kwargs)
 
-        self.simpleViewList = simpleViewList
+        self.simpleViewList = simpleViewList[:]
 
         def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):
             self.add(pr.RemoteVariable(

--- a/python/surf/xilinx/_Xadc.py
+++ b/python/surf/xilinx/_Xadc.py
@@ -30,7 +30,7 @@ class Xadc(pr.Device):
         if isinstance(auxChannels, int):
             auxChannels = list(range(auxChannels))
 
-        self.simpleViewList = simpleViewList
+        self.simpleViewList = simpleViewList[:]
         self.simpleViewList.append('enable')
 
         def addPair(name, offset, bitSize, units, bitOffset, description, function, pollInterval=0):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

`AxiSysMonUltraScale` and `Xadc` Rogue Devices allow a `simpleViewList` to be passed, and only those Variables will show in the GUI. This list needs to be copied when passed to the local instance variable, otherwise modifications to it get applied as the defaults to all instances of `Xadc` or `AxiSysMonUltraScale` in the tree. 

Most designs only have one FPGA, which is why this was not detected before.
