### PR TITLE
AxiStreamFifoV2 when CASCADE_SIZE_G>1 using pause flow control update

### DIFF
--- a/base/fifo/rtl/FifoCascade.vhd
+++ b/base/fifo/rtl/FifoCascade.vhd
@@ -63,6 +63,7 @@ entity FifoCascade is
       valid         : out sl;
       underflow     : out sl;
       prog_empty    : out sl;
+      progEmptyVec  : out slv(CASCADE_SIZE_G-1 downto 0);  -- Output stage = 0
       almost_empty  : out sl;
       empty         : out sl);
 end FifoCascade;
@@ -76,6 +77,7 @@ architecture mapping of FifoCascade is
    type FifoDataType is array (CASCADE_SIZE_C downto 0) of slv((DATA_WIDTH_G-1) downto 0);
 
    signal progFull   : sl;
+   signal progEmpty  : sl;
    signal cascadeClk : sl;
 
    signal readJump  : slv(CASCADE_SIZE_C downto 0);
@@ -96,6 +98,9 @@ begin
 
       prog_full      <= progFull;
       progFullVec(0) <= progFull;
+
+      prog_empty      <= progEmpty;
+      progEmptyVec(0) <= progEmpty;
 
       Fifo_1xStage : entity surf.Fifo
          generic map (
@@ -134,7 +139,7 @@ begin
             rd_data_count => rd_data_count,
             valid         => valid,
             underflow     => underflow,
-            prog_empty    => prog_empty,
+            prog_empty    => progEmpty,
             almost_empty  => almost_empty,
             empty         => empty);
 
@@ -181,6 +186,7 @@ begin
             not_full      => not_full,
             --Read Ports (rd_clk domain)
             rd_clk        => cascadeClk,
+            prog_empty    => progEmptyVec(CASCADE_SIZE_G-1),
             rd_en         => readJump(CASCADE_SIZE_G-2),
             dout          => dataJump(CASCADE_SIZE_G-2),
             valid         => validJump(CASCADE_SIZE_G-2));
@@ -218,6 +224,7 @@ begin
                   prog_full   => progFullVec(i),
                   --Read Ports (rd_clk domain)
                   rd_clk      => cascadeClk,
+                  prog_empty  => progEmptyVec(i),
                   rd_en       => readJump(i-1),
                   dout        => dataJump(i-1),
                   valid       => validJump(i-1));
@@ -258,9 +265,12 @@ begin
             rd_data_count => rd_data_count,
             valid         => valid,
             underflow     => underflow,
-            prog_empty    => prog_empty,
+            prog_empty    => progEmpty,
             almost_empty  => almost_empty,
             empty         => empty);
+
+      prog_empty      <= progEmpty;
+      progEmptyVec(0) <= progEmpty;
 
    end generate;
 

--- a/protocols/htsp/core/rtl/HtspRxFifo.vhd
+++ b/protocols/htsp/core/rtl/HtspRxFifo.vhd
@@ -27,6 +27,11 @@ use surf.HtspPkg.all;
 entity HtspRxFifo is
    generic (
       TPD_G                 : time     := 1 ns;
+      CASCADE_SIZE_G        : positive := 1;
+      FIFO_ADDR_WIDTH_G     : positive := 12;
+      FIFO_PAUSE_THRESH_G   : positive := 256;
+      INT_WIDTH_SELECT_G    : string   := "WIDE";
+      INT_DATA_WIDTH_G      : positive := 64;
       TX_MAX_PAYLOAD_SIZE_G : positive := 8192;
       NUM_VC_G              : positive);
    port (
@@ -105,9 +110,11 @@ begin
             SYNTH_MODE_G        => "xpm",
             MEMORY_TYPE_G       => "uram",
             GEN_SYNC_FIFO_G     => true,
-            FIFO_ADDR_WIDTH_G   => 12,  -- 4k URAM,
-            FIFO_FIXED_THRESH_G => true,
-            FIFO_PAUSE_THRESH_G => 1024,  -- 1/4 of buffer
+            FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
+            FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
+            CASCADE_SIZE_G      => CASCADE_SIZE_G,
+            INT_WIDTH_SELECT_G  => INT_WIDTH_SELECT_G,
+            INT_DATA_WIDTH_G    => INT_DATA_WIDTH_G,
             -- AXI Stream Port Configurations
             SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
             MASTER_AXI_CONFIG_G => HTSP_AXIS_CONFIG_C)

--- a/protocols/pgp/shared/PgpRxVcFifo.vhd
+++ b/protocols/pgp/shared/PgpRxVcFifo.vhd
@@ -35,6 +35,7 @@ entity PgpRxVcFifo is
       GEN_SYNC_FIFO_G     : boolean  := false;
       FIFO_ADDR_WIDTH_G   : positive := 9;
       FIFO_PAUSE_THRESH_G : positive := 256;
+      CASCADE_SIZE_G      : positive := 1;
       INT_WIDTH_SELECT_G  : string   := "WIDE";
       INT_DATA_WIDTH_G    : positive := 16;
       PHY_AXI_CONFIG_G    : AxiStreamConfigType;
@@ -105,6 +106,7 @@ begin
          GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
+         CASCADE_SIZE_G      => CASCADE_SIZE_G,
          INT_WIDTH_SELECT_G  => INT_WIDTH_SELECT_G,
          INT_DATA_WIDTH_G    => INT_DATA_WIDTH_G,
          -- AXI Stream Port Configurations

--- a/protocols/srp/rtl/SrpV3AxiLite.vhd
+++ b/protocols/srp/rtl/SrpV3AxiLite.vhd
@@ -35,6 +35,7 @@ entity SrpV3AxiLite is
       TPD_G                 : time                    := 1 ns;
       INT_PIPE_STAGES_G     : natural range 0 to 16   := 1;
       PIPE_STAGES_G         : natural range 0 to 16   := 1;
+      CASCADE_SIZE_G        : positive                := 1;
       FIFO_PAUSE_THRESH_G   : positive range 1 to 511 := 256;
       FIFO_SYNTH_MODE_G     : string                  := "inferred";
       FIFO_MEMORY_TYPE_G    : string                  := "block";
@@ -237,6 +238,7 @@ begin
          FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,  -- 8kB/FIFO = 128-bits x 512 entries
          FIFO_FIXED_THRESH_G => true,
          FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
+         CASCADE_SIZE_G      => CASCADE_SIZE_G,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => AXI_STREAM_CONFIG_G,
          MASTER_AXI_CONFIG_G => AXIS_CONFIG_C)


### PR DESCRIPTION
### Description
- [adding progEmptyVec to FifoCascade.vhd](https://github.com/slaclab/surf/commit/4d4c8032ea45496c07e3e427994dc93e362ac46a)
- [Enforces that the upper FIFOs in the FifoCascade are almost empty before the pause signal will be deasserted](https://github.com/slaclab/surf/commit/4201d2079718bb73e88795209f4dd728d58cb938)
- [exposing CASCADE_SIZE_G generic in SrpV3AxiLite.vhd & PgpRxVcFifo.vhd](https://github.com/slaclab/surf/commit/aa6c0eb66e1360cd3bc09bff21a30af4afc630ea)
- [exposing more FIFO config generics in HtspRxFifo.vhd](https://github.com/slaclab/surf/commit/cf1753c1df08a71a17c2f3a098ac55c16d13cdb5)