### PR TITLE
Misc. GT Clock outputs for the GTY+ ETH modules

### DIFF
--- a/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
+++ b/ethernet/GigEthCore/gtyUltraScale+/rtl/GigEthGtyUltraScaleWrapper.vhd
@@ -77,6 +77,7 @@ entity GigEthGtyUltraScaleWrapper is
       gtRefClk            : in  sl                                             := '0';
       gtClkP              : in  sl                                             := '1';
       gtClkN              : in  sl                                             := '0';
+      gtClkOut            : out sl;
       -- Copy of internal MMCM reference clock and Reset
       refClkOut           : out sl;
       refRstOut           : out sl;
@@ -122,7 +123,7 @@ begin
          IB    => gtClkN,
          CEB   => '0',
          ODIV2 => gtClk,
-         O     => open);
+         O     => gtClkOut);
 
    BUFG_GT_Inst : BUFG_GT
       port map (

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
@@ -70,7 +70,7 @@ entity XauiGtyUltraScaleWrapper is
       -- MGT Clock Port (156.25MHz or 312.5MHz)
       gtClkP             : in  sl;
       gtClkN             : in  sl;
-      refClkOut          : out  sl;
+      gtClkOut           : out  sl;
       -- MGT Ports
       gtTxP              : out slv(3 downto 0);
       gtTxN              : out slv(3 downto 0);

--- a/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
+++ b/ethernet/XauiCore/gtyUltraScale+/rtl/XauiGtyUltraScaleWrapper.vhd
@@ -70,6 +70,7 @@ entity XauiGtyUltraScaleWrapper is
       -- MGT Clock Port (156.25MHz or 312.5MHz)
       gtClkP             : in  sl;
       gtClkN             : in  sl;
+      refClkOut          : out  sl;
       -- MGT Ports
       gtTxP              : out slv(3 downto 0);
       gtTxN              : out slv(3 downto 0);
@@ -88,6 +89,7 @@ architecture mapping of XauiGtyUltraScaleWrapper is
 begin
 
    phyReady <= linkUp;
+   gtClkOut <= refClk;
 
    U_refClk : IBUFDS_GTE4
       port map (


### PR DESCRIPTION
### Description
- [exposing gtClkOut for XauiGtyUltraScaleWrapper.vhd](https://github.com/slaclab/surf/commit/329c929e85a0ce33176e46b9bf3d79902656766b)
- [exposing gtClkOut for GigEthGtyUltraScaleWrapper.vhd](https://github.com/slaclab/surf/commit/4a6b8e9a638ca9e059edea6a6c908c91b32225a4)