### PR TITLE
UDP Tx Engine: Fix inferred latch

### DIFF
--- a/ethernet/UdpEngine/rtl/UdpEngineTx.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineTx.vhd
@@ -81,6 +81,7 @@ architecture rtl of UdpEngineTx is
       chPntr      : natural range 0 to SIZE_G-1;
       index       : natural range 0 to SIZE_G-1;
       arpPos      : Slv8Array(SIZE_G-1 downto 0);
+      arpTabPos   : Slv8Array(SIZE_G-1 downto 0);
       obDhcpSlave : AxiStreamSlaveType;
       ibSlaves    : AxiStreamSlaveArray(SIZE_G-1 downto 0);
       txMaster    : AxiStreamMasterType;
@@ -95,6 +96,7 @@ architecture rtl of UdpEngineTx is
       chPntr      => 0,
       index       => 0,
       arpPos      => (others => (others => '0')),
+      arpTabPos   => (others => (others => '0')),
       obDhcpSlave => AXI_STREAM_SLAVE_INIT_C,
       ibSlaves    => (others => AXI_STREAM_SLAVE_INIT_C),
       txMaster    => AXI_STREAM_MASTER_INIT_C,
@@ -114,8 +116,7 @@ begin
    comb : process (arpTabFound, arpTabIpAddr, arpTabMacAddr, ibMasters,
                    localIp, localMac, obDhcpMaster, r, remoteIp, remoteMac,
                    remotePort, rst, txSlave) is
-      variable v       : RegType;
-      variable arpPosV : Slv8Array(SIZE_G-1 downto 0);
+      variable v : RegType;
    begin
       -- Latch the current value
       v := r;
@@ -204,14 +205,14 @@ begin
                      v.ibSlaves(r.index).tReady := '1';
                   end if;
                else
-                  v.chPntr         := r.index;
-                  arpPosV(r.index) := ibMasters(r.index).tDest;
-                  v.state          := ACC_ARP_TAB_S;
+                  v.chPntr             := r.index;
+                  v.arpTabPos(r.index) := ibMasters(r.index).tDest;
+                  v.state              := ACC_ARP_TAB_S;
                end if;
             end if;
          -----------------------------------------------------------------------
          when ACC_ARP_TAB_S =>
-            arpPosV(r.chPntr) := ibMasters(r.chPntr).tDest;
+            v.arpTabPos(r.chPntr) := ibMasters(r.chPntr).tDest;
             if arpTabFound(r.chPntr) = '0' then
                v.linkUp(r.chPntr)          := '0';
                -- Blow off the data..
@@ -444,7 +445,7 @@ begin
       obDhcpSlave <= v.obDhcpSlave;
       txMaster    <= r.txMaster;
       linkUp      <= r.linkUp;
-      arpTabPos   <= arpPosV;
+      arpTabPos   <= v.arpTabPos;
 
       -- Reset
       if (rst = '1') then


### PR DESCRIPTION
### Description
- After a bug fix in ruckus (https://github.com/slaclab/ruckus/pull/347), we discovered this latch in the UDP code, which is bad practice and not allow in the SURF coding style