### PR TITLE
TenGigEth Patch for Vivado 2025.1

### DIFF
--- a/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
+++ b/ethernet/TenGigEthCore/gth7/rtl/TenGigEthGth7.vhd
@@ -158,6 +158,10 @@ architecture mapping of TenGigEthGth7 is
    signal macTxAxisMaster : AxiStreamMasterType;
    signal macTxAxisSlave  : AxiStreamSlaveType;
 
+   -- Bug fix for building with Vivado 2025.1
+   attribute dont_touch                        : string;
+   attribute dont_touch of configurationVector : signal is "TRUE";
+
 begin
 
    phyReady        <= status.phyReady;

--- a/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
+++ b/ethernet/TenGigEthCore/gthUltraScale/rtl/TenGigEthGthUltraScale.vhd
@@ -203,6 +203,11 @@ architecture mapping of TenGigEthGthUltraScale is
    signal macTxAxisMaster : AxiStreamMasterType;
    signal macTxAxisSlave  : AxiStreamSlaveType;
 
+   -- Bug fix for building with Vivado 2025.1
+   -- ERROR: [Opt 31-67] Problem: A LUT2 cell in the design is missing a connection on input pin I0, which is used by the LUT equation. This pin has either been left unconnected in the design or the connection was removed due to the trimming of unused logic.
+   attribute dont_touch                        : string;
+   attribute dont_touch of configurationVector : signal is "TRUE";
+
 begin
 
    phyClk          <= phyClock;

--- a/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
+++ b/ethernet/TenGigEthCore/gtx7/rtl/TenGigEthGtx7.vhd
@@ -185,6 +185,10 @@ architecture mapping of TenGigEthGtx7 is
    signal macTxAxisMaster : AxiStreamMasterType;
    signal macTxAxisSlave  : AxiStreamSlaveType;
 
+   -- Bug fix for building with Vivado 2025.1
+   attribute dont_touch                        : string;
+   attribute dont_touch of configurationVector : signal is "TRUE";
+
 begin
 
    phyReady        <= status.phyReady;


### PR DESCRIPTION
### Description
-  Bug fix for building with Vivado 2025.1
- Here's the error message that this pull request patches ....
```TCL
The following error(s) were detected during implementation:
ERROR: [Opt 31-67] Problem: A LUT2 cell in the design is missing a connection on input pin I0, which is used by the LUT equation. This pin has either been left unconnected in the design or the connection was removed due to the trimming of unused logic. The LUT cell name is: U_Core/GEN_ETH.U_Rudp/GEN_10G.U_10GigE/GEN_LANE[0].TenGigEthGthUltraScale_Inst/U_TenGigEthGthUltraScaleCore/U0/TenGigEthGthUltraScale156p25MHzCore_core/ten_gig_eth_pcs_pma_inst/G_IS_BASER.ten_gig_eth_pcs_pma_inst/BASER.ten_gig_eth_pcs_pma_inst/gt_txd[61]_i_3.
ERROR: [Opt 31-67] Problem: A LUT2 cell in the design is missing a connection on input pin I0, which is used by the LUT equation. This pin has either been left unconnected in the design or the connection was removed due to the trimming of unused logic. The LUT cell name is: 
U_Core/GEN_ETH.U_Rudp/GEN_10G.U_10GigE/GEN_LANE[0].TenGigEthGthUltraScale_Inst/U_TenGigEthGthUltraScaleCore/U0/TenGigEthGthUltraScale156p25MHzCore_core/ten_gig_eth_pcs_pma_inst/G_IS_BASER.ten_gig_eth_pcs_pma_inst/BASER.ten_gig_eth_pcs_pma_inst/gt_txd[61]_i_3.

```