### PR TITLE
Sensitivity list fix in AxiStreamDepacketizer2

### DIFF
--- a/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
+++ b/protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd
@@ -272,8 +272,8 @@ begin
 
    end generate;
 
-   comb : process (inputAxisMaster, linkGood, outputAxisSlave, r, ramCrcRem,
-                   ramPacketActiveOut, ramPacketSeqOut, ramSentEofeOut) is
+   comb : process (crcOut, inputAxisMaster, linkGood, outputAxisSlave, r, ramCrcRem, ramPacketActiveOut,
+                   ramPacketSeqOut, ramSentEofeOut) is
       variable v         : RegType;
       variable sof       : sl;
       variable lastBytes : integer;
@@ -451,7 +451,7 @@ begin
                      -- Set packetActive in ram for this tdest
                      -- v.packetSeq is already correct
                      v.packetActive := '1';
-                     v.sentEofe     := '0';  -- Clear any frame error
+                     v.sentEofe     := '0';                   -- Clear any frame error
                      v.ramWe        := '1';
                      v.debug.sop    := '1';
                      v.debug.sof    := sof;

--- a/scripts/emacs_beautify_all_vhdl.sh
+++ b/scripts/emacs_beautify_all_vhdl.sh
@@ -18,6 +18,9 @@ while IFS= read -r file; do EXCLUDE_FILES+=("$file"); done < <(find "$SCRIPT_DIR
 while IFS= read -r file; do EXCLUDE_FILES+=("$file"); done < <(find "$SCRIPT_DIR/../protocols/i2c/rtl/stdlib.vhd" -type f -name "*.vhd")
 while IFS= read -r file; do EXCLUDE_FILES+=("$file"); done < <(find "$SCRIPT_DIR/../protocols/i2c/rtl/orig" -type f -name "*.vhd")
 
+# Manually add a specific file to the exclude list
+EXCLUDE_FILES+=("$SCRIPT_DIR/../protocols/packetizer/rtl/AxiStreamDepacketizer2.vhd")
+
 # Build a lookup table using associative array
 declare -A EXCLUDE_MAP
 for file in "${EXCLUDE_FILES[@]}"; do


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

There is a bug in the emacs vhdl-mode sensitivity list generator that doesn't catch that `crcOut` is used in the process.
This is probably because its usage is buried in a procedure.
The signal has been manually added to the sensitivity list.