### PR TITLE
Update _Si5345Pages.py

### DIFF
--- a/python/surf/devices/silabs/_Si5345Pages.py
+++ b/python/surf/devices/silabs/_Si5345Pages.py
@@ -9,7 +9,6 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
-import rogue
 
 class Si5345PageBase(pr.Device):
     def __init__(self,

--- a/python/surf/devices/silabs/_Si5345Pages.py
+++ b/python/surf/devices/silabs/_Si5345Pages.py
@@ -11,8 +11,6 @@
 import pyrogue as pr
 import rogue
 
-rogue.Version.minVersion('5.4.0')
-
 class Si5345PageBase(pr.Device):
     def __init__(self,
             name          = "PageBase",


### PR DESCRIPTION
### Description
- Removed `rogue.Version.minVersion('5.4.0')` since it is overridden by `rogue.Version.minVersion('6.1.0')` in `python/surf/__init__.py`.