### PR TITLE
SugoiSubordinateFsm.vhd Updates

### DIFF
--- a/protocols/sugoi/rtl/SugoiSubordinateCore.vhd
+++ b/protocols/sugoi/rtl/SugoiSubordinateCore.vhd
@@ -29,7 +29,7 @@ entity SugoiSubordinateCore is
       RST_POLARITY_G : sl      := '1';  -- '1' for active high rst, '0' for active low
       RST_ASYNC_G    : boolean := false);
    port (
-      pwrOnRst        : in  sl := not(RST_POLARITY_G);
+      pwrOnRst        : in  sl;
       -- Clock and Reset
       clk             : in  sl;
       rst             : out sl;         -- Active HIGH global reset

--- a/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
+++ b/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
@@ -30,7 +30,7 @@ entity SugoiSubordinateFsm is
       RST_POLARITY_G : sl      := '1';  -- '1' for active high rst, '0' for active low
       RST_ASYNC_G    : boolean := false);
    port (
-      pwrOnRst        : in  sl := not(RST_POLARITY_G);
+      pwrOnRst        : in  sl;
       -- Clock and Reset
       clk             : in  sl;
       rst             : out sl;

--- a/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
+++ b/protocols/sugoi/rtl/SugoiSubordinateFsm.vhd
@@ -513,6 +513,9 @@ begin
                v.state := RX_SOF_S;
 
             end if;
+         ----------------------------------------------------------------------
+         when others =>  -- For ASIC designs it is best to declare a ’Default’ state which returns to INIT_S state
+            v := REG_INIT_C;
       ----------------------------------------------------------------------
       end case;
 


### PR DESCRIPTION
### Description
- For ASIC designs it is best to declare a 'Default' state which returns to INIT_S state
  - force INIT_S state if 4-bit r.state is not enum define state
- removing 'default' on pwrOnRst because it should always be connected on ASIC