### PR TITLE
QSFP I2C Updates

### DIFF
--- a/devices/transceivers/rtl/QsfpCdrDisable.vhd
+++ b/devices/transceivers/rtl/QsfpCdrDisable.vhd
@@ -24,7 +24,7 @@ use surf.AxiLitePkg.all;
 entity QsfpCdrDisable is
    generic (
       TPD_G             : time     := 1 ns;
-      SIMULATION_G      : boolean;
+      SIMULATION_G      : boolean  := false;
       PERIODIC_UPDATE_G : positive := 30;  -- Units of seconds
       QSFP_BASE_ADDR_G  : Slv32Array;  -- List of the QSFP base address offsets
       AXIL_CLK_FREQ_G   : real);        -- Units of Hz

--- a/devices/transceivers/rtl/QsfpCdrDisable.vhd
+++ b/devices/transceivers/rtl/QsfpCdrDisable.vhd
@@ -1,0 +1,190 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Used to periodically write CDR disable to the QSFP modules via AXI-Lite crossbar
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity QsfpCdrDisable is
+   generic (
+      TPD_G             : time     := 1 ns;
+      SIMULATION_G      : boolean;
+      PERIODIC_UPDATE_G : positive := 30;  -- Units of seconds
+      QSFP_BASE_ADDR_G  : Slv32Array;  -- List of the QSFP base address offsets
+      AXIL_CLK_FREQ_G   : real);        -- Units of Hz
+   port (
+      -- AXI-Lite Register Interface (axilClk domain)
+      axilClk          : in  sl;
+      axilRst          : in  sl;
+      mAxilReadMaster  : out AxiLiteReadMasterType;
+      mAxilReadSlave   : in  AxiLiteReadSlaveType;
+      mAxilWriteMaster : out AxiLiteWriteMasterType;
+      mAxilWriteSlave  : in  AxiLiteWriteSlaveType);
+end QsfpCdrDisable;
+
+architecture rtl of QsfpCdrDisable is
+
+   constant TIMEOUT_1SEC_C : positive := ite(SIMULATION_G, 100, getTimeRatio(AXIL_CLK_FREQ_G, 1.0));
+
+   constant NUM_CH_G : positive := QSFP_BASE_ADDR_G'length;
+
+   type StateType is (
+      IDLE_S,
+      REQ_S,
+      ACK_S);
+
+   type RegType is record
+      ch    : natural range 0 to NUM_CH_G-1;
+      cnt   : natural range 0 to PERIODIC_UPDATE_G-1;
+      timer : natural range 0 to TIMEOUT_1SEC_C;
+      req   : AxiLiteReqType;
+      state : StateType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      ch    => 0,
+      cnt   => 0,
+      timer => 0,
+      req   => AXI_LITE_REQ_INIT_C,
+      state => IDLE_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal ack : AxiLiteAckType;
+
+begin
+
+   U_AxiLiteMaster : entity surf.AxiLiteMaster
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         req             => r.req,
+         ack             => ack,
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         axilWriteMaster => mAxilWriteMaster,
+         axilWriteSlave  => mAxilWriteSlave,
+         axilReadMaster  => mAxilReadMaster,
+         axilReadSlave   => mAxilReadSlave);
+
+   ---------------------
+   -- AXI Lite Interface
+   ---------------------
+   comb : process (ack, axilRst, r) is
+      variable v      : RegType;
+      variable regCon : AxiLiteEndPointType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Decrement the timer
+      if (r.timer /= 0) then
+         v.timer := r.timer -1;
+      end if;
+
+      -- State Machine
+      case (r.state) is
+         ----------------------------------------------------------------------
+         when IDLE_S =>
+            -- Check for timeout
+            if (r.timer = 0) then
+
+               -- Re-arm the timer
+               v.timer := TIMEOUT_1SEC_C;
+
+               -- Check for timeout
+               if (r.cnt = 0) then
+
+                  -- Re-arm the counter
+                  v.cnt := PERIODIC_UPDATE_G - 1;
+
+                  -- Next state
+                  v.state := REQ_S;
+
+               else
+                  -- Decrement the counter
+                  v.cnt := r.cnt - 1;
+               end if;
+
+            end if;
+         ----------------------------------------------------------------------
+         when REQ_S =>
+            -- Check if ready for next transaction
+            if (ack.done = '0') then
+
+               -- Setup the AXI-Lite Master request
+               v.req.request := '1';
+               v.req.rnw     := '0';    -- Write operation
+               v.req.address := QSFP_BASE_ADDR_G(r.ch) + x"0000_0188";  -- 0x188 = 98 x 4 (Page 00h, byte 98: Tx and Rx CDR control bits)
+               v.req.wrData  := x"0000_0000";  -- Turn off all the TX and RX CDR channels
+
+               -- Next state
+               v.state := ACK_S;
+
+            end if;
+         ----------------------------------------------------------------------
+         when ACK_S =>
+            -- Wait for DONE to set
+            if (ack.done = '1') then
+
+               -- Reset the flag
+               v.req.request := '0';
+
+               -- Check if this was last channel
+               if (r.ch = NUM_CH_G-1) then
+
+                  -- Reset the index
+                  v.ch := 0;
+
+                  -- Next state
+                  v.state := IDLE_S;
+
+               else
+
+                  -- Increment the channel
+                  v.ch := r.ch + 1;
+
+                  -- Next state
+                  v.state := REQ_S;
+
+               end if;
+
+            end if;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end rtl;

--- a/devices/transceivers/rtl/Sff8472.vhd
+++ b/devices/transceivers/rtl/Sff8472.vhd
@@ -51,7 +51,7 @@ architecture mapping of Sff8472 is
          dataSize    => 8,              -- in units of bits
          addrSize    => 8,              -- in units of bits
          endianness  => '0',            -- Little endian
-         repeatStart => '1'),           -- No repeat start
+         repeatStart => '1'),           -- Repeat Start
       1              => MakeI2cAxiLiteDevType(
          i2cAddress  => "1010001",      -- 2 wire address 1010001X (A2h)
          dataSize    => 8,              -- in units of bits

--- a/devices/transceivers/rtl/Sff8472Core.vhd
+++ b/devices/transceivers/rtl/Sff8472Core.vhd
@@ -49,7 +49,7 @@ architecture mapping of Sff8472Core is
          dataSize    => 8,              -- in units of bits
          addrSize    => 8,              -- in units of bits
          endianness  => '0',            -- Little endian
-         repeatStart => '1'),           -- No repeat start
+         repeatStart => '1'),           -- Repeat Start
       1              => MakeI2cAxiLiteDevType(
          i2cAddress  => "1010001",      -- 2 wire address 1010001X (A2h)
          dataSize    => 8,              -- in units of bits

--- a/devices/transceivers/rtl/Sff8472Core.vhd
+++ b/devices/transceivers/rtl/Sff8472Core.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Optical Module SFF-8472 Wrapper (I2C for SFP, QSFP, etc)
+-- Description: Optical Module SFF-8472 Core (I2C for SFP, QSFP, etc)
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -14,36 +14,34 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
-use ieee.std_logic_arith.all;
-
 
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
 use surf.I2cPkg.all;
 
-entity Sff8472 is
+entity Sff8472Core is
    generic (
-      TPD_G           : time := 1 ns;
-      I2C_SCL_FREQ_G  : real := 100.0E+3;    -- units of Hz
-      I2C_MIN_PULSE_G : real := 100.0E-9;    -- units of seconds
-      AXI_CLK_FREQ_G  : real := 156.25E+6);  -- units of Hz
+      TPD_G           : time    := 1 ns;
+      AXIL_PROXY_G    : boolean := false;
+      I2C_SCL_FREQ_G  : real    := 100.0E+3;    -- units of Hz
+      I2C_MIN_PULSE_G : real    := 100.0E-9;    -- units of seconds
+      AXI_CLK_FREQ_G  : real    := 156.25E+6);  -- units of Hz
    port (
-      -- I2C Ports
-      scl             : inout sl;
-      sda             : inout sl;
-      -- AXI-Lite Register Interface
-      axilReadMaster  : in    AxiLiteReadMasterType;
-      axilReadSlave   : out   AxiLiteReadSlaveType;
-      axilWriteMaster : in    AxiLiteWriteMasterType;
-      axilWriteSlave  : out   AxiLiteWriteSlaveType;
       -- Clocks and Resets
-      axilClk         : in    sl;
-      axilRst         : in    sl);
-end Sff8472;
+      axiClk         : in  sl;
+      axiRst         : in  sl;
+      -- AXI-Lite Register Interface
+      axiReadMaster  : in  AxiLiteReadMasterType;
+      axiReadSlave   : out AxiLiteReadSlaveType;
+      axiWriteMaster : in  AxiLiteWriteMasterType;
+      axiWriteSlave  : out AxiLiteWriteSlaveType;
+      -- I2C Ports
+      i2ci           : in  i2c_in_type;
+      i2co           : out i2c_out_type);
+end Sff8472Core;
 
-architecture mapping of Sff8472 is
+architecture mapping of Sff8472Core is
 
    constant SFF8472_I2C_CONFIG_C : I2cAxiLiteDevArray(0 to 1) := (
       0              => MakeI2cAxiLiteDevType(
@@ -61,24 +59,25 @@ architecture mapping of Sff8472 is
 
 begin
 
-   U_AxiI2C : entity surf.AxiI2cRegMaster
+   U_Core : entity surf.AxiI2cRegMasterCore
       generic map (
          TPD_G           => TPD_G,
+         AXIL_PROXY_G    => AXIL_PROXY_G,
          DEVICE_MAP_G    => SFF8472_I2C_CONFIG_C,
          I2C_SCL_FREQ_G  => I2C_SCL_FREQ_G,
          I2C_MIN_PULSE_G => I2C_MIN_PULSE_G,
          AXI_CLK_FREQ_G  => AXI_CLK_FREQ_G)
       port map (
-         -- I2C Ports
-         scl            => scl,
-         sda            => sda,
-         -- AXI-Lite Register Interface
-         axiReadMaster  => axilReadMaster,
-         axiReadSlave   => axilReadSlave,
-         axiWriteMaster => axilWriteMaster,
-         axiWriteSlave  => axilWriteSlave,
          -- Clocks and Resets
-         axiClk         => axilClk,
-         axiRst         => axilRst);
+         axiClk         => axiClk,
+         axiRst         => axiRst,
+         -- AXI-Lite Register Interface
+         axiReadMaster  => axiReadMaster,
+         axiReadSlave   => axiReadSlave,
+         axiWriteMaster => axiWriteMaster,
+         axiWriteSlave  => axiWriteSlave,
+         -- I2C Ports
+         i2ci           => i2ci,
+         i2co           => i2co);
 
 end mapping;

--- a/python/surf/devices/transceivers/_Qsfp.py
+++ b/python/surf/devices/transceivers/_Qsfp.py
@@ -19,7 +19,7 @@ import pyrogue as pr
 from surf.devices import transceivers
 
 class Qsfp(pr.Device):
-    def __init__(self,**kwargs):
+    def __init__(self, advDebug=False, **kwargs):
         super().__init__(**kwargs)
 
         ################
@@ -27,204 +27,206 @@ class Qsfp(pr.Device):
         ################
 
         self.add(pr.RemoteVariable(
-            name         = 'LowerIdentifier',
+            name         = 'Identifier',
             description  = 'Type of serial transceiver',
             offset       = (0 << 2),
-            bitSize      = 8,
+            bitSize      = 5,
             mode         = 'RO',
             enum         = transceivers.IdentifierDict,
         ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'RevisionCompliance',
-            description  = 'Type of serial transceiver',
-            offset       = (1 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            enum         = {
-                0x00: 'Revision not specified. Do not use for SFF-8636 rev 2.5 or higher.',
-                0x01: 'SFF-8436 Rev 4.8 or earlier',
-                0x02: 'Includes functionality described in revision 4.8 or earlier of SFF-8436, except that this byte and Bytes 186-189 are as defined in this document',
-                0x03: 'SFF-8636 Rev 1.3 or earlier',
-                0x04: 'SFF-8636 Rev 1.4',
-                0x05: 'SFF-8636 Rev 1.5',
-                0x06: 'SFF-8636 Rev 2.0',
-                0x07: 'SFF-8636 Rev 2.5, 2.6 and 2.7',
-                0x08: 'SFF-8636 Rev 2.8, 2.9 and 2.10',
-                0xFF: 'Reserved',
-            },
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name         = 'Flat_mem',
-            description  = 'Upper memory flat or paged',
-            offset       = (2 << 2),
-            bitSize      = 1,
-            bitOffset    = 2,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'RevisionCompliance',
+                description  = 'SFF-8636 revision compliance',
+                offset       = (1 << 2),
+                bitSize      = 8,
+                mode         = 'RO',
+                enum         = {
+                    0x00: 'Revision not specified. Do not use for SFF-8636 rev 2.5 or higher.',
+                    0x01: 'SFF-8436 Rev 4.8 or earlier',
+                    0x02: 'Includes functionality described in revision 4.8 or earlier of SFF-8436, except that this byte and Bytes 186-189 are as defined in this document',
+                    0x03: 'SFF-8636 Rev 1.3 or earlier',
+                    0x04: 'SFF-8636 Rev 1.4',
+                    0x05: 'SFF-8636 Rev 1.5',
+                    0x06: 'SFF-8636 Rev 2.0',
+                    0x07: 'SFF-8636 Rev 2.5, 2.6 and 2.7',
+                    0x08: 'SFF-8636 Rev 2.8, 2.9 and 2.10',
+                    0xFF: 'Reserved',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IntL',
-            description  = 'Digital state of the IntL Interrupt output pin',
-            offset       = (2 << 2),
-            bitSize      = 1,
-            bitOffset    = 1,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'Flat_mem',
+                description  = 'Upper memory flat or paged',
+                offset       = (2 << 2),
+                bitSize      = 1,
+                bitOffset    = 2,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'Data_Not_Ready',
-            description  = 'Indicates free-side does not yet have valid monitor data. The bit remains high until valid data can be read at which time the bit goes low.',
-            offset       = (2 << 2),
-            bitSize      = 1,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IntL',
+                description  = 'Digital state of the IntL Interrupt output pin',
+                offset       = (2 << 2),
+                bitSize      = 1,
+                bitOffset    = 1,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTxLos',
-            description  = 'Interrupt flags for TX LOS',
-            offset       = (3 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'Data_Not_Ready',
+                description  = 'Indicates free-side does not yet have valid monitor data. The bit remains high until valid data can be read at which time the bit goes low.',
+                offset       = (2 << 2),
+                bitSize      = 1,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedRxLos',
-            description  = 'Interrupt flags for RX LOS',
-            offset       = (3 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTxLos',
+                description  = 'Interrupt flags for TX LOS',
+                offset       = (3 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTxAdaptEqFault',
-            description  = 'Interrupt flags for TX Adapt EQ Fault',
-            offset       = (4 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedRxLos',
+                description  = 'Interrupt flags for RX LOS',
+                offset       = (3 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedRxFault',
-            description  = 'Interrupt flags for TX Transmitter/Laser fault indicator',
-            offset       = (4 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTxAdaptEqFault',
+                description  = 'Interrupt flags for TX Adapt EQ Fault',
+                offset       = (4 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTxCdrLol',
-            description  = 'Interrupt flags for TX CDR LOL indicator',
-            offset       = (5 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedRxFault',
+                description  = 'Interrupt flags for TX Transmitter/Laser fault indicator',
+                offset       = (4 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedRxCdrLol',
-            description  = 'Interrupt flags for RX CDR LOL indicator',
-            offset       = (5 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTxCdrLol',
+                description  = 'Interrupt flags for TX CDR LOL indicator',
+                offset       = (5 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTempHighAlarm',
-            description  = 'Interrupt flags for high-temperature alarm',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 7,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedRxCdrLol',
+                description  = 'Interrupt flags for RX CDR LOL indicator',
+                offset       = (5 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTempLowAlarm',
-            description  = 'Interrupt flags for low-temperature alarm',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 6,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTempHighAlarm',
+                description  = 'Interrupt flags for high-temperature alarm',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 7,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTempHighWarning',
-            description  = 'Interrupt flags for high-temperature warning',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 5,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTempLowAlarm',
+                description  = 'Interrupt flags for low-temperature alarm',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 6,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedTempLowWarning',
-            description  = 'Interrupt flags for low-temperature warning',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTempHighWarning',
+                description  = 'Interrupt flags for high-temperature warning',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'TcReadinessFlag',
-            description  = 'Asserted (one) after TC has stabilized. Returns to zero when read',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 1,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedTempLowWarning',
+                description  = 'Interrupt flags for low-temperature warning',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'InitComplete',
-            description  = 'Asserted (one) after initialization and/or reset has completed. Returns to zero when read.',
-            offset       = (6 << 2),
-            bitSize      = 1,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'TcReadinessFlag',
+                description  = 'Asserted (one) after TC has stabilized. Returns to zero when read',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 1,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedVccHighAlarm',
-            description  = 'Interrupt flags for high supply voltage alarm',
-            offset       = (7 << 2),
-            bitSize      = 1,
-            bitOffset    = 7,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'InitComplete',
+                description  = 'Asserted (one) after initialization and/or reset has completed. Returns to zero when read.',
+                offset       = (6 << 2),
+                bitSize      = 1,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedVccLowAlarm',
-            description  = 'Interrupt flags for low supply voltage alarm',
-            offset       = (7 << 2),
-            bitSize      = 1,
-            bitOffset    = 6,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedVccHighAlarm',
+                description  = 'Interrupt flags for high supply voltage alarm',
+                offset       = (7 << 2),
+                bitSize      = 1,
+                bitOffset    = 7,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedVccHighWarning',
-            description  = 'Interrupt flags for high supply voltage alarm',
-            offset       = (7 << 2),
-            bitSize      = 1,
-            bitOffset    = 5,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedVccLowAlarm',
+                description  = 'Interrupt flags for low supply voltage alarm',
+                offset       = (7 << 2),
+                bitSize      = 1,
+                bitOffset    = 6,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LatchedVccLowWarning',
-            description  = 'Interrupt flags for low supply voltage alarm',
-            offset       = (7 << 2),
-            bitSize      = 1,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedVccHighWarning',
+                description  = 'Interrupt flags for high supply voltage alarm',
+                offset       = (7 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'LatchedVccLowWarning',
+                description  = 'Interrupt flags for low supply voltage alarm',
+                offset       = (7 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
         # 8 All Vendor Specific
 
@@ -365,65 +367,71 @@ class Qsfp(pr.Device):
                 base         = pr.Bool,
             ))
 
-        for i in range(4):
-            self.add(pr.RemoteVariable(
-                name         = f'RxRateSelect[{i}]',
-                description  = f'Software rate select. Rx Channel {i} (refer Table 6-12 xN_Rate_Select with Extended Rate Selection)',
-                offset       = (87 << 2),
-                bitSize      = 2,
-                bitOffset    = 2*i,
-                mode         = 'RW',
-            ))
+        if advDebug:
 
-        for i in range(4):
-            self.add(pr.RemoteVariable(
-                name         = f'TxRateSelect[{i}]',
-                description  = f'Software rate select. Tx Channel {i} (refer Table 6-12 xN_Rate_Select with Extended Rate Selection)',
-                offset       = (88 << 2),
-                bitSize      = 2,
-                bitOffset    = 2*i,
-                mode         = 'RW',
-            ))
+            for i in range(4):
+                self.add(pr.RemoteVariable(
+                    name         = f'RxRateSelect[{i}]',
+                    description  = f'Software rate select. Rx Channel {i} (refer Table 6-12 xN_Rate_Select with Extended Rate Selection)',
+                    offset       = (87 << 2),
+                    bitSize      = 2,
+                    bitOffset    = 2*i,
+                    mode         = 'RW',
+                    hidden       = True,
+                ))
+
+            for i in range(4):
+                self.add(pr.RemoteVariable(
+                    name         = f'TxRateSelect[{i}]',
+                    description  = f'Software rate select. Tx Channel {i} (refer Table 6-12 xN_Rate_Select with Extended Rate Selection)',
+                    offset       = (88 << 2),
+                    bitSize      = 2,
+                    bitOffset    = 2*i,
+                    mode         = 'RW',
+                    hidden       = True,
+                ))
 
         # 89-92 All Reserved (Prior to Rev 2.10 used for SFF-8079 – now deprecated.)
 
-        self.add(pr.RemoteCommand(
-            name         = 'SoftReset',
-            description  = 'Software reset is a self-clearing bit that causes the module to be reset',
-            offset       = (93 << 2),
-            bitSize      = 1,
-            bitOffset    = 7,
-            function     = lambda cmd: cmd.post(1),
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name         = 'HighPowerClassEnable',
-            description  = 'Table 6-11 Truth table for enabling power classes (Page 00h Byte 93)',
-            offset       = (93 << 2),
-            bitSize      = 2,
-            bitOffset    = 2,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteCommand(
+                name         = 'SoftReset',
+                description  = 'Software reset is a self-clearing bit that causes the module to be reset',
+                offset       = (93 << 2),
+                bitSize      = 1,
+                bitOffset    = 7,
+                function     = lambda cmd: cmd.post(1),
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'PowerMode',
-            description  = 'Power set to low power mode: 1 sets to LP mode if PowerOverride is 1',
-            offset       = (93 << 2),
-            bitSize      = 1,
-            bitOffset    = 1,
-            mode         = 'RW',
-            base         = pr.Bool,
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'HighPowerClassEnable',
+                description  = 'Table 6-11 Truth table for enabling power classes (Page 00h Byte 93)',
+                offset       = (93 << 2),
+                bitSize      = 2,
+                bitOffset    = 2,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'PowerOverride',
-            description  = '0: allows setting power mode with hardware, 1: allows setting power mode with software',
-            offset       = (93 << 2),
-            bitSize      = 1,
-            bitOffset    = 0,
-            mode         = 'RW',
-            base         = pr.Bool,
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'PowerMode',
+                description  = 'Power set to low power mode: 1 sets to LP mode if PowerOverride is 1',
+                offset       = (93 << 2),
+                bitSize      = 1,
+                bitOffset    = 1,
+                mode         = 'RW',
+                base         = pr.Bool,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'PowerOverride',
+                description  = '0: allows setting power mode with hardware, 1: allows setting power mode with software',
+                offset       = (93 << 2),
+                bitSize      = 1,
+                bitOffset    = 0,
+                mode         = 'RW',
+                base         = pr.Bool,
+            ))
 
         # 94-97 All Reserved
 
@@ -449,323 +457,329 @@ class Qsfp(pr.Device):
                 base         = pr.Bool,
             ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'LPMode_TxDis_Pin',
-            description  = 'IntL/LOSL output signal control',
-            offset       = (99 << 2),
-            bitSize      = 1,
-            bitOffset    = 1,
-            mode         = 'RW',
-            enum         = {
-                0x0: 'LPMode',
-                0x1: 'TxDis',
-            },
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name         = 'IntL_LOSL_Pin',
-            description  = 'IntL/LOSL output signal control',
-            offset       = (99 << 2),
-            bitSize      = 1,
-            bitOffset    = 0,
-            mode         = 'RW',
-            enum         = {
-                0x0: 'IntL',
-                0x1: 'LOSL',
-            },
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LPMode_TxDis_Pin',
+                description  = 'IntL/LOSL output signal control',
+                offset       = (99 << 2),
+                bitSize      = 1,
+                bitOffset    = 1,
+                mode         = 'RW',
+                enum         = {
+                    0x0: 'LPMode',
+                    0x1: 'TxDis',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTxLosMask',
-            description  = 'Masking bits for TX LOS',
-            offset       = (100 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IntL_LOSL_Pin',
+                description  = 'IntL/LOSL output signal control',
+                offset       = (99 << 2),
+                bitSize      = 1,
+                bitOffset    = 0,
+                mode         = 'RW',
+                enum         = {
+                    0x0: 'IntL',
+                    0x1: 'LOSL',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqRxLosMask',
-            description  = 'Masking bits for RX LOS',
-            offset       = (100 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTxLosMask',
+                description  = 'Masking bits for TX LOS',
+                offset       = (100 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTxAdaptEqFaultMask',
-            description  = 'Masking bits for TX Adapt EQ Fault',
-            offset       = (101 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqRxLosMask',
+                description  = 'Masking bits for RX LOS',
+                offset       = (100 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqRxFaultMask',
-            description  = 'Masking bits for TX Transmitter/Laser fault indicator',
-            offset       = (101 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTxAdaptEqFaultMask',
+                description  = 'Masking bits for TX Adapt EQ Fault',
+                offset       = (101 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTxCdrLolMask',
-            description  = 'Masking bits for TX CDR LOL indicator',
-            offset       = (102 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqRxFaultMask',
+                description  = 'Masking bits for TX Transmitter/Laser fault indicator',
+                offset       = (101 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqRxCdrLolMask',
-            description  = 'Masking bits for RX CDR LOL indicator',
-            offset       = (102 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTxCdrLolMask',
+                description  = 'Masking bits for TX CDR LOL indicator',
+                offset       = (102 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTempHighAlarmMask',
-            description  = 'Masking bits for high-temperature alarm',
-            offset       = (103 << 2),
-            bitSize      = 1,
-            bitOffset    = 7,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqRxCdrLolMask',
+                description  = 'Masking bits for RX CDR LOL indicator',
+                offset       = (102 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTempLowAlarmMask',
-            description  = 'Masking bits for low-temperature alarm',
-            offset       = (103 << 2),
-            bitSize      = 1,
-            bitOffset    = 6,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTempHighAlarmMask',
+                description  = 'Masking bits for high-temperature alarm',
+                offset       = (103 << 2),
+                bitSize      = 1,
+                bitOffset    = 7,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTempHighWarningMask',
-            description  = 'Masking bits for high-temperature warning',
-            offset       = (103 << 2),
-            bitSize      = 1,
-            bitOffset    = 5,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTempLowAlarmMask',
+                description  = 'Masking bits for low-temperature alarm',
+                offset       = (103 << 2),
+                bitSize      = 1,
+                bitOffset    = 6,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqTempLowWarningMask',
-            description  = 'Masking bits for low-temperature warning',
-            offset       = (103 << 2),
-            bitSize      = 1,
-            bitOffset    = 4,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTempHighWarningMask',
+                description  = 'Masking bits for high-temperature warning',
+                offset       = (103 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'TcReadinessFlagMask',
-            description  = 'Masking bit for TC readiness flag',
-            offset       = (103 << 2),
-            bitSize      = 1,
-            bitOffset    = 1,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqTempLowWarningMask',
+                description  = 'Masking bits for low-temperature warning',
+                offset       = (103 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqVccHighAlarmMask',
-            description  = 'Masking bits for high supply voltage alarm',
-            offset       = (104 << 2),
-            bitSize      = 1,
-            bitOffset    = 7,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'TcReadinessFlagMask',
+                description  = 'Masking bit for TC readiness flag',
+                offset       = (103 << 2),
+                bitSize      = 1,
+                bitOffset    = 1,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqVccLowAlarmMask',
-            description  = 'Masking bits for low supply voltage alarm',
-            offset       = (104 << 2),
-            bitSize      = 1,
-            bitOffset    = 6,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqVccHighAlarmMask',
+                description  = 'Masking bits for high supply voltage alarm',
+                offset       = (104 << 2),
+                bitSize      = 1,
+                bitOffset    = 7,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqVccHighWarningMask',
-            description  = 'Masking bits for high supply voltage alarm',
-            offset       = (104 << 2),
-            bitSize      = 1,
-            bitOffset    = 5,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqVccLowAlarmMask',
+                description  = 'Masking bits for low supply voltage alarm',
+                offset       = (104 << 2),
+                bitSize      = 1,
+                bitOffset    = 6,
+                mode         = 'RW',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'IrqVccLowWarningMask',
-            description  = 'Masking bits for low supply voltage alarm',
-            offset       = (104 << 2),
-            bitSize      = 1,
-            bitOffset    = 4,
-            mode         = 'RW',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'IrqVccHighWarningMask',
+                description  = 'Masking bits for high supply voltage alarm',
+                offset       = (104 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'IrqVccLowWarningMask',
+                description  = 'Masking bits for low supply voltage alarm',
+                offset       = (104 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RW',
+            ))
 
         # 105-106 Vendor Specific
 
-        self.add(pr.RemoteVariable(
-            name         = 'MaxPowerConsumption',
-            description  = 'Maximum power consumption of module',
-            offset       = (107 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            units        = '0.1W',
-        ))
+        if advDebug:
 
-        self.addRemoteVariables(
-            name         = 'PropagationDelayRaw',
-            description  = 'propagation delay',
-            offset       = (108 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            number       = 2, # BYTE108:BYTE109
-            stride       = 4,
-            hidden       = True,
-        )
+            self.add(pr.RemoteVariable(
+                name         = 'MaxPowerConsumption',
+                description  = 'Maximum power consumption of module',
+                offset       = (107 << 2),
+                bitSize      = 8,
+                mode         = 'RO',
+                units        = '0.1W',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'AdvLowPwrMode',
-            description  = 'The code indicates maximum power consumption less than 1.5 W',
-            offset       = (110 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-            enum         = {
-                0x0: '1.5W or higher',
-                0x1: 'no more than 1 W',
-                0x2: 'no more than 0.75 W',
-                0x3: 'no more than 0.5 W',
-                0xF: 'UNDEFINED',
-            },
-        ))
+            self.addRemoteVariables(
+                name         = 'PropagationDelayRaw',
+                description  = 'propagation delay',
+                offset       = (108 << 2),
+                bitSize      = 8,
+                mode         = 'RO',
+                number       = 2, # BYTE108:BYTE109
+                stride       = 4,
+                hidden       = True,
+            )
 
-        self.add(pr.RemoteVariable(
-            name         = 'FarSideManaged',
-            description  = 'A value of 1 indicates that the far end is managed and complies with SFF-8636',
-            offset       = (110 << 2),
-            bitSize      = 1,
-            bitOffset    = 3,
-            mode         = 'RO',
-            base         = pr.Bool,
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'AdvLowPwrMode',
+                description  = 'The code indicates maximum power consumption less than 1.5 W',
+                offset       = (110 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+                enum         = {
+                    0x0: '1.5W or higher',
+                    0x1: 'no more than 1 W',
+                    0x2: 'no more than 0.75 W',
+                    0x3: 'no more than 0.5 W',
+                    0xF: 'UNDEFINED',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'MinOperatingVoltage',
-            description  = 'The code indicates nominal supply voltages lower than 3.3 V.',
-            offset       = (110 << 2),
-            bitSize      = 3,
-            bitOffset    = 0,
-            mode         = 'RO',
-            enum         = {
-                0x0: '3.3 V',
-                0x1: '2.5 V',
-                0x2: '1.8 V',
-                0x7: 'UNDEFINED',
-            },
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'FarSideManaged',
+                description  = 'A value of 1 indicates that the far end is managed and complies with SFF-8636',
+                offset       = (110 << 2),
+                bitSize      = 1,
+                bitOffset    = 3,
+                mode         = 'RO',
+                base         = pr.Bool,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'MinOperatingVoltage',
+                description  = 'The code indicates nominal supply voltages lower than 3.3 V.',
+                offset       = (110 << 2),
+                bitSize      = 3,
+                bitOffset    = 0,
+                mode         = 'RO',
+                enum         = {
+                    0x0: '3.3 V',
+                    0x1: '2.5 V',
+                    0x2: '1.8 V',
+                    0x7: 'UNDEFINED',
+                },
+            ))
 
         # 111-112 Assigned for use by PCI Express
 
-        self.add(pr.RemoteVariable(
-            name         = 'FarEndImpl',
-            description  = 'Far End Implementation',
-            offset       = (113 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-            enum         = {
-                0x0: 'Far end is unspecified',
-                0x1: 'Cable with single far-end with 4 channels implemented, or separable module with a 4-channel connector',
-                0x2: 'Cable with single far-end with 2 channels implemented, or separable module with a 2-channel connector',
-                0x3: 'Cable with single far-end with 1 channel implemented, or separable module with a 1-channel connector',
-                0x4: '4 far-ends with 1 channel implemented in each (i.e. 4x1 break out)',
-                0x5: '2 far-ends with 2 channels implemented in each (i.e. 2x2 break out)',
-                0x6: '2 far-ends with 1 channel implemented in each (i.e. 2x1 break out)',
-                0xF: 'UNDEFINED',
-            },
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name         = 'NearEndImpl',
-            description  = 'Near End Implementation Bit Mask (1: implemented, 0: Not implemented)',
-            offset       = (113 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'FarEndImpl',
+                description  = 'Far End Implementation',
+                offset       = (113 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+                enum         = {
+                    0x0: 'Far end is unspecified',
+                    0x1: 'Cable with single far-end with 4 channels implemented, or separable module with a 4-channel connector',
+                    0x2: 'Cable with single far-end with 2 channels implemented, or separable module with a 2-channel connector',
+                    0x3: 'Cable with single far-end with 1 channel implemented, or separable module with a 1-channel connector',
+                    0x4: '4 far-ends with 1 channel implemented in each (i.e. 4x1 break out)',
+                    0x5: '2 far-ends with 2 channels implemented in each (i.e. 2x2 break out)',
+                    0x6: '2 far-ends with 1 channel implemented in each (i.e. 2x1 break out)',
+                    0xF: 'UNDEFINED',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'Tx_TurnOn_MaxDuration',
-            description  = 'Tx_TurnOn_MaxDuration for microQSFP MSA (0000b=Not implemented)',
-            offset       = (114 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'NearEndImpl',
+                description  = 'Near End Implementation Bit Mask (1: implemented, 0: Not implemented)',
+                offset       = (113 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'DataPathInit_MaxDuration',
-            description  = 'DataPathInit_MaxDuration for microQSFP MSA (0000b=Not implemented)',
-            offset       = (114 << 2),
-            bitSize      = 4,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'Tx_TurnOn_MaxDuration',
+                description  = 'Tx_TurnOn_MaxDuration for microQSFP MSA (0000b=Not implemented)',
+                offset       = (114 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'ModSelL_wait_time_exponent',
-            description  = 'The ModSelL wait time is the mantissa x 2^exponent expressed in microseconds. (0=Not implemented)',
-            offset       = (115 << 2),
-            bitSize      = 3,
-            bitOffset    = 5,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'DataPathInit_MaxDuration',
+                description  = 'DataPathInit_MaxDuration for microQSFP MSA (0000b=Not implemented)',
+                offset       = (114 << 2),
+                bitSize      = 4,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'ModSelL_wait_time_mantissa',
-            description  = 'The ModSelL wait time is the mantissa x 2^exponent expressed in microseconds. (0=Not implemented)',
-            offset       = (115 << 2),
-            bitSize      = 5,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'ModSelL_wait_time_exponent',
+                description  = 'The ModSelL wait time is the mantissa x 2^exponent expressed in microseconds. (0=Not implemented)',
+                offset       = (115 << 2),
+                bitSize      = 3,
+                bitOffset    = 5,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'SecondExtSpecCompliance',
-            description  = 'Secondary Extended Specification Compliance Codes (See SFF-8024 Transceiver Management)',
-            offset       = (116 << 2),
-            bitSize      = 8,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'ModSelL_wait_time_mantissa',
+                description  = 'The ModSelL wait time is the mantissa x 2^exponent expressed in microseconds. (0=Not implemented)',
+                offset       = (115 << 2),
+                bitSize      = 5,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'SecondExtSpecCompliance',
+                description  = 'Secondary Extended Specification Compliance Codes (See SFF-8024 Transceiver Management)',
+                offset       = (116 << 2),
+                bitSize      = 8,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
 
-        self.add(pr.RemoteVariable(
-            name         = 'TransceiverSubtype',
-            description  = 'Transceiver Sub-type code (See SFF-8024 Transceiver Management)',
-            offset       = (117 << 2),
-            bitSize      = 4,
-            bitOffset    = 4,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'TransceiverSubtype',
+                description  = 'Transceiver Sub-type code (See SFF-8024 Transceiver Management)',
+                offset       = (117 << 2),
+                bitSize      = 4,
+                bitOffset    = 4,
+                mode         = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'FiberFaceType',
-            description  = 'Fiber Face Type code (See SFF-8024 Transceiver Management)',
-            offset       = (117 << 2),
-            bitSize      = 2,
-            bitOffset    = 0,
-            mode         = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'FiberFaceType',
+                description  = 'Fiber Face Type code (See SFF-8024 Transceiver Management)',
+                offset       = (117 << 2),
+                bitSize      = 2,
+                bitOffset    = 0,
+                mode         = 'RO',
+            ))
 
         # 118 118 Reserved
         # 119 122 Optional Password Change
@@ -776,49 +790,51 @@ class Qsfp(pr.Device):
         # Upper Page 00h
         ################
 
-        self.add(pr.RemoteVariable(
-            name         = 'UppperIdentifier',
-            description  = 'Type of serial transceiver',
-            offset       = (128 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            enum         = transceivers.IdentifierDict,
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name         = 'LowPowerClass',
-            description  = 'Extended Identifier of free side device. Includes power classes, CLEI codes, CDR capability (See Table 6-16)',
-            offset       = (129 << 2),
-            bitSize      = 2,
-            bitOffset    = 6,
-            mode         = 'RO',
-            enum         = {
-                0x0: 'Power Class 1 (1.5 W max.)',
-                0x1: 'Power Class 2 (2.0 W max.)',
-                0x2: 'Power Class 3 (2.5 W max.)',
-                0x3: 'Power Class 4 (3.5 W max.) and Power Classes 5, 6 or 7',
-            },
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'UppperIdentifier',
+                description  = 'Type of serial transceiver',
+                offset       = (128 << 2),
+                bitSize      = 5,
+                mode         = 'RO',
+                enum         = transceivers.IdentifierDict,
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'PowerClass8Impl',
-            description  = 'Power Class 8 implemented (Max power declared in byte 107)',
-            offset       = (129 << 2),
-            bitSize      = 1,
-            bitOffset    = 5,
-            mode         = 'RO',
-            base         = pr.Bool,
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'LowPowerClass',
+                description  = 'Extended Identifier of free side device. Includes power classes, CLEI codes, CDR capability (See Table 6-16)',
+                offset       = (129 << 2),
+                bitSize      = 2,
+                bitOffset    = 6,
+                mode         = 'RO',
+                enum         = {
+                    0x0: 'Power Class 1 (1.5 W max.)',
+                    0x1: 'Power Class 2 (2.0 W max.)',
+                    0x2: 'Power Class 3 (2.5 W max.)',
+                    0x3: 'Power Class 4 (3.5 W max.) and Power Classes 5, 6 or 7',
+                },
+            ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'CleiCodePresent',
-            description  = 'CLEI code present in Page 02h',
-            offset       = (129 << 2),
-            bitSize      = 1,
-            bitOffset    = 4,
-            mode         = 'RO',
-            base         = pr.Bool,
-        ))
+            self.add(pr.RemoteVariable(
+                name         = 'PowerClass8Impl',
+                description  = 'Power Class 8 implemented (Max power declared in byte 107)',
+                offset       = (129 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RO',
+                base         = pr.Bool,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'CleiCodePresent',
+                description  = 'CLEI code present in Page 02h',
+                offset       = (129 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RO',
+                base         = pr.Bool,
+            ))
 
         self.add(pr.RemoteVariable(
             name         = 'TxCdrPresent',
@@ -840,20 +856,21 @@ class Qsfp(pr.Device):
             base         = pr.Bool,
         ))
 
-        self.add(pr.RemoteVariable(
-            name         = 'HighPowerClass',
-            description  = 'See Byte 93 bit 2 to enable.',
-            offset       = (129 << 2),
-            bitSize      = 2,
-            bitOffset    = 0,
-            mode         = 'RO',
-            enum         = {
-                0x0: 'Power Classes 1 to 4',
-                0x1: 'Power Class 5 (4.0 W max.) See Byte 93 bit 2 to enable.',
-                0x2: 'Power Class 6 (4.5 W max.) See Byte 93 bit 2 to enable.',
-                0x3: 'Power Class 7 (5.0 W max.) See Byte 93 bit 2 to enable',
-            },
-        ))
+        if advDebug:
+            self.add(pr.RemoteVariable(
+                name         = 'HighPowerClass',
+                description  = 'See Byte 93 bit 2 to enable.',
+                offset       = (129 << 2),
+                bitSize      = 2,
+                bitOffset    = 0,
+                mode         = 'RO',
+                enum         = {
+                    0x0: 'Power Classes 1 to 4',
+                    0x1: 'Power Class 5 (4.0 W max.) See Byte 93 bit 2 to enable.',
+                    0x2: 'Power Class 6 (4.5 W max.) See Byte 93 bit 2 to enable.',
+                    0x3: 'Power Class 7 (5.0 W max.) See Byte 93 bit 2 to enable',
+                },
+            ))
 
         self.add(pr.RemoteVariable(
             name        = 'Connector',
@@ -868,77 +885,79 @@ class Qsfp(pr.Device):
         # TODO: Add registers 131 ~ 138
         ###############################################################
 
-        self.add(pr.RemoteVariable(
-            name        = 'Encoding',
-            description = 'Code for serial encoding algorithm. (See SFF-8024 Transceiver Management)',
-            offset      = (139 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+        if advDebug:
 
-        self.add(pr.RemoteVariable(
-            name        = 'SignalingRate',
-            description = 'Nominal signaling rate, units of 100 MBd. For rate > 25.4 GBd, set this to FFh and use Byte 222.',
-            offset      = (140 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Encoding',
+                description = 'Code for serial encoding algorithm. (See SFF-8024 Transceiver Management)',
+                offset      = (139 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'ExtendedRateSelect',
-            description = 'Tags for extended rate select compliance. See Table 6-18.',
-            offset      = (141 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'SignalingRate',
+                description = 'Nominal signaling rate, units of 100 MBd. For rate > 25.4 GBd, set this to FFh and use Byte 222.',
+                offset      = (140 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'Length_SMF',
-            description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for SMF fiber in km *. A value of 1 shall be used for reaches from 0 to 1 km.',
-            offset      = (142 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'ExtendedRateSelect',
+                description = 'Tags for extended rate select compliance. See Table 6-18.',
+                offset      = (141 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'Length_OM3',
-            description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for EBW 50/125 um fiber (OM3), units of 2 m',
-            offset      = (143 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Length_SMF',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for SMF fiber in km *. A value of 1 shall be used for reaches from 0 to 1 km.',
+                offset      = (142 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'Length_OM2',
-            description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 62.5/125 um fiber (OM1), units of 1 m *, or copper cable attenuation in dB at 25.78 GHz.',
-            offset      = (145 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM3',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for EBW 50/125 um fiber (OM3), units of 2 m',
+                offset      = (143 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'Length_OM1',
-            description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 50/125 um fiber (OM2), units of 1 m',
-            offset      = (144 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM2',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 62.5/125 um fiber (OM1), units of 1 m *, or copper cable attenuation in dB at 25.78 GHz.',
+                offset      = (145 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'Length_Copper',
-            description = 'Length of passive or active cable assembly (units of 1 m) or link length supported at the signaling rate in byte 140 or page 00h byte 222, for OM4 50/125 um fiber (units of 2 m) as indicated by Byte 147. See 6.3.12',
-            offset      = (146 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM1',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 50/125 um fiber (OM2), units of 1 m',
+                offset      = (144 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
-        self.add(pr.RemoteVariable(
-            name        = 'DeviceTechnology',
-            description = 'Device technology (Table 6-19 and Table 6-20).',
-            offset      = (147 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-        ))
+            self.add(pr.RemoteVariable(
+                name        = 'Length_Copper',
+                description = 'Length of passive or active cable assembly (units of 1 m) or link length supported at the signaling rate in byte 140 or page 00h byte 222, for OM4 50/125 um fiber (units of 2 m) as indicated by Byte 147. See 6.3.12',
+                offset      = (146 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'DeviceTechnology',
+                description = 'Device technology (Table 6-19 and Table 6-20).',
+                offset      = (147 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
 
         self.addRemoteVariables(
             name         = 'VendorNameRaw',

--- a/python/surf/devices/transceivers/__init__.py
+++ b/python/surf/devices/transceivers/__init__.py
@@ -111,6 +111,7 @@ IdentifierDict = {
     0x1C: 'MiniLinkx4',
     0x1D: 'MiniLinkx8',
     0x1E: 'QSFP+',
+    0x1F: 'SFP-DD',
 }
 
 ExtIdentifierDict = {


### PR DESCRIPTION
### Description
- This module used to periodically write CDR disable to the QSFP modules via AXI-Lite crossbar
- The reason why this is not integrated into a AXI-Lite I2C Master endpoint is because the QSFP I2C access might be behind a I2C MUX and periodically updates with the I2C MUX context will cause collisions on the I2C bus