### PR TITLE
FirFilterSingleChannel.vhd - Bug fix patch

### DIFF
--- a/dsp/generic/fixed/FirFilterSingleChannel.vhd
+++ b/dsp/generic/fixed/FirFilterSingleChannel.vhd
@@ -154,8 +154,8 @@ begin
       v.coeffce := (others => '0');
 
       -- Convert write/read address into integers
-      wrAddrInt := to_integer(unsigned(writeMaster.awaddr(NUM_ADDR_BITS_C-1 downto 2)));
-      rdAddrInt := to_integer(unsigned(readMaster.araddr(NUM_ADDR_BITS_C-1 downto 2)));
+      wrAddrInt := to_integer(unsigned(writeMaster.awaddr(NUM_ADDR_BITS_C+1 downto 2)));
+      rdAddrInt := to_integer(unsigned(readMaster.araddr(NUM_ADDR_BITS_C+1 downto 2)));
 
       -- Determine the transaction type
       axiSlaveWaitTxn(writeMaster, readMaster, v.writeSlave, v.readSlave, axiStatus);


### PR DESCRIPTION
### Description
- [bug fix for the wrAddrInt/rdAddrInt](https://github.com/slaclab/surf/commit/0eab2ba17c7c09c2494b6c4ffef6265a96216996)
- Discovered this when I was using 32 taps and the read back of the registers were repeating taps[15:0] valus into the taps[31:0] values