### PR TITLE
Add some AxiVersion Rogue Device Variables to NoConfig group

### DIFF
--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -89,6 +89,7 @@ class AxiVersion(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'FpgaReloadHalt',
             description  = 'Used to halt automatic reloads via AxiVersion',
+            groups       = ['NoConfig']
             offset       = 0x100,
             bitSize      = 1,
             bitOffset    = 0x00,
@@ -127,6 +128,7 @@ class AxiVersion(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'UserReset',
             description  = 'Optional User Reset',
+            groups       = ['NoConfig'],
             hidden       = True,
             offset       = 0x10C,
             bitSize      = 1,

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -89,7 +89,7 @@ class AxiVersion(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'FpgaReloadHalt',
             description  = 'Used to halt automatic reloads via AxiVersion',
-            groups       = ['NoConfig']
+            groups       = ['NoConfig'],
             offset       = 0x100,
             bitSize      = 1,
             bitOffset    = 0x00,


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

`FpgaReloatHalt` and `UserReset` have been added to the "NoConfig" group. There is no reason these should be in a configuration YAML file.