### PR TITLE
Qsfp.py: bug fix for TxCdrEnable register mapping

### DIFF
--- a/python/surf/devices/transceivers/_Qsfp.py
+++ b/python/surf/devices/transceivers/_Qsfp.py
@@ -442,7 +442,7 @@ class Qsfp(pr.Device):
             description  = 'Enable CDR for Tx lane[3:0]',
             offset       = (98 << 2),
             bitSize      = 4,
-            bitOffset    = 4+i,
+            bitOffset    = 4,
             mode         = 'RW',
         ))
 


### PR DESCRIPTION
### Description
- removing the leftover '+i' that carrier over from PR #1318