### PR TITLE
Fixed missing import in __init__.py

### DIFF
--- a/python/surf/__init__.py
+++ b/python/surf/__init__.py
@@ -7,4 +7,6 @@
 ## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
+import rogue
+
 rogue.Version.minVersion('6.1.0')

--- a/python/surf/__init__.py
+++ b/python/surf/__init__.py
@@ -8,5 +8,4 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 import rogue
-
 rogue.Version.minVersion('6.1.0')


### PR DESCRIPTION
### Description
The command for the minimum required rogue version in the _surf_ package initialization file (\_\_init__.py) was missing the _rogue_ package import.
