### PR TITLE
DMA write timeout issue resolved

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -399,7 +399,7 @@ begin
                v.stCount := r.stCount + 1;
             end if;
          ----------------------------------------------------------------------
-         when PAD_S => 
+         when PAD_S =>
             v.stCount := (others=>'0');
             -- We are able to push more data
             if v.wMaster.wvalid = '0' then
@@ -439,10 +439,10 @@ begin
 
                -- Write data channel
                v.wMaster.wlast := '1';
-               
+
                -- Increment the counter
                v.reqCount := r.reqCount + 1;
-               
+
                -- Descriptor data, 64-bits
                v.wMaster.wdata(63 downto 32)   := r.dmaWrTrack.size;
                v.wMaster.wdata(31 downto 24)   := r.dmaWrTrack.firstUser;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -412,9 +412,9 @@ begin
                   -- Frame is done. Go to return. Otherwise go to idle.
                   if r.dmaWrTrack.inUse = '0' then
                      if r.dmaWrTrack.metaEnable = '1' then
-                        v.state := META_S;
-                     else
                         v.state := RETURN_S;
+--                     else
+--                        v.state := RETURN_S;
                      end if;
                   else
                      v.state := IDLE_S;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -399,7 +399,7 @@ begin
                v.stCount := r.stCount + 1;
             end if;
          ----------------------------------------------------------------------
-         when PAD_S =>
+         when PAD_S => 
             v.stCount := (others=>'0');
             -- We are able to push more data
             if v.wMaster.wvalid = '0' then


### PR DESCRIPTION
Corrects the timeout issue we have been seeing before returning the write descriptor

### Description
Timeout would happen when the FSM waited for all the transactions to conclude before sending the write descriptor. It is resolved by incrementing the 'reqCount' when the metadata is sent. It now matches the 'ackCount' and timeout is fixed.


