### PR TITLE
pgp2fc/gtyUltraScale+/ruckus.tcl:  bug fix for Vivado version checking

### DIFF
--- a/protocols/pgp/pgp2fc/gtyUltraScale+/ruckus.tcl
+++ b/protocols/pgp/pgp2fc/gtyUltraScale+/ruckus.tcl
@@ -2,7 +2,7 @@
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_PROC_TCL)
 
 # Load local source Code and constraints
-if { $::env(VIVADO_VERSION) >= 2020.1 } {
+if { $::env(VIVADO_VERSION) >= 2023.1 } {
 
    loadSource -lib surf   -dir "$::DIR_PATH/rtl"
 
@@ -10,5 +10,5 @@ if { $::env(VIVADO_VERSION) >= 2020.1 } {
    #loadIpCore  -path "$::DIR_PATH/ip/Pgp2fcGtyCore.xci"
 
 } else {
-   puts "\n\nWARNING: $::DIR_PATH requires Vivado 2020.1 (or later)\n\n"
+   puts "\n\nWARNING: $::DIR_PATH requires Vivado 2023.1 (or later)\n\n"
 }


### PR DESCRIPTION
### Description
- Pgp2fcGtyCore was build with 2023.1 (not 2020.1)