### PR TITLE
Fixing broken I2C devices due to PR#1146

### DIFF
--- a/devices/Nxp/Sc18Is602/rtl/Sc18Is602Core.vhd
+++ b/devices/Nxp/Sc18Is602/rtl/Sc18Is602Core.vhd
@@ -90,8 +90,7 @@ architecture rtl of Sc18Is602Core is
       regReq      => '0',
       busReq      => '0',
       endianness  => '1',               -- Big endian
-      repeatStart => '0',
-      wrDataOnRd  => '0');
+      repeatStart => '0');
 
    type StateType is (
       IDLE_S,

--- a/devices/Silabs/si5394/rtl/Si5394I2cCore.vhd
+++ b/devices/Silabs/si5394/rtl/Si5394I2cCore.vhd
@@ -84,8 +84,7 @@ architecture rtl of Si5394I2cCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '0',
-      repeatStart => '0',
-      wrDataOnRd  => '0');
+      repeatStart => '0');
 
    type StateType is (
       POR_WAIT_S,

--- a/protocols/i2c/axi/AxiI2cEepromCore.vhd
+++ b/protocols/i2c/axi/AxiI2cEepromCore.vhd
@@ -82,8 +82,7 @@ architecture rtl of AxiI2cEepromCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '1',               -- Big endian
-      repeatStart => '0',
-      wrDataOnRd  => '0');
+      repeatStart => '0');
 
    type StateType is (
       IDLE_S,

--- a/protocols/i2c/axi/AxiLiteCrossbarI2cMux.vhd
+++ b/protocols/i2c/axi/AxiLiteCrossbarI2cMux.vhd
@@ -85,8 +85,7 @@ architecture mapping of AxiLiteCrossbarI2cMux is
       regReq      => '0',
       busReq      => '0',
       endianness  => DEVICE_MAP_C.endianness,
-      repeatStart => DEVICE_MAP_C.repeatStart,
-      wrDataOnRd => '0');
+      repeatStart => DEVICE_MAP_C.repeatStart);
 
    type StateType is (
       IDLE_S,

--- a/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
+++ b/protocols/pmbus/rtl/AxiLitePMbusMasterCore.vhd
@@ -116,8 +116,7 @@ architecture rtl of AxiLitePMbusMasterCore is
       regReq      => '0',
       busReq      => '0',
       endianness  => '0',               -- Little endian
-      repeatStart => '1',
-      wrDataOnRd  => '0');
+      repeatStart => '1');
 
    type StateType is (
       IDLE_S,


### PR DESCRIPTION
### Description
- [wrDataOnRd does not exist in I2cRegMasterInType record type](https://github.com/slaclab/surf/commit/9ccb9e1ee8d340d0c9e983bc48892d7ba27b913e)