### PR TITLE
bug fix for determining the Link status speed/width & Link Cap speed/width

### DIFF
--- a/python/surf/xilinx/_AxiPciePhy.py
+++ b/python/surf/xilinx/_AxiPciePhy.py
@@ -253,22 +253,6 @@ class AxiPciePhy(pr.Device):
         }
 
         self.add(pr.LocalVariable(
-            name   = 'LnkStaSpeed',
-            mode   = 'RO',
-            value  = 0,
-            units  = 'GT/s',
-            enum   = speedEnum
-        ))
-
-        self.add(pr.LocalVariable(
-            name   = 'LnkStaWidth',
-            mode   = 'RO',
-            value  = 0,
-            units  = 'lanes',
-            disp   = '{:d}',
-        ))
-
-        self.add(pr.LocalVariable(
             name   = 'LnkCapSpeed',
             mode   = 'RO',
             value  = 0,
@@ -284,6 +268,22 @@ class AxiPciePhy(pr.Device):
             disp   = '{:d}',
         ))
 
+        self.add(pr.LocalVariable(
+            name   = 'LnkStaSpeed',
+            mode   = 'RO',
+            value  = 0,
+            units  = 'GT/s',
+            enum   = speedEnum
+        ))
+
+        self.add(pr.LocalVariable(
+            name   = 'LnkStaWidth',
+            mode   = 'RO',
+            value  = 0,
+            units  = 'lanes',
+            disp   = '{:d}',
+        ))
+
     def updateLinkStatus(self):
         # Check if value points to the Device Specific Region
         if (self.CapabilitiesPointer.value() >= 0x40):
@@ -292,13 +292,13 @@ class AxiPciePhy(pr.Device):
             offset = self.DevSpecRegion[(self.CapabilitiesPointer.value()-0x40) + 1].get()
 
             # Capabilities Express Endpoint offset
-            linkStatus = self.DevSpecRegion[(offset-0x40) + 0x12].get() | (self.DevSpecRegion[(offset-0x40) + 0x13].get() << 8)
             linkCap    = self.DevSpecRegion[(offset-0x40) + 0x0C].get() | (self.DevSpecRegion[(offset-0x40) + 0x0D].get() << 8)
+            linkStatus = self.DevSpecRegion[(offset-0x40) + 0x12].get() | (self.DevSpecRegion[(offset-0x40) + 0x13].get() << 8)
+
+            # Set the link speed and width capabilities
+            self.LnkCapSpeed.set( (linkCap>>0) & 0xF )
+            self.LnkCapWidth.set( (linkCap>>4) & 0xFF )
 
             # Set the link speed and width status
             self.LnkStaSpeed.set( (linkStatus>>0) & 0xF )
             self.LnkStaWidth.set( (linkStatus>>4) & 0xFF )
-
-            # Set the link speed and width status
-            self.LnkCapSpeed.set( (linkCap>>0) & 0xF )
-            self.LnkCapWidth.set( (linkCap>>4) & 0xFF )


### PR DESCRIPTION
### Description
To determine the byte offset for the Capabilities: Express (v2) Endpoint register based on the provided PCIe configuration dump, you'll need to follow the PCIe specification for parsing the configuration space, focusing on finding the correct capability structure within it. Here's a step-by-step guide to do this:

1. **Start from the PCI Configuration Space**: The dump you've provided looks like the content of the PCI Express (PCIe) configuration space. This space contains a variety of information including device capabilities, status, and control settings.

2. **Identify the PCI Express Capability**: Capabilities in PCI configuration space start at byte 0x34 (the Capabilities Pointer field in the standard PCI Configuration space), which points to the first capability structure in a linked list. Each capability has a format that includes an ID, a pointer to the next capability (if any), and then the capability-specific data.

3. **Look for the Express Capability ID**: PCI Express capabilities have a specific Capability ID, which is 0x10 for the PCIe base specification. You'll need to follow the capability pointers starting from the pointer at 0x34 until you find a capability with the ID 0x10. 

4. **Parse Through the Configuration Dump**: Starting from the offset given by the Capabilities Pointer at 0x34, you'll parse through the linked list of capabilities. Each entry in this list has at least two bytes: the first byte is the Capability ID, and the second byte is the pointer to the next capability (relative to the start of the configuration space).
