### PR TITLE
Fix default address

### DIFF
--- a/axi/simlink/src/RogueSideBand.c
+++ b/axi/simlink/src/RogueSideBand.c
@@ -41,13 +41,13 @@ void RogueSideBandRestart(RogueSideBandData *data, portDataT *portData) {
 
    vhpi_printf("RogueSideBand: Listening on ports %i & %i\n",data->port, data->port+1);
 
-   sprintf(buffer,"tcp://*:%i",data->port+1);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port+1);
    if ( zmq_bind(data->zmqPull,buffer) ) {
       vhpi_assert("RogueSideBand: Failed to bind sideband port",vhpiFatal);
       return;
    }
 
-   sprintf(buffer,"tcp://*:%i",data->port);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port);
    if ( zmq_bind(data->zmqPush,buffer) ) {
       vhpi_assert("RogueSideBand: Failed to bind push port",vhpiFatal);
       return;

--- a/axi/simlink/src/RogueTcpMemory.c
+++ b/axi/simlink/src/RogueTcpMemory.c
@@ -41,13 +41,13 @@ void RogueTcpMemoryRestart(RogueTcpMemoryData *data, portDataT *portData) {
 
    vhpi_printf("RogueTcpMemory: Listening on ports %i & %i\n",data->port,data->port+1);
 
-   sprintf(buffer,"tcp://*:%i",data->port);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port);
    if ( zmq_bind(data->zmqPull,buffer) ) {
       vhpi_assert("RogueTcpMemory: Failed to bind pull port",vhpiFatal);
       return;
    }
 
-   sprintf(buffer,"tcp://*:%i",data->port+1);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port+1);
    if ( zmq_bind(data->zmqPush,buffer) ) {
       vhpi_assert("RogueTcpMemory: Failed to bind push port",vhpiFatal);
       return;

--- a/axi/simlink/src/RogueTcpStream.c
+++ b/axi/simlink/src/RogueTcpStream.c
@@ -42,13 +42,13 @@ void RogueTcpStreamRestart(RogueTcpStreamData *data, portDataT *portData) {
 
    vhpi_printf("RogueTcpStream: Listening on ports %i & %i\n",data->port,data->port+1);
 
-   sprintf(buffer,"tcp://*:%i",data->port);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port);
    if ( zmq_bind(data->zmqPull,buffer) ) {
       vhpi_assert("RogueTcpStream: Failed to bind pull port",vhpiFatal);
       return;
    }
 
-   sprintf(buffer,"tcp://*:%i",data->port+1);
+   sprintf(buffer,"tcp://127.0.0.1:%i",data->port+1);
    if ( zmq_bind(data->zmqPush,buffer) ) {
       vhpi_assert("RogueTcpStream: Failed to bind push port",vhpiFatal);
       return;


### PR DESCRIPTION
### Description
- refer to https://github.com/slaclab/rogue/pull/985
- This will avoid getting annoying messages from cyber security port scanners.
- Only open the local 127.0.0.1 (and not all network interfaces)
