### PR TITLE
CXPoF: TID VHDL Style Fix

### DIFF
--- a/protocols/coaxpress/core/rtl/CoaXPressAxiL.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressAxiL.vhd
@@ -30,7 +30,7 @@ entity CoaXPressAxiL is
       TPD_G              : time                   := 1 ns;
       NUM_LANES_G        : positive               := 1;
       STATUS_CNT_WIDTH_G : positive range 1 to 32 := 12;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIL_CLK_FREQ_G    : real                   := 156.25E+6;  -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real                   := 156.25E+6;  -- dataClk frequency (units of Hz)
       AXIS_CONFIG_G      : AxiStreamConfigType);
@@ -212,7 +212,7 @@ begin
 
       axiSlaveRegisterR(axilEp, x"FE0", 0, toSlv(NUM_LANES_G, 8));
       axiSlaveRegisterR(axilEp, x"FE0", 8, toSlv(STATUS_CNT_WIDTH_G, 8));
-      axiSlaveRegisterR(axilEp, x"FE0", 16, toSlv(RX_FSM_CNT_WIDTH_C, 8));
+      axiSlaveRegisterR(axilEp, x"FE0", 16, toSlv(RX_FSM_CNT_WIDTH_G, 8));
 
       axiSlaveRegister (axilEp, X"FE8", 0, v.rxFsmRst);
       axiSlaveRegister (axilEp, X"FEC", 0, v.txPulseWidth);

--- a/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
@@ -28,7 +28,7 @@ entity CoaXPressCore is
       TPD_G              : time                   := 1 ns;
       NUM_LANES_G        : positive range 1 to 8  := 1;
       STATUS_CNT_WIDTH_G : positive range 1 to 32 := 12;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIL_CLK_FREQ_G    : real                   := 156.25E+6;  -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real                   := 156.25E+6;  -- dataClk frequency (units of Hz)
       DATA_AXIS_CONFIG_G : AxiStreamConfigType;
@@ -162,7 +162,7 @@ begin
       generic map (
          TPD_G              => TPD_G,
          NUM_LANES_G        => NUM_LANES_G,
-         RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
+         RX_FSM_CNT_WIDTH_G => RX_FSM_CNT_WIDTH_G,
          AXIS_CONFIG_G      => DATA_AXIS_CONFIG_G)
       port map (
          -- Data Interface (dataClk domain)
@@ -199,7 +199,7 @@ begin
          TPD_G              => TPD_G,
          NUM_LANES_G        => NUM_LANES_G,
          STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
-         RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
+         RX_FSM_CNT_WIDTH_G => RX_FSM_CNT_WIDTH_G,
          AXIL_CLK_FREQ_G    => AXIL_CLK_FREQ_G,
          AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,
          AXIS_CONFIG_G      => DATA_AXIS_CONFIG_G)

--- a/protocols/coaxpress/core/rtl/CoaXPressRx.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressRx.vhd
@@ -29,7 +29,7 @@ entity CoaXPressRx is
    generic (
       TPD_G              : time                   := 1 ns;
       NUM_LANES_G        : positive               := 1;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIS_CONFIG_G      : AxiStreamConfigType);
    port (
       -- Data Interface (dataClk domain)
@@ -180,7 +180,7 @@ begin
    U_Fsm : entity surf.CoaXPressRxHsFsm
       generic map (
          TPD_G              => TPD_G,
-         RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
+         RX_FSM_CNT_WIDTH_G => RX_FSM_CNT_WIDTH_G,
          NUM_LANES_G        => NUM_LANES_G)
       port map (
          -- Clock and Reset

--- a/protocols/coaxpress/core/rtl/CoaXPressRxHsFsm.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressRxHsFsm.vhd
@@ -28,7 +28,7 @@ use surf.CoaXPressPkg.all;
 entity CoaXPressRxHsFsm is
    generic (
       TPD_G              : time                   := 1 ns;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       NUM_LANES_G        : positive               := 1);
    port (
       -- Clock and Reset
@@ -93,8 +93,8 @@ architecture rtl of CoaXPressRxHsFsm is
 
    type RegType is record
       endOfLine   : sl;
-      yCnt        : slv(RX_FSM_CNT_WIDTH_C-1 downto 0);
-      dCnt        : slv(RX_FSM_CNT_WIDTH_C-1 downto 0);
+      yCnt        : slv(RX_FSM_CNT_WIDTH_G-1 downto 0);
+      dCnt        : slv(RX_FSM_CNT_WIDTH_G-1 downto 0);
       hdrCnt      : natural range 0 to 25;
       hdr         : ImageHdrType;
       dbg         : DebugType;
@@ -194,7 +194,7 @@ begin
                   v.yCnt := (others => '0');
 
                   -- Check for out of sync header
-                  if (r.yCnt /= r.hdr.ySize(RX_FSM_CNT_WIDTH_C-1 downto 0)) then
+                  if (r.yCnt /= r.hdr.ySize(RX_FSM_CNT_WIDTH_G-1 downto 0)) then
                      -- Set the flag
                      v.dbg.errDet := '1';
                   end if;
@@ -273,7 +273,7 @@ begin
                      v.dCnt := v.dCnt + 1;
 
                      -- Check for max count
-                     if (v.dCnt = r.hdr.dsizeL(RX_FSM_CNT_WIDTH_C-1 downto 0)) then
+                     if (v.dCnt = r.hdr.dsizeL(RX_FSM_CNT_WIDTH_G-1 downto 0)) then
 
                         -- Set the "end of line" flag
                         v.endOfLine := '1';
@@ -350,7 +350,7 @@ begin
          v.yCnt := v.yCnt + 1;
 
          -- Check for max count
-         if (v.yCnt = r.hdr.ySize(RX_FSM_CNT_WIDTH_C-1 downto 0)) then
+         if (v.yCnt = r.hdr.ySize(RX_FSM_CNT_WIDTH_G-1 downto 0)) then
             -- Terminate the frame
             v.dataMasters(1).tLast := '1';
          end if;

--- a/protocols/coaxpress/gthUs/rtl/CoaxpressOverFiberGthUs.vhd
+++ b/protocols/coaxpress/gthUs/rtl/CoaxpressOverFiberGthUs.vhd
@@ -30,7 +30,7 @@ entity CoaxpressOverFiberGthUs is
       TPD_G              : time                   := 1 ns;
       NUM_LANES_G        : positive               := 1;
       STATUS_CNT_WIDTH_G : positive range 1 to 32 := 12;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIL_BASE_ADDR_G   : slv(31 downto 0);
       AXIL_CLK_FREQ_G    : real;        -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real;        -- dataClk frequency (units of Hz)
@@ -132,7 +132,7 @@ begin
          TPD_G              => TPD_G,
          NUM_LANES_G        => NUM_LANES_G,
          STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
-         RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
+         RX_FSM_CNT_WIDTH_G => RX_FSM_CNT_WIDTH_G,
          DATA_AXIS_CONFIG_G => DATA_AXIS_CONFIG_G,
          CFG_AXIS_CONFIG_G  => CFG_AXIS_CONFIG_G,
          AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,

--- a/protocols/coaxpress/gtyUs+/rtl/CoaxpressOverFiberGtyUs.vhd
+++ b/protocols/coaxpress/gtyUs+/rtl/CoaxpressOverFiberGtyUs.vhd
@@ -30,7 +30,7 @@ entity CoaxpressOverFiberGtyUs is
       TPD_G              : time                   := 1 ns;
       NUM_LANES_G        : positive               := 1;
       STATUS_CNT_WIDTH_G : positive range 1 to 32 := 12;
-      RX_FSM_CNT_WIDTH_C : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
+      RX_FSM_CNT_WIDTH_G : positive range 1 to 24 := 16;  -- Optimize this down w.r.t camera to help make timing in CoaXPressRxHsFsm.vhd
       AXIL_BASE_ADDR_G   : slv(31 downto 0);
       AXIL_CLK_FREQ_G    : real;        -- axilClk frequency (units of Hz)
       AXIS_CLK_FREQ_G    : real;        -- dataClk frequency (units of Hz)
@@ -132,7 +132,7 @@ begin
          TPD_G              => TPD_G,
          NUM_LANES_G        => NUM_LANES_G,
          STATUS_CNT_WIDTH_G => STATUS_CNT_WIDTH_G,
-         RX_FSM_CNT_WIDTH_C => RX_FSM_CNT_WIDTH_C,
+         RX_FSM_CNT_WIDTH_G => RX_FSM_CNT_WIDTH_G,
          DATA_AXIS_CONFIG_G => DATA_AXIS_CONFIG_G,
          CFG_AXIS_CONFIG_G  => CFG_AXIS_CONFIG_G,
          AXIS_CLK_FREQ_G    => AXIS_CLK_FREQ_G,

--- a/python/surf/protocols/coaxpress/_CoaXPressAxiL.py
+++ b/python/surf/protocols/coaxpress/_CoaXPressAxiL.py
@@ -193,7 +193,7 @@ class CoaXPressAxiL(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = 'RX_FSM_CNT_WIDTH_C',
+            name         = 'RX_FSM_CNT_WIDTH_G',
             offset       = 0xFE0,
             bitSize      = 8,
             bitOffset    = 16,


### PR DESCRIPTION
### Description
- generics should end in '_G' and not '_C'