### PR TITLE
AxiStreamDmaV2Write.vhd Updates

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -320,7 +320,7 @@ begin
                if intAxisMaster.tDest /= r.dmaWrTrack.dest then
                   v.state := PAD_S;
                -- Overflow detect
-               elsif (r.dmaWrTrack.maxSize(31 downto 5) = 0) then  -- Assumes max AXIS.TDATA width of 128-bits
+               elsif (r.dmaWrTrack.maxSize(31 downto log2(DATA_BYTES_C)) = 0) then
                   -- Multi-descriptor DMA is supported
                   if r.dmaWrTrack.contEn = '1' then
                      v.continue         := '1';

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -212,6 +212,7 @@ begin
             end if;
          ----------------------------------------------------------------------
          when IDLE_S =>
+            v.stCount := (others => '0');
             -- Set write dma request data
             v.dmaWrDescReq.dest := intAxisMaster.tDest;
             v.dmaWrDescReq.id   := intAxisMaster.tId;
@@ -260,7 +261,6 @@ begin
             end if;
          ----------------------------------------------------------------------
          when REQ_S =>
-            v.stCount := (others => '0');
             -- Wait for response and latch fields
             if dmaWrDescAck.valid = '1' then
                v.dmaWrTrack.inUse      := '1';
@@ -287,8 +287,7 @@ begin
             end if;
          ----------------------------------------------------------------------
          when ADDR_S =>
-            -- Reset counter, continue and last user
-            v.stCount  := (others => '0');
+            -- Reset continue and last user
             v.continue := '0';
             v.lastUser := (others => '0');
             -- Determine transfer size aligned to 4k boundaries

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -260,6 +260,7 @@ begin
             end if;
          ----------------------------------------------------------------------
          when REQ_S =>
+            v.stCount := (others => '0');
             -- Wait for response and latch fields
             if dmaWrDescAck.valid = '1' then
                v.dmaWrTrack.inUse      := '1';

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -477,13 +477,9 @@ begin
                   v.state              := IDLE_S;
                -- Check for ACK timeout
                elsif (r.stCount = r.dmaWrTrack.timeout) then
-                  -- Set the flags
+                  -- Latch the errors flags
                   v.dmaWrDescRet.result(1 downto 0) := "11";
-                  v.dmaWrDescRet.valid              := '1';
                   v.dmaWrDescRet.result(3)          := '1';
-                  v.reqCount                        := (others => '0');
-                  v.ackCount                        := (others => '0');
-                  v.state                           := IDLE_S;
                else
                   -- Increment the counter
                   v.stCount := r.stCount + 1;

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -428,24 +428,18 @@ begin
             end if;
          ----------------------------------------------------------------------
          when META_S =>
-
-            -- Wair for existing transactions to complete
-            if v.wMaster.wvalid = '0' and v.wMaster.awvalid = '0' then
-
-               -- Init
-               v.wMaster := axiWriteMasterInit(AXI_CONFIG_G, '1', "01", "0000");
+            -- Wait for existing transactions to complete
+            if (v.wMaster.wvalid = '0') and (v.wMaster.awvalid = '0') then
 
                -- Write address channel
-               v.wMaster.awaddr := r.dmaWrTrack.metaAddr;
-               v.wMaster.awlen  := x"00";  -- Single transaction
+               v.wMaster.awvalid := '1';
+               v.wMaster.awaddr  := r.dmaWrTrack.metaAddr;
+               v.wMaster.awlen   := x"00";  -- Single transaction
 
                -- Write data channel
-               v.wMaster.wlast := '1';
-
-               -- Increment the counter
-               v.reqCount := r.reqCount + 1;
-
-               -- Descriptor data, 64-bits
+               v.wMaster.wvalid              := '1';
+               v.wMaster.wlast               := '1';
+               v.wMaster.wstrb               := resize(x"FF", 128);  -- Descriptor data, 64-bits
                v.wMaster.wdata(63 downto 32) := r.dmaWrTrack.size;
                v.wMaster.wdata(31 downto 24) := r.dmaWrTrack.firstUser;
                v.wMaster.wdata(23 downto 16) := r.lastUser;
@@ -454,11 +448,11 @@ begin
                v.wMaster.wdata(2)            := r.dmaWrTrack.overflow;
                v.wMaster.wdata(1 downto 0)   := r.result;
 
-               v.wMaster.wstrb := resize(x"FF", 128);
+               -- Increment the counter
+               v.reqCount := r.reqCount + 1;
 
-               v.wMaster.awvalid := '1';
-               v.wMaster.wvalid  := '1';
-               v.state           := RETURN_S;
+               -- Next state
+               v.state := RETURN_S;
             end if;
          ----------------------------------------------------------------------
          when RETURN_S =>

--- a/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Write.vhd
@@ -362,7 +362,7 @@ begin
                      v.dmaWrTrack.firstUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) :=
                         axiStreamGetUserField(AXIS_CONFIG_G, intAxisMaster, 0);
                   end if;
-                  -- -- Check for last AXIS word
+                  -- Check for last AXIS word
                   if intAxisMaster.tLast = '1' then
                      -- Latch the tUser value
                      v.lastUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) :=
@@ -392,7 +392,9 @@ begin
                      v.awlen := r.awlen - 1;
                   end if;
                end if;
-            -- Timeout on stalled writes to avoid locking AXI crossbar
+            -- If the incoming AXI stream data stalled out ('timeout event') while we are in the
+            -- middle of a write, we treat it like a destination change and complete the write
+            -- with the valid strobes as '0' and re-start it when data is available
             elsif r.stCount = 100 then
                v.state := PAD_S;
             else
@@ -505,7 +507,7 @@ begin
                else
                   -- Accept the data
                   v.slave.tReady := '1';
-                  -- -- Check for last AXIS word
+                  -- Check for last AXIS word
                   if intAxisMaster.tLast = '1' then
                      v.dmaWrTrack.inUse := '0';
                      if r.dmaWrTrack.metaEnable = '1' then


### PR DESCRIPTION
### Description
- [bug fix for overflow detection when AXIS.TDATA width > 128-bits](https://github.com/slaclab/surf/commit/310d4705f6393052eac31809d173850ec9c65100)
- [code comment clean up](https://github.com/slaclab/surf/commit/0df3f81fc8c139f8179c1dfd3fc8bf2be8c95bc4)
- [bug fix for wMaster.awcache != axiCache in META_S state + general code clean up of the META_S state](https://github.com/slaclab/surf/commit/827490839aece52f89fcdbf7fe85759e128c3707)
- [AXI4 must wait for the bvalid (always) and don't reset the counts & continue until all the bvalids are received](https://github.com/slaclab/surf/commit/4cd1f176df14f2e5b128d616794cbf35ecb131d0)
- [adding stCount reset to prevent stCount acculating to a timeout when dmaWrDescAck.dropEn=1](https://github.com/slaclab/surf/pull/1312/commits/4e2fb852a248346c8e820e5c4d623b6e74c0c684)