### PR TITLE
Create AD5541 DAC

### DIFF
--- a/devices/AnalogDevices/ad5541/rtl/AxiAd5541Core.vhd
+++ b/devices/AnalogDevices/ad5541/rtl/AxiAd5541Core.vhd
@@ -1,0 +1,74 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: AXI-Lite interface to AD5541 DAC IC
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity AxiAd5541Core is
+  generic (
+    TPD_G               : time := 1 ns;
+    AXIL_CLK_PERIOD_G   : real := 1/(200.0E+6); -- In units of s, default 200 MHz
+    SPI_SCLK_PERIOD_G   : real := 1/(1.0E+6)    -- In units of s, default 1 MHz
+  );
+  port (
+    -- DAC Ports
+    dacSclk             : out sl;
+    dacSdi              : out sl;
+    dacCsL              : out sl;
+    dacLdacL            : out sl;
+    -- AXI-Lite Register Interface
+    axiClk              : in  sl;
+    axiRst              : in  sl;
+    axiReadMaster       : in  AxiLiteReadMasterType;
+    axiReadSlave        : out AxiLiteReadSlaveType;
+    axiWriteMaster      : in  AxiLiteWriteMasterType;
+    axiWriteSlave       : out AxiLiteWriteSlaveType
+  );
+end AxiAd5541Core;
+
+architecture mapping of AxiAd5541Core is
+begin
+  U_AxiSpiMaster : entity surf.AxiSpiMaster
+    generic map (
+      TPD_G             => TPD_G,
+      CPOL_G            => '1', -- SDIN sampled on falling edge
+      ADDRESS_SIZE_G    => 0,
+      DATA_SIZE_G       => 16,
+      MODE_G            => "WO", -- "WO" (write only)
+      CLK_PERIOD_G      => AXIL_CLK_PERIOD_G,
+      SPI_SCLK_PERIOD_G => SPI_SCLK_PERIOD_G
+    )
+    port map (
+      -- AXI-Lite Register Interface
+      axiClk            => axiClk,
+      axiRst            => axiRst,
+      axiReadMaster     => axiReadMaster,
+      axiReadSlave      => axiReadSlave,
+      axiWriteMaster    => axiWriteMaster,
+      axiWriteSlave     => axiWriteSlave,
+      -- SPI Ports
+      coreSclk          => dacSclk,
+      coreSDin          => '0',
+      coreSDout         => dacSdi,
+      coreCsb           => dacCsL
+    );
+
+  -- The LDAC_L signal of the DAC is tied low to load the data to the DAC on the rising edge of the CS_L
+  dacLdacL <= '0';
+
+end mapping;

--- a/devices/AnalogDevices/ad5541/ruckus.tcl
+++ b/devices/AnalogDevices/ad5541/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source $::env(RUCKUS_PROC_TCL)
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/python/surf/devices/analog_devices/_Ad5541.py
+++ b/python/surf/devices/analog_devices/_Ad5541.py
@@ -18,10 +18,11 @@ import pyrogue as pr
 
 class Ad5541(pr.Device):
     def __init__(self,
-        name        = 'AD5541',
-        description = 'AD5541 DAC',
-        maximum     = 0, # Sets the limit for the maximum allowed voltage from software
-        **kwargs):
+                 name        = 'AD5541',
+                 description = 'AD5541 DAC',
+                 maximum     = 0, # Sets the limit for the maximum allowed voltage from software
+                 **kwargs):
+
         super().__init__(name=name, description=description, **kwargs)
 
         self.add(pr.RemoteVariable(

--- a/python/surf/devices/analog_devices/_Ad5541.py
+++ b/python/surf/devices/analog_devices/_Ad5541.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python
 #-----------------------------------------------------------------------------
 # Title      : PyRogue _ad5541 Module
 #-----------------------------------------------------------------------------
 # File       : _ad5541.py
-# Created    : 2017-01-17
-# Last update: 2017-01-17
 #-----------------------------------------------------------------------------
 # Description:
-# PyRogue _ad5541 Module
+# PyRogue module for interfacing with a AD5541 DAC.
 #-----------------------------------------------------------------------------
 # This file is part of 'SLAC Firmware Standard Library'.
 # It is subject to the license terms in the LICENSE.txt file found in the
@@ -17,126 +14,23 @@
 # may be copied, modified, propagated, or distributed except according to
 # the terms contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-
 import pyrogue as pr
 
 class Ad5541(pr.Device):
     def __init__(self,
-            name        = "Ad5541",
-            description = "Ad5541",
-            **kwargs):
+        name        = 'AD5541',
+        description = 'AD5541 DAC',
+        maximum     = 0, # Sets the limit for the maximum allowed voltage from software
+        **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
         self.add(pr.RemoteVariable(
-            name        = 'dacRefreshRate',
-            description = 'DAC Rate (in units of Hz)',
-            offset      = 0x040,
-            bitSize     = 32,
+            name        = 'SetValue',
+            description = '16-bit DAC output value',
+            offset      = 0x000,
+            bitSize     = 16,
             bitOffset   = 0,
             base        = pr.UInt,
-            mode        = 'RO',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'dacData',
-            description = 'DAC Data',
-            offset      = 0x0C0,
-            bitSize     = 18,
-            bitOffset   = 0,
-            base        = pr.UInt,
-            mode        = 'RO',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'debugMux',
-            description = 'debugMux',
-            offset      = 0x200,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'debugData',
-            description = 'debugData',
-            offset      = 0x240,
-            bitSize     = 18,
-            bitOffset   = 0,
-            base        = pr.UInt,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'sdoDisable',
-            description = 'sdoDisable',
-            offset      = 0x280,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'binaryOffset',
-            description = 'binaryOffset',
-            offset      = 0x284,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'dacTriState',
-            description = 'dacTriState',
-            offset      = 0x288,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'opGnd',
-            description = 'opGnd',
-            offset      = 0x28C,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'rbuf',
-            description = 'rbuf',
-            offset      = 0x290,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.Bool,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'halfSckPeriod',
-            description = 'halfSckPeriod',
-            offset      = 0x294,
-            bitSize     = 32,
-            bitOffset   = 0,
-            base        = pr.UInt,
-            mode        = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'hrdRst',
-            description = 'hrdRst',
-            offset      = 0x3F8,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.UInt,
+            maximum     = maximum,
             mode        = 'WO',
-            hidden      = False,
         ))
-
-    def hardReset(self):
-        self.hrdRst.set(1)

--- a/python/surf/devices/analog_devices/__init__.py
+++ b/python/surf/devices/analog_devices/__init__.py
@@ -12,3 +12,4 @@ from surf.devices.analog_devices._Ad5780    import *
 from surf.devices.analog_devices._AttHmc624 import *
 from surf.devices.analog_devices._Adt7420   import *
 from surf.devices.analog_devices._Ad9681    import *
+from surf.devices.analog_devices._Ad5541    import *


### PR DESCRIPTION
### Description
Created AD5541 DAC VHDL module and updated Python class to match.

### Details
Created a new `AxiAd5541Core` VHDL module that is mostly a wrapper around a `AxiSpiMaster` with some generics set correctly to work with this device.

There is already a `Ad5541` Python class defined in surf, which was [created in 2019](https://github.com/slaclab/surf/commit/4687f43eb32288fd5d17dd26c2c1328cad7c2e3b), but the corresponding VHLD module seems to have been forgotten. This existing Python class has different `RemoteVariable` related to various debug features and I/O control of the missing HDL module. Since this module already exists in surf there might be some conflict in replacing it with this new simplified version. Would it be better to try and find the missing HDL module?


### JIRA

### Related
