### PR TITLE
updating scripts/vsg_linter.sh to use -of syntastic

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -67,17 +67,15 @@ jobs:
         run: |
           find . -name '*.h' -o -name '*.cpp' -o -name '*.c' | xargs cpplint
 
-# Waiting for this issue to be resolved: https://github.com/jeremiah-c-leary/vhdl-style-guide/issues/1461
-#      - name: VHDL Linter Checking
-#        run: |
-#          source scripts/vsg_linter.sh
+      - name: VHDL Linter Checking
+        run: |
+          source scripts/vsg_linter.sh
 
       - name: VHDL Regression Testing
         run: |
           make MODULES=$PWD
           python -m pytest --cov -v -n auto tests/
 
-      # Code Coverage
       - name: Code Coverage
         run: |
           codecov

--- a/protocols/saci/saci1/sim/SaciAxiLiteMasterTb.vhd
+++ b/protocols/saci/saci1/sim/SaciAxiLiteMasterTb.vhd
@@ -118,9 +118,9 @@ begin
    U_AxiLiteSaciMaster_1 : entity surf.AxiLiteSaciMaster
       generic map (
          TPD_G              => 1 ns,
-         AXIL_CLK_PERIOD_G  => 8.0e-9,
-         AXIL_TIMEOUT_G     => 1.0e-3,
-         SACI_CLK_PERIOD_G  => 50.0e-9,
+         AXIL_CLK_PERIOD_G  => 8.0E-9,
+         AXIL_TIMEOUT_G     => 1.0E-3,
+         SACI_CLK_PERIOD_G  => 50.0E-9,
          SACI_CLK_FREERUN_G => false,
          SACI_NUM_CHIPS_G   => 1,
          SACI_RSP_BUSSED_G  => false)

--- a/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
+++ b/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
@@ -118,9 +118,9 @@ begin
    U_AxiLiteToSaci2 : entity surf.AxiLiteToSaci2
       generic map (
          TPD_G              => 1 ns,
-         AXIL_CLK_PERIOD_G  => 8.0e-9,
-         AXIL_TIMEOUT_G     => 1.0e-3,
-         SACI_CLK_PERIOD_G  => 50.0e-9,
+         AXIL_CLK_PERIOD_G  => 8.0E-9,
+         AXIL_TIMEOUT_G     => 1.0E-3,
+         SACI_CLK_PERIOD_G  => 50.0E-9,
          SACI_CLK_FREERUN_G => false,
          SACI_NUM_CHIPS_G   => 1,
          SACI_RSP_BUSSED_G  => false)

--- a/scripts/vsg_linter.sh
+++ b/scripts/vsg_linter.sh
@@ -75,39 +75,27 @@ pids=()
 for filelist in "${split_file_list[@]}"; do
     (
         mapfile -t files < "$filelist"
-        output=$(vsg -f "${files[@]}" -c "$SCRIPT_DIR/../vsg-linter.yml")
-
-        echo "$output" | awk -v base="$PWD/" '
-            BEGIN { block=""; printing=0; }
-            # Save block and reset if delimiter line appears
-            /^=+$/ && block != "" {
-                if (printing) print block;
-                block=""; printing=0;
-            }
-            {
-                # Rewrite absolute file paths into relative paths
-                if ($0 ~ /^File:[[:space:]]+/) {
-                    gsub(base, "", $0);  # Remove leading directory
-                }
-                block = block $0 ORS;
-
-                # Enable printing if violations exist
-                if ($0 ~ /Total Violations:[[:space:]]*[1-9][0-9]*/) {
-                    printing=1;
-                }
-            }
-            END {
-                if (printing) print block;
-            }
-        '
+        vsg -f "${files[@]}" -c "$SCRIPT_DIR/../vsg-linter.yml" -of syntastic 2>&1 | tee /dev/stderr
+        exit_code=${PIPESTATUS[0]}
+        exit $exit_code
     ) &
     pids+=($!)
 done
 
-# Wait for all jobs to finish
+# Wait for all jobs to finish and collect exit statuses
+error=0
 for pid in "${pids[@]}"; do
-    wait "$pid"
+    wait "$pid" || error=1
 done
 
 # Clean up
 rm -rf "$TMP_DIR"
+
+# Final error status based on children
+if [[ $error -ne 0 ]]; then
+    echo "ERROR: Linting failed (see messages above)"
+    return 1 2>/dev/null || exit 1
+else
+    echo "No issues found"
+    return 0 2>/dev/null || exit 0
+fi

--- a/vsg-linter.yml
+++ b/vsg-linter.yml
@@ -735,6 +735,10 @@ rule:
   instantiation_034:
     disable: true
 
+  # https://vhdl-style-guide.readthedocs.io/en/3.33.0/instantiation_rules.html#instantiation-036
+  instantiation_036:
+    disable: true
+
   ##############################################################################################################
   # Length Rules
   ##############################################################################################################
@@ -1236,6 +1240,10 @@ rule:
 
   # https://vhdl-style-guide.readthedocs.io/en/3.31.0/variable_rules.html#variable-011
   variable_011:
+    disable: true
+
+  # https://vhdl-style-guide.readthedocs.io/en/3.33.0/variable_rules.html#variable-015
+  variable_015:
     disable: true
 
   ##############################################################################################################


### PR DESCRIPTION
### Description
- https://github.com/jeremiah-c-leary/vhdl-style-guide/issues/1461#issuecomment-3042179562
- `-of syntastic` appears to do exactly what we need.  It will only stdout when there is an error
- Also linter updates for VSG@3.33.0 (latest release)