### PR TITLE
Update AxiStreamPkg.vhd from 512-bit to 1024-bit wide data bus support

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -24,7 +24,7 @@ use surf.StdRtlPkg.all;
 
 package AxiStreamPkg is
 
-   constant AXI_STREAM_MAX_TDATA_WIDTH_C : positive := 512;  -- Units of bits
+   constant AXI_STREAM_MAX_TDATA_WIDTH_C : positive := 1024;  -- Units of bits
    constant AXI_STREAM_MAX_TKEEP_WIDTH_C : positive := (AXI_STREAM_MAX_TDATA_WIDTH_C/8);  -- Units of bytes
 
    type AxiStreamMasterType is record


### PR DESCRIPTION
### Description
- Not ideal because in simulation the unused bits doe not get optimized away.
- However, I am working with a user than needs a 1024-bit wide AXI stream data bus.