### PR TITLE
Require a minimum Rogue version

### DIFF
--- a/python/surf/__init__.py
+++ b/python/surf/__init__.py
@@ -7,4 +7,4 @@
 ## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
-rogue.Version.minVersion('6.1.0')        
+rogue.Version.minVersion('6.1.0')

--- a/python/surf/__init__.py
+++ b/python/surf/__init__.py
@@ -7,3 +7,4 @@
 ## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
+rogue.Version.minVersion('6.1.0')        


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Set the minimum Rogue version to 6.1.0

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
In 6.1.0 we changed it so that bitSize is no longer necessary for arrays.
```python
            self.add(pr.RemoteVariable(
                name        = "Mem",
                description = "Memory Array",
                offset      = 0x0000,
                numValues   = nelms,
                valueBits   = 32,
                valueStride = 32,
                bitSize     = 32 * nelms, # This is no longer necessary
                bulkOpEn    = False,
            ))
```
But if it's not set, older rogue will default to bitSize=32 then fail.
Then the uses gets a cryptic (to them) error from inside library code they don't know.
When the real problem is just that they need to update rogue to match the version of surf they are using.

We could do this individually for each Rogue python file that needs it, but that seems difficult to manage.

