### PR TITLE
SyncTrigPeriod.vhd: bug fix for wrong period measurement for first trigger

### DIFF
--- a/base/sync/rtl/SyncTrigPeriod.vhd
+++ b/base/sync/rtl/SyncTrigPeriod.vhd
@@ -113,10 +113,10 @@ begin
                v.periodMin := v.cnt;
             end if;
 
-            -- Reset the counter
-            v.cnt := (others => '0');
-
          end if;
+
+         -- Reset the counter
+         v.cnt := (others => '0');
 
       end if;
 


### PR DESCRIPTION
### Description
- `v.cnt` needs to be reset to zero after any trigger (not only the armed state) 