### PR TITLE
Event Frame Sequencer Protocol development

### DIFF
--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerDemux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerDemux.vhd
@@ -116,6 +116,9 @@ begin
    assert (AXIS_CONFIG_G.TDATA_BYTES_C >= 8)
       report "AXIS_CONFIG_G.TDATA_BYTES_C must be >= 8" severity error;
 
+   assert (isPowerOf2(AXIS_CONFIG_G.TDATA_BYTES_C) = true)
+      report "AXIS_CONFIG_G.TDATA_BYTES_C must be power of 2" severity failure;
+
    -----------------
    -- Input pipeline
    -----------------

--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerDemux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerDemux.vhd
@@ -1,0 +1,373 @@
+-------------------------------------------------------------------------------
+-- Title      : Event Frame Sequencer Protocol: https://confluence.slac.stanford.edu/x/hCRXI
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Event Frame Sequencer DEUX
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+
+entity EventFrameSequencerDemux is
+   generic (
+      TPD_G                : time     := 1 ns;
+      NUM_MASTERS_G        : positive := 2;
+      AXIS_CONFIG_G        : AxiStreamConfigType;
+      INPUT_PIPE_STAGES_G  : natural  := 0;
+      OUTPUT_PIPE_STAGES_G : natural  := 0);
+   port (
+      -- Clock and Reset
+      axisClk         : in  sl;
+      axisRst         : in  sl;
+      -- Misc
+      blowoffExt      : in  sl                     := '0';
+      -- AXI-Lite Interface
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType;
+      -- AXIS Interfaces
+      sAxisMaster     : in  AxiStreamMasterType;
+      sAxisSlave      : out AxiStreamSlaveType;
+      mAxisMasters    : out AxiStreamMasterArray(NUM_MASTERS_G-1 downto 0);
+      mAxisSlaves     : in  AxiStreamSlaveArray(NUM_MASTERS_G-1 downto 0));
+end entity EventFrameSequencerDemux;
+
+architecture rtl of EventFrameSequencerDemux is
+
+   type StateType is (
+      IDLE_S,
+      MOVE_S);
+
+   type RegType is record
+      softRst        : sl;
+      hardRst        : sl;
+      blowoffReg     : sl;
+      blowoff        : sl;
+      cntRst         : sl;
+      sof            : sl;
+      frameCnt       : slv(7 downto 0);
+      numFrames      : slv(7 downto 0);
+      seqCnt         : slv(15 downto 0);
+      dataCnt        : Slv32Array(NUM_MASTERS_G-1 downto 0);
+      dropCnt        : slv(31 downto 0);
+      index          : natural range 0 to NUM_MASTERS_G-1;
+      tUserFirst     : slv(7 downto 0);
+      tDest          : slv(7 downto 0);
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
+      rxSlave        : AxiStreamSlaveType;
+      txMasters      : AxiStreamMasterArray(NUM_MASTERS_G-1 downto 0);
+      state          : StateType;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      softRst        => '0',
+      hardRst        => '0',
+      blowoffReg     => '0',
+      blowoff        => '0',
+      cntRst         => '0',
+      sof            => '1',
+      frameCnt       => (others => '0'),
+      numFrames      => (others => '0'),
+      seqCnt         => (others => '0'),
+      dataCnt        => (others => (others => '0')),
+      dropCnt        => (others => '0'),
+      index          => 0,
+      tUserFirst     => (others => '0'),
+      tDest          => (others => '0'),
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C,
+      rxSlave        => AXI_STREAM_SLAVE_INIT_C,
+      txMasters      => (others => AXI_STREAM_MASTER_INIT_C),
+      state          => IDLE_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal rxMaster  : AxiStreamMasterType;
+   signal rxSlave   : AxiStreamSlaveType;
+   signal txMasters : AxiStreamMasterArray(NUM_MASTERS_G-1 downto 0);
+   signal txSlaves  : AxiStreamSlaveArray(NUM_MASTERS_G-1 downto 0);
+
+begin
+
+   assert (AXIS_CONFIG_G.TDATA_BYTES_C >= 8)
+      report "AXIS_CONFIG_G.TDATA_BYTES_C must be >= 8" severity error;
+
+   -----------------
+   -- Input pipeline
+   -----------------
+   U_Input : entity surf.AxiStreamPipeline
+      generic map (
+         TPD_G         => TPD_G,
+         PIPE_STAGES_G => INPUT_PIPE_STAGES_G)
+      port map (
+         axisClk     => axisClk,
+         axisRst     => axisRst,
+         sAxisMaster => sAxisMaster,
+         sAxisSlave  => sAxisSlave,
+         mAxisMaster => rxMaster,
+         mAxisSlave  => rxSlave);
+
+   comb : process (axilReadMaster, axilWriteMaster, axisRst, blowoffExt, r,
+                   rxMaster, txSlaves) is
+      variable v        : RegType;
+      variable axilEp   : AxiLiteEndPointType;
+      variable validHdr : sl;
+      variable dbg    : slv(7 downto 0);
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Update the local variable
+      dbg := x"00";
+      if (v.state = IDLE_S) then
+         dbg(0) := '0';
+      else
+         dbg(0) := '1';
+      end if;
+
+      -- Reset strobes
+      v.cntRst  := '0';
+      v.hardRst := '0';
+      v.softRst := '0';
+
+      -- Check for hard reset or soft reset
+      if (r.hardRst = '1') or (r.softRst = '1') then
+         -- Reset the register
+         v := REG_INIT_C;
+
+         -- Preserve the resister configurations
+         v.blowoffReg := r.blowoffReg;
+
+         -- Preserve the state of AXI-Lite
+         v.axilWriteSlave := r.axilWriteSlave;
+         v.axilReadSlave  := r.axilReadSlave;
+
+      end if;
+
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilEp, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
+
+      -- Map the registers
+      for i in (NUM_MASTERS_G-1) downto 0 loop
+         axiSlaveRegisterR(axilEp, toSlv(4*i + 0, 12), 0, r.dataCnt(i));
+      end loop;
+      axiSlaveRegisterR(axilEp, x"FBC", 0, r.seqCnt);
+      axiSlaveRegisterR(axilEp, x"FC0", 0, r.dropCnt);
+      axiSlaveRegisterR(axilEp, x"FF4", 0, toSlv(NUM_MASTERS_G, 8));
+      axiSlaveRegisterR(axilEp, x"FF4", 8, dbg);
+      axiSlaveRegisterR(axilEp, X"FF4", 16, blowoffExt);
+      axiSlaveRegister (axilEp, x"FF8", 0, v.blowoffReg);
+      axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);
+      axiSlaveRegister (axilEp, x"FFC", 2, v.hardRst);
+      axiSlaveRegister (axilEp, x"FFC", 3, v.softRst);
+
+      -- Closeout the transaction
+      axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
+
+      -- Combine the external and internal blowoff together
+      v.blowoff := v.blowoffReg or blowoffExt;
+
+      -- Check for any change to blowoff 1->0 transition
+      if (r.blowoff = '1') and (v.blowoff = '0') then
+         -- Perform a soft-reset
+         v.softRst := '1';
+      end if;
+
+      -- AXIS flow control
+      v.rxSlave.tReady := r.blowoff;
+      for i in (NUM_MASTERS_G-1) downto 0 loop
+         if (txSlaves(i).tReady = '1') then
+            v.txMasters(i).tValid := '0';
+         end if;
+      end loop;
+
+      -- Check for SOF
+      validHdr := ssiGetUserSof(AXIS_CONFIG_G, rxMaster);
+
+      -- Check for EOF
+      if (rxMaster.tLast = '1') then
+         validHdr := '0';
+      end if;
+
+      -- Check for valid version field
+      if (rxMaster.tData(7 downto 0) /= x"01") then
+         validHdr := '0';
+      end if;
+
+      if (rxMaster.tData(15 downto 8) >= NUM_MASTERS_G) then
+         validHdr := '0';
+      end if;
+
+      -- Check for valid event frame index
+      if (rxMaster.tData(24 downto 16) /= r.frameCnt) then
+         validHdr := '0';
+      end if;
+
+      -- Check for valid event frame index
+      if (rxMaster.tData(63 downto 48) /= r.seqCnt) then
+         validHdr := '0';
+      end if;
+
+      -- State machine
+      case r.state is
+         ----------------------------------------------------------------------
+         when IDLE_S =>
+            -- Arm the flag
+            v.sof := '1';
+
+            -- Check for blowoff flag
+            if (r.blowoff = '1') then
+
+               -- Reset the flags
+               v.frameCnt := (others => '0');
+               v.seqCnt   := (others => '0');
+
+            elsif (rxMaster.tValid = '1') then
+
+               -- Accept the data
+               v.rxSlave.tReady := '1';
+
+               -- Check for valid header
+               if (validHdr = '1') then
+
+                  -- Save the meta-data
+                  v.index      := conv_integer(rxMaster.tData(15 downto 8));
+                  v.numFrames  := rxMaster.tData(31 downto 24);
+                  v.tUserFirst := rxMaster.tData(39 downto 32);
+                  v.tDest      := rxMaster.tData(47 downto 40);
+
+                  -- Next state
+                  v.state := MOVE_S;
+
+               -- Check for the EOF of the dropped frame
+               elsif (rxMaster.tLast = '1') then
+
+                  -- Increment the counter
+                  v.dropCnt := r.dropCnt + 1;
+
+                  -- Reset the flags
+                  v.frameCnt := (others => '0');
+                  v.seqCnt   := (others => '0');
+
+               end if;
+
+            end if;
+         ----------------------------------------------------------------------
+         when MOVE_S =>
+            if (rxMaster.tValid = '1') and (v.txMasters(r.index).tValid = '0') then
+
+               -- Move the data
+               v.rxSlave.tReady     := '1';
+               v.txMasters(r.index) := rxMaster;
+
+               -- Update the TDEST field
+               v.txMasters(r.index).tDest := r.tDest;
+
+               -- Check if sending the TUSER_FIRST
+               if (r.sof = '1') then
+
+                  -- Reset the flag
+                  v.sof := '0';
+
+                  -- Update the tUser for 1st byte
+                  v.txMasters(r.index).tUser(7 downto 0) := r.tUserFirst;
+
+               end if;
+
+               -- Check for the last transfer
+               if (rxMaster.tLast = '1') then
+
+                  -- Next state
+                  v.state := IDLE_S;
+
+               end if;
+
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Check for state transitioning from MOVE_S to IDLE_S
+      if (r.state = MOVE_S) and (v.state = IDLE_S) then
+
+         -- Increment frame counter
+         v.frameCnt         := r.frameCnt + 1;
+         v.seqCnt           := r.seqCnt + 1;
+         v.dataCnt(r.index) := r.dataCnt(r.index) + 1;
+
+         -- Check if reseting frame counters
+         if (r.numFrames = r.frameCnt) then
+            v.frameCnt := (others => '0');
+         end if;
+
+      end if;
+
+      -- Check if reseting status counters
+      if (r.cntRst = '1') then
+         v.dataCnt := (others => (others => '0'));
+         v.dropCnt := (others => '0');
+      end if;
+
+      -- Outputs
+      rxSlave        <= v.rxSlave;
+      txMasters      <= r.txMasters;
+      axilWriteSlave <= r.axilWriteSlave;
+      axilReadSlave  <= r.axilReadSlave;
+
+      -- Reset
+      if (axisRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (axisClk) is
+   begin
+      if (rising_edge(axisClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   ------------------
+   -- Output pipeline
+   ------------------
+   GEN_VEC :
+   for i in (NUM_MASTERS_G-1) downto 0 generate
+      U_Output : entity surf.AxiStreamPipeline
+         generic map (
+            TPD_G         => TPD_G,
+            PIPE_STAGES_G => OUTPUT_PIPE_STAGES_G)
+         port map (
+            -- Clock and Reset
+            axisClk     => axisClk,
+            axisRst     => axisRst,
+            -- AXIS Interfaces
+            sAxisMaster => txMasters(i),
+            sAxisSlave  => txSlaves(i),
+            mAxisMaster => mAxisMasters(i),
+            mAxisSlave  => mAxisSlaves(i));
+   end generate GEN_VEC;
+
+end rtl;

--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
@@ -1,0 +1,500 @@
+-------------------------------------------------------------------------------
+-- Title      : AxiStream BatcherV1 Protocol: https://confluence.slac.stanford.edu/x/hCRXI
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Wrapper on AxiStreamBatcher for multi-AXI stream event building
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+
+entity EventFrameSequencerMux is
+   generic (
+      TPD_G : time := 1 ns;
+
+      -- Number of Inbound AXIS stream SLAVES
+      NUM_SLAVES_G : positive := 2;
+
+      -- In INDEXED mode, the output TDEST is set based on the selected slave index
+      -- In ROUTED mode, TDEST is set according to the TDEST_ROUTES_G table
+      MODE_G : string := "INDEXED";
+
+      -- In ROUTED mode, an array mapping how TDEST should be assigned for each slave port
+      -- Each TDEST bit can be set to '0', '1' or '-' for passthrough from slave TDEST.
+      TDEST_ROUTES_G : Slv8Array := (0 => "--------");
+
+      -- In INDEXED mode, assign slave index to TDEST at this bit offset
+      TDEST_LOW_G : integer range 0 to 7 := 0;
+
+      -- Set the TDEST to detect for transition frame
+      TRANS_TDEST_G : slv(7 downto 0) := x"FF";
+
+      AXIS_CONFIG_G        : AxiStreamConfigType;
+      INPUT_PIPE_STAGES_G  : natural := 0;
+      OUTPUT_PIPE_STAGES_G : natural := 0);
+   port (
+      -- Clock and Reset
+      axisClk         : in  sl;
+      axisRst         : in  sl;
+      -- Misc
+      blowoffExt      : in  sl                     := '0';
+      -- AXI-Lite Interface
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType;
+      -- AXIS Interfaces
+      sAxisMasters    : in  AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
+      sAxisSlaves     : out AxiStreamSlaveArray(NUM_SLAVES_G-1 downto 0);
+      mAxisMaster     : out AxiStreamMasterType;
+      mAxisSlave      : in  AxiStreamSlaveType);
+end entity EventFrameSequencerMux;
+
+architecture rtl of EventFrameSequencerMux is
+
+   constant DEST_SIZE_C : integer := bitSize(NUM_SLAVES_G-1);
+
+   type StateType is (
+      IDLE_S,
+      MOVE_S);
+
+   type RegType is record
+      softRst        : sl;
+      hardRst        : sl;
+      blowoffReg     : sl;
+      blowoff        : sl;
+      cntRst         : sl;
+      ready          : sl;
+      sof            : sl;
+      frameCnt       : slv(7 downto 0);
+      numFrames      : slv(7 downto 0);
+      seqCnt         : slv(15 downto 0);
+      bypass         : slv(NUM_SLAVES_G-1 downto 0);
+      dataCnt        : Slv32Array(NUM_SLAVES_G-1 downto 0);
+      transCnt       : slv(31 downto 0);
+      accept         : slv(NUM_SLAVES_G-1 downto 0);
+      transDet       : slv(NUM_SLAVES_G-1 downto 0);
+      skipCh         : slv(NUM_SLAVES_G-1 downto 0);
+      index          : natural range 0 to NUM_SLAVES_G-1;
+      axilReadSlave  : AxiLiteReadSlaveType;
+      axilWriteSlave : AxiLiteWriteSlaveType;
+      rxSlaves       : AxiStreamSlaveArray(NUM_SLAVES_G-1 downto 0);
+      txMaster       : AxiStreamMasterType;
+      state          : StateType;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      softRst        => '0',
+      hardRst        => '0',
+      blowoffReg     => '0',
+      blowoff        => '0',
+      cntRst         => '0',
+      ready          => '0',
+      sof            => '1',
+      frameCnt       => (others => '0'),
+      numFrames      => (others => '0'),
+      seqCnt         => (others => '0'),
+      bypass         => (others => '0'),
+      dataCnt        => (others => (others => '0')),
+      transCnt       => (others => '0'),
+      accept         => (others => '0'),
+      transDet       => (others => '0'),
+      skipCh         => (others => '0'),
+      index          => 0,
+      axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C,
+      rxSlaves       => (others => AXI_STREAM_SLAVE_INIT_C),
+      txMaster       => AXI_STREAM_MASTER_INIT_C,
+      state          => IDLE_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal sAxisMastersTmp : AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
+   signal rxMasters       : AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
+   signal rxSlaves        : AxiStreamSlaveArray(NUM_SLAVES_G-1 downto 0);
+   signal txMaster        : AxiStreamMasterType;
+   signal txSlave         : AxiStreamSlaveType;
+
+begin
+
+   assert (AXIS_CONFIG_G.TDATA_BYTES_C >= 8)
+      report "AXIS_CONFIG_G.TDATA_BYTES_C must be >= 8" severity error;
+
+   -------------------------
+   -- Override Inbound TDEST
+   -------------------------
+   TDEST_REMAP : process (sAxisMasters) is
+      variable tmp : AxiStreamMasterArray(NUM_SLAVES_G-1 downto 0);
+      variable i   : natural;
+      variable j   : natural;
+   begin
+      tmp := sAxisMasters;
+      for i in NUM_SLAVES_G-1 downto 0 loop
+         if MODE_G = "ROUTED" then
+            for j in 7 downto 0 loop
+               if (TDEST_ROUTES_G(i)(j) = '1') then
+                  tmp(i).tDest(j) := '1';
+               elsif(TDEST_ROUTES_G(i)(j) = '0') then
+                  tmp(i).tDest(j) := '0';
+               else
+                  tmp(i).tDest(j) := sAxisMasters(i).tDest(j);
+               end if;
+            end loop;
+         else
+            tmp(i).tDest(7 downto TDEST_LOW_G)                         := (others => '0');
+            tmp(i).tDest(DEST_SIZE_C+TDEST_LOW_G-1 downto TDEST_LOW_G) := toSlv(i, DEST_SIZE_C);
+         end if;
+      end loop;
+      sAxisMastersTmp <= tmp;
+   end process;
+
+   -----------------
+   -- Input pipeline
+   -----------------
+   GEN_VEC :
+   for i in (NUM_SLAVES_G-1) downto 0 generate
+      U_Input : entity surf.AxiStreamPipeline
+         generic map (
+            TPD_G         => TPD_G,
+            PIPE_STAGES_G => INPUT_PIPE_STAGES_G)
+         port map (
+            axisClk     => axisClk,
+            axisRst     => axisRst,
+            sAxisMaster => sAxisMastersTmp(i),
+            sAxisSlave  => sAxisSlaves(i),
+            mAxisMaster => rxMasters(i),
+            mAxisSlave  => rxSlaves(i));
+   end generate GEN_VEC;
+
+   comb : process (axilReadMaster, axilWriteMaster, axisRst, blowoffExt, r,
+                   rxMasters, txSlave) is
+      variable v      : RegType;
+      variable axilEp : AxiLiteEndPointType;
+      variable i      : natural;
+      variable dbg    : slv(7 downto 0);
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Update the local variable
+      dbg := x"00";
+      if (v.state = IDLE_S) then
+         dbg(0) := '0';
+      else
+         dbg(0) := '1';
+      end if;
+
+      -- Reset strobes
+      v.cntRst  := '0';
+      v.hardRst := '0';
+      v.softRst := '0';
+
+      -- Check for hard reset or soft reset
+      if (r.hardRst = '1') or (r.softRst = '1') then
+         -- Reset the register
+         v := REG_INIT_C;
+
+         -- Preserve the resister configurations
+         v.bypass     := r.bypass;
+         v.blowoffReg := r.blowoffReg;
+
+         -- Preserve the state of AXI-Lite
+         v.axilWriteSlave := r.axilWriteSlave;
+         v.axilReadSlave  := r.axilReadSlave;
+
+      end if;
+
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilEp, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
+
+      -- Map the registers
+      for i in (NUM_SLAVES_G-1) downto 0 loop
+         axiSlaveRegisterR(axilEp, toSlv(4*i + 0, 12), 0, r.dataCnt(i));
+      end loop;
+      axiSlaveRegisterR(axilEp, x"FBC", 0, r.seqCnt);
+      axiSlaveRegisterR(axilEp, x"FC0", 0, r.transCnt);
+      axiSlaveRegisterR(axilEp, x"FC4", 0, TRANS_TDEST_G);
+      axiSlaveRegister (axilEp, x"FD0", 0, v.bypass);
+      axiSlaveRegisterR(axilEp, x"FF4", 0, toSlv(NUM_SLAVES_G, 8));
+      axiSlaveRegisterR(axilEp, x"FF4", 8, dbg);
+      axiSlaveRegisterR(axilEp, X"FF4", 16, blowoffExt);
+      axiSlaveRegister (axilEp, x"FF8", 0, v.blowoffReg);
+      axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);
+      axiSlaveRegister (axilEp, x"FFC", 2, v.hardRst);
+      axiSlaveRegister (axilEp, x"FFC", 3, v.softRst);
+
+      -- Closeout the transaction
+      axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
+
+      -- Combine the external and internal blowoff together
+      v.blowoff := v.blowoffReg or blowoffExt;
+
+      -- Check for any change to bypass or blowoff 1->0 transition
+      if (r.bypass /= v.bypass) or ((r.blowoff = '1') and (v.blowoff = '0')) then
+         -- Perform a soft-reset
+         v.softRst := '1';
+      end if;
+
+      -- Reset the flow control strobes
+      for i in (NUM_SLAVES_G-1) downto 0 loop
+         v.rxSlaves(i).tReady := r.bypass(i);
+      end loop;
+      if (txSlave.tReady = '1') then
+         v.txMaster.tValid := '0';
+      end if;
+
+      -- State machine
+      case r.state is
+         ----------------------------------------------------------------------
+         when IDLE_S =>
+            -- Arm the flag
+            v.ready := '1';
+            v.sof   := '1';
+
+            -- Loop through RX channels
+            for i in (NUM_SLAVES_G-1) downto 0 loop
+
+               -- Check if no data and not bypassing
+               if (rxMasters(i).tValid = '0') and (r.bypass(i) = '0') then
+                  -- Reset the flags
+                  v.ready       := '0';
+                  v.accept(i)   := '0';
+                  v.transDet(i) := '0';
+               else
+                  -- Check if not a transition TDEST
+                  if (rxMasters(i).tDest /= TRANS_TDEST_G) then
+                     -- Normal frame detected
+                     v.accept(i)   := not(r.bypass(i));
+                     v.transDet(i) := '0';
+
+                  -- Else a transitions TDEST
+                  else
+                     -- Transitions frame detected
+                     v.accept(i)   := '0';
+                     v.transDet(i) := not(r.bypass(i));
+
+                  end if;
+
+               end if;
+            end loop;
+
+
+            -- Check if transition detected
+            if (v.transDet /= 0) then
+               -- Set the flag
+               v.ready := '1';
+            end if;
+
+            -- Check if ready to move data and not blowing off the data
+            if (r.ready = '1') and (r.blowoff = '0') then
+
+               -- Check for transition
+               if (r.transDet /= 0) then
+
+                  -- Increment transition counter
+                  v.transCnt := r.transCnt + 1;
+
+                  -- Set the number of event frame (zero inclusive)
+                  v.numFrames := x"00";
+
+                  -- Re-write the accept mask
+                  v.accept := r.transDet;
+                  v.skipCh := not(r.transDet);
+
+               else
+
+                  for i in (NUM_SLAVES_G-1) downto 0 loop
+
+                     -- Increment data counter
+                     if (r.accept(i) = '1') then
+                        v.dataCnt(i) := r.dataCnt(i) + 1;
+                     end if;
+
+                  end loop;
+
+                  -- Set the number of event frame (zero inclusive)
+                  v.numFrames := resize(onesCount(r.accept), 8) - 1;
+
+               end if;
+
+               -- Next state
+               v.state := MOVE_S;
+
+            -- Check for blowoff flag
+            elsif (r.blowoff = '1') then
+
+               -- Blow off the inbound data
+               for i in (NUM_SLAVES_G-1) downto 0 loop
+                  v.rxSlaves(i).tReady := '1';
+               end loop;
+
+               -- Reset the flags
+               v.ready    := '0';
+               v.accept   := (others => '0');
+               v.transDet := (others => '0');
+               v.skipCh   := (others => '0');
+               v.seqCnt   := (others => '0');
+
+            end if;
+         ----------------------------------------------------------------------
+         when MOVE_S =>
+            -- Check for skip channel or bypass on the channel
+            if (r.skipCh(r.index) = '1') or (r.bypass(r.index) = '1') then
+
+               -- Check for last channel
+               if (r.index = NUM_SLAVES_G-1) then
+                  -- Next state
+                  v.state := IDLE_S;
+               else
+                  -- Increment the counter
+                  v.index := r.index + 1;
+               end if;
+
+            -- Check if ready to move data
+            elsif (rxMasters(r.index).tValid = '1') and (v.txMaster.tValid = '0') then
+
+               -- Move the data
+               v.rxSlaves(r.index).tReady := not(r.sof);
+               v.txMaster                 := rxMasters(r.index);
+
+               -- Only forward the accepted frames
+               v.txMaster.tValid := r.accept(r.index);
+
+               -- Check if sending the Event Frame Sequence Header
+               if (r.sof = '1') then
+
+                  -- Reset the flag
+                  v.sof := '0';
+
+                  -- Update the meta-data for a HEADER
+                  v.txMaster.tLast := '0';
+                  v.txMaster.tKeep := (others => '1');
+                  v.txMaster.tUser := (others => '0');
+
+                  -- Set SOF flag
+                  ssiSetUserSof(AXIS_CONFIG_G, v.txMaster, '1');
+
+                  -- HEADER context
+                  v.txMaster.tData(7 downto 0)   := x"01";     -- Version Field
+                  v.txMaster.tData(15 downto 8)  := rxMasters(r.index).tUser(7 downto 0);  -- TUSER_FIRST
+                  v.txMaster.tData(23 downto 16) := rxMasters(r.index).tDest;  -- TDEST
+                  v.txMaster.tData(31 downto 24) := rxMasters(r.index).tId;  -- TID
+                  v.txMaster.tData(39 downto 32) := r.frameCnt;  -- Event frame index
+                  v.txMaster.tData(47 downto 40) := r.numFrames;  -- Event frame Size (zero inclusive)
+                  v.txMaster.tData(63 downto 48) := r.seqCnt;  -- Sequence Counter
+
+                  -- Increment frame counter
+                  if (r.accept(r.index) = '1') then
+                     v.frameCnt := r.frameCnt + 1;
+                  end if;
+
+               -- Check for the last transfer
+               elsif (rxMasters(r.index).tLast = '1') then
+
+                  -- Rearm the flag
+                  v.sof := '1';
+
+                  -- Check for last channel
+                  if (r.index = NUM_SLAVES_G-1) then
+                     -- Next state
+                     v.state := IDLE_S;
+                  else
+                     -- Increment the counter
+                     v.index := r.index + 1;
+                  end if;
+
+               end if;
+
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Mask off the TDEST/TID (encoded in header)
+      v.txMaster.tDest := x"00";
+      v.txMaster.tId   := x"00";
+
+      -- Check for state transitioning from MOVE_S to IDLE_S
+      if (r.state = MOVE_S) and (v.state = IDLE_S) then
+
+         -- Reset the index pointer
+         v.index := 0;
+
+         -- Reset the flags
+         v.ready    := '0';
+         v.accept   := (others => '0');
+         v.transDet := (others => '0');
+         v.skipCh   := (others => '0');
+
+         -- Reset the counter
+         v.frameCnt := (others => '0');
+
+         -- Increment frame counter
+         v.seqCnt := r.seqCnt + 1;
+
+      end if;
+
+      -- Check if reseting counters
+      if (r.cntRst = '1') then
+         v.dataCnt  := (others => (others => '0'));
+         v.transCnt := (others => '0');
+      end if;
+
+      -- Outputs
+      rxSlaves       <= v.rxSlaves;
+      txMaster       <= r.txMaster;
+      axilWriteSlave <= r.axilWriteSlave;
+      axilReadSlave  <= r.axilReadSlave;
+
+      -- Reset
+      if (axisRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (axisClk) is
+   begin
+      if (rising_edge(axisClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   ------------------
+   -- Output pipeline
+   ------------------
+   U_Output : entity surf.AxiStreamPipeline
+      generic map (
+         TPD_G         => TPD_G,
+         PIPE_STAGES_G => OUTPUT_PIPE_STAGES_G)
+      port map (
+         -- Clock and Reset
+         axisClk     => axisClk,
+         axisRst     => axisRst,
+         -- AXIS Interfaces
+         sAxisMaster => txMaster,
+         sAxisSlave  => txSlave,
+         mAxisMaster => mAxisMaster,
+         mAxisSlave  => mAxisSlave);
+
+end rtl;

--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
@@ -394,23 +394,23 @@ begin
 
                   -- HEADER context
                   v.txMaster.tData(7 downto 0)   := x"01";     -- Version Field
-                  v.txMaster.tData(15 downto 8)  := toSlv(r.index, 8); -- MUX Index
+                  v.txMaster.tData(15 downto 8)  := toSlv(r.index, 8);  -- MUX Index
                   v.txMaster.tData(23 downto 16) := r.frameCnt;  -- Event frame index
                   v.txMaster.tData(31 downto 24) := r.numFrames;  -- Event frame Size (zero inclusive)
                   v.txMaster.tData(39 downto 32) := rxMasters(r.index).tUser(7 downto 0);  -- TUSER_FIRST
                   v.txMaster.tData(47 downto 40) := rxMasters(r.index).tDest;  -- TDEST
                   v.txMaster.tData(63 downto 48) := r.seqCnt;  -- Sequence Counter
 
-                  -- Increment frame counter
-                  if (r.accept(r.index) = '1') then
-                     v.frameCnt := r.frameCnt + 1;
-                  end if;
-
                -- Check for the last transfer
                elsif (rxMasters(r.index).tLast = '1') then
 
                   -- Rearm the flag
                   v.sof := '1';
+
+                  -- Increment frame counter
+                  if (r.accept(r.index) = '1') then
+                     v.frameCnt := r.frameCnt + 1;
+                  end if;
 
                   -- Check for last channel
                   if (r.index = NUM_SLAVES_G-1) then

--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------------------
--- Title      : AxiStream BatcherV1 Protocol: https://confluence.slac.stanford.edu/x/hCRXI
+-- Title      : Event Frame Sequencer Protocol: https://confluence.slac.stanford.edu/x/hCRXI
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Wrapper on AxiStreamBatcher for multi-AXI stream event building
+-- Description: Event Frame Sequencer MUX
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -394,11 +394,11 @@ begin
 
                   -- HEADER context
                   v.txMaster.tData(7 downto 0)   := x"01";     -- Version Field
-                  v.txMaster.tData(15 downto 8)  := rxMasters(r.index).tUser(7 downto 0);  -- TUSER_FIRST
-                  v.txMaster.tData(23 downto 16) := rxMasters(r.index).tDest;  -- TDEST
-                  v.txMaster.tData(31 downto 24) := rxMasters(r.index).tId;  -- TID
-                  v.txMaster.tData(39 downto 32) := r.frameCnt;  -- Event frame index
-                  v.txMaster.tData(47 downto 40) := r.numFrames;  -- Event frame Size (zero inclusive)
+                  v.txMaster.tData(15 downto 8)  := toSlv(r.index, 8); -- MUX Index
+                  v.txMaster.tData(23 downto 16) := r.frameCnt;  -- Event frame index
+                  v.txMaster.tData(31 downto 24) := r.numFrames;  -- Event frame Size (zero inclusive)
+                  v.txMaster.tData(39 downto 32) := rxMasters(r.index).tUser(7 downto 0);  -- TUSER_FIRST
+                  v.txMaster.tData(47 downto 40) := rxMasters(r.index).tDest;  -- TDEST
                   v.txMaster.tData(63 downto 48) := r.seqCnt;  -- Sequence Counter
 
                   -- Increment frame counter

--- a/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
+++ b/protocols/event-frame-sequencer/rtl/EventFrameSequencerMux.vhd
@@ -140,6 +140,9 @@ begin
    assert (AXIS_CONFIG_G.TDATA_BYTES_C >= 8)
       report "AXIS_CONFIG_G.TDATA_BYTES_C must be >= 8" severity error;
 
+   assert (isPowerOf2(AXIS_CONFIG_G.TDATA_BYTES_C) = true)
+      report "AXIS_CONFIG_G.TDATA_BYTES_C must be power of 2" severity failure;
+
    -------------------------
    -- Override Inbound TDEST
    -------------------------
@@ -402,7 +405,7 @@ begin
                   v.txMaster.tData(31 downto 24) := rxMasters(r.index).tDest;  -- TDEST
                   v.txMaster.tData(39 downto 32) := toSlv(NUM_SLAVES_G, 8);  -- Number of streams
                   v.txMaster.tData(47 downto 40) := toSlv(r.index, 8);  -- MUX Index
-                  v.txMaster.tData(55 downto 48) := r.frameCnt;  -- Event frame index
+                  v.txMaster.tData(55 downto 48) := r.frameCnt;  -- Event frame count
                   v.txMaster.tData(63 downto 56) := r.numFrames;  -- Event frame Size (zero inclusive)
 
                -- Check for the last transfer

--- a/protocols/event-frame-sequencer/ruckus.tcl
+++ b/protocols/event-frame-sequencer/ruckus.tcl
@@ -3,3 +3,6 @@ source $::env(RUCKUS_PROC_TCL)
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"
+
+# Load Simulation
+loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"

--- a/protocols/event-frame-sequencer/ruckus.tcl
+++ b/protocols/event-frame-sequencer/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source $::env(RUCKUS_PROC_TCL)
+
+# Load Source Code
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/event-frame-sequencer/tb/EventFrameSequencerTb.vhd
+++ b/protocols/event-frame-sequencer/tb/EventFrameSequencerTb.vhd
@@ -1,0 +1,365 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: surf.EventFrameSequencerMux/surf.EventFrameSequencerDemux cocoTB testbed
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+
+entity EventFrameSequencerTb is
+   generic (
+      -- AXI Stream Configuration
+      TUSER_WIDTH_G     : positive range 8 to 8   := 8;
+      TID_WIDTH_G       : positive range 8 to 8   := 8;
+      TDEST_WIDTH_G     : positive range 8 to 8   := 8;
+      TDATA_NUM_BYTES_G : positive range 8 to 128 := 8);
+   port (
+      -- Clock and Reset
+      AXIS_ACLK      : in  std_logic                                          := '0';
+      AXIS_ARESETN   : in  std_logic                                          := '0';
+      -- IP Integrator Slave AXI Stream Interface
+      S_AXIS0_TVALID : in  std_logic                                          := '0';
+      S_AXIS0_TDATA  : in  std_logic_vector((8*TDATA_NUM_BYTES_G)-1 downto 0) := (others => '0');
+      S_AXIS0_TSTRB  : in  std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0)     := (others => '0');
+      S_AXIS0_TKEEP  : in  std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0)     := (others => '0');
+      S_AXIS0_TLAST  : in  std_logic                                          := '0';
+      S_AXIS0_TDEST  : in  std_logic_vector(TDEST_WIDTH_G-1 downto 0)         := (others => '0');
+      S_AXIS0_TID    : in  std_logic_vector(TID_WIDTH_G-1 downto 0)           := (others => '0');
+      S_AXIS0_TUSER  : in  std_logic_vector(TUSER_WIDTH_G-1 downto 0)         := (others => '0');
+      S_AXIS0_TREADY : out std_logic;
+      -- IP Integrator Slave AXI Stream Interface
+      S_AXIS1_TVALID : in  std_logic                                          := '0';
+      S_AXIS1_TDATA  : in  std_logic_vector((8*TDATA_NUM_BYTES_G)-1 downto 0) := (others => '0');
+      S_AXIS1_TSTRB  : in  std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0)     := (others => '0');
+      S_AXIS1_TKEEP  : in  std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0)     := (others => '0');
+      S_AXIS1_TLAST  : in  std_logic                                          := '0';
+      S_AXIS1_TDEST  : in  std_logic_vector(TDEST_WIDTH_G-1 downto 0)         := (others => '0');
+      S_AXIS1_TID    : in  std_logic_vector(TID_WIDTH_G-1 downto 0)           := (others => '0');
+      S_AXIS1_TUSER  : in  std_logic_vector(TUSER_WIDTH_G-1 downto 0)         := (others => '0');
+      S_AXIS1_TREADY : out std_logic;
+      -- IP Integrator Master AXI Stream Interface
+      M_AXIS0_TVALID : out std_logic;
+      M_AXIS0_TDATA  : out std_logic_vector((8*TDATA_NUM_BYTES_G)-1 downto 0);
+      M_AXIS0_TSTRB  : out std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0);
+      M_AXIS0_TKEEP  : out std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0);
+      M_AXIS0_TLAST  : out std_logic;
+      M_AXIS0_TDEST  : out std_logic_vector(TDEST_WIDTH_G-1 downto 0);
+      M_AXIS0_TID    : out std_logic_vector(TID_WIDTH_G-1 downto 0);
+      M_AXIS0_TUSER  : out std_logic_vector(TUSER_WIDTH_G-1 downto 0);
+      M_AXIS0_TREADY : in  std_logic;
+      -- IP Integrator Master AXI Stream Interface
+      M_AXIS1_TVALID : out std_logic;
+      M_AXIS1_TDATA  : out std_logic_vector((8*TDATA_NUM_BYTES_G)-1 downto 0);
+      M_AXIS1_TSTRB  : out std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0);
+      M_AXIS1_TKEEP  : out std_logic_vector(TDATA_NUM_BYTES_G-1 downto 0);
+      M_AXIS1_TLAST  : out std_logic;
+      M_AXIS1_TDEST  : out std_logic_vector(TDEST_WIDTH_G-1 downto 0);
+      M_AXIS1_TID    : out std_logic_vector(TID_WIDTH_G-1 downto 0);
+      M_AXIS1_TUSER  : out std_logic_vector(TUSER_WIDTH_G-1 downto 0);
+      M_AXIS1_TREADY : in  std_logic;
+      -- AXI-Lite Interface
+      S_AXIL_AWADDR   : in  std_logic_vector(31 downto 0);
+      S_AXIL_AWPROT   : in  std_logic_vector(2 downto 0);
+      S_AXIL_AWVALID  : in  std_logic;
+      S_AXIL_AWREADY  : out std_logic;
+      S_AXIL_WDATA    : in  std_logic_vector(31 downto 0);
+      S_AXIL_WSTRB    : in  std_logic_vector(3 downto 0);
+      S_AXIL_WVALID   : in  std_logic;
+      S_AXIL_WREADY   : out std_logic;
+      S_AXIL_BRESP    : out std_logic_vector(1 downto 0);
+      S_AXIL_BVALID   : out std_logic;
+      S_AXIL_BREADY   : in  std_logic;
+      S_AXIL_ARADDR   : in  std_logic_vector(31 downto 0);
+      S_AXIL_ARPROT   : in  std_logic_vector(2 downto 0);
+      S_AXIL_ARVALID  : in  std_logic;
+      S_AXIL_ARREADY  : out std_logic;
+      S_AXIL_RDATA    : out std_logic_vector(31 downto 0);
+      S_AXIL_RRESP    : out std_logic_vector(1 downto 0);
+      S_AXIL_RVALID   : out std_logic;
+      S_AXIL_RREADY   : in  std_logic);
+end EventFrameSequencerTb;
+
+architecture mapping of EventFrameSequencerTb is
+
+   constant TPD_C : time := 3 ns;
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => true,
+      TDATA_BYTES_C => TDATA_NUM_BYTES_G,
+      TDEST_BITS_C  => TDEST_WIDTH_G,
+      TID_BITS_C    => TID_WIDTH_G,
+      TKEEP_MODE_C  => TKEEP_COMP_C,
+      TUSER_BITS_C  => TUSER_WIDTH_G,
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+
+   constant AXIL_CONFIG_C : AxiLiteCrossbarMasterConfigArray(1 downto 0) := genAxiLiteConfig(2, x"0000_0000", 20, 16);
+
+   signal axilReadMaster  : AxiLiteReadMasterType;
+   signal axilReadSlave   : AxiLiteReadSlaveType;
+   signal axilWriteMaster : AxiLiteWriteMasterType;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType;
+
+   signal axilReadMasters  : AxiLiteReadMasterArray(1 downto 0);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(1 downto 0);
+   signal axilWriteMasters : AxiLiteWriteMasterArray(1 downto 0);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(1 downto 0);
+
+   signal axisClk : sl := '0';
+   signal axisRst : sl := '0';
+
+   signal sAxisMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal sAxisSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
+
+   signal axisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal axisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+
+   signal mAxisMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal mAxisSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
+
+begin
+
+   ---------------------------------------------------------------------------
+   -- Adding Shim Layers for translating between cocoTB and local record types
+   ---------------------------------------------------------------------------
+   U_ShimLayerSlave_0 : entity surf.SlaveAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => "S_AXIS",
+         HAS_TLAST       => 1,
+         HAS_TKEEP       => 1,
+         HAS_TSTRB       => 1,
+         HAS_TREADY      => 1,
+         TUSER_WIDTH     => TUSER_WIDTH_G,
+         TID_WIDTH       => TID_WIDTH_G,
+         TDEST_WIDTH     => TDEST_WIDTH_G,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES_G)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         S_AXIS_ACLK    => AXIS_ACLK,
+         S_AXIS_ARESETN => AXIS_ARESETN,
+         S_AXIS_TVALID  => S_AXIS0_TVALID,
+         S_AXIS_TDATA   => S_AXIS0_TDATA,
+         S_AXIS_TSTRB   => S_AXIS0_TSTRB,
+         S_AXIS_TKEEP   => S_AXIS0_TKEEP,
+         S_AXIS_TLAST   => S_AXIS0_TLAST,
+         S_AXIS_TDEST   => S_AXIS0_TDEST,
+         S_AXIS_TID     => S_AXIS0_TID,
+         S_AXIS_TUSER   => S_AXIS0_TUSER,
+         S_AXIS_TREADY  => S_AXIS0_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => axisClk,
+         axisRst        => axisRst,
+         axisMaster     => sAxisMasters(0),
+         axisSlave      => sAxisSlaves(0));
+
+   U_ShimLayerSlave_1 : entity surf.SlaveAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => "S_AXIS",
+         HAS_TLAST       => 1,
+         HAS_TKEEP       => 1,
+         HAS_TSTRB       => 1,
+         HAS_TREADY      => 1,
+         TUSER_WIDTH     => TUSER_WIDTH_G,
+         TID_WIDTH       => TID_WIDTH_G,
+         TDEST_WIDTH     => TDEST_WIDTH_G,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES_G)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         S_AXIS_ACLK    => AXIS_ACLK,
+         S_AXIS_ARESETN => AXIS_ARESETN,
+         S_AXIS_TVALID  => S_AXIS1_TVALID,
+         S_AXIS_TDATA   => S_AXIS1_TDATA,
+         S_AXIS_TSTRB   => S_AXIS1_TSTRB,
+         S_AXIS_TKEEP   => S_AXIS1_TKEEP,
+         S_AXIS_TLAST   => S_AXIS1_TLAST,
+         S_AXIS_TDEST   => S_AXIS1_TDEST,
+         S_AXIS_TID     => S_AXIS1_TID,
+         S_AXIS_TUSER   => S_AXIS1_TUSER,
+         S_AXIS_TREADY  => S_AXIS1_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => open,
+         axisRst        => open,
+         axisMaster     => sAxisMasters(1),
+         axisSlave      => sAxisSlaves(1));
+
+   U_ShimLayerMaster_0 : entity surf.MasterAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => "M_AXIS",
+         HAS_TLAST       => 1,
+         HAS_TKEEP       => 1,
+         HAS_TSTRB       => 1,
+         HAS_TREADY      => 1,
+         TUSER_WIDTH     => TUSER_WIDTH_G,
+         TID_WIDTH       => TID_WIDTH_G,
+         TDEST_WIDTH     => TDEST_WIDTH_G,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES_G)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         M_AXIS_ACLK    => AXIS_ACLK,
+         M_AXIS_ARESETN => AXIS_ARESETN,
+         M_AXIS_TVALID  => M_AXIS0_TVALID,
+         M_AXIS_TDATA   => M_AXIS0_TDATA,
+         M_AXIS_TSTRB   => M_AXIS0_TSTRB,
+         M_AXIS_TKEEP   => M_AXIS0_TKEEP,
+         M_AXIS_TLAST   => M_AXIS0_TLAST,
+         M_AXIS_TDEST   => M_AXIS0_TDEST,
+         M_AXIS_TID     => M_AXIS0_TID,
+         M_AXIS_TUSER   => M_AXIS0_TUSER,
+         M_AXIS_TREADY  => M_AXIS0_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => open,
+         axisRst        => open,
+         axisMaster     => mAxisMasters(0),
+         axisSlave      => mAxisSlaves(0));
+
+   U_ShimLayerMaster_1 : entity surf.MasterAxiStreamIpIntegrator
+      generic map (
+         INTERFACENAME   => "M_AXIS",
+         HAS_TLAST       => 1,
+         HAS_TKEEP       => 1,
+         HAS_TSTRB       => 1,
+         HAS_TREADY      => 1,
+         TUSER_WIDTH     => TUSER_WIDTH_G,
+         TID_WIDTH       => TID_WIDTH_G,
+         TDEST_WIDTH     => TDEST_WIDTH_G,
+         TDATA_NUM_BYTES => TDATA_NUM_BYTES_G)
+      port map (
+         -- IP Integrator AXI Stream Interface
+         M_AXIS_ACLK    => AXIS_ACLK,
+         M_AXIS_ARESETN => AXIS_ARESETN,
+         M_AXIS_TVALID  => M_AXIS1_TVALID,
+         M_AXIS_TDATA   => M_AXIS1_TDATA,
+         M_AXIS_TSTRB   => M_AXIS1_TSTRB,
+         M_AXIS_TKEEP   => M_AXIS1_TKEEP,
+         M_AXIS_TLAST   => M_AXIS1_TLAST,
+         M_AXIS_TDEST   => M_AXIS1_TDEST,
+         M_AXIS_TID     => M_AXIS1_TID,
+         M_AXIS_TUSER   => M_AXIS1_TUSER,
+         M_AXIS_TREADY  => M_AXIS1_TREADY,
+         -- SURF AXI Stream Interface
+         axisClk        => open,
+         axisRst        => open,
+         axisMaster     => mAxisMasters(1),
+         axisSlave      => mAxisSlaves(1));
+
+   U_ShimLayer : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         EN_ERROR_RESP => true,
+         FREQ_HZ       => 100000000,
+         ADDR_WIDTH    => 32)
+      port map (
+         -- IP Integrator AXI-Lite Interface
+         S_AXI_ACLK      => AXIS_ACLK,
+         S_AXI_ARESETN   => AXIS_ARESETN,
+         S_AXI_AWADDR    => S_AXIL_AWADDR,
+         S_AXI_AWPROT    => S_AXIL_AWPROT,
+         S_AXI_AWVALID   => S_AXIL_AWVALID,
+         S_AXI_AWREADY   => S_AXIL_AWREADY,
+         S_AXI_WDATA     => S_AXIL_WDATA,
+         S_AXI_WSTRB     => S_AXIL_WSTRB,
+         S_AXI_WVALID    => S_AXIL_WVALID,
+         S_AXI_WREADY    => S_AXIL_WREADY,
+         S_AXI_BRESP     => S_AXIL_BRESP,
+         S_AXI_BVALID    => S_AXIL_BVALID,
+         S_AXI_BREADY    => S_AXIL_BREADY,
+         S_AXI_ARADDR    => S_AXIL_ARADDR,
+         S_AXI_ARPROT    => S_AXIL_ARPROT,
+         S_AXI_ARVALID   => S_AXIL_ARVALID,
+         S_AXI_ARREADY   => S_AXIL_ARREADY,
+         S_AXI_RDATA     => S_AXIL_RDATA,
+         S_AXI_RRESP     => S_AXIL_RRESP,
+         S_AXI_RVALID    => S_AXIL_RVALID,
+         S_AXI_RREADY    => S_AXIL_RREADY,
+         -- SURF AXI-Lite Interface
+         axilClk         => open,
+         axilRst         => open,
+         axilReadMaster  => axilReadMaster,
+         axilReadSlave   => axilReadSlave,
+         axilWriteMaster => axilWriteMaster,
+         axilWriteSlave  => axilWriteSlave);
+
+   U_AXIL_XBAR : entity surf.AxiLiteCrossbar
+      generic map (
+         TPD_G              => TPD_C,
+         NUM_SLAVE_SLOTS_G  => 1,
+         NUM_MASTER_SLOTS_G => 2,
+         MASTERS_CONFIG_G   => AXIL_CONFIG_C)
+      port map (
+         axiClk              => axisClk,
+         axiClkRst           => axisRst,
+         sAxiWriteMasters(0) => axilWriteMaster,
+         sAxiWriteSlaves(0)  => axilWriteSlave,
+         sAxiReadMasters(0)  => axilReadMaster,
+         sAxiReadSlaves(0)   => axilReadSlave,
+         mAxiWriteMasters    => axilWriteMasters,
+         mAxiWriteSlaves     => axilWriteSlaves,
+         mAxiReadMasters     => axilReadMasters,
+         mAxiReadSlaves      => axilReadSlaves);
+
+   ---------------------------------------------------------------------------
+   -- Design Under Testing (DUT) Modules
+   ---------------------------------------------------------------------------
+
+   -- Module used on the front end board for sequencing the frames to back end
+   U_DUT_MUX : entity surf.EventFrameSequencerMux
+      generic map (
+         TPD_G          => TPD_C,
+         NUM_SLAVES_G   => 2,
+         MODE_G         => "ROUTED",
+         TDEST_ROUTES_G => (
+            0           => "0000000-",   -- Trig on 0x1, Event on 0x0
+            1           => "00000010"),  -- Map PGP[tap] to TDEST 0x2
+         TRANS_TDEST_G  => X"00",
+         AXIS_CONFIG_G  => AXIS_CONFIG_C)
+      port map (
+         -- Clock and Reset
+         axisClk         => axisClk,
+         axisRst         => axisRst,
+         -- AXI-Lite Interface (axisClk domain)
+         axilReadMaster  => axilReadMasters(0),
+         axilReadSlave   => axilReadSlaves(0),
+         axilWriteMaster => axilWriteMasters(0),
+         axilWriteSlave  => axilWriteSlaves(0),
+         -- AXIS Interfaces
+         sAxisMasters    => sAxisMasters,
+         sAxisSlaves     => sAxisSlaves,
+         mAxisMaster     => axisMaster,
+         mAxisSlave      => axisSlave);
+
+   -- Module used on the back end board (e.g. FPGA PCIe) for decoding
+   U_DUT_DEMUX : entity surf.EventFrameSequencerDemux
+      generic map (
+         TPD_G         => TPD_C,
+         NUM_MASTERS_G => 2,
+         AXIS_CONFIG_G => AXIS_CONFIG_C)
+      port map (
+         -- Clock and Reset
+         axisClk         => axisClk,
+         axisRst         => axisRst,
+         -- AXI-Lite Interface
+         axilReadMaster  => axilReadMasters(1),
+         axilReadSlave   => axilReadSlaves(1),
+         axilWriteMaster => axilWriteMasters(1),
+         axilWriteSlave  => axilWriteSlaves(1),
+         -- AXIS Interfaces
+         sAxisMaster     => axisMaster,
+         sAxisSlave      => axisSlave,
+         mAxisMasters    => mAxisMasters,
+         mAxisSlaves     => mAxisSlaves);
+
+end mapping;

--- a/protocols/ruckus.tcl
+++ b/protocols/ruckus.tcl
@@ -3,6 +3,7 @@ source $::env(RUCKUS_PROC_TCL)
 
 # Load ruckus files
 loadRuckusTcl "$::DIR_PATH/batcher"
+loadRuckusTcl "$::DIR_PATH/event-frame-sequencer"
 loadRuckusTcl "$::DIR_PATH/hamming-ecc"
 loadRuckusTcl "$::DIR_PATH/i2c"
 loadRuckusTcl "$::DIR_PATH/jesd204b"

--- a/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
+++ b/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
@@ -102,7 +102,7 @@ class AxiStreamBatcherEventBuilder(pr.Device):
         self.add(pr.RemoteVariable(
             name         = "State",
             description  = "current state of FSM (for debugging)",
-            offset       =  0xFF8,
+            offset       =  0xFF4,
             bitSize      =  1,
             bitOffset    =  8,
             mode         = "RO",

--- a/python/surf/protocols/event_frame_sequencer/_EventFrameSequencerDemux.py
+++ b/python/surf/protocols/event_frame_sequencer/_EventFrameSequencerDemux.py
@@ -1,0 +1,146 @@
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class EventFrameSequencerDemux(pr.Device):
+    def __init__(
+            self,
+            numberSlaves = 1,
+            **kwargs):
+        super().__init__(**kwargs)
+
+        self.addRemoteVariables(
+            name         = 'DataCnt',
+            description  = 'Increments every time a data frame is received',
+            offset       = 0x000,
+            bitSize      = 32,
+            mode         = 'RO',
+            number       = numberSlaves,
+            stride       = 4,
+            pollInterval = 1,
+        )
+
+        self.add(pr.RemoteVariable(
+            name         = 'SeqCnt',
+            description  = 'Increments every time there is a frame sent',
+            offset       = 0xFBC,
+            bitSize      = 8,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'DropCnt',
+            description  = 'Increments every time a frame is dropped',
+            offset       = 0xFC0,
+            bitSize      = 32,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'NUM_MASTERS_G',
+            description  = 'NUM_MASTERS_G generic value',
+            offset       = 0xFF4,
+            bitSize      = 8,
+            mode         = 'RO',
+            disp         = '{:d}',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "State",
+            description  = "current state of FSM (for debugging)",
+            offset       =  0xFF4,
+            bitSize      =  1,
+            bitOffset    =  8,
+            mode         = "RO",
+            pollInterval = 1,
+            enum         = {
+                0x0: 'IDLE_S',
+                0x1: 'MOVE_S',
+            },
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "BlowoffExt",
+            description  = "Status of external blowoff input",
+            offset       =  0xFF4,
+            bitSize      =  1,
+            bitOffset    =  16,
+            base         = pr.Bool,
+            mode         = "RO",
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "HdrError",
+            description  = "Header error code when last frame dropped",
+            offset       =  0xFF4,
+            bitSize      =  8,
+            bitOffset    =  24,
+            mode         = "RO",
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "Blowoff",
+            description  = "Blows off the inbound AXIS stream (for debugging)",
+            offset       =  0xFF8,
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.Bool,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "CntRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 0,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "TimerRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 1,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "HardRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 2,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "SoftRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 3,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+    def hardReset(self):
+        self.HardRst()
+
+    def initialize(self):
+        self.SoftRst()
+
+    def countReset(self):
+        self.CntRst()

--- a/python/surf/protocols/event_frame_sequencer/_EventFrameSequencerMux.py
+++ b/python/surf/protocols/event_frame_sequencer/_EventFrameSequencerMux.py
@@ -1,0 +1,152 @@
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class EventFrameSequencerMux(pr.Device):
+    def __init__(
+            self,
+            numberSlaves = 1,
+            **kwargs):
+        super().__init__(**kwargs)
+
+        self.addRemoteVariables(
+            name         = 'DataCnt',
+            description  = 'Increments every time a data frame is received',
+            offset       = 0x000,
+            bitSize      = 32,
+            mode         = 'RO',
+            number       = numberSlaves,
+            stride       = 4,
+            pollInterval = 1,
+        )
+
+        self.add(pr.RemoteVariable(
+            name         = 'SeqCnt',
+            description  = 'Increments every time there is a frame sent',
+            offset       = 0xFBC,
+            bitSize      = 8,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TransactionCnt',
+            description  = 'Increments every time a transition frame is received',
+            offset       = 0xFC0,
+            bitSize      = 32,
+            mode         = 'RO',
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TRANS_TDEST_G',
+            description  = 'TRANS_TDEST_G generic value',
+            offset       = 0xFC4,
+            bitSize      = 8,
+            mode         = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'Bypass',
+            description  = 'Mask to bypass a channel',
+            offset       = 0xFD0,
+            bitSize      = numberSlaves,
+            mode         = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'NUM_SLAVES_G',
+            description  = 'NUM_SLAVES_G generic value',
+            offset       = 0xFF4,
+            bitSize      = 8,
+            mode         = 'RO',
+            disp         = '{:d}',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "State",
+            description  = "current state of FSM (for debugging)",
+            offset       =  0xFF4,
+            bitSize      =  1,
+            bitOffset    =  8,
+            mode         = "RO",
+            pollInterval = 1,
+            enum         = {
+                0x0: 'IDLE_S',
+                0x1: 'MOVE_S',
+            },
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "BlowoffExt",
+            description  = "Status of external blowoff input",
+            offset       =  0xFF4,
+            bitSize      =  1,
+            bitOffset    =  16,
+            base         = pr.Bool,
+            mode         = "RO",
+            pollInterval = 1,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "Blowoff",
+            description  = "Blows off the inbound AXIS stream (for debugging)",
+            offset       =  0xFF8,
+            bitSize      =  1,
+            bitOffset    =  0,
+            base         = pr.Bool,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "CntRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 0,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "TimerRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 1,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "HardRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 2,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = "SoftRst",
+            description  = "",
+            offset       = 0xFFC,
+            bitSize      = 1,
+            bitOffset    = 3,
+            function     = pr.BaseCommand.toggle,
+        ))
+
+    def hardReset(self):
+        self.HardRst()
+
+    def initialize(self):
+        self.SoftRst()
+
+    def countReset(self):
+        self.CntRst()

--- a/python/surf/protocols/event_frame_sequencer/__init__.py
+++ b/python/surf/protocols/event_frame_sequencer/__init__.py
@@ -1,0 +1,2 @@
+from surf.protocols.event_frame_sequencer._EventFrameSequencerMux   import *
+from surf.protocols.event_frame_sequencer._EventFrameSequencerDemux import *

--- a/tests/test_EventFrameSequencerTb.py
+++ b/tests/test_EventFrameSequencerTb.py
@@ -1,0 +1,199 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# dut_tb
+import itertools
+import logging
+import cocotb
+from cocotb.clock      import Clock
+from cocotb.triggers   import RisingEdge
+from cocotb.regression import TestFactory
+
+from cocotbext.axi import AxiStreamFrame, AxiStreamBus, AxiStreamSource, AxiStreamSink, AxiLiteBus, AxiLiteMaster
+
+# test_EventFrameSequencerTb
+from cocotb_test.simulator import run
+import pytest
+import glob
+import os
+
+# Define a new log level
+CUSTOM_LEVEL = 60
+logging.addLevelName(CUSTOM_LEVEL, "CUSTOM")
+
+def custom(self, message, *args, **kwargs):
+    if self.isEnabledFor(CUSTOM_LEVEL):
+        self._log(CUSTOM_LEVEL, message, args, **kwargs)
+
+# Add the custom level to the logging.Logger class
+logging.Logger.custom = custom
+
+class TB:
+    def __init__(self, dut):
+
+        # Pointer to DUT object
+        self.dut = dut
+
+        self.log = logging.getLogger('cocotb.tb')
+        self.log.setLevel(logging.DEBUG)
+
+        # Start AXIS_ACLK clock (100 MHz) in a separate thread
+        cocotb.start_soon(Clock(dut.AXIS_ACLK, 10.0, units='ns').start())
+
+        # Setup the AXI stream source
+        self.sources = [None for _ in range(2)]
+        for i in range(2):
+            self.sources[i] = AxiStreamSource(
+                bus   = AxiStreamBus.from_prefix(dut, f'S_AXIS{i}'),
+                clock = dut.AXIS_ACLK,
+                reset = dut.AXIS_ARESETN,
+                reset_active_level = False,
+            )
+
+        # Setup the AXI stream sink
+        self.sinks = [None for _ in range(2)]
+        for i in range(2):
+            self.sinks[i] = AxiStreamSink(
+                bus   = AxiStreamBus.from_prefix(dut, f'M_AXIS{i}'),
+                clock = dut.AXIS_ACLK,
+                reset = dut.AXIS_ARESETN,
+                reset_active_level = False,
+            )
+
+        # Create the AXI-Lite Master
+        self.axil_master = AxiLiteMaster(
+            bus   = AxiLiteBus.from_prefix(dut, 'S_AXIL'),
+            clock = dut.AXIS_ACLK,
+            reset = dut.AXIS_ARESETN,
+            reset_active_level=False)
+
+    async def cycle_reset(self):
+        self.dut.AXIS_ARESETN.setimmediatevalue(0)
+        await RisingEdge(self.dut.AXIS_ACLK)
+        await RisingEdge(self.dut.AXIS_ACLK)
+        self.dut.AXIS_ARESETN.value = 0
+        await RisingEdge(self.dut.AXIS_ACLK)
+        await RisingEdge(self.dut.AXIS_ACLK)
+        self.dut.AXIS_ARESETN.value = 1
+        await RisingEdge(self.dut.AXIS_ACLK)
+        await RisingEdge(self.dut.AXIS_ACLK)
+
+async def run_test(dut):
+
+    tb = TB(dut)
+    await tb.cycle_reset()
+
+    # Byte sweeping to check for corner cases
+    for x in range(8):
+
+        # Generate the transition data frame
+        trans_frame = AxiStreamFrame(bytearray(list(range(0+x, 16))))
+        trans_frame.tdest = 0x0
+        trans_frame.tuser = x
+
+        # Generate the payload data frames
+        test_frames = [None for _ in range(2)]
+        for i in range(2):
+            test_frames[i] = AxiStreamFrame(bytearray(list(range(1+i+x, 16+1))))
+            test_frames[i].tdest = i+1
+            test_frames[i].tuser = x
+
+        # Send the transition frame
+        await tb.sources[0].send(trans_frame)
+        tb.log.custom( f'trans_frame.tdata={trans_frame.tdata}' )
+        tb.log.custom( f'trans_frame.tdest={trans_frame.tdest}' )
+        tb.log.custom( f'trans_frame.tuser={trans_frame.tuser}' )
+
+        # Received the transition frame
+        rx_frame = await tb.sinks[0].recv()
+        tb.log.custom( f'rx_frame.tdata={rx_frame.tdata}' )
+        tb.log.custom( f'rx_frame.tdest={rx_frame.tdest}' )
+        tb.log.custom( f'rx_frame.tuser={rx_frame.tuser}' )
+        assert rx_frame.tdata == trans_frame.tdata
+        assert rx_frame.tdest == trans_frame.tdest
+        assert rx_frame.tuser == trans_frame.tuser
+        assert tb.sinks[0].empty()
+
+        # Send the payload data frames
+        for i in range(2):
+            tb.log.custom( f'test_frames[{i}].tdata={test_frames[i].tdata}' )
+            tb.log.custom( f'test_frames[{i}].tdest={test_frames[i].tdest}' )
+            tb.log.custom( f'test_frames[{i}].tuser={test_frames[i].tuser}' )
+            await tb.sources[i].send(test_frames[i])
+
+        # Received the payload data frame
+        for i in range(2):
+            rx_frame = await tb.sinks[i].recv()
+            tb.log.custom( f'rx_frame.tdata={rx_frame.tdata}' )
+            tb.log.custom( f'rx_frame.tdest={rx_frame.tdest}' )
+            tb.log.custom( f'rx_frame.tuser={rx_frame.tuser}' )
+            assert rx_frame.tdata == test_frames[i].tdata
+            assert rx_frame.tdest == test_frames[i].tdest
+            assert rx_frame.tuser == test_frames[i].tuser
+            assert tb.sinks[i].empty()
+
+if cocotb.SIM_NAME:
+    factory = TestFactory(run_test)
+    factory.generate_tests()
+
+tests_dir = os.path.dirname(__file__)
+tests_module = 'EventFrameSequencerTb'
+
+##############################################################################
+
+@pytest.mark.parametrize(
+    "parameters", [
+        None
+    ])
+def test_EventFrameSequencerTb(parameters):
+
+    # https://github.com/themperek/cocotb-test#arguments-for-simulatorrun
+    # https://github.com/themperek/cocotb-test/blob/master/cocotb_test/simulator.py
+    run(
+        # top level HDL
+        toplevel = f'surf.{tests_module}'.lower(),
+
+        # name of the file that contains @cocotb.test() -- this file
+        # https://docs.cocotb.org/en/stable/building.html?#envvar-MODULE
+        module = f'test_{tests_module}',
+
+        # https://docs.cocotb.org/en/stable/building.html?#var-TOPLEVEL_LANG
+        toplevel_lang = 'vhdl',
+
+        # VHDL source files to include.
+        # Can be specified as a list or as a dict of lists with the library name as key,
+        # if the simulator supports named libraries.
+        vhdl_sources = {
+            'surf'   : glob.glob(f'{tests_dir}/../build/SRC_VHDL/surf/*'),
+            'ruckus' : glob.glob(f'{tests_dir}/../build/SRC_VHDL/ruckus/*'),
+        },
+
+        # A dictionary of top-level parameters/generics.
+        parameters = parameters,
+
+        # The directory used to compile the tests. (default: sim_build)
+        sim_build = f'{tests_dir}/sim_build/{tests_module}',
+
+        # A dictionary of extra environment variables set in simulator process.
+        extra_env=parameters,
+
+        # Select a simulator
+        simulator="ghdl",
+
+        # use of synopsys package "std_logic_arith" needs the -fsynopsys option
+        # -frelaxed-rules option to allow IP integrator attributes
+        # When two operators are overloaded, give preference to the explicit declaration (-fexplicit)
+        vhdl_compile_args = ['-fsynopsys','-frelaxed-rules', '-fexplicit'],
+
+        ########################################################################
+        # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
+        ########################################################################
+        sim_args =[f'--wave={tests_module}.ghw'],
+    )

--- a/tests/test_EventFrameSequencerTb.py
+++ b/tests/test_EventFrameSequencerTb.py
@@ -194,5 +194,5 @@ def test_EventFrameSequencerTb(parameters):
         ########################################################################
         # Dump waveform to file ($ gtkwave sim_build/path/To/{tests_module}.ghw)
         ########################################################################
-        sim_args =[f'--wave={tests_module}.ghw'],
+        # sim_args =[f'--wave={tests_module}.ghw'],
     )

--- a/tests/test_EventFrameSequencerTb.py
+++ b/tests/test_EventFrameSequencerTb.py
@@ -9,7 +9,6 @@
 ##############################################################################
 
 # dut_tb
-import itertools
 import logging
 import cocotb
 from cocotb.clock      import Clock


### PR DESCRIPTION
### Description
This module draws inspiration from the [AxiStream Batcher Protocol Version 1](https://confluence.slac.stanford.edu/display/ppareg/AxiStream+Batcher+Protocol+Version+1), which uses the [AxiStreamBatcherEventBuilder.vhd](https://github.com/slaclab/surf/blob/main/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd). Unlike the original design, which creates a single super-frame per event, this module transmits event frames in a guaranteed sequence. As a result, each event consists of multiple frames, but the order of these frames within an event is always preserved.

In the [AxiStreamBatcherEventBuilder.vhd](https://github.com/slaclab/surf/blob/main/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd), a super-header and multiple sub-frame tails are prepended or appended to the stream. In contrast, this module eliminates tail appending and instead prepends a header to each frame as it is forwarded through the sequencer. This header includes all the metadata necessary to reconstruct AXI stream sideband information on the receiver side, such as TDEST, TUSER_FIRST, and other relevant signals.

### Documenation
- [Event Frame Sequencer Version1](https://confluence.slac.stanford.edu/display/ppareg/Event+Frame+Sequencer+Version1)