### PR TITLE
QSFP Python: Adding proxy for optional Upper Page support

### DIFF
--- a/python/surf/devices/transceivers/_Qsfp.py
+++ b/python/surf/devices/transceivers/_Qsfp.py
@@ -793,17 +793,27 @@ class Qsfp(pr.Device):
 
         # 127 127 Page Select Byte
         self.add(_UpperPageProxy(
-            name    = 'UpperPageProxy',
-            memBase = self,
-            offset  = 0x0000,
-            hidden  = True,
+            name     = 'UpperPageProxy',
+            memBase  = self,
+            offset   = 0x0000,
+            hidden   = True,
         ))
         self.proxy = _ProxySlave(self.UpperPageProxy)
 
-        self.add(UpperPage00h(
-            memBase    = self.proxy,
-            advDebug   = advDebug,
-            offset     = (0+1)<<10, # Page00 plus 1 mem addres region offset
+        self.add(transceivers.QsfpUpperPage00h(
+            name     = 'UpperPage00h',
+            memBase  = self.proxy,
+            advDebug = advDebug,
+            offset   = (0+1)<<10, # Page00 plus 1 mem addres region offset
+            enabled  = False, # enabled=False because I2C are slow transactions
+        ))
+
+        self.add(transceivers.QsfpUpperPage03h(
+            name     = 'UpperPage03h',
+            memBase  = self.proxy,
+            advDebug = advDebug,
+            offset   = (3+1)<<10, # Page03 plus 1 mem addres region offset
+            enabled  = False, # enabled=False because I2C are slow transactions
         ))
 
     def add(self, node):
@@ -828,7 +838,7 @@ class _UpperPageProxy(pr.Device):
             name         = 'PageSelectByte',
             description  = 'Byte 127 is used to select the upper page',
             offset       = (127 << 2),
-            bitSize      = 1,
+            bitSize      = 8,
             mode         = 'WO',
             hidden       = True,
             groups        = ['NoStream','NoState','NoConfig'],
@@ -908,300 +918,3 @@ class _ProxySlave(rim.Slave):
 
     def _doTransaction(self, transaction):
         self._UpperPageProxy.proxyTransaction(transaction)
-
-#################################################
-#               Upper Page 00h
-#################################################
-class UpperPage00h(pr.Device):
-    def __init__(self, advDebug=False, **kwargs):
-        super().__init__(**kwargs)
-
-        if advDebug:
-
-            self.add(pr.RemoteVariable(
-                name         = 'UppperIdentifier',
-                description  = 'Type of serial transceiver',
-                offset       = (128 << 2),
-                bitSize      = 5,
-                mode         = 'RO',
-                enum         = transceivers.IdentifierDict,
-            ))
-
-            self.add(pr.RemoteVariable(
-                name         = 'LowPowerClass',
-                description  = 'Extended Identifier of free side device. Includes power classes, CLEI codes, CDR capability (See Table 6-16)',
-                offset       = (129 << 2),
-                bitSize      = 2,
-                bitOffset    = 6,
-                mode         = 'RO',
-                enum         = {
-                    0x0: 'Power Class 1 (1.5 W max.)',
-                    0x1: 'Power Class 2 (2.0 W max.)',
-                    0x2: 'Power Class 3 (2.5 W max.)',
-                    0x3: 'Power Class 4 (3.5 W max.) and Power Classes 5, 6 or 7',
-                },
-            ))
-
-            self.add(pr.RemoteVariable(
-                name         = 'PowerClass8Impl',
-                description  = 'Power Class 8 implemented (Max power declared in byte 107)',
-                offset       = (129 << 2),
-                bitSize      = 1,
-                bitOffset    = 5,
-                mode         = 'RO',
-                base         = pr.Bool,
-            ))
-
-            self.add(pr.RemoteVariable(
-                name         = 'CleiCodePresent',
-                description  = 'CLEI code present in Page 02h',
-                offset       = (129 << 2),
-                bitSize      = 1,
-                bitOffset    = 4,
-                mode         = 'RO',
-                base         = pr.Bool,
-            ))
-
-        self.add(pr.RemoteVariable(
-            name         = 'TxCdrPresent',
-            description  = '0: No CDR in Tx, 1: CDR present in Tx',
-            offset       = (129 << 2),
-            bitSize      = 1,
-            bitOffset    = 3,
-            mode         = 'RO',
-            base         = pr.Bool,
-        ))
-
-        self.add(pr.RemoteVariable(
-            name         = 'RxCdrPresent',
-            description  = '0: No CDR in Rx, 1: CDR present in Rx',
-            offset       = (129 << 2),
-            bitSize      = 1,
-            bitOffset    = 2,
-            mode         = 'RO',
-            base         = pr.Bool,
-        ))
-
-        if advDebug:
-            self.add(pr.RemoteVariable(
-                name         = 'HighPowerClass',
-                description  = 'See Byte 93 bit 2 to enable.',
-                offset       = (129 << 2),
-                bitSize      = 2,
-                bitOffset    = 0,
-                mode         = 'RO',
-                enum         = {
-                    0x0: 'Power Classes 1 to 4',
-                    0x1: 'Power Class 5 (4.0 W max.) See Byte 93 bit 2 to enable.',
-                    0x2: 'Power Class 6 (4.5 W max.) See Byte 93 bit 2 to enable.',
-                    0x3: 'Power Class 7 (5.0 W max.) See Byte 93 bit 2 to enable',
-                },
-            ))
-
-        self.add(pr.RemoteVariable(
-            name        = 'Connector',
-            description = 'Code for connector type',
-            offset      = (130 << 2),
-            bitSize     = 8,
-            mode        = 'RO',
-            enum        = transceivers.ConnectorDict,
-        ))
-
-        ###############################################################
-        # TODO: Add registers 131 ~ 138
-        ###############################################################
-
-        if advDebug:
-
-            self.add(pr.RemoteVariable(
-                name        = 'Encoding',
-                description = 'Code for serial encoding algorithm. (See SFF-8024 Transceiver Management)',
-                offset      = (139 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'SignalingRate',
-                description = 'Nominal signaling rate, units of 100 MBd. For rate > 25.4 GBd, set this to FFh and use Byte 222.',
-                offset      = (140 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'ExtendedRateSelect',
-                description = 'Tags for extended rate select compliance. See Table 6-18.',
-                offset      = (141 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Length_SMF',
-                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for SMF fiber in km *. A value of 1 shall be used for reaches from 0 to 1 km.',
-                offset      = (142 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Length_OM3',
-                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for EBW 50/125 um fiber (OM3), units of 2 m',
-                offset      = (143 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Length_OM2',
-                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 62.5/125 um fiber (OM1), units of 1 m *, or copper cable attenuation in dB at 25.78 GHz.',
-                offset      = (145 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Length_OM1',
-                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 50/125 um fiber (OM2), units of 1 m',
-                offset      = (144 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Length_Copper',
-                description = 'Length of passive or active cable assembly (units of 1 m) or link length supported at the signaling rate in byte 140 or page 00h byte 222, for OM4 50/125 um fiber (units of 2 m) as indicated by Byte 147. See 6.3.12',
-                offset      = (146 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'DeviceTechnology',
-                description = 'Device technology (Table 6-19 and Table 6-20).',
-                offset      = (147 << 2),
-                bitSize     = 8,
-                mode        = 'RO',
-            ))
-
-        self.addRemoteVariables(
-            name         = 'VendorNameRaw',
-            description  = 'SFP vendor name (ASCII)',
-            offset       = (148 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            base         = pr.String,
-            number       = 16,  # BYTE148:BYTE163
-            stride       = 4,
-            hidden       = True,
-        )
-
-        self.add(pr.LinkVariable(
-            name         = 'VendorName',
-            description  = 'SFP vendor name (ASCII)',
-            mode         = 'RO',
-            linkedGet    = transceivers.parseStrArrayByte,
-            dependencies = [self.VendorNameRaw[x] for x in range(16)],
-        ))
-
-        # TODO: 164 1 Extended Module Extended Module codes for InfiniBand (See Table 6-21 )
-        # TODO: 165-167 3 Vendor OUI Free side device vendor IEEE company ID
-
-        self.addRemoteVariables(
-            name         = 'VendorPnRaw',
-            description  = 'Part number provided by SFP vendor (ASCII)',
-            offset       = (168 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            base         = pr.String,
-            number       = 16, # BYTE168:BYTE183
-            stride       = 4,
-            hidden       = True,
-        )
-
-        self.add(pr.LinkVariable(
-            name         = 'VendorPn',
-            description  = 'Part number provided by SFP vendor (ASCII)',
-            mode         = 'RO',
-            linkedGet    = transceivers.parseStrArrayByte,
-            dependencies = [self.VendorPnRaw[x] for x in range(16)],
-        ))
-
-        self.addRemoteVariables(
-            name         = 'VendorRevRaw',
-            description  = 'Revision level for part number provided by vendor (ASCII)',
-            offset       = (184 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            base         = pr.String,
-            number       = 2, # BYTE184:BYTE185
-            stride       = 4,
-            hidden       = True,
-        )
-
-        self.add(pr.LinkVariable(
-            name         = 'VendorRev',
-            description  = 'Revision level for part number provided by vendor (ASCII)',
-            mode         = 'RO',
-            linkedGet    = transceivers.parseStrArrayByte,
-            dependencies = [self.VendorRevRaw[x] for x in range(2)],
-        ))
-
-        # TODO: 186-187 2 Wavelength or Copper Cable Attenuation
-        # TODO: 188-189 2 Wavelength tolerance or Copper Cable Attenuation
-        # TODO: 190 1 Max case temp. Maximum case temperature
-        # TODO: 191 1 CC_BASE Check code for base ID fields (Bytes 128-190)
-        # TODO: 192 1 Link codes Extended Specification Compliance Codes (See SFF-8024)
-        # TODO: 193-195 3 Options Optional features implemented. See Table 6-22.
-
-        self.addRemoteVariables(
-            name         = 'VendorSnRaw',
-            description  = 'Serial number provided by vendor (ASCII)',
-            offset       = (196 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            base         = pr.String,
-            number       = 16, # BYTE196:BYTE211
-            stride       = 4,
-            hidden       = True,
-        )
-
-        self.add(pr.LinkVariable(
-            name         = 'VendorSn',
-            description  = 'Serial number provided by vendor (ASCII)',
-            mode         = 'RO',
-            linkedGet    = transceivers.parseStrArrayByte,
-            dependencies = [self.VendorSnRaw[x] for x in range(16)],
-        ))
-
-        self.addRemoteVariables(
-            name         = 'DateCode',
-            description  = 'Vendor\'s manufacturing date code (ASCII)',
-            offset       = (212 << 2),
-            bitSize      = 8,
-            mode         = 'RO',
-            number       = 6, # BYTE212:BYTE219
-            stride       = 4,
-            base         = pr.String,
-            hidden       = True,
-        )
-
-        self.add(pr.LinkVariable(
-            name         = 'ManufactureDate',
-            description  = 'Vendor\'s manufacturing date code (ASCII)',
-            mode         = 'RO',
-            linkedGet    = transceivers.getDate,
-            dependencies = [self.DateCode[x] for x in [0,1,4,5,2,3] ],
-        ))
-
-        # TODO: 220 1 Diagnostic Monitoring Type Indicates which type of diagnostic monitoring is implemented (if any) in the free side device. Bit 1,0 Reserved. See Table 6-24.
-        # TODO: 221 1 Enhanced Options Indicates which optional enhanced features are implemented in the free side device. See Table 6-24.
-        # TODO: 222 1 Baud Rate, nominal Nominal baud rate per channel, units of 250 MBd. Complements Byte 140. See Table 6-26.
-        # TODO: 223 1 CC_EXT Check code for the Extended ID Fields (Bytes 192-222)
-        # TODO: 224-255 32 Vendor Specific Vendor Specific EEPROM
-
-        ###############################################################
-        # TODO: Need to add the ability in the future to use
-        # Page Select Byte (address=127) for other optional page access
-        ###############################################################

--- a/python/surf/devices/transceivers/_QsfpUpperPage00h.py
+++ b/python/surf/devices/transceivers/_QsfpUpperPage00h.py
@@ -1,0 +1,311 @@
+#-----------------------------------------------------------------------------
+# Description:
+#
+# Based on SFF-8636 Rev Rev 2.11 (03JAN2023)
+# https://members.snia.org/document/dl/26418
+#
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+from surf.devices import transceivers
+
+#################################################
+#               Upper Page 00h
+#################################################
+class QsfpUpperPage00h(pr.Device):
+    def __init__(self, advDebug=False, **kwargs):
+        super().__init__(**kwargs)
+
+        if advDebug:
+
+            self.add(pr.RemoteVariable(
+                name         = 'UppperIdentifier',
+                description  = 'Type of serial transceiver',
+                offset       = (128 << 2),
+                bitSize      = 5,
+                mode         = 'RO',
+                enum         = transceivers.IdentifierDict,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'LowPowerClass',
+                description  = 'Extended Identifier of free side device. Includes power classes, CLEI codes, CDR capability (See Table 6-16)',
+                offset       = (129 << 2),
+                bitSize      = 2,
+                bitOffset    = 6,
+                mode         = 'RO',
+                enum         = {
+                    0x0: 'Power Class 1 (1.5 W max.)',
+                    0x1: 'Power Class 2 (2.0 W max.)',
+                    0x2: 'Power Class 3 (2.5 W max.)',
+                    0x3: 'Power Class 4 (3.5 W max.) and Power Classes 5, 6 or 7',
+                },
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'PowerClass8Impl',
+                description  = 'Power Class 8 implemented (Max power declared in byte 107)',
+                offset       = (129 << 2),
+                bitSize      = 1,
+                bitOffset    = 5,
+                mode         = 'RO',
+                base         = pr.Bool,
+            ))
+
+            self.add(pr.RemoteVariable(
+                name         = 'CleiCodePresent',
+                description  = 'CLEI code present in Page 02h',
+                offset       = (129 << 2),
+                bitSize      = 1,
+                bitOffset    = 4,
+                mode         = 'RO',
+                base         = pr.Bool,
+            ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TxCdrPresent',
+            description  = '0: No CDR in Tx, 1: CDR present in Tx',
+            offset       = (129 << 2),
+            bitSize      = 1,
+            bitOffset    = 3,
+            mode         = 'RO',
+            base         = pr.Bool,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'RxCdrPresent',
+            description  = '0: No CDR in Rx, 1: CDR present in Rx',
+            offset       = (129 << 2),
+            bitSize      = 1,
+            bitOffset    = 2,
+            mode         = 'RO',
+            base         = pr.Bool,
+        ))
+
+        if advDebug:
+            self.add(pr.RemoteVariable(
+                name         = 'HighPowerClass',
+                description  = 'See Byte 93 bit 2 to enable.',
+                offset       = (129 << 2),
+                bitSize      = 2,
+                bitOffset    = 0,
+                mode         = 'RO',
+                enum         = {
+                    0x0: 'Power Classes 1 to 4',
+                    0x1: 'Power Class 5 (4.0 W max.) See Byte 93 bit 2 to enable.',
+                    0x2: 'Power Class 6 (4.5 W max.) See Byte 93 bit 2 to enable.',
+                    0x3: 'Power Class 7 (5.0 W max.) See Byte 93 bit 2 to enable',
+                },
+            ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'Connector',
+            description = 'Code for connector type',
+            offset      = (130 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            enum        = transceivers.ConnectorDict,
+        ))
+
+        ###############################################################
+        # TODO: Add registers 131 ~ 138
+        ###############################################################
+
+        if advDebug:
+
+            self.add(pr.RemoteVariable(
+                name        = 'Encoding',
+                description = 'Code for serial encoding algorithm. (See SFF-8024 Transceiver Management)',
+                offset      = (139 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'SignalingRate',
+                description = 'Nominal signaling rate, units of 100 MBd. For rate > 25.4 GBd, set this to FFh and use Byte 222.',
+                offset      = (140 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'ExtendedRateSelect',
+                description = 'Tags for extended rate select compliance. See Table 6-18.',
+                offset      = (141 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'Length_SMF',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for SMF fiber in km *. A value of 1 shall be used for reaches from 0 to 1 km.',
+                offset      = (142 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM3',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for EBW 50/125 um fiber (OM3), units of 2 m',
+                offset      = (143 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM2',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 62.5/125 um fiber (OM1), units of 1 m *, or copper cable attenuation in dB at 25.78 GHz.',
+                offset      = (145 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'Length_OM1',
+                description = 'Link length supported at the signaling rate in byte 140 or page 00h byte 222, for 50/125 um fiber (OM2), units of 1 m',
+                offset      = (144 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'Length_Copper',
+                description = 'Length of passive or active cable assembly (units of 1 m) or link length supported at the signaling rate in byte 140 or page 00h byte 222, for OM4 50/125 um fiber (units of 2 m) as indicated by Byte 147. See 6.3.12',
+                offset      = (146 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'DeviceTechnology',
+                description = 'Device technology (Table 6-19 and Table 6-20).',
+                offset      = (147 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+        self.addRemoteVariables(
+            name         = 'VendorNameRaw',
+            description  = 'SFP vendor name (ASCII)',
+            offset       = (148 << 2),
+            bitSize      = 8,
+            mode         = 'RO',
+            base         = pr.String,
+            number       = 16,  # BYTE148:BYTE163
+            stride       = 4,
+            hidden       = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorName',
+            description  = 'SFP vendor name (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorNameRaw[x] for x in range(16)],
+        ))
+
+        # TODO: 164 1 Extended Module Extended Module codes for InfiniBand (See Table 6-21 )
+        # TODO: 165-167 3 Vendor OUI Free side device vendor IEEE company ID
+
+        self.addRemoteVariables(
+            name         = 'VendorPnRaw',
+            description  = 'Part number provided by SFP vendor (ASCII)',
+            offset       = (168 << 2),
+            bitSize      = 8,
+            mode         = 'RO',
+            base         = pr.String,
+            number       = 16, # BYTE168:BYTE183
+            stride       = 4,
+            hidden       = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorPn',
+            description  = 'Part number provided by SFP vendor (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorPnRaw[x] for x in range(16)],
+        ))
+
+        self.addRemoteVariables(
+            name         = 'VendorRevRaw',
+            description  = 'Revision level for part number provided by vendor (ASCII)',
+            offset       = (184 << 2),
+            bitSize      = 8,
+            mode         = 'RO',
+            base         = pr.String,
+            number       = 2, # BYTE184:BYTE185
+            stride       = 4,
+            hidden       = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorRev',
+            description  = 'Revision level for part number provided by vendor (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorRevRaw[x] for x in range(2)],
+        ))
+
+        # TODO: 186-187 2 Wavelength or Copper Cable Attenuation
+        # TODO: 188-189 2 Wavelength tolerance or Copper Cable Attenuation
+        # TODO: 190 1 Max case temp. Maximum case temperature
+        # TODO: 191 1 CC_BASE Check code for base ID fields (Bytes 128-190)
+        # TODO: 192 1 Link codes Extended Specification Compliance Codes (See SFF-8024)
+        # TODO: 193-195 3 Options Optional features implemented. See Table 6-22.
+
+        self.addRemoteVariables(
+            name         = 'VendorSnRaw',
+            description  = 'Serial number provided by vendor (ASCII)',
+            offset       = (196 << 2),
+            bitSize      = 8,
+            mode         = 'RO',
+            base         = pr.String,
+            number       = 16, # BYTE196:BYTE211
+            stride       = 4,
+            hidden       = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorSn',
+            description  = 'Serial number provided by vendor (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorSnRaw[x] for x in range(16)],
+        ))
+
+        self.addRemoteVariables(
+            name         = 'DateCode',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
+            offset       = (212 << 2),
+            bitSize      = 8,
+            mode         = 'RO',
+            number       = 6, # BYTE212:BYTE219
+            stride       = 4,
+            base         = pr.String,
+            hidden       = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'ManufactureDate',
+            description  = 'Vendor\'s manufacturing date code (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.getDate,
+            dependencies = [self.DateCode[x] for x in [0,1,4,5,2,3] ],
+        ))
+
+        # TODO: 220 1 Diagnostic Monitoring Type Indicates which type of diagnostic monitoring is implemented (if any) in the free side device. Bit 1,0 Reserved. See Table 6-24.
+        # TODO: 221 1 Enhanced Options Indicates which optional enhanced features are implemented in the free side device. See Table 6-24.
+        # TODO: 222 1 Baud Rate, nominal Nominal baud rate per channel, units of 250 MBd. Complements Byte 140. See Table 6-26.
+        # TODO: 223 1 CC_EXT Check code for the Extended ID Fields (Bytes 192-222)
+        # TODO: 224-255 32 Vendor Specific Vendor Specific EEPROM

--- a/python/surf/devices/transceivers/_QsfpUpperPage03h.py
+++ b/python/surf/devices/transceivers/_QsfpUpperPage03h.py
@@ -1,0 +1,325 @@
+#-----------------------------------------------------------------------------
+# Description:
+#
+# Based on SFF-8636 Rev Rev 2.11 (03JAN2023)
+# https://members.snia.org/document/dl/26418
+#
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+from surf.devices import transceivers
+
+#################################################
+#               Upper Page 03h
+#################################################
+class QsfpUpperPage03h(pr.Device):
+    def __init__(self, advDebug=False, **kwargs):
+        super().__init__(**kwargs)
+
+        ###############################################################
+        # TODO: Add registers 128 ~ 223) - Free Side Device and Channel Thresholds
+        ###############################################################
+
+        self.add(pr.RemoteVariable(
+            name         = 'MaxTxInputEqualization',
+            description  = 'Max Tx input equalization supported (controls are in bytes 234-235 and codes are in Table 6-32)',
+            offset       = (224 << 2),
+            bitSize      = 4,
+            bitOffset    = 4,
+            mode         = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'MaxRxOutputEmphasis',
+            description  = 'Max Rx output emphasis supported (controls are in bytes 236-237 and codes are in Table 6-33)',
+            offset       = (224 << 2),
+            bitSize      = 4,
+            bitOffset    = 0,
+            mode         = 'RO',
+        ))
+
+        # 225 7-6 Reserved
+
+        self.add(pr.RemoteVariable(
+            name         = 'RxOutputEmphasisType',
+            description  = 'Codes are in Table 6-29',
+            offset       = (225 << 2),
+            bitSize      = 2,
+            bitOffset    = 4,
+            mode         = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'RxOutputAmplitudeSupport',
+            description  = 'Codes are in Table 6-29',
+            offset       = (225 << 2),
+            bitSize      = 4,
+            bitOffset    = 0,
+            mode         = 'RO',
+        ))
+
+        # 226 All Reserved
+
+        if advDebug:
+
+            self.add(pr.RemoteVariable(
+                name        = 'ControllableHostSideFecSupport',
+                description = 'See Page 03h, Byte 230, bit 7 for the control bit',
+                offset      = (227 << 2),
+                bitSize     = 1,
+                bitOffset   = 7,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'ControllableMediaSideFecsupport',
+                description = 'See Page 03h, Byte 230, bit 6 for the control bit',
+                offset      = (227 << 2),
+                bitSize     = 1,
+                bitOffset   = 6,
+                mode        = 'RO',
+            ))
+
+            # 227 5-4 Reserved
+
+            self.add(pr.RemoteVariable(
+                name        = 'TxForceSquelchImplemented',
+                description = '0 = Tx Force Squelch not implemented, 1 = Tx Force Squelch implemented',
+                offset      = (227 << 2),
+                bitSize     = 1,
+                bitOffset   = 3,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'RxLosLFastModeSupported',
+                description = '0 = RxLOSL fast mode is not supported., 1 = RxLOSL fast mode supported',
+                offset      = (227 << 2),
+                bitSize     = 1,
+                bitOffset   = 2,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'TxDisFastModeSupported',
+                description = '0 = TxDis fast mode is not supported., 1 = TxDis fast mode supported',
+                offset      = (227 << 2),
+                bitSize     = 1,
+                bitOffset   = 1,
+                mode        = 'RO',
+            ))
+
+            # 227 0 Reserved
+
+            self.add(pr.RemoteVariable(
+                name        = 'MaximumTcStabilizationTime',
+                description = 'Maximum time for the TC to reach its target working point under worst-case conditions (LSB = 1 s)',
+                offset      = (228 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'MaximumCtleSettlingTime',
+                description = 'Maximum time needed by CTLE adaptive algorithm to converge to an appropriate value under worstcase conditions (LSB = 100 ms)',
+                offset      = (229 << 2),
+                bitSize     = 8,
+                mode        = 'RO',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'HostSideFecEnable',
+                description = '0b = disable, 1b = enable. Default = 0',
+                offset      = (230 << 2),
+                bitSize     = 1,
+                bitOffset   = 7,
+                mode        = 'RW',
+            ))
+
+            self.add(pr.RemoteVariable(
+                name        = 'MediaSideFecEnable',
+                description = '0b = disable, 1b = enable. Default = 0',
+                offset      = (230 << 2),
+                bitSize     = 1,
+                bitOffset   = 6,
+                mode        = 'RW',
+            ))
+
+            # 230 5-0 Reserved
+
+        # 231 7-4 Reserved
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxForceSquelch',
+            description = '0b = No impact on Tx behavior 1b = Tx output squelched',
+            offset      = (231 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        # 232 All Reserved
+
+        # 233 7-4 Reserved
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxAEFreeze',
+            description = 'Controls to freeze Tx input adaptive equalizers. 1 to freeze, else 0',
+            offset      = (233 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxInputEqualizer[0]',
+            description = 'Tx input equalizer controls (see Page 03h Byte 224 and Table 6-32)',
+            offset      = (234 << 2),
+            bitOffset   = 4,
+            bitSize     = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxInputEqualizer[1]',
+            description = 'Tx input equalizer controls (see Page 03h Byte 224 and Table 6-32)',
+            offset      = (234 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxInputEqualizer[2]',
+            description = 'Tx input equalizer controls (see Page 03h Byte 224 and Table 6-32)',
+            offset      = (235 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxInputEqualizer[3]',
+            description = 'Tx input equalizer controls (see Page 03h Byte 224 and Table 6-32)',
+            offset      = (235 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputEqualizer[0]',
+            description = 'Rx output emphasis controls (see Page 03h Byte 224 and Table 6-33)',
+            offset      = (236 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputEqualizer[1]',
+            description = 'Rx output emphasis controls (see Page 03h Byte 224 and Table 6-33)',
+            offset      = (236 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputEqualizer[2]',
+            description = 'Rx output emphasis controls (see Page 03h Byte 224 and Table 6-33)',
+            offset      = (237 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputEqualizer[3]',
+            description = 'Rx output emphasis controls (see Page 03h Byte 224 and Table 6-33)',
+            offset      = (237 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputAmplitude[0]',
+            description = 'Controls for Rx output differential amplitude. (See Table 6-31)',
+            offset      = (238 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputAmplitude[1]',
+            description = 'Controls for Rx output differential amplitude. (See Table 6-31)',
+            offset      = (238 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputAmplitude[2]',
+            description = 'Controls for Rx output differential amplitude. (See Table 6-31)',
+            offset      = (239 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputAmplitude[3]',
+            description = 'Controls for Rx output differential amplitude. (See Table 6-31)',
+            offset      = (239 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxSqDisable',
+            description = 'Controls to disable squelch of Rx outputs 1 = Disabled, 0 = Enabled Default = 0',
+            offset      = (240 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxSqDisable',
+            description = 'Controls to disable squelch of Tx outputs 1 = Disabled, 0 = Enabled Default = 0',
+            offset      = (240 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'RxOutputDisable',
+            description = 'Controls to disable Rx outputs 1 = Disabled, 0 = Enabled Default = 0',
+            offset      = (241 << 2),
+            bitSize     = 4,
+            bitOffset   = 4,
+            mode        = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'TxAdaptiveEqualization',
+            description = 'Controls for Tx input adaptive equalizers. 1b=Enable (default) 0b=Disable (use manual EQ)',
+            offset      = (241 << 2),
+            bitSize     = 4,
+            bitOffset   = 0,
+            mode        = 'RW',
+        ))

--- a/python/surf/devices/transceivers/__init__.py
+++ b/python/surf/devices/transceivers/__init__.py
@@ -8,6 +8,8 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 from surf.devices.transceivers._Sfp  import *
+from surf.devices.transceivers._QsfpUpperPage00h import *
+from surf.devices.transceivers._QsfpUpperPage03h import *
 from surf.devices.transceivers._Qsfp import *
 
 import math
@@ -114,6 +116,10 @@ IdentifierDict = {
     0x1F: 'SFP-DD',
 }
 
+# Fill 0x20 through 0xFF with 'Undefined'
+for code in range(0x20, 0x100):  # 0x100 is 256 (exclusive)
+    IdentifierDict[code] = 'Undefined'
+
 ExtIdentifierDict = {
     0x00: 'Unspecified',
     0x01: '100G AOC (Active Optical Cable) or 25GAUI C2M AOC',
@@ -179,6 +185,10 @@ ExtIdentifierDict = {
     0x81: 'Capable of 128GFC',
 }
 
+# Fill 0x82 through 0xFF with 'Undefined'
+for code in range(0x82, 0x100):  # 0x100 is 256 (exclusive)
+    ExtIdentifierDict[code] = 'Undefined'
+
 ConnectorDict = {
     0x00: 'Unspecified',
     0x01: 'SC',
@@ -205,6 +215,10 @@ ConnectorDict = {
     0x28: 'MPO 1x16',
 }
 
+# Fill 0x29 through 0xFF with 'Undefined'
+for code in range(0x29, 0x100):  # 0x100 is 256 (exclusive)
+    ConnectorDict[code] = 'Undefined'
+
 EncodingDict = {
     0x0: 'Unspecified',
     0x1: '8B10B',
@@ -214,6 +228,10 @@ EncodingDict = {
     0x5: 'SONET Scrambled',
     0x6: '64B/66B',
 }
+
+# Fill 0x7 through 0xF with 'Undefined'
+for code in range(0x7, 0x10):  # 0x10 is 16 (exclusive)
+    EncodingDict[code] = 'Undefined'
 
 RateIdDict = {
     0x0: 'Unspecified',
@@ -227,4 +245,8 @@ RateIdDict = {
     0x8: 'FC-PI-5 (16/8/4G RX Rate Select Only) High=16G, Low=8/4G',
     0x9: 'Unspecified',
     0xA: 'FC-PI-5 (16/8/4G Independent TX and RX Rate Select) High=16G, Low=8/4G',
-},
+}
+
+# Fill 0xB through 0xF with 'Undefined'
+for code in range(0xB, 0x10):  # 0x10 is 16 (exclusive)
+    RateIdDict[code] = 'Undefined'


### PR DESCRIPTION
### Description
- [adding memory proxy for UpperPage access](https://github.com/slaclab/surf/commit/7b21d3a52c8e3189fd25ffa658dce4d0ab95a940)
- [adding _QsfpUpperPage03h.py](https://github.com/slaclab/surf/commit/b9cc713f6db2cdfd7fbe62c4d2dfe892116b7f59)
- [moving UpperPage00h registers from _Qsfp.py to new _QsfpUpperPage00h.py](https://github.com/slaclab/surf/commit/f5fb0bcb282ff7d1aaaf9775a664fabcb9aaeecd)
- [filling dict with Undefined when unmapped in __init__.py](https://github.com/slaclab/surf/commit/454215467a992e4f232eaf9048b5a47e8088907e)