### PR TITLE
Increased range of SACI_NUM_CHIPS_G to support more than 4 chips

### DIFF
--- a/protocols/saci/rtl/AxiLiteSaciMaster.vhd
+++ b/protocols/saci/rtl/AxiLiteSaciMaster.vhd
@@ -27,13 +27,13 @@ use surf.SaciMasterPkg.all;
 
 entity AxiLiteSaciMaster is
    generic (
-      TPD_G              : time                  := 1 ns;
-      AXIL_CLK_PERIOD_G  : real                  := 8.0e-9;  -- In units of seconds
-      AXIL_TIMEOUT_G     : real                  := 1.0E-3;  -- In units of seconds
-      SACI_CLK_PERIOD_G  : real                  := 1.0e-6;  -- In units of seconds
-      SACI_CLK_FREERUN_G : boolean               := false;
-      SACI_NUM_CHIPS_G   : positive range 1 to 6 := 1;
-      SACI_RSP_BUSSED_G  : boolean               := false);
+      TPD_G              : time     := 1 ns;
+      AXIL_CLK_PERIOD_G  : real     := 8.0e-9;  -- In units of seconds
+      AXIL_TIMEOUT_G     : real     := 1.0E-3;  -- In units of seconds
+      SACI_CLK_PERIOD_G  : real     := 1.0e-6;  -- In units of seconds
+      SACI_CLK_FREERUN_G : boolean  := false;
+      SACI_NUM_CHIPS_G   : positive := 1;
+      SACI_RSP_BUSSED_G  : boolean  := false);
    port (
       -- SACI interface
       saciClk         : out sl;

--- a/protocols/saci/rtl/AxiLiteSaciMaster.vhd
+++ b/protocols/saci/rtl/AxiLiteSaciMaster.vhd
@@ -32,7 +32,7 @@ entity AxiLiteSaciMaster is
       AXIL_TIMEOUT_G     : real                  := 1.0E-3;  -- In units of seconds
       SACI_CLK_PERIOD_G  : real                  := 1.0e-6;  -- In units of seconds
       SACI_CLK_FREERUN_G : boolean               := false;
-      SACI_NUM_CHIPS_G   : positive range 1 to 4 := 1;
+      SACI_NUM_CHIPS_G   : positive range 1 to 6 := 1;
       SACI_RSP_BUSSED_G  : boolean               := false);
    port (
       -- SACI interface


### PR DESCRIPTION
### Description
The `AxiLiteSaciMaster` currently has a fixed limit of four ASICs ("chips"). This has been increased to six to work with a new readout system with that many ASICs.

### Details
The new 3x2 Readout (https://confluence.slac.stanford.edu/x/eKRxG) seems to be first system to use more than four ASICs with a common SACI interfaces. There is no mention why only four chips were allowed previously. The hardware will arrive in a couple of weeks with which we can test running SACI with six chips, but from the code alone I don't see any reason why more than four would not work.
