### PR TITLE
git hash leading zero bug fix

### DIFF
--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -281,7 +281,7 @@ class AxiVersion(pr.Device):
             print("FwVersion    = {}".format(hex(self.FpgaVersion.get())))
             print("UpTime       = {}".format(self.UpTime.get()))
             if (gitHash != 0):
-                print("GitHash      = {}".format(hex(self.GitHash.get())))
+                print("GitHash      = {:040x}".format(self.GitHash.get()))
             else:
                 print("GitHash      = dirty (uncommitted code)")
             print("XilinxDnaId  = {}".format(hex(self.DeviceDna.get())))


### PR DESCRIPTION
Here's what the print would look like if there was a leading zero in the value:
```bash
GitHash      = 0x2a6000a172a68c0ad2e83f4b816701fd159603c
```
Here's what the print looks like with this path:
```bash
GitHash      = 02a6000a172a68c0ad2e83f4b816701fd159603c
```
Removed the `0x` characters to make it easier to copy/paste into Github web browser UI for githash searching