### PR TITLE
introduce rst_polarity feature to all pgp4txlite/pgp4rx modules to prepare for asic deployment

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamDeMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamDeMux.vhd
@@ -37,7 +37,7 @@ entity AxiStreamDeMux is
    port (
       -- Clock and reset
       axisClk           : in  sl;
-      axisRst           : in  sl := not RST_POLARITY_G;
+      axisRst           : in  sl;
       -- Dynamic Route Table (only used when MODE_G = "DYNAMIC")
       dynamicRouteMasks : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");
       dynamicRouteDests : in  slv8Array(NUM_MASTERS_G-1 downto 0) := (others => "00000000");

--- a/axi/axi-stream/rtl/AxiStreamMux.vhd
+++ b/axi/axi-stream/rtl/AxiStreamMux.vhd
@@ -67,7 +67,7 @@ entity AxiStreamMux is
    port (
       -- Clock and reset
       axisClk      : in  sl;
-      axisRst      : in  sl := not RST_POLARITY_G;
+      axisRst      : in  sl;
       -- Slaves
       disableSel   : in  slv(NUM_SLAVES_G-1 downto 0) := (others => '0');
       rearbitrate  : in  sl                           := '0';

--- a/axi/axi-stream/rtl/AxiStreamPipeline.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPipeline.vhd
@@ -23,13 +23,14 @@ use surf.AxiStreamPkg.all;
 entity AxiStreamPipeline is
    generic (
       TPD_G             : time     := 1 ns;
+      RST_POLARITY_G    : sl       := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G       : boolean  := false;
       SIDE_BAND_WIDTH_G : positive := 1;  -- General purpose sideband
       PIPE_STAGES_G     : natural  := 0);
    port (
       -- Clock and Reset
       axisClk     : in  sl;
-      axisRst     : in  sl;
+      axisRst     : in  sl := not RST_POLARITY_G;
       -- Slave Port
       sAxisMaster : in  AxiStreamMasterType;
       sSideBand   : in  slv(SIDE_BAND_WIDTH_G-1 downto 0) := (others => '0');
@@ -148,7 +149,7 @@ begin
          mSideBand   <= r.mSideBand(PIPE_STAGES_C);
 
          -- Synchronous Reset
-         if (RST_ASYNC_G = false and axisRst = '1') then
+         if (RST_ASYNC_G = false and axisRst = RST_POLARITY_G) then
             v := REG_INIT_C;
          end if;
 
@@ -159,7 +160,7 @@ begin
 
       seq : process (axisClk, axisRst) is
       begin
-         if (RST_ASYNC_G and axisRst = '1') then
+         if (RST_ASYNC_G and axisRst = RST_POLARITY_G) then
             r <= REG_INIT_C after TPD_G;
          elsif rising_edge(axisClk) then
             r <= rin after TPD_G;

--- a/axi/axi-stream/rtl/AxiStreamPipeline.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPipeline.vhd
@@ -30,7 +30,7 @@ entity AxiStreamPipeline is
    port (
       -- Clock and Reset
       axisClk     : in  sl;
-      axisRst     : in  sl := not RST_POLARITY_G;
+      axisRst     : in  sl;
       -- Slave Port
       sAxisMaster : in  AxiStreamMasterType;
       sSideBand   : in  slv(SIDE_BAND_WIDTH_G-1 downto 0) := (others => '0');

--- a/base/crc/rtl/Crc32.vhd
+++ b/base/crc/rtl/Crc32.vhd
@@ -34,13 +34,14 @@ use surf.CrcPkg.all;
 entity Crc32 is
    generic (
       TPD_G            : time             := 1 ns;
+      RST_POLARITY_G   : sl               := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G      : boolean          := false;
       BYTE_WIDTH_G     : positive         := 4;
       INPUT_REGISTER_G : boolean          := true;
       CRC_INIT_G       : slv(31 downto 0) := x"FFFFFFFF";
       CRC_POLY_G       : slv(31 downto 0) := x"04C11DB7");
    port (
-      crcPwrOnRst  : in  sl := '0';
+      crcPwrOnRst  : in  sl := not RST_POLARITY_G;
       crcOut       : out slv(31 downto 0);  -- CRC output
       crcRem       : out slv(31 downto 0);  -- CRC interim remainder
       crcClk       : in  sl;            -- system clock
@@ -146,10 +147,10 @@ begin
 
    seq : process (crcClk, crcPwrOnRst) is
    begin
-      if (RST_ASYNC_G and crcPwrOnRst = '1') then
+      if (RST_ASYNC_G and crcPwrOnRst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif  (rising_edge(crcClk)) then
-         if (RST_ASYNC_G = false and crcPwrOnRst = '1') then
+         if (RST_ASYNC_G = false and crcPwrOnRst = RST_POLARITY_G) then
             r <= REG_INIT_C after TPD_G;
          else
             r <= rin after TPD_G;

--- a/base/crc/rtl/Crc32.vhd
+++ b/base/crc/rtl/Crc32.vhd
@@ -41,7 +41,7 @@ entity Crc32 is
       CRC_INIT_G       : slv(31 downto 0) := x"FFFFFFFF";
       CRC_POLY_G       : slv(31 downto 0) := x"04C11DB7");
    port (
-      crcPwrOnRst  : in  sl := not RST_POLARITY_G;
+      crcPwrOnRst  : in  sl;
       crcOut       : out slv(31 downto 0);  -- CRC output
       crcRem       : out slv(31 downto 0);  -- CRC interim remainder
       crcClk       : in  sl;            -- system clock

--- a/base/crc/rtl/Crc32Parallel.vhd
+++ b/base/crc/rtl/Crc32Parallel.vhd
@@ -40,12 +40,13 @@ use surf.CrcPkg.all;
 entity Crc32Parallel is
    generic (
       TPD_G            : time             := 1 ns;
+      RST_POLARITY_G   : sl               := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G      : boolean          := false;
       BYTE_WIDTH_G     : positive         := 4;
       INPUT_REGISTER_G : boolean          := true;
       CRC_INIT_G       : slv(31 downto 0) := x"FFFFFFFF");
    port (
-      crcPwrOnRst  : in  sl := '0';
+      crcPwrOnRst  : in  sl := not RST_POLARITY_G;
       crcOut       : out slv(31 downto 0);  -- CRC output
       crcRem       : out slv(31 downto 0);  -- CRC interim remainder
       crcClk       : in  sl;            -- system clock
@@ -188,10 +189,10 @@ begin
 
    seq : process (crcClk, crcPwrOnRst) is
    begin
-      if (RST_ASYNC_G and crcPwrOnRst = '1') then
+      if (RST_ASYNC_G and crcPwrOnRst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif  (rising_edge(crcClk)) then
-         if (RST_ASYNC_G = false and crcPwrOnRst = '1') then
+         if (RST_ASYNC_G = false and crcPwrOnRst = RST_POLARITY_G) then
             r <= REG_INIT_C after TPD_G;
          else
             r <= rin after TPD_G;

--- a/base/crc/rtl/Crc32Parallel.vhd
+++ b/base/crc/rtl/Crc32Parallel.vhd
@@ -46,7 +46,7 @@ entity Crc32Parallel is
       INPUT_REGISTER_G : boolean          := true;
       CRC_INIT_G       : slv(31 downto 0) := x"FFFFFFFF");
    port (
-      crcPwrOnRst  : in  sl := not RST_POLARITY_G;
+      crcPwrOnRst  : in  sl;
       crcOut       : out slv(31 downto 0);  -- CRC output
       crcRem       : out slv(31 downto 0);  -- CRC interim remainder
       crcClk       : in  sl;            -- system clock

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -34,7 +34,7 @@ entity Gearbox is
    port (
       -- Clock and Reset
       clk            : in  sl;
-      rst            : in  sl := not RST_POLARITY_G;
+      rst            : in  sl;
       -- input side data and flow control
       slaveData      : in  slv(SLAVE_WIDTH_G-1 downto 0);
       slaveValid     : in  sl := '1';

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -34,7 +34,7 @@ entity Gearbox is
    port (
       -- Clock and Reset
       clk            : in  sl;
-      rst            : in  sl;
+      rst            : in  sl := not RST_POLARITY_G;
       -- input side data and flow control
       slaveData      : in  slv(SLAVE_WIDTH_G-1 downto 0);
       slaveValid     : in  sl := '1';

--- a/base/general/rtl/Scrambler.vhd
+++ b/base/general/rtl/Scrambler.vhd
@@ -35,7 +35,7 @@ entity Scrambler is
       TAPS_G            : IntegerArray := (0 => 39, 1 => 58));
    port (
       clk            : in  sl;
-      rst            : in  sl := not RST_POLARITY_G;
+      rst            : in  sl;
       inputValid     : in  sl := '1';
       inputReady     : out sl;
       inputData      : in  slv(DATA_WIDTH_G-1 downto 0);

--- a/base/general/rtl/Scrambler.vhd
+++ b/base/general/rtl/Scrambler.vhd
@@ -25,6 +25,7 @@ use surf.StdRtlPkg.all;
 entity Scrambler is
    generic (
       TPD_G             : time         := 1 ns;
+      RST_POLARITY_G    : sl           := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G       : boolean      := false;
       DIRECTION_G       : string       := "SCRAMBLER";  -- or DESCRAMBLER
       DATA_WIDTH_G      : integer      := 64;
@@ -34,7 +35,7 @@ entity Scrambler is
       TAPS_G            : IntegerArray := (0 => 39, 1 => 58));
    port (
       clk            : in  sl;
-      rst            : in  sl;
+      rst            : in  sl := not RST_POLARITY_G;
       inputValid     : in  sl := '1';
       inputReady     : out sl;
       inputData      : in  slv(DATA_WIDTH_G-1 downto 0);
@@ -129,7 +130,7 @@ begin
       inputReady <= v.inputReady;
 
       -- Reset
-      if (RST_ASYNC_G = false and rst = '1') then
+      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
          v := REG_INIT_C;
       end if;
 
@@ -150,7 +151,7 @@ begin
 
    seq : process (clk, rst) is
    begin
-      if (RST_ASYNC_G and rst = '1') then
+      if (RST_ASYNC_G and rst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif rising_edge(clk) then
          r <= rin after TPD_G;

--- a/base/sync/rtl/SynchronizerFifo.vhd
+++ b/base/sync/rtl/SynchronizerFifo.vhd
@@ -34,7 +34,7 @@ entity SynchronizerFifo is
       INIT_G         : slv                        := "0");
    port (
       -- Asynchronous Reset
-      rst    : in  sl := not RST_POLARITY_G;
+      rst    : in  sl;
       -- Write Ports (wr_clk domain)
       wr_clk : in  sl;
       wr_en  : in  sl := '1';

--- a/base/sync/rtl/SynchronizerFifo.vhd
+++ b/base/sync/rtl/SynchronizerFifo.vhd
@@ -34,7 +34,7 @@ entity SynchronizerFifo is
       INIT_G         : slv                        := "0");
    port (
       -- Asynchronous Reset
-      rst    : in  sl;
+      rst    : in sl := not RST_POLARITY_G;
       -- Write Ports (wr_clk domain)
       wr_clk : in  sl;
       wr_en  : in  sl := '1';

--- a/base/sync/rtl/SynchronizerFifo.vhd
+++ b/base/sync/rtl/SynchronizerFifo.vhd
@@ -22,18 +22,19 @@ use surf.StdRtlPkg.all;
 
 entity SynchronizerFifo is
    generic (
-      TPD_G         : time                       := 1 ns;
-      RST_ASYNC_G   : boolean                    := false;
-      COMMON_CLK_G  : boolean                    := false;  -- Bypass FifoAsync module for synchronous data configuration
-      MEMORY_TYPE_G : string                     := "distributed";
-      SYNC_STAGES_G : integer range 3 to (2**24) := 3;
-      PIPE_STAGES_G : natural range 0 to 16      := 0;
-      DATA_WIDTH_G  : integer range 1 to (2**24) := 16;
-      ADDR_WIDTH_G  : integer range 2 to 48      := 4;
-      INIT_G        : slv                        := "0");
+      TPD_G          : time                       := 1 ns;
+      RST_POLARITY_G : sl                         := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean                    := false;
+      COMMON_CLK_G   : boolean                    := false;  -- Bypass FifoAsync module for synchronous data configuration
+      MEMORY_TYPE_G  : string                     := "distributed";
+      SYNC_STAGES_G  : integer range 3 to (2**24) := 3;
+      PIPE_STAGES_G  : natural range 0 to 16      := 0;
+      DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
+      ADDR_WIDTH_G   : integer range 2 to 48      := 4;
+      INIT_G         : slv                        := "0");
    port (
       -- Asynchronous Reset
-      rst    : in  sl := '0';
+      rst    : in  sl := not RST_POLARITY_G;
       -- Write Ports (wr_clk domain)
       wr_clk : in  sl;
       wr_en  : in  sl := '1';
@@ -58,15 +59,16 @@ begin
 
       FifoAsync_1 : entity surf.FifoAsync
          generic map (
-            TPD_G         => TPD_G,
-            RST_ASYNC_G   => RST_ASYNC_G,
-            MEMORY_TYPE_G => MEMORY_TYPE_G,
-            FWFT_EN_G     => true,
-            SYNC_STAGES_G => SYNC_STAGES_G,
-            PIPE_STAGES_G => PIPE_STAGES_G,
-            DATA_WIDTH_G  => DATA_WIDTH_G,
-            ADDR_WIDTH_G  => ADDR_WIDTH_G,
-            INIT_G        => INIT_C)
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            MEMORY_TYPE_G  => MEMORY_TYPE_G,
+            FWFT_EN_G      => true,
+            SYNC_STAGES_G  => SYNC_STAGES_G,
+            PIPE_STAGES_G  => PIPE_STAGES_G,
+            DATA_WIDTH_G   => DATA_WIDTH_G,
+            ADDR_WIDTH_G   => ADDR_WIDTH_G,
+            INIT_G         => INIT_C)
          port map (
             rst           => rst,
             wr_clk        => wr_clk,

--- a/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
@@ -43,7 +43,7 @@ entity AxiStreamDepacketizer2 is
    port (
       -- Clock and Reset
       axisClk     : in  sl;
-      axisRst     : in  sl := not RST_POLARITY_G;
+      axisRst     : in  sl;
       -- Link Status monitoring and debug interfaces
       linkGood    : in  sl;
       debug       : out Packetizer2DebugType;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxGearboxAligner.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxGearboxAligner.vhd
@@ -33,7 +33,7 @@ entity Pgp3RxGearboxAligner is
       SLIP_WAIT_G    : integer := 32);
    port (
       clk           : in  sl;
-      rst           : in  sl := not RST_POLARITY_G;
+      rst           : in  sl;
       rxHeader      : in  slv(1 downto 0);
       rxHeaderValid : in  sl;
       slip          : out sl;

--- a/protocols/pgp/pgp3/core/rtl/Pgp3RxGearboxAligner.vhd
+++ b/protocols/pgp/pgp3/core/rtl/Pgp3RxGearboxAligner.vhd
@@ -27,12 +27,13 @@ use surf.StdRtlPkg.all;
 
 entity Pgp3RxGearboxAligner is
    generic (
-      TPD_G        : time    := 1 ns;
-      RST_ASYNC_G  : boolean := false;
-      SLIP_WAIT_G  : integer := 32);
+      TPD_G          : time    := 1 ns;
+      RST_POLARITY_G : sl      := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean := false;
+      SLIP_WAIT_G    : integer := 32);
    port (
       clk           : in  sl;
-      rst           : in  sl;
+      rst           : in  sl := not RST_POLARITY_G;
       rxHeader      : in  slv(1 downto 0);
       rxHeaderValid : in  sl;
       slip          : out sl;
@@ -119,7 +120,7 @@ begin
          when others => null;
       end case;
 
-      if (RST_ASYNC_G = false and rst = '1') then
+      if (RST_ASYNC_G = false and rst = RST_POLARITY_G) then
          v := REG_INIT_C;
       end if;
 
@@ -132,7 +133,7 @@ begin
 
    seq : process (clk, rst) is
    begin
-      if (RST_ASYNC_G) and (rst = '1') then
+      if (RST_ASYNC_G) and (rst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif rising_edge(clk) then
          r <= rin after TPD_G;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -31,7 +31,6 @@ entity Pgp4Rx is
       TPD_G              : time                  := 1 ns;
       RST_POLARITY_G     : sl                    := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G        : boolean               := false;
-      SIMULATION_G       : boolean               := false;  -- bypasses elastic buffer
       NUM_VC_G           : integer range 1 to 16 := 4;
       SKIP_EN_G          : boolean               := true;  -- TRUE for Elastic Buffer
       LITE_EN_G          : boolean               := false; -- TRUE: Lite does NOT support SOC/EOC
@@ -39,7 +38,7 @@ entity Pgp4Rx is
    port (
       -- User Transmit interface
       pgpRxClk     : in  sl;
-      pgpRxRst     : in  sl           := not RST_POLARITY_G;
+      pgpRxRst     : in  sl;
       pgpRxIn      : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
       pgpRxOut     : out Pgp4RxOutType;
       pgpRxMasters : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
@@ -134,7 +133,7 @@ begin
          outputData     => unscrambledData,     -- [out]
          outputSideband => unscrambledHeader);  -- [out]
 
-   GEN_EB : if (SKIP_EN_G = true and SIMULATION_G = false) generate
+   GEN_EB : if (SKIP_EN_G = true) generate
       -- Elastic Buffer
       U_Pgp4RxEb_1 : entity surf.Pgp4RxEb
          generic map (
@@ -157,7 +156,7 @@ begin
             linkError   => linkError,          -- [out]
             status      => ebStatus);          -- [out]
    end generate GEN_EB;
-   NO_EB : if (SKIP_EN_G = false or SIMULATION_G = true) generate
+   NO_EB : if (SKIP_EN_G = false) generate
       ebValid  <= unscrambledValid;
       ebHeader <= unscrambledHeader;
       ebData   <= unscrambledData;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -30,13 +30,13 @@ entity Pgp4RxEb is
       RST_ASYNC_G    : boolean := false);
    port (
       phyRxClk    : in sl;
-      phyRxRst    : in sl := not RST_POLARITY_G;
+      phyRxRst    : in sl;
       phyRxValid  : in sl;
       phyRxData   : in slv(63 downto 0);  -- Unscrambled data from the PHY
       phyRxHeader : in slv(1 downto 0);
       -- User Transmit interface
       pgpRxClk    : in  sl;
-      pgpRxRst    : in  sl := not RST_POLARITY_G;
+      pgpRxRst    : in  sl;
       pgpRxValid  : out sl;
       pgpRxData   : out slv(63 downto 0);
       pgpRxHeader : out slv(1 downto 0);

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -31,13 +31,14 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4RxProtocol is
    generic (
-      TPD_G       : time                  := 1 ns;
-      RST_ASYNC_G : boolean               := false;
-      NUM_VC_G    : integer range 1 to 16 := 4);
+      TPD_G          : time                  := 1 ns;
+      RST_POLARITY_G : sl                    := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean               := false;
+      NUM_VC_G       : integer range 1 to 16 := 4);
    port (
       -- User Transmit interface
       pgpRxClk       : in  sl;
-      pgpRxRst       : in  sl;
+      pgpRxRst       : in  sl := not RST_POLARITY_G;
       pgpRxIn        : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
       pgpRxOut       : out Pgp4RxOutType;
       pgpRxMaster    : out AxiStreamMasterType;
@@ -90,8 +91,9 @@ begin
 
    U_phyRxActiveSync : entity surf.SynchronizerEdge
       generic map (
-         TPD_G       => TPD_G,
-         RST_ASYNC_G => RST_ASYNC_G)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G)
       port map (
          clk         => pgpRxClk,
          rst         => pgpRxRst,
@@ -278,7 +280,7 @@ begin
       locRxLinkReady <= r.pgpRxOut.linkReady;
 
       -- Reset
-      if (RST_ASYNC_G = false and pgpRxRst = '1') then
+      if (RST_ASYNC_G = false and pgpRxRst = RST_POLARITY_G) then
          v := REG_INIT_C;
       end if;
 
@@ -289,7 +291,7 @@ begin
 
    seq : process (pgpRxClk, pgpRxRst) is
    begin
-      if (RST_ASYNC_G) and (pgpRxRst = '1') then
+      if (RST_ASYNC_G) and (pgpRxRst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif rising_edge(pgpRxClk) then
          r <= rin after TPD_G;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxProtocol.vhd
@@ -38,7 +38,7 @@ entity Pgp4RxProtocol is
    port (
       -- User Transmit interface
       pgpRxClk       : in  sl;
-      pgpRxRst       : in  sl := not RST_POLARITY_G;
+      pgpRxRst       : in  sl;
       pgpRxIn        : in  Pgp4RxInType := PGP4_RX_IN_INIT_C;
       pgpRxOut       : out Pgp4RxOutType;
       pgpRxMaster    : out AxiStreamMasterType;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLite.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLite.vhd
@@ -28,6 +28,7 @@ use surf.Pgp4Pkg.all;
 entity Pgp4TxLite is
    generic (
       TPD_G          : time                  := 1 ns;
+      RST_POLARITY_G : sl                    := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G    : boolean               := false;
       NUM_VC_G       : integer range 1 to 16 := 1;
       SKIP_EN_G      : boolean               := false;
@@ -35,7 +36,7 @@ entity Pgp4TxLite is
    port (
       -- Transmit interface
       pgpTxClk     : in  sl;
-      pgpTxRst     : in  sl;
+      pgpTxRst     : in  sl := not RST_POLARITY_G;
       pgpTxIn      : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
       pgpTxOut     : out Pgp4TxOutType;
       pgpTxActive  : in  sl;
@@ -82,8 +83,9 @@ begin
       -- Synchronize remote link and FIFO status to tx clock
       U_Synchronizer_REM : entity surf.Synchronizer
          generic map (
-            TPD_G       => TPD_G,
-            RST_ASYNC_G => RST_ASYNC_G)
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G)
          port map (
             clk     => pgpTxClk,                              -- [in]
             rst     => pgpTxRst,                              -- [in]
@@ -92,9 +94,10 @@ begin
       REM_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
          U_SynchronizerVector_1 : entity surf.SynchronizerVector
             generic map (
-               TPD_G       => TPD_G,
-               RST_ASYNC_G => RST_ASYNC_G,
-               WIDTH_G     => 2)
+               TPD_G          => TPD_G,
+               RST_POLARITY_G => RST_POLARITY_G,
+               RST_ASYNC_G    => RST_ASYNC_G,
+               WIDTH_G        => 2)
             port map (
                clk        => pgpTxClk,                        -- [in]
                rst        => pgpTxRst,                        -- [in]
@@ -107,8 +110,9 @@ begin
       -- Synchronize local rx status
       U_Synchronizer_LOC : entity surf.Synchronizer
          generic map (
-            TPD_G       => TPD_G,
-            RST_ASYNC_G => RST_ASYNC_G)
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G)
          port map (
             clk     => pgpTxClk,                           -- [in]
             rst     => pgpTxRst,                           -- [in]
@@ -117,8 +121,9 @@ begin
       LOC_STATUS_SYNC : for i in NUM_VC_G-1 downto 0 generate
          U_Synchronizer_pause : entity surf.Synchronizer
             generic map (
-               TPD_G       => TPD_G,
-               RST_ASYNC_G => RST_ASYNC_G)
+               TPD_G          => TPD_G,
+               RST_POLARITY_G => RST_POLARITY_G,
+               RST_ASYNC_G    => RST_ASYNC_G)
             port map (
                clk     => pgpTxClk,                        -- [in]
                rst     => pgpTxRst,                        -- [in]
@@ -126,8 +131,9 @@ begin
                dataOut => syncLocRxFifoCtrl(i).pause);     -- [out]
          U_Synchronizer_overflow : entity surf.SynchronizerOneShot
             generic map (
-               TPD_G       => TPD_G,
-               RST_ASYNC_G => RST_ASYNC_G)
+               TPD_G          => TPD_G,
+               RST_POLARITY_G => RST_POLARITY_G,
+               RST_ASYNC_G    => RST_ASYNC_G)
             port map (
                clk     => pgpTxClk,                        -- [in]
                rst     => pgpTxRst,                        -- [in]
@@ -158,6 +164,7 @@ begin
       U_AxiStreamMux_1 : entity surf.AxiStreamMux
          generic map (
             TPD_G                => TPD_G,
+            RST_POLARITY_G       => RST_POLARITY_G,
             RST_ASYNC_G          => RST_ASYNC_G,
             NUM_SLAVES_G         => NUM_VC_G,
             MODE_G               => "INDEXED",
@@ -189,6 +196,7 @@ begin
    U_Protocol : entity surf.Pgp4TxLiteProtocol
       generic map (
          TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
          RST_ASYNC_G    => RST_ASYNC_G,
          NUM_VC_G       => NUM_VC_G,
          SKIP_EN_G      => SKIP_EN_G,
@@ -216,6 +224,7 @@ begin
    U_Scrambler_1 : entity surf.Scrambler
       generic map (
          TPD_G            => TPD_G,
+         RST_POLARITY_G   => RST_POLARITY_G,
          RST_ASYNC_G      => RST_ASYNC_G,
          DIRECTION_G      => "SCRAMBLER",
          DATA_WIDTH_G     => 64,
@@ -237,6 +246,7 @@ begin
          outputSideband(1 downto 0) => phyTxHeader,   -- [out]
          outputSideband(2)          => phyTxStart);   -- [out]
 
-   phyTxActiveL <= not(phyTxActive);
+   -- not using ite to prevent errors in ASIC synth flow
+   phyTxActiveL <= not(phyTxActive) when RST_POLARITY_G = '1' else phyTxActive;
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLite.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLite.vhd
@@ -36,7 +36,7 @@ entity Pgp4TxLite is
    port (
       -- Transmit interface
       pgpTxClk     : in  sl;
-      pgpTxRst     : in  sl := not RST_POLARITY_G;
+      pgpTxRst     : in  sl;
       pgpTxIn      : in  Pgp4TxInType := PGP4_TX_IN_INIT_C;
       pgpTxOut     : out Pgp4TxOutType;
       pgpTxActive  : in  sl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteProtocol.vhd
@@ -32,6 +32,7 @@ use surf.Pgp4Pkg.all;
 entity Pgp4TxLiteProtocol is
    generic (
       TPD_G          : time                  := 1 ns;
+      RST_POLARITY_G : sl                    := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G    : boolean               := false;
       NUM_VC_G       : integer range 1 to 16 := 1;
       SKIP_EN_G      : boolean               := false;
@@ -40,7 +41,7 @@ entity Pgp4TxLiteProtocol is
    port (
       -- User Transmit interface
       pgpTxClk       : in  sl;
-      pgpTxRst       : in  sl;
+      pgpTxRst       : in  sl := not RST_POLARITY_G;
       pgpTxIn        : in  Pgp4TxInType                            := PGP4_TX_IN_INIT_C;
       pgpTxOut       : out Pgp4TxOutType;
       pgpTxActive    : in  sl                                      := '1';
@@ -127,6 +128,7 @@ begin
    U_Crc32 : entity surf.Crc32Parallel
       generic map (
          TPD_G            => TPD_G,
+         RST_POLARITY_G   => RST_POLARITY_G,
          RST_ASYNC_G      => RST_ASYNC_G,
          INPUT_REGISTER_G => false,
          BYTE_WIDTH_G     => 8,
@@ -453,7 +455,7 @@ begin
       end loop;
 
       -- Reset
-      if (RST_ASYNC_G = false and pgpTxRst = '1') then
+      if (RST_ASYNC_G = false and pgpTxRst = RST_POLARITY_G) then
          v := REG_INIT_C;
       end if;
 
@@ -464,7 +466,7 @@ begin
 
    seq : process (pgpTxClk, pgpTxRst) is
    begin
-      if (RST_ASYNC_G) and (pgpTxRst = '1') then
+      if (RST_ASYNC_G) and (pgpTxRst = RST_POLARITY_G) then
          r <= REG_INIT_C after TPD_G;
       elsif rising_edge(pgpTxClk) then
          r <= rin after TPD_G;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteProtocol.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteProtocol.vhd
@@ -41,7 +41,7 @@ entity Pgp4TxLiteProtocol is
    port (
       -- User Transmit interface
       pgpTxClk       : in  sl;
-      pgpTxRst       : in  sl := not RST_POLARITY_G;
+      pgpTxRst       : in  sl;
       pgpTxIn        : in  Pgp4TxInType                            := PGP4_TX_IN_INIT_C;
       pgpTxOut       : out Pgp4TxOutType;
       pgpTxActive    : in  sl                                      := '1';

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
@@ -24,12 +24,13 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4TxLiteWrapper is
    generic (
-      TPD_G       : time    := 1 ns;
-      RST_ASYNC_G : boolean := false);
+      TPD_G          : time    := 1 ns;
+      RST_POLARITY_G : sl      := '1';    -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean := false);
    port (
       -- Clock and Reset
       clk        : in  sl;
-      rst        : in  sl;                 -- Active HIGH reset
+      rst        : in  sl := not RST_POLARITY_G;
       -- 64-bit Input Framing Interface
       txValid    : in  sl;                 -- tValid
       txReady    : out sl;                 -- tReady
@@ -71,8 +72,9 @@ begin
    U_Pgp4TxLite : entity surf.Pgp4TxLite
       generic map (
          TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
          RST_ASYNC_G    => RST_ASYNC_G,
-         NUM_VC_G       => 1,           -- Only 1 VC per PGPv4 link
+         NUM_VC_G       => 1,      -- Only 1 VC per PGPv4 link
          SKIP_EN_G      => false,  -- No skips (assumes clock source synchronous system)
          FLOW_CTRL_EN_G => false)  -- no pause flow control from PGPv4.RX side
       port map (
@@ -97,6 +99,7 @@ begin
          phyTxData       => phyTxData(63 downto 0),
          phyTxHeader     => phyTxData(65 downto 64));
 
-   rstL <= not(rst);
+   -- not using ite to prevent errors in ASIC synth flow
+   rstL <= not(rst) when RST_POLARITY_G = '1' else rst;
 
 end architecture mapping;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4TxLiteWrapper.vhd
@@ -30,7 +30,7 @@ entity Pgp4TxLiteWrapper is
    port (
       -- Clock and Reset
       clk        : in  sl;
-      rst        : in  sl := not RST_POLARITY_G;
+      rst        : in  sl;
       -- 64-bit Input Framing Interface
       txValid    : in  sl;                 -- tValid
       txReady    : out sl;                 -- tReady


### PR DESCRIPTION
introduce rst_polarity feature to all pgp4txlite/pgp4rx modules to prepare for asic deployment

(ASIC designs usually employ an active-LOW reset/i.e. a rstN/enable signal)

add RST_POLARITY_G to all modules.

note that I also added RST_POLARITY_G to RX-related modules because I use them in my local behavioral simulation (no receiver in ASICs are foreseen). Since the RST_POLARITY_G generic default values are consistent, the changes in the TX/RX modules hopefully should not have impact on existing designs.
