### PR TITLE
Fix review findings: bugs, convention violations, register mismatches

### DIFF
--- a/axi/axi-lite/rtl/AxiLiteMasterProxy.vhd
+++ b/axi/axi-lite/rtl/AxiLiteMasterProxy.vhd
@@ -47,7 +47,7 @@ entity AxiLiteMasterProxy is
       mAxiWriteSlave  : in  AxiLiteWriteSlaveType);
 end AxiLiteMasterProxy;
 
-architecture mapping of AxiLiteMasterProxy is
+architecture rtl of AxiLiteMasterProxy is
 
    type StateType is (READY_S, ACK_S);
 
@@ -175,4 +175,4 @@ begin
          axilReadMaster  => mAxiReadMaster,
          axilReadSlave   => mAxiReadSlave);
 
-end mapping;
+end rtl;

--- a/axi/axi-lite/rtl/AxiLiteMasterProxy.vhd
+++ b/axi/axi-lite/rtl/AxiLiteMasterProxy.vhd
@@ -104,7 +104,7 @@ begin
       axiWrDetect (axilEp, X"00", newCmd);
 
       -- Close out the transaction
-      axiSlaveDefault(axilEp, v.sAxiWriteSlave, v.sAxiReadSlave, AXI_RESP_OK_C);
+      axiSlaveDefault(axilEp, v.sAxiWriteSlave, v.sAxiReadSlave, AXI_RESP_DECERR_C);
 
       -- State Machine
       case r.state is

--- a/base/crc/wrappers/Crc32PolyWrapper.vhd
+++ b/base/crc/wrappers/Crc32PolyWrapper.vhd
@@ -42,7 +42,7 @@ entity Crc32PolyWrapper is
       crcPwrOnRst  : in  sl);
 end entity Crc32PolyWrapper;
 
-architecture rtl of Crc32PolyWrapper is
+architecture mapping of Crc32PolyWrapper is
 
    constant CRC_POLY_C : slv(31 downto 0) := toSlv(CRC_POLY_INT_G, 32);
 
@@ -68,4 +68,4 @@ begin
          crcRem       => crcRem,
          crcPwrOnRst  => crcPwrOnRst);
 
-end architecture rtl;
+end architecture mapping;

--- a/devices/AnalogDevices/ad9681/core/Ad9681Config.vhd
+++ b/devices/AnalogDevices/ad9681/core/Ad9681Config.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: AD9249 Configuration/Status Module
+-- Description: AD9681 Configuration/Status Module
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the

--- a/dsp/generic/fixed/BoxcarIntegrator.vhd
+++ b/dsp/generic/fixed/BoxcarIntegrator.vhd
@@ -96,7 +96,7 @@ begin
 
    SIGNED_DATA : if (SIGNED_G = true) generate
       ramDoutE <= signed(ramDout(DATA_WIDTH_G-1) & ramDout);
-      ibDataE  <= signed(ibDataE(DATA_WIDTH_G-1) & r.ibData);
+      ibDataE  <= signed(r.ibData(DATA_WIDTH_G-1) & r.ibData);
    end generate;
 
    U_RAM : entity surf.SimpleDualPortRam

--- a/ethernet/GigEthCore/core/rtl/GigEthReg.vhd
+++ b/ethernet/GigEthCore/core/rtl/GigEthReg.vhd
@@ -176,12 +176,12 @@ begin
          --axiSlaveRegister(regCon,x"210", 0, v.config.macConfig.txShift);
          --axiSlaveRegister(regCon,x"214", 0, v.config.macConfig.txShiftEn);
          --axiSlaveRegister(regCon, x"218", 0, v.config.macConfig.interFrameGap);
-         axiSlaveRegister(regCon, x"21C", 0, v.config.macConfig.pauseTime);
+         axiSlaveRegisterR(regCon, x"21C", 0, r.config.macConfig.pauseTime);
 
          --axiSlaveRegister(regCon,x"220", 0, v.config.macConfig.rxShift);
          --axiSlaveRegister(regCon,x"224", 0, v.config.macConfig.rxShiftEn);
-         axiSlaveRegister(regCon, x"228", 0, v.config.macConfig.filtEnable);
-         axiSlaveRegister(regCon, x"22C", 0, v.config.macConfig.pauseEnable);
+         axiSlaveRegisterR(regCon, x"228", 0, r.config.macConfig.filtEnable);
+         axiSlaveRegisterR(regCon, x"22C", 0, r.config.macConfig.pauseEnable);
 
          axiSlaveRegister(regCon, x"800", 0, v.config.macConfig.pauseThresh);
 

--- a/ethernet/XauiCore/core/rtl/XauiReg.vhd
+++ b/ethernet/XauiCore/core/rtl/XauiReg.vhd
@@ -178,12 +178,12 @@ begin
          --axiSlaveRegister(regCon, x"210", 0, v.config.macConfig.txShift);
          --axiSlaveRegister(regCon, x"214", 0, v.config.macConfig.txShiftEn);
          --axiSlaveRegister(regCon, x"218", 0, v.config.macConfig.interFrameGap);
-         axiSlaveRegister(regCon, x"21C", 0, v.config.macConfig.pauseTime);
+         axiSlaveRegisterR(regCon, x"21C", 0, r.config.macConfig.pauseTime);
 
          --axiSlaveRegister(regCon, x"220", 0, v.config.macConfig.rxShift);
          --axiSlaveRegister(regCon, x"224", 0, v.config.macConfig.rxShiftEn);
-         axiSlaveRegister(regCon, x"228", 0, v.config.macConfig.filtEnable);
-         axiSlaveRegister(regCon, x"22C", 0, v.config.macConfig.pauseEnable);
+         axiSlaveRegisterR(regCon, x"228", 0, r.config.macConfig.filtEnable);
+         axiSlaveRegisterR(regCon, x"22C", 0, r.config.macConfig.pauseEnable);
 
          axiSlaveRegister(regCon, x"230", 0, v.config.configVector);
 

--- a/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
@@ -198,7 +198,7 @@ begin
    ---------------------
    -- AXI-Lite Registers
    ---------------------
-   process (axilReadMaster, axilRst, axilWriteMaster, locData, locOverflowCnt,
+   comb : process (axilReadMaster, axilRst, axilWriteMaster, locData, locOverflowCnt,
             locPause, locPauseCnt, phyFec, phyFecCnt, r, remLinkData,
             remRxOverflowCnt, remRxPause, remRxPauseCnt, rxClkFreq, rxError,
             rxErrorCnt, rxOpCodeData, rxStatusCnt, txClkFreq, txError,

--- a/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
@@ -199,10 +199,10 @@ begin
    -- AXI-Lite Registers
    ---------------------
    comb : process (axilReadMaster, axilRst, axilWriteMaster, locData, locOverflowCnt,
-            locPause, locPauseCnt, phyFec, phyFecCnt, r, remLinkData,
-            remRxOverflowCnt, remRxPause, remRxPauseCnt, rxClkFreq, rxError,
-            rxErrorCnt, rxOpCodeData, rxStatusCnt, txClkFreq, txError,
-            txErrorCnt, txOpCodeData, txStatusCnt) is
+                   locPause, locPauseCnt, phyFec, phyFecCnt, r, remLinkData,
+                   remRxOverflowCnt, remRxPause, remRxPauseCnt, rxClkFreq, rxError,
+                   rxErrorCnt, rxOpCodeData, rxStatusCnt, txClkFreq, txError,
+                   txErrorCnt, txOpCodeData, txStatusCnt) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndpointType;
    begin

--- a/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
@@ -76,7 +76,7 @@ entity Pgp4AxiL is
       axilWriteSlave   : out AxiLiteWriteSlaveType);
 end Pgp4AxiL;
 
-architecture mapping of Pgp4AxiL is
+architecture rtl of Pgp4AxiL is
 
    constant TIMEOUT_1HZ_C : natural := getTimeRatio(AXIL_CLK_FREQ_G, 1.0) - 1;
 
@@ -733,4 +733,4 @@ begin
          rdClk        => axilClk,
          rdRst        => axilRst);
 
-end mapping;
+end rtl;

--- a/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
+++ b/protocols/ssp/rtl/SspLowSpeedDecoderReg.vhd
@@ -55,7 +55,7 @@ entity SspLowSpeedDecoderReg is
       axilWriteSlave  : out AxiLiteWriteSlaveType);
 end SspLowSpeedDecoderReg;
 
-architecture mapping of SspLowSpeedDecoderReg is
+architecture rtl of SspLowSpeedDecoderReg is
 
    constant STATUS_SIZE_C  : positive := 3*NUM_LANE_G;
    constant STATUS_WIDTH_C : positive := 16;
@@ -236,4 +236,4 @@ begin
    statusIn((1*NUM_LANE_G)+NUM_LANE_G-1 downto 1*NUM_LANE_G) <= bitSlip;
    statusIn((0*NUM_LANE_G)+NUM_LANE_G-1 downto 0*NUM_LANE_G) <= locked;
 
-end mapping;
+end rtl;

--- a/python/surf/axi/_AxiVersion.py
+++ b/python/surf/axi/_AxiVersion.py
@@ -118,7 +118,7 @@ class AxiVersion(pr.Device):
             base         = pr.UInt,
             mode         = 'RW',
             hidden       = True,
-            groups       = 'NoConfig',
+            groups       = ['NoConfig'],
         ))
 
         @self.command(hidden=True)

--- a/python/surf/devices/analog_devices/_Ad9249.py
+++ b/python/surf/devices/analog_devices/_Ad9249.py
@@ -450,7 +450,7 @@ class Ad9249ReadoutGroup2(pr.Device):
             base         = pr.UInt,
             mode         = 'RW',
             verify       = False,
-            groups       = 'NoConfig',
+            groups       = ['NoConfig'],
         ))
 
         self.add(pr.RemoteCommand(

--- a/python/surf/devices/linear/_Ltc3815.py
+++ b/python/surf/devices/linear/_Ltc3815.py
@@ -57,7 +57,7 @@ class Ltc3815(surf.protocols.i2c.PMBus):
         ))
 
         self.add(pr.LinkVariable(
-            name         = "DieTempature",
+            name         = "DieTemperature",
             mode         = 'RO',
             linkedGet    = lambda read: self.READ_TEMPERATURE_1.get(read=read)*1.0, # Conversion factor: 1 degC/Bit
             typeStr      = "Float32",

--- a/python/surf/devices/ti/_Ina237.py
+++ b/python/surf/devices/ti/_Ina237.py
@@ -229,7 +229,7 @@ class Ina237(pr.Device):
         ))
 
         self.add(pr.LinkVariable(
-            name         = "DieTempature",
+            name         = "DieTemperature",
             mode         = 'RO',
             linkedGet    = lambda read: self.DIETEMP.get(read=read)*0.125, # Conversion factor: 0.125 degC/LSB
             typeStr      = "Float32",

--- a/python/surf/devices/ti/_Ina237.py
+++ b/python/surf/devices/ti/_Ina237.py
@@ -53,7 +53,7 @@ class Ina237(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = 'ADCRANGE',
-            description  = 'Reset Bit. Setting this bit to 1 generates a system reset that is the same as power-on reset.',
+            description  = 'ADC input range setting: 0 = +/-163.84mV, 1 = +/-40.96mV',
             offset       = (0x0 << 2),
             bitSize      = 1,
             bitOffset    = 4,

--- a/python/surf/xilinx/_TmrSem.py
+++ b/python/surf/xilinx/_TmrSem.py
@@ -10,7 +10,7 @@
 
 import pyrogue as pr
 
-class TmrInject(pr.Device):
+class TmrSem(pr.Device):
     def __init__(
             self,
             description = 'Xilinx TMR Soft Error Mitigation (SEM) registers (refer to PG268 v1.0, page 52 - 55)',

--- a/python/surf/xilinx/__init__.py
+++ b/python/surf/xilinx/__init__.py
@@ -15,6 +15,7 @@ from surf.xilinx._GtRxAlignCheck      import *
 from surf.xilinx._Gtye4Channel        import *
 from surf.xilinx._Gtye4Common         import *
 from surf.xilinx._Gthe3Channel        import *
+from surf.xilinx._Gthe3Common         import *
 from surf.xilinx._Gtxe2Channel        import *
 from surf.xilinx._Gtpe2Channel        import *
 from surf.xilinx._Gtpe2Common         import *


### PR DESCRIPTION
## Summary

- Fix combinatorial loop in BoxcarIntegrator signed mode (self-referencing signal)
- Fix architecture type mismatches (3x mapping->rtl, 1x rtl->mapping)
- Add missing process label in Pgp4AxiL and fix AXI default response in AxiLiteMasterProxy
- Fix copy-paste description errors in Ad9681Config and Ina237
- Fix TmrSem/TmrInject class name collision (TmrSem was inaccessible)
- Add missing Gthe3Common import to xilinx `__init__.py`
- Fix `groups` parameter type from string to list in AxiVersion and Ad9249
- Fix DieTempature typo to DieTemperature in Ina237 and Ltc3815
- Change GigEthReg/XauiReg pauseTime/filtEnable/pauseEnable to read-only

## Test plan

- [x] Python linting passes (`flake8 --count python/`)
- [x] Python compilation passes (`python -m compileall -f python/`)
- [x] VHDL syntax check passes (`make MODULES=$PWD analysis`)
- [x] Regression tests pass (`pytest tests/`)