### PR TITLE
updating ruckus.tcl to be consistent

### DIFF
--- a/devices/Silabs/si5394/ruckus.tcl
+++ b/devices/Silabs/si5394/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source $::env(RUCKUS_PROC_TCL)
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2fc/core/ruckus.tcl
+++ b/protocols/pgp/pgp2fc/core/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source $::env(RUCKUS_PROC_TCL)
 
 # Load Source Code
 loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2fc/gtp7/ruckus.tcl
+++ b/protocols/pgp/pgp2fc/gtp7/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
+source $::env(RUCKUS_PROC_TCL)
 
 # Load Source Code
 loadSource -lib surf -dir  "$::DIR_PATH/rtl"

--- a/protocols/pgp/pgp2fc/ruckus.tcl
+++ b/protocols/pgp/pgp2fc/ruckus.tcl
@@ -1,5 +1,5 @@
 # Load RUCKUS library
-source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+source $::env(RUCKUS_PROC_TCL)
 
 # Load the Core
 loadRuckusTcl "$::DIR_PATH/core"


### PR DESCRIPTION
### Description
- updating remaining ruckus.tcl files to use the more portable version of loading proc
- Required for non-Vivado projects to load the SURF source code into their IDE software