### PR TITLE
SugoiAxiLitePixelMatrixConfig: Added function to read programmed pixel 

### DIFF
--- a/python/surf/protocols/sugoi/_SugoiAxiLitePixelMatrixConfig.py
+++ b/python/surf/protocols/sugoi/_SugoiAxiLitePixelMatrixConfig.py
@@ -186,3 +186,9 @@ class SugoiAxiLitePixelMatrixConfig(pr.Device):
                     click.secho( f'.CSV file must be {self.numCol} X {self.numRow} (cols X rows) pixels')
             else:
                 click.secho( "Warning: ASIC enable is set to False!")
+
+        @self.command(value='',description="",)
+        def ReadAllMatrix(arg):
+            for i in range (self.numRow):
+                click.secho(f' Row: {i}')
+                click.secho(f' Read: {self._PixData[i].get()}')


### PR DESCRIPTION
### Description
Added a function to read the programmed pixels of the ASICs that use this function.
This is especially useful for SparkPixRT and SparkPixS ASICs where the slow control physical signals have an extra dangling lane inside the ASIC (this makes readsback-verify to fail).
