### PR TITLE
bug fix for SsiPrbsRx.WordRate

### DIFF
--- a/python/surf/protocols/ssi/_SsiPrbsRx.py
+++ b/python/surf/protocols/ssi/_SsiPrbsRx.py
@@ -168,7 +168,7 @@ class SsiPrbsRx(pr.Device):
             dependencies = [self.PacketRate, self.PacketLength],
             units = 'Words/sec',
             disp = '{:0.1f}',
-            linkedGet = lambda read: self.PacketRate.read(read=read) * self.PacketLength.get(read=read)))
+            linkedGet = lambda read: self.PacketRate.get(read=read) * self.PacketLength.get(read=read)))
 
         self.add(pr.LinkVariable(
             name = 'BitRate',


### PR DESCRIPTION
### Description
- LinkVariable function to be called should be `get()` [not `read()`]