### PR TITLE
adding support for Ultrascale Virtex Part Numbers in ruckus.tcl loading

### DIFF
--- a/devices/AnalogDevices/ad9249/ruckus.tcl
+++ b/devices/AnalogDevices/ad9249/ruckus.tcl
@@ -16,6 +16,7 @@ if { ${family} eq {artix7}  ||
 }
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/devices/AnalogDevices/ad9681/ruckus.tcl
+++ b/devices/AnalogDevices/ad9681/ruckus.tcl
@@ -16,6 +16,7 @@ if { ${family} eq {artix7}  ||
 }
 
 # if { ${family} eq {kintexu} ||
+     # ${family} eq {virtexu} ||
      # ${family} eq {kintexuplus} ||
      # ${family} eq {virtexuplus} ||
      # ${family} eq {virtexuplusHBM} ||

--- a/devices/Marvell/Sgmii88E1111/ruckus.tcl
+++ b/devices/Marvell/Sgmii88E1111/ruckus.tcl
@@ -8,6 +8,7 @@ loadSource -lib surf -dir "$::DIR_PATH/core"
 set family [getFpgaArch]
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/devices/Ti/dp83867/ruckus.tcl
+++ b/devices/Ti/dp83867/ruckus.tcl
@@ -8,6 +8,7 @@ loadSource -lib surf -dir "$::DIR_PATH/core"
 set family [getFpgaArch]
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/ethernet/GigEthCore/ruckus.tcl
+++ b/ethernet/GigEthCore/ruckus.tcl
@@ -27,7 +27,8 @@ if { ${family} eq {virtex7} } {
    loadRuckusTcl "$::DIR_PATH/gth7"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale"
    loadRuckusTcl "$::DIR_PATH/lvdsUltraScale"
 }

--- a/ethernet/TenGigEthCore/ruckus.tcl
+++ b/ethernet/TenGigEthCore/ruckus.tcl
@@ -16,7 +16,8 @@ if { ${family} eq {virtex7} } {
    loadRuckusTcl "$::DIR_PATH/gth7"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale"
 }
 

--- a/ethernet/XauiCore/ruckus.tcl
+++ b/ethernet/XauiCore/ruckus.tcl
@@ -16,7 +16,8 @@ if { ${family} eq {virtex7} } {
    loadRuckusTcl "$::DIR_PATH/gth7"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale"
 }
 

--- a/ethernet/XlauiCore/ruckus.tcl
+++ b/ethernet/XlauiCore/ruckus.tcl
@@ -16,7 +16,8 @@ if { ${family} eq {virtex7} } {
    loadRuckusTcl "$::DIR_PATH/gth7"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale"
 }
 

--- a/protocols/clink/ruckus.tcl
+++ b/protocols/clink/ruckus.tcl
@@ -18,6 +18,7 @@ if {  ${family} == "artix7" ||
 }
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/protocols/coaxpress/ruckus.tcl
+++ b/protocols/coaxpress/ruckus.tcl
@@ -7,7 +7,8 @@ loadRuckusTcl "$::DIR_PATH/core"
 # Get the family type
 set family [getFpgaArch]
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUs"
 }
 

--- a/protocols/pgp/pgp2b/ruckus.tcl
+++ b/protocols/pgp/pgp2b/ruckus.tcl
@@ -27,7 +27,8 @@ if { ${family} eq {virtex7} } {
    loadRuckusTcl "$::DIR_PATH/gth7"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/gthUltraScale"
 }
 

--- a/protocols/pgp/pgp3/ruckus.tcl
+++ b/protocols/pgp/pgp3/ruckus.tcl
@@ -30,7 +30,8 @@ if {  $::env(VIVADO_VERSION) > 0.0} {
       # loadRuckusTcl "$::DIR_PATH/gth7"
    # }
 
-   if { ${family} eq {kintexu} } {
+   if { ${family} eq {kintexu} ||
+        ${family} eq {virtexu} } {
       loadRuckusTcl "$::DIR_PATH/gthUs"
    }
 

--- a/protocols/pgp/pgp4/ruckus.tcl
+++ b/protocols/pgp/pgp4/ruckus.tcl
@@ -30,7 +30,8 @@ if {  $::env(VIVADO_VERSION) > 0.0} {
       # loadRuckusTcl "$::DIR_PATH/gth7"
    # }
 
-   if { ${family} eq {kintexu} } {
+   if { ${family} eq {kintexu} ||
+        ${family} eq {virtexu} } {
       loadRuckusTcl "$::DIR_PATH/gthUs"
    }
 

--- a/protocols/salt/ruckus.tcl
+++ b/protocols/salt/ruckus.tcl
@@ -12,6 +12,7 @@ if { ${family} eq {artix7}  ||
 }
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/protocols/ssp/ruckus.tcl
+++ b/protocols/ssp/ruckus.tcl
@@ -11,6 +11,7 @@ loadSource -lib surf -dir "$::DIR_PATH/rtl"
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
 
 if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} ||
      ${family} eq {kintexuplus} ||
      ${family} eq {virtexuplus} ||
      ${family} eq {virtexuplusHBM} ||

--- a/protocols/xvc-udp/ruckus.tcl
+++ b/protocols/xvc-udp/ruckus.tcl
@@ -21,6 +21,7 @@ if { [isVersal] == true } {
    }
 
    if { ${family} eq {kintexu} ||
+        ${family} eq {virtexu} ||
         ${family} eq {kintexuplus} ||
         ${family} eq {virtexuplus} ||
         ${family} eq {virtexuplusHBM} ||

--- a/xilinx/ruckus.tcl
+++ b/xilinx/ruckus.tcl
@@ -20,7 +20,8 @@ if { ${family} eq {artix7}  ||
    loadRuckusTcl "$::DIR_PATH/7Series"
 }
 
-if { ${family} eq {kintexu} } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {virtexu} } {
    loadRuckusTcl "$::DIR_PATH/UltraScale"
 }
 


### PR DESCRIPTION
### Description
- Discovered by @AnthonyL01 while working on KLM Trigger firmware for Belle-2
- Only impact users with Ultrascale (not Ultrascale+) Virtex.  We have not ran into this issue in the past because most of the users leaped frogged from Kintex Ultrascale to Kintex/Virtex Ultrascale+ in their designs