### PR TITLE
Add missing record element to initializers

### DIFF
--- a/devices/Nxp/Sc18Is602/rtl/Sc18Is602Core.vhd
+++ b/devices/Nxp/Sc18Is602/rtl/Sc18Is602Core.vhd
@@ -24,14 +24,14 @@ use surf.I2cPkg.all;
 
 entity Sc18Is602Core is
    generic (
-      TPD_G             : time                      := 1 ns;
-      I2C_BASE_ADDR_G   : slv(2 downto 0)           := "000";  -- A[2:0] pin config
-      I2C_SCL_FREQ_G    : real                      := 100.0E+3;  -- units of Hz
-      I2C_MIN_PULSE_G   : real                      := 100.0E-9;  -- units of seconds
-      SDO_MUX_SEL_MAP_G : Slv2Array(3 downto 0)     := (0      => "00", 1 => "01", 2 => "10", 3 => "11");
-      ADDRESS_SIZE_G    : IntegerArray(3 downto 0)  := (others => 7);  -- SPI Address bits per channel
-      DATA_SIZE_G       : IntegerArray(3 downto 0)  := (others => 16);  -- SPI Data bits per channel
-      AXIL_CLK_FREQ_G   : real                      := 156.25E+6);  -- units of Hz
+      TPD_G             : time                     := 1 ns;
+      I2C_BASE_ADDR_G   : slv(2 downto 0)          := "000";          -- A[2:0] pin config
+      I2C_SCL_FREQ_G    : real                     := 100.0E+3;       -- units of Hz
+      I2C_MIN_PULSE_G   : real                     := 100.0E-9;       -- units of seconds
+      SDO_MUX_SEL_MAP_G : Slv2Array(3 downto 0)    := (0      => "00", 1 => "01", 2 => "10", 3 => "11");
+      ADDRESS_SIZE_G    : IntegerArray(3 downto 0) := (others => 7);  -- SPI Address bits per channel
+      DATA_SIZE_G       : IntegerArray(3 downto 0) := (others => 16);  -- SPI Data bits per channel
+      AXIL_CLK_FREQ_G   : real                     := 156.25E+6);     -- units of Hz
    port (
       -- I2C Ports
       i2ci            : in  i2c_in_type;
@@ -90,7 +90,8 @@ architecture rtl of Sc18Is602Core is
       regReq      => '0',
       busReq      => '0',
       endianness  => '1',               -- Big endian
-      repeatStart => '0');
+      repeatStart => '0',
+      wrDataOnRd  => '0');
 
    type StateType is (
       IDLE_S,

--- a/devices/Silabs/si5394/rtl/Si5394I2cCore.vhd
+++ b/devices/Silabs/si5394/rtl/Si5394I2cCore.vhd
@@ -25,8 +25,8 @@ use surf.I2cPkg.all;
 entity Si5394I2cCore is
    generic (
       TPD_G              : time            := 1 ns;
-      MEMORY_INIT_FILE_G : string          := "none";  -- Used to initialization boot ROM
-      I2C_BASE_ADDR_G    : slv(1 downto 0) := "00";    -- A[1:0] pin config
+      MEMORY_INIT_FILE_G : string          := "none";      -- Used to initialization boot ROM
+      I2C_BASE_ADDR_G    : slv(1 downto 0) := "00";        -- A[1:0] pin config
       I2C_SCL_FREQ_G     : real            := 100.0E+3;    -- units of Hz
       I2C_MIN_PULSE_G    : real            := 100.0E-9;    -- units of seconds
       AXIL_CLK_FREQ_G    : real            := 156.25E+6);  -- units of Hz
@@ -84,7 +84,8 @@ architecture rtl of Si5394I2cCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '0',
-      repeatStart => '0');
+      repeatStart => '0',
+      wrDataOnRd  => '0');
 
    type StateType is (
       POR_WAIT_S,
@@ -422,8 +423,8 @@ begin
       generic map(
          TPD_G          => TPD_G,
          DURATION_G     => getTimeRatio(100.0E-9, (1.0/AXIL_CLK_FREQ_G)),  -- min 100 ns pulse
-         IN_POLARITY_G  => '1',         -- active HIGH input
-         OUT_POLARITY_G => '0')         -- active LOW output
+         IN_POLARITY_G  => '1',                                            -- active HIGH input
+         OUT_POLARITY_G => '0')                                            -- active LOW output
       port map (
          clk    => axilClk,
          arst   => axilRst,

--- a/protocols/i2c/axi/AxiI2cEepromCore.vhd
+++ b/protocols/i2c/axi/AxiI2cEepromCore.vhd
@@ -36,13 +36,13 @@ use surf.I2cPkg.all;
 
 entity AxiI2cEepromCore is
    generic (
-      TPD_G            : time            := 1 ns;
-      ADDR_WIDTH_G     : positive        := 16;
-      POLL_TIMEOUT_G   : positive        := 16;
-      I2C_ADDR_G       : slv(6 downto 0) := "1010000";
-      I2C_SCL_FREQ_G   : real            := 100.0E+3;   -- units of Hz
-      I2C_MIN_PULSE_G  : real            := 100.0E-9;   -- units of seconds
-      AXI_CLK_FREQ_G   : real            := 156.25E+6);  -- units of Hz
+      TPD_G           : time            := 1 ns;
+      ADDR_WIDTH_G    : positive        := 16;
+      POLL_TIMEOUT_G  : positive        := 16;
+      I2C_ADDR_G      : slv(6 downto 0) := "1010000";
+      I2C_SCL_FREQ_G  : real            := 100.0E+3;    -- units of Hz
+      I2C_MIN_PULSE_G : real            := 100.0E-9;    -- units of seconds
+      AXI_CLK_FREQ_G  : real            := 156.25E+6);  -- units of Hz
    port (
       -- I2C Ports
       i2ci            : in  i2c_in_type;
@@ -82,7 +82,8 @@ architecture rtl of AxiI2cEepromCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '1',               -- Big endian
-      repeatStart => '0');
+      repeatStart => '0',
+      wrDataOnRd  => '0');
 
    type StateType is (
       IDLE_S,

--- a/protocols/i2c/axi/AxiLiteCrossbarI2cMux.vhd
+++ b/protocols/i2c/axi/AxiLiteCrossbarI2cMux.vhd
@@ -85,7 +85,8 @@ architecture mapping of AxiLiteCrossbarI2cMux is
       regReq      => '0',
       busReq      => '0',
       endianness  => DEVICE_MAP_C.endianness,
-      repeatStart => DEVICE_MAP_C.repeatStart);
+      repeatStart => DEVICE_MAP_C.repeatStart,
+      wrDataOnRd => '0');
 
    type StateType is (
       IDLE_S,

--- a/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
+++ b/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
@@ -116,7 +116,8 @@ architecture rtl of AxiLitePMbusMasterCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '0',               -- Little endian
-      repeatStart => '1');
+      repeatStart => '1',
+      wrDataOnRd  => '0');
 
    type StateType is (
       IDLE_S,
@@ -236,9 +237,9 @@ begin
 
                      -- Read back I2C configuration
                      if axilWriteMaster.awaddr(7 downto 0) = x"00" then
-                        v.regIn.i2cAddr     := axilWriteMaster.wData(9 downto 0);
-                        v.regIn.tenbit      := axilWriteMaster.wData(10);
-                        v.ignoreResp        := axilWriteMaster.wData(11);
+                        v.regIn.i2cAddr := axilWriteMaster.wData(9 downto 0);
+                        v.regIn.tenbit  := axilWriteMaster.wData(10);
+                        v.ignoreResp    := axilWriteMaster.wData(11);
                      end if;
 
                      -- Send AXI-Lite response


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Some time ago we added `wrDataOnRd` to the `I2cRegMasterInType` record in `I2cPkg.vhd`.
Not all instances of initializers of that type were updated. This has now been fixed.

