### PR TITLE
Dac38J84 yaml changes

### DIFF
--- a/yaml/Dac38J84.yaml
+++ b/yaml/Dac38J84.yaml
@@ -16,7 +16,7 @@ Dac38J84: &Dac38J84
   class: MMIODev
   configPrio: 1
   metadata:
-    numTxLanes: &numTxLanes 2
+    numTxLanes: &numTxLanes 8
   children:
     #########################################################
     DacReg:
@@ -28,6 +28,14 @@ Dac38J84: &Dac38J84
       sizeBits:     16
       mode:         RW
       description:  DAC Registers[125:0]
+    #########################################################
+    LaneEnable:
+      at:
+        offset:     0x129
+      class:        IntField
+      sizeBits:     8
+      mode:         RO
+      description:  Lane Enable
     #########################################################
     LaneBufferDelay:
       at:


### PR DESCRIPTION
Modifications to Dac38J84 yaml
- Changed lane number to 8 (DAC has upto 8). A value of 2 or below does not allow access to 3 to 8.
- Added laneEnable register RO

### JIRA
https://jira.slac.stanford.edu/browse/AAASPGR-1

