### PR TITLE
check for AXI_CONFIG_G.ADDR_WIDTH_C <= 40 in AxiStreamDmaV2Desc.vhd

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -285,6 +285,9 @@ architecture rtl of AxiStreamDmaV2Desc is
 
 begin
 
+   assert (AXI_CONFIG_G.ADDR_WIDTH_C <= 40)
+      report "AXI_CONFIG_G.ADDR_WIDTH_C must be <= 40" severity failure;
+
    -----------------------------------------
    -- Write Free List FIFOs
    -----------------------------------------

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -286,7 +286,7 @@ architecture rtl of AxiStreamDmaV2Desc is
 begin
 
    assert (AXI_CONFIG_G.ADDR_WIDTH_C <= 40)
-      report "AXI_CONFIG_G.ADDR_WIDTH_C must be <= 40" severity failure;
+      report "AXI_CONFIG_G.ADDR_WIDTH_C (" & str(AXI_CONFIG_G.ADDR_WIDTH_C) & ") must be <= 40" severity failure;
 
    -----------------------------------------
    -- Write Free List FIFOs

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -286,7 +286,7 @@ architecture rtl of AxiStreamDmaV2Desc is
 begin
 
    assert (AXI_CONFIG_G.ADDR_WIDTH_C <= 40)
-      report "AXI_CONFIG_G.ADDR_WIDTH_C (" & str(AXI_CONFIG_G.ADDR_WIDTH_C) & ") must be <= 40" severity failure;
+      report "AXI_CONFIG_G.ADDR_WIDTH_C (" & integer'image(AXI_CONFIG_G.ADDR_WIDTH_C) & ") must be <= 40" severity failure;
 
    -----------------------------------------
    -- Write Free List FIFOs


### PR DESCRIPTION
### Description
- Required because we ran out of bits to map the address from the FIFO:
```vhdl
v.dmaWrDescAck(i).address(63 downto 40) := (others => '0');
v.dmaWrDescAck(i).address(39 downto 4)  := wrFifoDout(63 downto 28);
v.dmaWrDescAck(i).address(3 downto 0)   := (others => '0');
```