### PR TITLE
bug fix to prevent AxiStreamFifoV2 lock up when (VALID_THOLD_G=0) and frame bigger than FIFO

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
+++ b/axi/axi-stream/rtl/AxiStreamFifoV2.vhd
@@ -313,7 +313,12 @@ begin
                -- Start output when a block or end of frame is available
                elsif fifoValidLast = '1' or (VALID_THOLD_G /= 0 and fifoRdCount >= VALID_THOLD_G) then
                   fifoInFrame <= '1' after TPD_G;
+
+               -- Prevent the FIFO from locking up when frame deeper than what the U_Fifo can hold
+               elsif (fifoAFull = '1') then
+                  fifoInFrame <= '1' after TPD_G;
                end if;
+
             end if;
          end process;
 

--- a/tests/test_AxiStreamFifoV2IpIntegrator.py
+++ b/tests/test_AxiStreamFifoV2IpIntegrator.py
@@ -148,6 +148,7 @@ tests_module = 'AxiStreamFifoV2IpIntegrator'
 ##############################################################################
 
 paramSweep = []
+# Sweep through different master/slave data sizes
 for sTdataByte in ['2','5','6']:
     for mTdataByte in ['2','5','6']:
         tmpDict = {
@@ -155,6 +156,12 @@ for sTdataByte in ['2','5','6']:
           "S_TDATA_NUM_BYTES": sTdataByte,
         }
         paramSweep.append(tmpDict)
+# Check for the case where the (VALID_THOLD_G=0) and AXI stream frame is buffer than the FIFO
+tmpDict = {
+  "VALID_THOLD": '0',
+  "FIFO_ADDR_WIDTH": '4',
+}
+paramSweep.append(tmpDict)
 
 ##############################################################################
 


### PR DESCRIPTION
### Description
- Bug discovered by @Abhilasha-D during SNL testing when she has a 4kB FIFO w/  (VALID_THOLD_G=0) and sending a 16kB frame from software