### PR TITLE
Updates to Saci2ToAxiLite

### DIFF
--- a/protocols/saci/saci2/rtl/Saci2Subordinate.vhd
+++ b/protocols/saci/saci2/rtl/Saci2Subordinate.vhd
@@ -40,6 +40,7 @@ entity Saci2Subordinate is
       -- Detector (Parallel) Interface
       exec   : out sl;
       ack    : in  sl;
+      resp   : in  sl := '0';
       readL  : out sl;
       addr   : out slv(29 downto 0);
       wrData : out slv(31 downto 0);
@@ -97,7 +98,7 @@ begin
       end if;
    end process seq;
 
-   comb : process (ack, r, rdData, saciCmdFall) is
+   comb : process (ack, r, rdData, resp, saciCmdFall) is
       variable v : RegType;
    begin
       v := r;
@@ -134,8 +135,13 @@ begin
                else
                   v.shiftReg(32 downto 1) := rdData;           -- read
                end if;
-            end if;
 
+               -- Invert the returned OP bit if non-zero resp to communicate to coordinator about failure
+               if (resp = '1') then
+                  v.shiftReg(63) := not(r.shiftReg(63));
+               end if;
+
+            end if;
 
          when others =>
             v.shiftReg := (others => '0');

--- a/protocols/saci/saci2/rtl/Saci2ToAxiLite.vhd
+++ b/protocols/saci/saci2/rtl/Saci2ToAxiLite.vhd
@@ -56,6 +56,7 @@ architecture mapping of Saci2ToAxiLite is
    -- SACI Slave parallel interface
    signal exec   : sl;
    signal ack    : sl;
+   signal resp   : sl;
    signal readL  : sl;
    signal addr   : slv(29 downto 0);
    signal wrData : slv(31 downto 0);
@@ -78,6 +79,7 @@ begin
          rstInL   => rstInL,            -- [in]
          exec     => exec,              -- [out]
          ack      => ack,               -- [in]
+         resp     => resp,              -- [in]
          readL    => readL,             -- [out]
          addr     => addr,              -- [out]
          wrData   => wrData,            -- [out]
@@ -133,6 +135,7 @@ begin
    -- By the time axilAck.done gets synced to ack
    ------------------------------------------------------
    rdData <= axilAck.rdData;
+   resp   <= uOr(axilAck.resp);         -- OR the bits together
 
    U_AxiLiteMaster_1 : entity surf.AxiLiteMaster
       generic map (

--- a/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
+++ b/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
@@ -49,6 +49,12 @@ end Saci2ToAxiLiteTb;
 
 architecture mapping of Saci2ToAxiLiteTb is
 
+   constant AXIL_CONFIG_C : AxiLiteCrossbarMasterConfigArray(0 downto 0) := (
+      0 => (
+         baseAddr     => x"0000_0000",
+         addrBits     => 24,
+         connectivity => x"FFFF"));
+
    signal fpgaAxilClk : sl;
    signal fpgaAxilRst : sl;
 
@@ -64,6 +70,11 @@ architecture mapping of Saci2ToAxiLiteTb is
    signal asicAxilReadSlave   : AxiLiteReadSlaveType;
    signal asicAxilWriteMaster : AxiLiteWriteMasterType;
    signal asicAxilWriteSlave  : AxiLiteWriteSlaveType;
+
+   signal memAxilReadMaster  : AxiLiteReadMasterType;
+   signal memAxilReadSlave   : AxiLiteReadSlaveType;
+   signal memAxilWriteMaster : AxiLiteWriteMasterType;
+   signal memAxilWriteSlave  : AxiLiteWriteSlaveType;
 
    signal rstL : sl;
 
@@ -165,6 +176,25 @@ begin
          axilWriteMaster => asicAxilWriteMaster,  -- [in]
          axilWriteSlave  => asicAxilWriteSlave);  -- [out]
 
+   -- AXI-Lite Crossbar is to assert non-zero for AXI-Lite bus response outside of U_MEM
+   U_XBAR : entity surf.AxiLiteCrossbar
+      generic map (
+         NUM_SLAVE_SLOTS_G  => 1,
+         NUM_MASTER_SLOTS_G => 1,
+         MASTERS_CONFIG_G   => AXIL_CONFIG_C)
+      port map (
+         axiClk              => asicAxilClk,
+         axiClkRst           => asicAxilRst,
+         -- Slave AXIL Ports
+         sAxiWriteMasters(0) => asicAxilWriteMaster,
+         sAxiWriteSlaves(0)  => asicAxilWriteSlave,
+         sAxiReadMasters(0)  => asicAxilReadMaster,
+         sAxiReadSlaves(0)   => asicAxilReadSlave,
+         -- Master AXIL Ports
+         mAxiWriteMasters(0)    => memAxilWriteMaster,
+         mAxiWriteSlaves(0)     => memAxilWriteSlave,
+         mAxiReadMasters(0)     => memAxilReadMaster,
+         mAxiReadSlaves(0)      => memAxilReadSlave);
 
    U_MEM : entity surf.AxiDualPortRam
       generic map (
@@ -174,10 +204,9 @@ begin
          -- Axi Port
          axiClk         => asicAxilClk,
          axiRst         => asicAxilRst,
-         axiReadMaster  => asicAxilReadMaster,
-         axiReadSlave   => asicAxilReadSlave,
-         axiWriteMaster => asicAxilWriteMaster,
-         axiWriteSlave  => asicAxilWriteSlave);
-
+         axiReadMaster  => memAxilReadMaster,
+         axiReadSlave   => memAxilReadSlave,
+         axiWriteMaster => memAxilWriteMaster,
+         axiWriteSlave  => memAxilWriteSlave);
 
 end mapping;

--- a/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
+++ b/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
@@ -52,7 +52,7 @@ architecture mapping of Saci2ToAxiLiteTb is
    constant AXIL_CONFIG_C : AxiLiteCrossbarMasterConfigArray(0 downto 0) := (
       0               => (
          baseAddr     => x"0000_0000",
-         addrBits     => 24,
+         addrBits     => 20,
          connectivity => x"FFFF"));
 
    signal fpgaAxilClk : sl;
@@ -198,7 +198,7 @@ begin
 
    U_MEM : entity surf.AxiDualPortRam
       generic map (
-         ADDR_WIDTH_G => 22,
+         ADDR_WIDTH_G => 18,  -- 18 bits of word address (20 bits of byte address)
          DATA_WIDTH_G => 32)
       port map (
          -- Axi Port

--- a/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
+++ b/protocols/saci/saci2/sim/Saci2ToAxiLiteTb.vhd
@@ -50,7 +50,7 @@ end Saci2ToAxiLiteTb;
 architecture mapping of Saci2ToAxiLiteTb is
 
    constant AXIL_CONFIG_C : AxiLiteCrossbarMasterConfigArray(0 downto 0) := (
-      0 => (
+      0               => (
          baseAddr     => x"0000_0000",
          addrBits     => 24,
          connectivity => x"FFFF"));
@@ -191,10 +191,10 @@ begin
          sAxiReadMasters(0)  => asicAxilReadMaster,
          sAxiReadSlaves(0)   => asicAxilReadSlave,
          -- Master AXIL Ports
-         mAxiWriteMasters(0)    => memAxilWriteMaster,
-         mAxiWriteSlaves(0)     => memAxilWriteSlave,
-         mAxiReadMasters(0)     => memAxilReadMaster,
-         mAxiReadSlaves(0)      => memAxilReadSlave);
+         mAxiWriteMasters(0) => memAxilWriteMaster,
+         mAxiWriteSlaves(0)  => memAxilWriteSlave,
+         mAxiReadMasters(0)  => memAxilReadMaster,
+         mAxiReadSlaves(0)   => memAxilReadSlave);
 
    U_MEM : entity surf.AxiDualPortRam
       generic map (

--- a/tests/test_Saci2ToAxiLiteTb.py
+++ b/tests/test_Saci2ToAxiLiteTb.py
@@ -13,7 +13,7 @@ from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 from cocotb.regression import TestFactory
 
-from cocotbext.axi import AxiLiteBus, AxiLiteMaster
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiResp
 
 # test_Saci2ToAxiLiteTb
 from cocotb_test.simulator import run
@@ -74,19 +74,34 @@ async def run_test_words(dut):
     # Wait for internal reset to fall
     await Timer(10, 'us')
 
+    ########################################################################
+    # Positive test coverage:
+    # Iterate over all valid high address offsets (0–16) and low word offsets
+    # to verify correct AXI-Lite read/write behavior across the full mapped
+    # SACI-to-AXI-Lite address space.
+    ########################################################################
     for offsetHigh in range(17):
         for offsetLow in range(0, 0xF, 4):
             high = 0
             if offsetHigh != 0:
                 high = (1 << (offsetHigh+3))
             addr = high | offsetLow
-
             test_data = addr.to_bytes(length=4, byteorder='little')
-            event = tb.axil_master.init_write(addr, test_data)
-            await event.wait()
-            event = tb.axil_master.init_read(addr, 4)
-            await event.wait()
-            assert event.data.data == test_data
+
+            rsp = await tb.axil_master.write(addr, test_data)
+            assert rsp.resp == AxiResp.OKAY
+
+    for offsetHigh in range(17):
+        for offsetLow in range(0, 0xF, 4):
+            high = 0
+            if offsetHigh != 0:
+                high = (1 << (offsetHigh+3))
+            addr = high | offsetLow
+            test_data = addr.to_bytes(length=4, byteorder='little')
+
+            rsp = await tb.axil_master.read(addr, 4)
+            assert rsp.resp == AxiResp.OKAY
+            assert rsp.data == test_data
 
     await RisingEdge(dut.S_AXI_ACLK)
     await RisingEdge(dut.S_AXI_ACLK)

--- a/tests/test_Saci2ToAxiLiteTb.py
+++ b/tests/test_Saci2ToAxiLiteTb.py
@@ -103,6 +103,19 @@ async def run_test_words(dut):
             assert rsp.resp == AxiResp.OKAY
             assert rsp.data == test_data
 
+    ########################################################################
+    # Negative test: access an unmapped/invalid AXI-Lite address and confirm
+    # that BOTH the write and read return a non-zero AXI response (error).
+    ########################################################################
+    bad_addr = 0x0010_0000
+    bad_data = (0xFFFFFFFF).to_bytes(length=4, byteorder='little')
+
+    rsp = await tb.axil_master.write(bad_addr, bad_data)
+    assert rsp.resp != AxiResp.OKAY
+
+    rsp = await tb.axil_master.read(bad_addr, 4)
+    assert rsp.resp != AxiResp.OKAY
+
     await RisingEdge(dut.S_AXI_ACLK)
     await RisingEdge(dut.S_AXI_ACLK)
 


### PR DESCRIPTION
### Description
- Clean up cocotb CI to improve positive test coverage.
- Add support for propagating non-zero AXI-Lite responses to report transaction (TXN) errors to the upstream coordinator.
  - This is implemented by inverting the return OP bit when a non-zero response is detected.
  - The coordinator validates that the returned OP matches the one it sent; a mismatch triggers a memory error that is surfaced to software.
