### PR TITLE
Update DmaXvcWrapper.vhd

### DIFF
--- a/protocols/xvc-udp/rtl/DmaXvcWrapper.vhd
+++ b/protocols/xvc-udp/rtl/DmaXvcWrapper.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: XVC Wrapper
+-- Description: XVC Wrapper for DMA applications (no XON/XOFF flow control)
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -20,45 +20,61 @@ use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
 use surf.EthMacPkg.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity DmaXvcWrapper is
    generic (
-      TPD_G                    : time                  := 1 ns;
-      COMMON_CLOCK_G           : boolean               := false;
-      XVC_CLK_FREQ_G           : real                  := 156.25e6;
-      FIFO_INT_PIPE_STAGES_G   : natural range 0 to 16 := 0;  -- Internal FIFO setting
-      FIFO_PIPE_STAGES_G       : natural range 0 to 16 := 1;
-      OB_FIFO_SLAVE_READY_EN_G : boolean               := true;
-      FIFO_ADDR_WIDTH_G        : integer range 4 to 48 := 9;
-      FIFO_SYNTH_MODE_G        : string                := "inferred";
-      FIFO_MEMORY_TYPE_G       : string                := "block";
-      AXIS_CONFIG_G            : AxiStreamConfigType);
+      TPD_G              : time     := 1 ns;
+      COMMON_CLOCK_G     : boolean  := false;
+      FIFO_ADDR_WIDTH_G  : positive := 9;
+      FIFO_SYNTH_MODE_G  : string   := "inferred";
+      FIFO_MEMORY_TYPE_G : string   := "block";
+      DMA_AXIS_CONFIG_G  : AxiStreamConfigType);
    port (
-      -- Clock and Reset (xvcClk domain)
-      xvcClk       : in  sl;
-      xvcRst       : in  sl;
-      -- Clock and Reset (axisClk domain)
-      axisClk      : in  sl;
-      axisRst      : in  sl;
-      -- OB FIFO (axisClk domain)
-      obFifoMaster : in  AxiStreamMasterType;
-      obFifoSlave  : out AxiStreamSlaveType;
-      obFifoCtrl   : out AxiStreamCtrlType;
-      -- IB FIFO (axisClk domain)
-      ibFifoSlave  : in  AxiStreamSlaveType;
-      ibFifoMaster : out AxiStreamMasterType);
+      -- 156.25MHz XVC Clock/Reset (xvcClk156 domain)
+      xvcClk156   : in  sl;
+      xvcRst156   : in  sl;
+      -- DMA Interface (dmaClk domain)
+      dmaClk      : in  sl;
+      dmaRst      : in  sl;
+      dmaObMaster : in  AxiStreamMasterType;
+      dmaObSlave  : out AxiStreamSlaveType;
+      dmaIbMaster : out AxiStreamMasterType;
+      dmaIbSlave  : in  AxiStreamSlaveType);
 end DmaXvcWrapper;
 
 architecture rtl of DmaXvcWrapper is
 
    signal ibXvcMaster : AxiStreamMasterType := axiStreamMasterInit(EMAC_AXIS_CONFIG_C);
    signal ibXvcSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+
    signal obXvcMaster : AxiStreamMasterType := axiStreamMasterInit(EMAC_AXIS_CONFIG_C);
    signal obXvcSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
 
 begin
+
+   U_RX_FIFO : entity surf.AxiStreamFifoV2
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         VALID_THOLD_G       => 0,      -- 0 = only when frame ready
+         -- FIFO configurations
+         GEN_SYNC_FIFO_G     => COMMON_CLOCK_G,
+         MEMORY_TYPE_G       => FIFO_MEMORY_TYPE_G,
+         FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
+         SYNTH_MODE_G        => FIFO_SYNTH_MODE_G,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => DMA_AXIS_CONFIG_G,
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
+      port map (
+         -- Slave Port
+         sAxisClk    => dmaClk,
+         sAxisRst    => dmaRst,
+         sAxisMaster => dmaObMaster,
+         sAxisSlave  => dmaObSlave,
+         -- Master Port
+         mAxisClk    => xvcClk156,
+         mAxisRst    => xvcRst156,
+         mAxisMaster => obXvcMaster,
+         mAxisSlave  => obXvcSlave);
 
    -----------------------------------------------------------------
    -- Xilinx Virtual Cable (XVC)
@@ -66,71 +82,39 @@ begin
    -----------------------------------------------------------------
    U_XVC : entity surf.UdpDebugBridgeWrapper
       generic map (
-         TPD_G           => TPD_G,
-         AXIS_CLK_FREQ_G => XVC_CLK_FREQ_G)
+         TPD_G => TPD_G)
       port map (
          -- Clock and Reset
-         clk            => xvcClk,
-         rst            => xvcRst,
+         clk            => xvcClk156,
+         rst            => xvcRst156,
          -- UDP XVC Interface
          obServerMaster => obXvcMaster,
          obServerSlave  => obXvcSlave,
          ibServerMaster => ibXvcMaster,
          ibServerSlave  => ibXvcSlave);
 
-   U_OB_FIFO : entity surf.AxiStreamFifoV2
+   U_TX_FIFO : entity surf.AxiStreamFifoV2
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
          -- FIFO configurations
-         INT_PIPE_STAGES_G   => FIFO_INT_PIPE_STAGES_G,
-         PIPE_STAGES_G       => FIFO_PIPE_STAGES_G,
-         SLAVE_READY_EN_G    => OB_FIFO_SLAVE_READY_EN_G,
-         GEN_SYNC_FIFO_G     => COMMON_CLOCK_G,
-         MEMORY_TYPE_G       => FIFO_MEMORY_TYPE_G,
-         FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
-         SYNTH_MODE_G        => FIFO_SYNTH_MODE_G,
-         -- AXI Stream Port Configurations
-         SLAVE_AXI_CONFIG_G  => AXIS_CONFIG_G,
-         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
-      port map (
-         -- Slave Port
-         sAxisClk    => axisClk,
-         sAxisRst    => axisRst,
-         sAxisMaster => obFifoMaster,
-         sAxisSlave  => obFifoSlave,
-         sAxisCtrl   => obFifoCtrl,
-         -- Master Port
-         mAxisClk    => xvcClk,
-         mAxisRst    => xvcRst,
-         mAxisMaster => obXvcMaster,
-         mAxisSlave  => obXvcSlave);
-
-   U_IB_FIFO : entity surf.AxiStreamFifoV2
-      generic map (
-         -- General Configurations
-         TPD_G               => TPD_G,
-         -- FIFO configurations
-         INT_PIPE_STAGES_G   => FIFO_INT_PIPE_STAGES_G,
-         PIPE_STAGES_G       => FIFO_PIPE_STAGES_G,
-         SLAVE_READY_EN_G    => OB_FIFO_SLAVE_READY_EN_G,
          GEN_SYNC_FIFO_G     => COMMON_CLOCK_G,
          MEMORY_TYPE_G       => FIFO_MEMORY_TYPE_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
          SYNTH_MODE_G        => FIFO_SYNTH_MODE_G,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_CONFIG_G)
+         MASTER_AXI_CONFIG_G => DMA_AXIS_CONFIG_G)
       port map (
          -- Slave Port
-         sAxisClk    => xvcClk,
-         sAxisRst    => xvcRst,
+         sAxisClk    => xvcClk156,
+         sAxisRst    => xvcRst156,
          sAxisMaster => ibXvcMaster,
          sAxisSlave  => ibXvcSlave,
          -- Master Port
-         mAxisClk    => axisClk,
-         mAxisRst    => axisRst,
-         mAxisMaster => ibFifoMaster,
-         mAxisSlave  => ibFifoSlave);
+         mAxisClk    => dmaClk,
+         mAxisRst    => dmaRst,
+         mAxisMaster => dmaIbMaster,
+         mAxisSlave  => dmaIbSlave);
 
 end rtl;

--- a/protocols/xvc-udp/rtl/DmaXvcWrapper.vhd
+++ b/protocols/xvc-udp/rtl/DmaXvcWrapper.vhd
@@ -27,7 +27,7 @@ entity DmaXvcWrapper is
    generic (
       TPD_G                    : time                  := 1 ns;
       COMMON_CLOCK_G           : boolean               := false;
-      AXIS_CLK_FREQ_G          : real                  := 156.25e6;
+      XVC_CLK_FREQ_G           : real                  := 156.25e6;
       FIFO_INT_PIPE_STAGES_G   : natural range 0 to 16 := 0;  -- Internal FIFO setting
       FIFO_PIPE_STAGES_G       : natural range 0 to 16 := 1;
       OB_FIFO_SLAVE_READY_EN_G : boolean               := true;
@@ -67,7 +67,7 @@ begin
    U_XVC : entity surf.UdpDebugBridgeWrapper
       generic map (
          TPD_G           => TPD_G,
-         AXIS_CLK_FREQ_G => AXIS_CLK_FREQ_G)
+         AXIS_CLK_FREQ_G => XVC_CLK_FREQ_G)
       port map (
          -- Clock and Reset
          clk            => xvcClk,

--- a/protocols/xvc-udp/rtl/UdpDebugBridgeWrapper.vhd
+++ b/protocols/xvc-udp/rtl/UdpDebugBridgeWrapper.vhd
@@ -42,8 +42,8 @@ end UdpDebugBridgeWrapper;
 architecture rtl of UdpDebugBridgeWrapper is
 
    component UdpDebugBridge is
-      generic (
-         AXIS_CLK_FREQ_G : real);
+--      generic (
+--         AXIS_CLK_FREQ_G : real);
       port (
          axisClk            : in  std_logic;
          axisRst            : in  std_logic;
@@ -81,6 +81,10 @@ architecture rtl of UdpDebugBridgeWrapper is
 
 begin
 
+   assert (AXIS_CLK_FREQ_G = 156.25E+6)
+      report "AXIS_CLK_FREQ_G: Must be 156.25E+6"
+      severity error;
+
    ----------------------------
    -- 'XVC' Server @2542 (modified protocol to work over UDP)
    ----------------------------
@@ -115,8 +119,8 @@ begin
    end process P_SOF_SPLICE;
 
    U_XvcServer : component UdpDebugBridge
-      generic map (
-         AXIS_CLK_FREQ_G => AXIS_CLK_FREQ_G)
+--      generic map (
+--         AXIS_CLK_FREQ_G => AXIS_CLK_FREQ_G)
       port map (
          axisClk => clk,
          axisRst => rst,


### PR DESCRIPTION
### Description
- AXIS_CLK_FREQ_G is misleading name because generic is associated with the xvcClk (not axisClk) at surf.UdpDebugBridgeWrapper
- Renaming this generic to XVC_CLK_FREQ_G
- `VALID_THOLD_G => 0, -- 0 = only when frame ready` is required to fix the issue when there are tValid gaps in the transfer
