### PR TITLE
Actually check for LTS timeout in ST_WAIT_C state in Pgp2bRxPhy

### DIFF
--- a/protocols/pgp/pgp2b/core/rtl/Pgp2bRxPhy.vhd
+++ b/protocols/pgp/pgp2b/core/rtl/Pgp2bRxPhy.vhd
@@ -279,6 +279,15 @@ begin
                nxtRxPolarity <= (others => '0');
                nxtState      <= ST_RESET_C;
 
+            -- Terminal count without seeing a valid LTS
+            elsif stateCnt = x"FFFFF" then
+               stateCntRst   <= '1';
+               ltsCntEn      <= '0';
+               ltsCntRst     <= '1';
+               -- nxtRxPolarity <= intRxPolarity;
+               nxtRxPolarity <= (others => '0');
+               nxtState      <= ST_RESET_C;
+
             -- Decode or disparity error, clear lts count
             elsif phyRxReady = '0' or dly1RxDispErr /= 0 or dly1RxDecErr /= 0 then
                stateCntRst   <= '0';
@@ -325,15 +334,6 @@ begin
                -- nxtRxPolarity <= intRxPolarity;
                nxtRxPolarity <= (others => '0');
                nxtState      <= ST_READY_C;
-
-            -- Terminal count without seeing a valid LTS
-            elsif stateCnt = x"FFFFF" then
-               stateCntRst   <= '1';
-               ltsCntEn      <= '0';
-               ltsCntRst     <= '1';
-               -- nxtRxPolarity <= intRxPolarity;
-               nxtRxPolarity <= (others => '0');
-               nxtState      <= ST_RESET_C;
 
             -- Count cycles without LTS
             else


### PR DESCRIPTION
While tracking down an rare error in link establishment for LSSTCam, I found that if there are decode or disparity errors when the LTS timeout reaches FFFFF, then state counter wraps and we don't reset the link.  If the link parameters are bad enough, I found I could remain perpetually in the state ST_WAIT_C, and the link never gets reset.

This commit just moves the LTS timeout check before the Decode/Disparity checks.
