### PR TITLE
Updated FSM to latch meta data 

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -132,6 +132,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       maxSize     : slv(31 downto 0);
       contEn      : sl;
       dropEn      : sl;
+      metaEnable  : sl;
       enable      : sl;
       forceInt    : sl;
       intEnable   : sl;
@@ -209,6 +210,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       maxSize         => (others => '0'),
       contEn          => '0',
       dropEn          => '0',
+      metaEnable      => '0',
       enable          => '0',
       forceInt        => '0',
       intEnable       => '0',
@@ -483,6 +485,8 @@ begin
 
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
 
+      axiSlaveRegister(regCon, x"088", 0, v.metaEnable);
+
       for i in 0 to 7 loop
          axiSlaveRegister(regCon, toSlv(144 + i*4, 12), 0, v.idBuffThold(i));  -- 0x090 - 0xAC
          axiSlaveRegisterR(regCon, toSlv(176 + i*4, 12), 0, r.idBuffCount(i));  -- 0x0B0 - 0xCC
@@ -579,6 +583,7 @@ begin
 
             v.dmaWrDescAck(i).dropEn  := r.dropEn;
             v.dmaWrDescAck(i).contEn  := r.contEn;
+            v.dmaWrDescAck(i).metaEnable  := r.metaEnable;
             v.dmaWrDescAck(i).maxSize := r.maxSize;
 
             v.dmaWrDescAck(i).buffId(27 downto 0) := wrFifoDout(27 downto 0);

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -132,7 +132,6 @@ architecture rtl of AxiStreamDmaV2Desc is
       maxSize     : slv(31 downto 0);
       contEn      : sl;
       dropEn      : sl;
-      metaEnable  : sl;
       enable      : sl;
       forceInt    : sl;
       intEnable   : sl;
@@ -210,7 +209,6 @@ architecture rtl of AxiStreamDmaV2Desc is
       maxSize         => (others => '0'),
       contEn          => '0',
       dropEn          => '0',
-      metaEnable      => '0',
       enable          => '0',
       forceInt        => '0',
       intEnable       => '0',
@@ -462,7 +460,7 @@ begin
       axiSlaveRegister(regCon, x"048", 0, v.fifoDin);
       axiWrDetect(regCon, x"048", v.wrFifoWr(0));
 
-      axiSlaveRegister(regCon, x"04C", 0, v.intAckCount(15 downto 0));
+      axiSlaveRegister(regCon, x"04C", 0, v.intAckCount(15 downto 0)); 
       axiSlaveRegister(regCon, x"04C", 17, v.intEnable);
       axiWrDetect(regCon, x"04C", v.intSwAckReq);
 
@@ -484,8 +482,6 @@ begin
       axiSlaveRegister(regCon, x"080", 0, v.forceInt);
 
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
-
-      axiSlaveRegister(regCon, x"088", 0, v.metaEnable);
 
       for i in 0 to 7 loop
          axiSlaveRegister(regCon, toSlv(144 + i*4, 12), 0, v.idBuffThold(i));  -- 0x090 - 0xAC
@@ -583,7 +579,6 @@ begin
 
             v.dmaWrDescAck(i).dropEn  := r.dropEn;
             v.dmaWrDescAck(i).contEn  := r.contEn;
-            v.dmaWrDescAck(i).metaEnable  := r.metaEnable;
             v.dmaWrDescAck(i).maxSize := r.maxSize;
 
             v.dmaWrDescAck(i).buffId(27 downto 0) := wrFifoDout(27 downto 0);

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -460,7 +460,7 @@ begin
       axiSlaveRegister(regCon, x"048", 0, v.fifoDin);
       axiWrDetect(regCon, x"048", v.wrFifoWr(0));
 
-      axiSlaveRegister(regCon, x"04C", 0, v.intAckCount(15 downto 0)); 
+      axiSlaveRegister(regCon, x"04C", 0, v.intAckCount(15 downto 0));
       axiSlaveRegister(regCon, x"04C", 17, v.intEnable);
       axiWrDetect(regCon, x"04C", v.intSwAckReq);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -500,7 +500,11 @@ begin
                   -- -- Check for last AXIS word
                   if intAxisMaster.tLast = '1' then
                      v.dmaWrTrack.inUse := '0';
-                     v.state := META_S;
+                     if r.dmaWrTrack.metaEnable = '1' then
+                        v.state := META_S;
+                     else
+                        v.state := RETURN_S;
+                     end if;
                   end if;
                end if;
             end if;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -500,7 +500,7 @@ begin
                   -- -- Check for last AXIS word
                   if intAxisMaster.tLast = '1' then
                      v.dmaWrTrack.inUse := '0';
-                     v.state := RETURN_S;
+                     v.state := META_S;
                   end if;
                end if;
             end if;


### PR DESCRIPTION
### Description
Updated FSM to latch the meta data to the AXIS in AxiStreamDmaV2Write.vhd. The 'overflow' bit should now be available in the AXIS header. 


