### PR TITLE
Hot Fix for CI: Removing C++ linter

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -49,9 +49,9 @@ jobs:
           python -m compileall -f python/ scripts/ tests/
           flake8 --count python/ scripts/ tests/
 
-      - name: C/C++ Linter
-        run: |
-          find . -name '*.h' -o -name '*.cpp' -o -name '*.c' | xargs cpplint
+#      - name: C/C++ Linter
+#        run: |
+#          find . -name '*.h' -o -name '*.cpp' -o -name '*.c' | xargs cpplint
 
       - name: VHDL Regression Testing
         run: |

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -20,3 +20,7 @@ filter=-readability/casting
 # Disable the build/include_subdir check
 # Because headers are organized in same directory and C code
 filter=-build/include_subdir
+
+# Disable the build/include_what_you_use check
+# Because C code use <stdio.h> instead of <cstdio> for C code
+filter=-build/include_what_you_use

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -20,7 +20,3 @@ filter=-readability/casting
 # Disable the build/include_subdir check
 # Because headers are organized in same directory and C code
 filter=-build/include_subdir
-
-# Disable the build/include_what_you_use check
-# Because C code use <stdio.h> instead of <cstdio> for C code
-filter=-build/include_what_you_use


### PR DESCRIPTION
### Description
-  remove all the linting for now since cpplint is really only for c++ files
- We should find another linter for these pure C files