### PR TITLE
Added DMA configurable timeout register

### DIFF
--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -194,7 +194,7 @@ package AxiDmaPkg is
       maxSize    : slv(31 downto 0);
       contEn     : sl;
       buffId     : slv(31 downto 0);
-      timout     : slv(31 downto 0);
+      timeout    : slv(31 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_DESC_ACK_INIT_C : AxiWriteDmaDescAckType := (
@@ -206,7 +206,7 @@ package AxiDmaPkg is
       maxSize    => (others=>'0'),
       contEn     => '0',
       buffId     => (others=>'0'),
-      timout     => x"0000FFFF"
+      timeout    => x"0000FFFF"
    );
 
    type AxiWriteDmaDescAckArray is array (natural range<>) of AxiWriteDmaDescAckType;
@@ -231,7 +231,6 @@ package AxiDmaPkg is
       result     : slv(2  downto 0);
       dest       : slv(7  downto 0);
       id         : slv(7  downto 0); -- TID
-      timout     : slv(31 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_DESC_RET_INIT_C : AxiWriteDmaDescRetType := (
@@ -243,8 +242,7 @@ package AxiDmaPkg is
       continue   => '0',
       result     => (others=>'0'),
       dest       => (others=>'0'),
-      id         => (others=>'0'),
-      timout     => x"0000FFFF"
+      id         => (others=>'0')
    );
 
    type AxiWriteDmaDescRetArray is array (natural range<>) of AxiWriteDmaDescRetType;
@@ -273,6 +271,7 @@ package AxiDmaPkg is
       id         : slv(7  downto 0); -- TID
       buffId     : slv(31 downto 0);
       overflow   : sl;
+      timeout    : slv(31 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_TRACK_INIT_C : AxiWriteDmaTrackType := (
@@ -288,7 +287,8 @@ package AxiDmaPkg is
       dropEn     => '0',
       id         => (others=>'0'),
       buffId     => (others=>'0'),
-      overflow   => '0'
+      overflow   => '0',
+      timeout    => x"0000FFFF"
    );
 
    type AxiWriteDmaTrackArray is array (natural range<>) of AxiWriteDmaTrackType;

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -228,7 +228,7 @@ package AxiDmaPkg is
       lastUser   : slv(7  downto 0);
       size       : slv(31 downto 0);
       continue   : sl;
-      result     : slv(2  downto 0);
+      result     : slv(3  downto 0);
       dest       : slv(7  downto 0);
       id         : slv(7  downto 0); -- TID
    end record;
@@ -342,7 +342,7 @@ package AxiDmaPkg is
    type AxiReadDmaDescRetType is record
       valid      : sl;
       buffId     : slv(31 downto 0);
-      result     : slv(2  downto 0);
+      result     : slv(3  downto 0);
    end record;
 
    constant AXI_READ_DMA_DESC_RET_INIT_C : AxiReadDmaDescRetType := (

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -194,6 +194,7 @@ package AxiDmaPkg is
       maxSize    : slv(31 downto 0);
       contEn     : sl;
       buffId     : slv(31 downto 0);
+      timout     : slv(31 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_DESC_ACK_INIT_C : AxiWriteDmaDescAckType := (
@@ -204,7 +205,8 @@ package AxiDmaPkg is
       dropEn     => '0',
       maxSize    => (others=>'0'),
       contEn     => '0',
-      buffId     => (others=>'0')
+      buffId     => (others=>'0'),
+      timout     => x"0000FFFF"
    );
 
    type AxiWriteDmaDescAckArray is array (natural range<>) of AxiWriteDmaDescAckType;

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -342,7 +342,7 @@ package AxiDmaPkg is
    type AxiReadDmaDescRetType is record
       valid      : sl;
       buffId     : slv(31 downto 0);
-      result     : slv(3  downto 0);
+      result     : slv(2  downto 0);
    end record;
 
    constant AXI_READ_DMA_DESC_RET_INIT_C : AxiReadDmaDescRetType := (

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -231,6 +231,7 @@ package AxiDmaPkg is
       result     : slv(2  downto 0);
       dest       : slv(7  downto 0);
       id         : slv(7  downto 0); -- TID
+      timout     : slv(31 downto 0);
    end record;
 
    constant AXI_WRITE_DMA_DESC_RET_INIT_C : AxiWriteDmaDescRetType := (
@@ -242,7 +243,8 @@ package AxiDmaPkg is
       continue   => '0',
       result     => (others=>'0'),
       dest       => (others=>'0'),
-      id         => (others=>'0')
+      id         => (others=>'0'),
+      timout     => x"FFFF"
    );
 
    type AxiWriteDmaDescRetArray is array (natural range<>) of AxiWriteDmaDescRetType;

--- a/axi/dma/rtl/AxiDmaPkg.vhd
+++ b/axi/dma/rtl/AxiDmaPkg.vhd
@@ -244,7 +244,7 @@ package AxiDmaPkg is
       result     => (others=>'0'),
       dest       => (others=>'0'),
       id         => (others=>'0'),
-      timout     => x"FFFF"
+      timout     => x"0000FFFF"
    );
 
    type AxiWriteDmaDescRetArray is array (natural range<>) of AxiWriteDmaDescRetType;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -587,7 +587,7 @@ begin
             v.dmaWrDescAck(i).dropEn  := r.dropEn;
             v.dmaWrDescAck(i).contEn  := r.contEn;
             v.dmaWrDescAck(i).maxSize := r.maxSize;
-            v.dmaWrDescAck(i).timeout := r.wrTimout;
+            v.dmaWrDescAck(i).timout := r.wrTimout;
 
             v.dmaWrDescAck(i).buffId(27 downto 0) := wrFifoDout(27 downto 0);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -699,8 +699,9 @@ begin
             v.axiWriteMaster.wdata(23 downto 16)   := dmaWrDescRet(descIndex).lastUser;
             v.axiWriteMaster.wdata(15 downto 8)    := dmaWrDescRet(descIndex).id;
             v.axiWriteMaster.wdata(7 downto 5)     := (others => '0');
-            v.axiWriteMaster.wdata(4)              := dmaWrDescRet(descIndex).continue;
-            v.axiWriteMaster.wdata(3 downto 0)     := dmaWrDescRet(descIndex).result;
+            v.axiWriteMaster.wdata(4)              := dmaWrDescRet(descIndex).result(3);
+            v.axiWriteMaster.wdata(3)              := dmaWrDescRet(descIndex).continue;
+            v.axiWriteMaster.wdata(2 downto 0)     := dmaWrDescRet(descIndex).result(2 downto 0);
 
             v.axiWriteMaster.wstrb := resize(x"FFFF", 128);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -145,6 +145,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffWrCache : slv(3 downto 0);
       enableCnt   : slv(7 downto 0);
       idBuffThold : Slv32Array(7 downto 0);
+      wrTimout    : slv(31 downto 0);
 
       -- FIFOs
       fifoDin        : slv(31 downto 0);
@@ -222,6 +223,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffWrCache     => (others => '0'),
       enableCnt       => (others => '0'),
       idBuffThold     => (others => (others => '0')),
+      wrTimout        => x"0000FFFF",
       -- FIFOs
       fifoDin         => (others => '0'),
       wrFifoWr        => (others => '0'),
@@ -433,7 +435,7 @@ begin
       axiSlaveRegister(regCon, x"000", 0, v.enable);
       axiSlaveRegisterR(regCon, x"000", 8, r.enableCnt);  -- Count the number of times enable transitions from 0->1
       axiSlaveRegisterR(regCon, x"000", 16, '1');  -- Legacy DESC_128_EN_C constant (always 0x1 now)
-      axiSlaveRegisterR(regCon, x"000", 24, toSlv(4, 8));  -- Version Number for aes-stream-driver to case on
+      axiSlaveRegisterR(regCon, x"000", 24, toSlv(5, 8));  -- Version Number for aes-stream-driver to case on
       axiSlaveRegister(regCon, x"004", 0, v.intEnable);
       axiSlaveRegister(regCon, x"008", 0, v.contEn);
       axiSlaveRegister(regCon, x"00C", 0, v.dropEn);
@@ -485,6 +487,8 @@ begin
       axiSlaveRegister(regCon, x"080", 0, v.forceInt);
 
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
+
+      axiSlaveRegister(regCon, x"088", 0, v.wrTimout);
 
       for i in 0 to 7 loop
          axiSlaveRegister(regCon, toSlv(144 + i*4, 12), 0, v.idBuffThold(i));  -- 0x090 - 0xAC
@@ -583,6 +587,7 @@ begin
             v.dmaWrDescAck(i).dropEn  := r.dropEn;
             v.dmaWrDescAck(i).contEn  := r.contEn;
             v.dmaWrDescAck(i).maxSize := r.maxSize;
+            v.dmaWrDescAck(i).timeout := r.wrTimout;
 
             v.dmaWrDescAck(i).buffId(27 downto 0) := wrFifoDout(27 downto 0);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -145,7 +145,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffWrCache : slv(3 downto 0);
       enableCnt   : slv(7 downto 0);
       idBuffThold : Slv32Array(7 downto 0);
-      wrTimout    : slv(31 downto 0);
+      wrTimeout    : slv(31 downto 0);
 
       -- FIFOs
       fifoDin        : slv(31 downto 0);
@@ -223,7 +223,7 @@ architecture rtl of AxiStreamDmaV2Desc is
       buffWrCache     => (others => '0'),
       enableCnt       => (others => '0'),
       idBuffThold     => (others => (others => '0')),
-      wrTimout        => x"0000FFFF",
+      wrTimeout        => x"0000FFFF",
       -- FIFOs
       fifoDin         => (others => '0'),
       wrFifoWr        => (others => '0'),
@@ -488,7 +488,7 @@ begin
 
       axiSlaveRegister(regCon, x"084", 0, v.intHoldoff);
 
-      axiSlaveRegister(regCon, x"088", 0, v.wrTimout);
+      axiSlaveRegister(regCon, x"088", 0, v.wrTimeout);
 
       for i in 0 to 7 loop
          axiSlaveRegister(regCon, toSlv(144 + i*4, 12), 0, v.idBuffThold(i));  -- 0x090 - 0xAC
@@ -587,7 +587,7 @@ begin
             v.dmaWrDescAck(i).dropEn  := r.dropEn;
             v.dmaWrDescAck(i).contEn  := r.contEn;
             v.dmaWrDescAck(i).maxSize := r.maxSize;
-            v.dmaWrDescAck(i).timout := r.wrTimout;
+            v.dmaWrDescAck(i).timeout := r.wrTimeout;
 
             v.dmaWrDescAck(i).buffId(27 downto 0) := wrFifoDout(27 downto 0);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Desc.vhd
@@ -698,9 +698,9 @@ begin
             v.axiWriteMaster.wdata(31 downto 24)   := dmaWrDescRet(descIndex).firstUser;
             v.axiWriteMaster.wdata(23 downto 16)   := dmaWrDescRet(descIndex).lastUser;
             v.axiWriteMaster.wdata(15 downto 8)    := dmaWrDescRet(descIndex).id;
-            v.axiWriteMaster.wdata(7 downto 4)     := (others => '0');
-            v.axiWriteMaster.wdata(3)              := dmaWrDescRet(descIndex).continue;
-            v.axiWriteMaster.wdata(2 downto 0)     := dmaWrDescRet(descIndex).result;
+            v.axiWriteMaster.wdata(7 downto 5)     := (others => '0');
+            v.axiWriteMaster.wdata(4)              := dmaWrDescRet(descIndex).continue;
+            v.axiWriteMaster.wdata(3 downto 0)     := dmaWrDescRet(descIndex).result;
 
             v.axiWriteMaster.wstrb := resize(x"FFFF", 128);
 

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -81,7 +81,7 @@ architecture rtl of AxiStreamDmaV2Write is
       result        : slv(1  downto 0);
       reqCount      : slv(31 downto 0);
       ackCount      : slv(31 downto 0);
-      stCount       : slv(15 downto 0);
+      stCount       : slv(31 downto 0);
       awlen         : slv(AXI_CONFIG_G.LEN_BITS_C-1 downto 0);
       axiLen        : AxiLenType;
       wMaster       : AxiWriteMasterType;
@@ -271,6 +271,7 @@ begin
                v.dmaWrTrack.metaAddr   := dmaWrDescAck.metaAddr;
                v.dmaWrTrack.address    := dmaWrDescAck.address;
                v.dmaWrTrack.maxSize    := dmaWrDescAck.maxSize;
+               v.dmaWrTrack.timout     := dmaWrDescAck.timout;
 
                -- Descriptor return calls for dumping frame?
                if dmaWrDescAck.dropEn = '1' then
@@ -473,7 +474,7 @@ begin
                   v.dmaWrDescRet.valid := '1';
                   v.state := IDLE_S;
                -- Check for ACK timeout
-               elsif (r.stCount = x"FFFF") then
+               elsif (r.stCount = r.dmaWrTrack.timout) then
                   -- Set the flags
                   v.dmaWrDescRet.result(1 downto 0) := "11";
                   v.dmaWrDescRet.valid := '1';

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -271,7 +271,7 @@ begin
                v.dmaWrTrack.metaAddr   := dmaWrDescAck.metaAddr;
                v.dmaWrTrack.address    := dmaWrDescAck.address;
                v.dmaWrTrack.maxSize    := dmaWrDescAck.maxSize;
-               v.dmaWrTrack.timout     := dmaWrDescAck.timout;
+               v.dmaWrTrack.timeout     := dmaWrDescAck.timeout;
 
                -- Descriptor return calls for dumping frame?
                if dmaWrDescAck.dropEn = '1' then
@@ -474,7 +474,7 @@ begin
                   v.dmaWrDescRet.valid := '1';
                   v.state := IDLE_S;
                -- Check for ACK timeout
-               elsif (r.stCount = r.dmaWrTrack.timout) then
+               elsif (r.stCount = r.dmaWrTrack.timeout) then
                   -- Set the flags
                   v.dmaWrDescRet.result(1 downto 0) := "11";
                   v.dmaWrDescRet.valid := '1';

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -82,6 +82,7 @@ architecture rtl of AxiStreamDmaV2Write is
       reqCount      : slv(31 downto 0);
       ackCount      : slv(31 downto 0);
       stCount       : slv(31 downto 0);
+      timeoutCnt    : slv(31 downto 0);
       awlen         : slv(AXI_CONFIG_G.LEN_BITS_C-1 downto 0);
       axiLen        : AxiLenType;
       wMaster       : AxiWriteMasterType;
@@ -100,6 +101,7 @@ architecture rtl of AxiStreamDmaV2Write is
       reqCount      => (others => '0'),
       ackCount      => (others => '0'),
       stCount       => (others => '0'),
+      timeoutCnt    => (others => '0'),
       awlen         => (others => '0'),
       axiLen        => AXI_LEN_INIT_C,
       wMaster       => axiWriteMasterInit(AXI_CONFIG_G, '1', "01", "0000"),
@@ -465,6 +467,7 @@ begin
                v.dmaWrDescRet.id        := r.dmaWrTrack.id;
                v.dmaWrDescRet.lastUser  := r.lastUser;
                v.dmaWrDescRet.continue  := r.continue;
+               v.dmaWrDescRet.result(3) := '0';
                v.dmaWrDescRet.result(2) := r.dmaWrTrack.overflow;
                v.dmaWrDescRet.result(1 downto 0) := r.result;
                -- Init record
@@ -478,6 +481,7 @@ begin
                   -- Set the flags
                   v.dmaWrDescRet.result(1 downto 0) := "11";
                   v.dmaWrDescRet.valid := '1';
+                  v.dmaWrDescRet.result(3) := '1';
                   v.reqCount := (others => '0');
                   v.ackCount := (others => '0');
                   v.state    := IDLE_S;


### PR DESCRIPTION
Added configurable timeout register to acknowledge the timeout

### Description
Added a configurable timeout register which was earlier hardcoded. If timeout reg value is reached before the write transactions are completed, the descriptor is returned.


