### PR TITLE
adding `iprogPrint` arg to _LoadMcsFile()

### DIFF
--- a/python/surf/devices/cypress/_CypressS25Fl.py
+++ b/python/surf/devices/cypress/_CypressS25Fl.py
@@ -36,7 +36,7 @@ class CypressS25Fl(surf.devices.micron.AxiMicronN25Q):
         self.FLAG_STATUS_RDY = (0x01)
         self.BRAC_CMD        = (0xB9 << 16)
 
-    def _LoadMcsFile(self,arg):
+    def _LoadMcsFile(self,arg,iprogPrint=True):
 
         click.secho( f'LoadMcsFile: {arg}', fg='green')
         self._progDone = False
@@ -72,17 +72,18 @@ class CypressS25Fl(surf.devices.micron.AxiMicronN25Q):
 
         # Add a power cycle reminder
         self._progDone = True
-        click.secho(
-            "\n\n\
-            ***************************************************\n\
-            ***************************************************\n\
-            The MCS data has been written into the PROM.       \n\
-            To reprogram the FPGA with the new PROM data,      \n\
-            a IPROG CMD or power cycle is be required.\n\
-            ***************************************************\n\
-            ***************************************************\n\n"
-            , bg='green',
-        )
+        if iprogPrint:
+            click.secho(
+                "\n\n\
+                ***************************************************\n\
+                ***************************************************\n\
+                The MCS data has been written into the PROM.       \n\
+                To reprogram the FPGA with the new PROM data,      \n\
+                a IPROG CMD or power cycle is be required.\n\
+                ***************************************************\n\
+                ***************************************************\n\n"
+                , bg='green',
+            )
 
     def resetFlash(self):
         # Send the "Mode Bit Reset" command

--- a/python/surf/devices/micron/_AxiMicronMt28ew.py
+++ b/python/surf/devices/micron/_AxiMicronMt28ew.py
@@ -128,7 +128,7 @@ class AxiMicronMt28ew(pr.Device):
             value       = '',
         ))
 
-    def _LoadMcsFile(self,arg):
+    def _LoadMcsFile(self,arg,iprogPrint=True):
         click.secho( f'{self.path}.LoadMcsFile: {arg}', fg='green')
         self._progDone = False
 
@@ -154,17 +154,18 @@ class AxiMicronMt28ew(pr.Device):
 
         # Add a power cycle reminder
         self._progDone = True
-        click.secho(
-            "\n\n\
-            ***************************************************\n\
-            ***************************************************\n\
-            The MCS data has been written into the PROM.       \n\
-            To reprogram the FPGA with the new PROM data,      \n\
-            a IPROG CMD or power cycle is be required.\n\
-            ***************************************************\n\
-            ***************************************************\n\n"
-            , bg='green',
-        )
+        if iprogPrint:
+            click.secho(
+                "\n\n\
+                ***************************************************\n\
+                ***************************************************\n\
+                The MCS data has been written into the PROM.       \n\
+                To reprogram the FPGA with the new PROM data,      \n\
+                a IPROG CMD or power cycle is be required.\n\
+                ***************************************************\n\
+                ***************************************************\n\n"
+                , bg='green',
+            )
 
     # Reset Command
     def _resetCmd(self):

--- a/python/surf/devices/micron/_AxiMicronN25Q.py
+++ b/python/surf/devices/micron/_AxiMicronN25Q.py
@@ -169,7 +169,7 @@ class AxiMicronN25Q(pr.Device):
             value       = '',
         ))
 
-    def _LoadMcsFile(self,arg):
+    def _LoadMcsFile(self,arg,iprogPrint=True):
         # arg = value
 
         click.secho( f'{self.path}.LoadMcsFile: {arg}', fg='green')
@@ -207,17 +207,18 @@ class AxiMicronN25Q(pr.Device):
 
         # Add a power cycle reminder
         self._progDone = True
-        click.secho(
-            "\n\n\
-            ***************************************************\n\
-            ***************************************************\n\
-            The MCS data has been written into the PROM.       \n\
-            To reprogram the FPGA with the new PROM data,      \n\
-            a IPROG CMD or power cycle is be required.\n\
-            ***************************************************\n\
-            ***************************************************\n\n"
-            , bg='green',
-        )
+        if iprogPrint:
+            click.secho(
+                "\n\n\
+                ***************************************************\n\
+                ***************************************************\n\
+                The MCS data has been written into the PROM.       \n\
+                To reprogram the FPGA with the new PROM data,      \n\
+                a IPROG CMD or power cycle is be required.\n\
+                ***************************************************\n\
+                ***************************************************\n\n"
+                , bg='green',
+            )
 
     def eraseProm(self):
         # Set the starting address index

--- a/python/surf/devices/micron/_AxiMicronP30.py
+++ b/python/surf/devices/micron/_AxiMicronP30.py
@@ -128,7 +128,7 @@ class AxiMicronP30(pr.Device):
             value       = '',
         ))
 
-    def _LoadMcsFile(self,arg):
+    def _LoadMcsFile(self,arg,iprogPrint=True):
 
         click.secho( f'{self.path}.LoadMcsFile: {arg}', fg='green')
         self._progDone = False
@@ -158,17 +158,18 @@ class AxiMicronP30(pr.Device):
 
         # Add a power cycle reminder
         self._progDone = True
-        click.secho(
-            "\n\n\
-            ***************************************************\n\
-            ***************************************************\n\
-            The MCS data has been written into the PROM.       \n\
-            To reprogram the FPGA with the new PROM data,      \n\
-            a IPROG CMD or power cycle is be required.\n\
-            ***************************************************\n\
-            ***************************************************\n\n"
-            , bg='green',
-        )
+        if iprogPrint:
+            click.secho(
+                "\n\n\
+                ***************************************************\n\
+                ***************************************************\n\
+                The MCS data has been written into the PROM.       \n\
+                To reprogram the FPGA with the new PROM data,      \n\
+                a IPROG CMD or power cycle is be required.\n\
+                ***************************************************\n\
+                ***************************************************\n\n"
+                , bg='green',
+            )
 
     def eraseProm(self):
         # Set the starting address index


### PR DESCRIPTION
### Description
- Option for this print to not be included when the IPROG is included or a power cycle is not required
- Maintaining default behavior if not define where the print is included