### PR TITLE
AxiSpiMaster - Fix bug in shadow RAM for multi-chip configurations

### DIFF
--- a/protocols/spi/rtl/AxiSpiMaster.vhd
+++ b/protocols/spi/rtl/AxiSpiMaster.vhd
@@ -55,8 +55,8 @@ entity AxiSpiMaster is
       axiWriteMaster : in  AxiLiteWriteMasterType;
       axiWriteSlave  : out AxiLiteWriteSlaveType;
       -- Copy of the shadow memory (SHADOW_EN_G=true)
-      shadowAddr     : in  slv(ADDRESS_SIZE_G-1 downto 0) := (others => '0');
-      shadowData     : out slv(DATA_SIZE_G-1 downto 0)    := (others => '0');
+      shadowAddr     : in  slv(log2(SPI_NUM_CHIPS_G)+ADDRESS_SIZE_G-1 downto 0) := (others => '0');
+      shadowData     : out slv(DATA_SIZE_G-1 downto 0)                          := (others => '0');
       -- SPI Interface
       coreSclk       : out sl;
       coreSDin       : in  sl;
@@ -77,7 +77,8 @@ architecture rtl of AxiSpiMaster is
    type StateType is (WAIT_AXI_TXN_S, WAIT_CYCLE_S, WAIT_CYCLE_SHADOW_S, WAIT_SPI_TXN_DONE_S, SHADOW_READ_DONE_S);
 
 
-   signal memData : slv(DATA_SIZE_G-1 downto 0) := (others => '0');
+   signal memData : slv(DATA_SIZE_G-1 downto 0)                := (others => '0');
+   signal memAddr : slv(ADDRESS_SIZE_G+CHIP_BITS_C-1 downto 0) := (others => '0');
 
    -- Registers
    type RegType is record
@@ -105,26 +106,27 @@ architecture rtl of AxiSpiMaster is
 begin
 
    SHADOW_RAM_GEN : if (SHADOW_EN_G) generate
+      memAddr <= r.chipSel & r.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G);
       U_DualPortRam_1 : entity surf.DualPortRam
          generic map (
             TPD_G         => TPD_G,
             MEMORY_TYPE_G => SHADOW_MEM_TYPE_G,
             REG_EN_G      => false,
             DATA_WIDTH_G  => DATA_SIZE_G,
-            ADDR_WIDTH_G  => ADDRESS_SIZE_G)
+            ADDR_WIDTH_G  => ADDRESS_SIZE_G+CHIP_BITS_C)
          port map (
-            clka  => axiClk,                                                     -- [in]
-            ena   => '1',                                                        -- [in]
-            wea   => r.wrEn,                                                     -- [in]
-            rsta  => axiRst,                                                     -- [in]
-            addra => r.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G),  -- [in]
-            dina  => r.wrData(DATA_SIZE_G-1 downto 0),                           -- [in]
-            douta => memData,                                                    -- [out]
-            clkb  => axiClk,                                                     -- [in]
-            enb   => '1',                                                        -- [in]
-            rstb  => axiRst,                                                     -- [in]
-            addrb => shadowAddr,                                                 -- [in]
-            doutb => shadowData);                                                -- [out]
+            clka  => axiClk,                            -- [in]
+            ena   => '1',                               -- [in]
+            wea   => r.wrEn,                            -- [in]
+            rsta  => axiRst,                            -- [in]
+            addra => memAddr,                           -- [in]
+            dina  => r.wrData(DATA_SIZE_G-1 downto 0),  -- [in]
+            douta => memData,                           -- [out]
+            clkb  => axiClk,                            -- [in]
+            enb   => '1',                               -- [in]
+            rstb  => axiRst,                            -- [in]
+            addrb => shadowAddr,                        -- [in]
+            doutb => shadowData);                       -- [out]
 
    end generate SHADOW_RAM_GEN;
 
@@ -147,6 +149,7 @@ begin
                   if (ADDRESS_SIZE_G > 0) then
                      v.wrData(DATA_SIZE_G+ADDRESS_SIZE_G-1 downto DATA_SIZE_G) := axiReadMaster.araddr(2+ADDRESS_SIZE_G-1 downto 2);  -- setup memAddr
                   end if;
+                  v.chipSel := axiReadMaster.araddr(CHIP_BITS_C+ADDRESS_SIZE_G+1 downto 2+ADDRESS_SIZE_G);
                elsif (MODE_G = "WO") then
                   axiSlaveReadResponse(v.axiReadSlave, AXI_RESP_DECERR_C);
                else


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

The `SHADOW_EN_G` feature that reads from a shadow RAM was broken for cases when `SPI_NUM_CHIPS_G > 1`.
It would use the same shadow RAM of all chips. The RAM size has been increased so that there is a separate address space in the RAM for each chip.

