### PR TITLE
AxiStreamDmaV2Fifo: debug status register bug fix

### DIFF
--- a/axi/dma/rtl/v2/AxiStreamDmaV2Fifo.vhd
+++ b/axi/dma/rtl/v2/AxiStreamDmaV2Fifo.vhd
@@ -483,7 +483,7 @@ begin
       -- Map the read registers
       axiSlaveRegisterR(axilEp, x"00", 0, toSlv(1, 4));  -- Version 1
 
-      axiSlaveRegisterR(axilEp, x"04", 8, AXI_BASE_ADDR_G);
+      axiSlaveRegisterR(axilEp, x"04", 0, AXI_BASE_ADDR_G);
 
       axiSlaveRegisterR(axilEp, x"0C", 0, AXI_CACHE_G);
       axiSlaveRegisterR(axilEp, x"0C", 8, AXI_BURST_G);


### PR DESCRIPTION
### Description
- Fixing a FW mismatch to the SW mapping

```python
        self.add(pr.RemoteVariable(
            name      ='AXI_BASE_ADDR_G',
            offset    = 0x04,
            bitSize   = 64,
            mode      ='RO',
        ))
```