### PR TITLE
AxiStreamBatcherAxil Async Mode Fix

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcherAxil.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherAxil.vhd
@@ -116,7 +116,7 @@ begin
          COMMON_CLK_G => COMMON_CLOCK_G)
       port map (
          sAxiClk         => axilClk,              -- [in]
-         sAxiClkRst      => axilClk,              -- [in]
+         sAxiClkRst      => axilRst,              -- [in]
          sAxiReadMaster  => axilReadMaster,       -- [in]
          sAxiReadSlave   => axilReadSlave,        -- [out]
          sAxiWriteMaster => axilWriteMaster,      -- [in]


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

The `axilClk` signal was accidentally hooked up to the `AxiLiteAsync` reset.
The module would work as long as `COMMON_CLK_G=true`.
Now it works also when `COMMON_CLK_G=false`.