### PR TITLE
HTSP Update: exposing ROGUE_SIM_SIDEBAND_G generic

### DIFF
--- a/protocols/htsp/core/tb/RogueHtspSim.vhd
+++ b/protocols/htsp/core/tb/RogueHtspSim.vhd
@@ -30,7 +30,7 @@ entity RogueHtspSim is
       TPD_G         : time                        := 1 ns;
       PORT_NUM_G    : natural range 1024 to 49151 := 9000;
       NUM_VC_G      : integer range 1 to 16       := 4;
-      EN_SIDEBAND_G : boolean                     := true);
+      EN_SIDEBAND_G : boolean                     := false);
    port (
       -- GT Ports
       htspRefClk      : in  sl;

--- a/protocols/htsp/gtyUs+/rtl/HtspCaui4Gty.vhd
+++ b/protocols/htsp/gtyUs+/rtl/HtspCaui4Gty.vhd
@@ -33,6 +33,7 @@ entity HtspCaui4Gty is
       TPD_G                 : time                        := 1 ns;
       SIM_SPEEDUP_G         : boolean                     := false;
       ROGUE_SIM_EN_G        : boolean                     := false;
+      ROGUE_SIM_SIDEBAND_G  : boolean                     := false;
       ROGUE_SIM_PORT_NUM_G  : natural range 1024 to 49151 := 9000;
       REFCLK_TYPE_G         : string                      := "161MHz";  -- or "156.25MHz"
       -- HTSP Settings
@@ -247,9 +248,10 @@ begin
 
       U_Rogue : entity surf.RogueHtspSim
          generic map(
-            TPD_G      => TPD_G,
-            PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
-            NUM_VC_G   => NUM_VC_G)
+            TPD_G         => TPD_G,
+            PORT_NUM_G    => ROGUE_SIM_PORT_NUM_G,
+            NUM_VC_G      => NUM_VC_G,
+            EN_SIDEBAND_G => ROGUE_SIM_SIDEBAND_G)
          port map(
             -- GT Ports
             htspRefClk      => htspRefClk,


### PR DESCRIPTION
### Description
- Allows users to control where sideband used or not in simulation (instead of always enabled)