### PR TITLE
corner case fix for AxiStreamPkg.vhd

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamPkg.vhd
+++ b/axi/axi-stream/rtl/AxiStreamPkg.vhd
@@ -256,7 +256,7 @@ package body AxiStreamPkg is
       lsb := axisConfig.TUSER_BITS_C*pos;
 
       if axisConfig.TUSER_BITS_C > 0 then
-         for i in 0 to 8*AXI_STREAM_MAX_TKEEP_WIDTH_C-1 loop
+         for i in 0 to AXI_STREAM_MAX_TDATA_WIDTH_C-ret'high-ret'low-1 loop
             if lsb = i then
                ret := axisMaster.tUser(ret'high+i downto ret'low+i);
             end if;
@@ -303,7 +303,7 @@ package body AxiStreamPkg is
 
       if (axisConfig.TUSER_BITS_C > 0 and axisConfig.TUSER_MODE_C /= TUSER_NONE_C) then
 
-         for i in 0 to 8*AXI_STREAM_MAX_TKEEP_WIDTH_C-1 loop
+         for i in 0 to AXI_STREAM_MAX_TDATA_WIDTH_C-fieldValue'high-fieldValue'low-1 loop
             if lsb = i then
                axisMaster.tUser(fieldValue'high+i downto fieldValue'low+i) := fieldValue;
             end if;


### PR DESCRIPTION
### Description
- Prevent `for loop` being beyond the range of the `tUser`
- Reminder that the loop is required (instead of setting the field directly) due to capability with [Cadence Genus support](https://github.com/slaclab/surf/commit/44f383b75e2a3a3dfd04d5db7ef15e6058f64b31)
