### PR TITLE
Update ruckus.tcl with missing ad5541 load

### DIFF
--- a/devices/AnalogDevices/ruckus.tcl
+++ b/devices/AnalogDevices/ruckus.tcl
@@ -2,6 +2,7 @@
 source $::env(RUCKUS_PROC_TCL)
 
 # Load ruckus files
+loadRuckusTcl "$::DIR_PATH/ad5541"
 loadRuckusTcl "$::DIR_PATH/ad5780"
 loadRuckusTcl "$::DIR_PATH/general"
 


### PR DESCRIPTION
### Description
In the previous pull request for AD5541 one ruckus.tcl file was missed that prevents this module from being found properly.

### Related
- https://github.com/slaclab/surf/pull/1172
