### PR TITLE
Fix PGP2FC Bug - Don't allow Fast Control RX when link is not up

### DIFF
--- a/protocols/pgp/pgp2fc/core/rtl/Pgp2fcRxPhy.vhd
+++ b/protocols/pgp/pgp2fc/core/rtl/Pgp2fcRxPhy.vhd
@@ -438,7 +438,7 @@ begin
    -- Fast Control logic
    process (pgpRxClk, pgpRxClkRst)
    begin
-      if pgpRxClkRst = '1' then
+      if pgpRxClkRst = '1' or intRxLinkReady = '0' then
          intFcValid    <= '0'             after TPD_G;
          intFcBusy     <= '0'             after TPD_G;
          intFcError    <= '0'             after TPD_G;

--- a/protocols/pgp/pgp2fc/core/rtl/Pgp2fcRxPhy.vhd
+++ b/protocols/pgp/pgp2fc/core/rtl/Pgp2fcRxPhy.vhd
@@ -436,7 +436,7 @@ begin
    end process;
 
    -- Fast Control logic
-   process (pgpRxClk, pgpRxClkRst)
+   process (intRxLinkReady, pgpRxClk, pgpRxClkRst)
    begin
       if pgpRxClkRst = '1' or intRxLinkReady = '0' then
          intFcValid    <= '0'             after TPD_G;


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

The Fast Control word RX logic was not checking to make sure the link was even up before outputting FC words. This caused disconnected links to output FC words fairly often from random input patterns.

The fix is to hold the entire FC RX logic in reset of the link is not up.
