### PR TITLE
fix Vivado synthesis hang in Gearbox.vhd shiftReg write

### DIFF
--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -146,7 +146,7 @@ begin
          else
             dataIn := slaveData;
          end if;
-         lo := v.writeIndex;
+         lo                                       := v.writeIndex;
          v.shiftReg(lo+SLAVE_WIDTH_G-1 downto lo) := dataIn;
 
          -- Increment writeIndex

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -82,7 +82,7 @@ begin
 
    comb : process (masterBitOrder, masterReady, r, rst, slaveBitOrder,
                    slaveData, slaveValid, slip, startOfSeq) is
-      variable v      : RegType;
+      variable v : RegType;
       -- Helper variables used to write the incoming word into shiftReg at a
       -- variable base index with a constant width (see the write below for
       -- the full rationale — this shape is load-bearing for both Vivado

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -82,7 +82,14 @@ begin
 
    comb : process (masterBitOrder, masterReady, r, rst, slaveBitOrder,
                    slaveData, slaveValid, slip, startOfSeq) is
-      variable v : RegType;
+      variable v      : RegType;
+      -- Helper variables used to write the incoming word into shiftReg at a
+      -- variable base index with a constant width (see the write below for
+      -- the full rationale — this shape is load-bearing for both Vivado
+      -- synthesis and GHDL --synth).
+      variable lo     : natural range 0 to SHIFT_WIDTH_C-1;
+      variable hi     : natural range 0 to SHIFT_WIDTH_C-1;
+      variable dataIn : slv(SLAVE_WIDTH_G-1 downto 0);
    begin
       v := r;
 
@@ -133,18 +140,30 @@ begin
          -- Accept the input word
          v.slaveReady := '1';
 
-         -- Assign incoming data at proper location in shift reg
+         -- Assign incoming data at proper location in shift reg.
+         --
+         -- Writing SLAVE_WIDTH_G bits into shiftReg at a runtime-varying
+         -- base has to be shaped carefully:
+         --   (a) inline slice `v.shiftReg(v.writeIndex+SLAVE_WIDTH_G-1
+         --       downto v.writeIndex) := slaveData;` -- synthesizes in
+         --       Vivado but GHDL --synth rejects with "cannot extract same
+         --       variable part for dynamic slice".
+         --   (b) per-bit for loop -- GHDL accepts it but Vivado treats each
+         --       iteration as an independent dynamic-index bit write,
+         --       hanging synthesis on wide instances (e.g.
+         --       Ssr12ToSsr16Gearbox, NUM_CH_G=4).
+         -- Pre-computing `lo`/`hi` as `hi := lo + const` satisfies GHDL's
+         -- same-variable-part check while still giving Vivado the variable-
+         -- base / constant-width slice it recognizes. bitReverse() is
+         -- hoisted into `dataIn` for the same reason.
          if (slaveBitOrder = '1') then
---            v.shiftReg(v.writeIndex+SLAVE_WIDTH_G-1 downto v.writeIndex) := bitReverse(slaveData);
-            for i in 0 to SLAVE_WIDTH_G-1 loop
-               v.shiftReg(v.writeIndex + i) := bitReverse(slaveData)(i);
-            end loop;
+            dataIn := bitReverse(slaveData);
          else
---            v.shiftReg(v.writeIndex+SLAVE_WIDTH_G-1 downto v.writeIndex) := slaveData;
-            for i in 0 to SLAVE_WIDTH_G-1 loop
-               v.shiftReg(v.writeIndex + i) := slaveData(i);
-            end loop;
+            dataIn := slaveData;
          end if;
+         lo                       := v.writeIndex;
+         hi                       := lo + SLAVE_WIDTH_G - 1;
+         v.shiftReg(hi downto lo) := dataIn;
 
          -- Increment writeIndex
          v.writeIndex := v.writeIndex + SLAVE_WIDTH_G;

--- a/base/general/rtl/Gearbox.vhd
+++ b/base/general/rtl/Gearbox.vhd
@@ -82,13 +82,8 @@ begin
 
    comb : process (masterBitOrder, masterReady, r, rst, slaveBitOrder,
                    slaveData, slaveValid, slip, startOfSeq) is
-      variable v : RegType;
-      -- Helper variables used to write the incoming word into shiftReg at a
-      -- variable base index with a constant width (see the write below for
-      -- the full rationale — this shape is load-bearing for both Vivado
-      -- synthesis and GHDL --synth).
+      variable v      : RegType;
       variable lo     : natural range 0 to SHIFT_WIDTH_C-1;
-      variable hi     : natural range 0 to SHIFT_WIDTH_C-1;
       variable dataIn : slv(SLAVE_WIDTH_G-1 downto 0);
    begin
       v := r;
@@ -141,29 +136,18 @@ begin
          v.slaveReady := '1';
 
          -- Assign incoming data at proper location in shift reg.
-         --
-         -- Writing SLAVE_WIDTH_G bits into shiftReg at a runtime-varying
-         -- base has to be shaped carefully:
-         --   (a) inline slice `v.shiftReg(v.writeIndex+SLAVE_WIDTH_G-1
-         --       downto v.writeIndex) := slaveData;` -- synthesizes in
-         --       Vivado but GHDL --synth rejects with "cannot extract same
-         --       variable part for dynamic slice".
-         --   (b) per-bit for loop -- GHDL accepts it but Vivado treats each
-         --       iteration as an independent dynamic-index bit write,
-         --       hanging synthesis on wide instances (e.g.
-         --       Ssr12ToSsr16Gearbox, NUM_CH_G=4).
-         -- Pre-computing `lo`/`hi` as `hi := lo + const` satisfies GHDL's
-         -- same-variable-part check while still giving Vivado the variable-
-         -- base / constant-width slice it recognizes. bitReverse() is
-         -- hoisted into `dataIn` for the same reason.
+         -- Copying v.writeIndex into lo (a plain variable, not a record
+         -- field) lets GHDL --synth see "lo + const downto lo" as the same
+         -- variable part. The inline constant-offset form also gives Vivado
+         -- the variable-base / constant-width slice it needs for correct
+         -- synthesis (two separate hi/lo variables lose that relationship).
          if (slaveBitOrder = '1') then
             dataIn := bitReverse(slaveData);
          else
             dataIn := slaveData;
          end if;
-         lo                       := v.writeIndex;
-         hi                       := lo + SLAVE_WIDTH_G - 1;
-         v.shiftReg(hi downto lo) := dataIn;
+         lo := v.writeIndex;
+         v.shiftReg(lo+SLAVE_WIDTH_G-1 downto lo) := dataIn;
 
          -- Increment writeIndex
          v.writeIndex := v.writeIndex + SLAVE_WIDTH_G;


### PR DESCRIPTION
## Summary

- The per-bit for-loop introduced in 9ccc0f48 as a workaround for a GHDL `--synth` dynamic-slice error causes Vivado to treat each iteration as an independent dynamic-index bit write. For wide instances such as `Ssr12ToSsr16Gearbox` (`NUM_CH_G=4` → `SLAVE_WIDTH_G=768`, `SHIFT_WIDTH_C=2305`) this inflates synthesis into O(`SLAVE_WIDTH_G * SHIFT_WIDTH_C`) mux analysis and hangs Vivado synthesis indefinitely (~55 s of no progress, then never completes).
- Pre-computes the slice bounds into local variables as `hi := lo + const`. That form satisfies GHDL `--synth`'s "same variable part" check while still presenting Vivado with the variable-base / constant-width slice pattern it recognizes as a single efficient write. `bitReverse()` is hoisted into a local variable for the same reason.

## Background

Bisected against a `Simple-rfsoc-4x2-Example` build that hangs Vivado synthesis on:

```vhdl
U_Gearbox : entity axi_soc_ultra_plus_core.Ssr12ToSsr16Gearbox
```

- `surf@v2.66.0`, `v2.67.0` → synthesis completes
- `surf@v2.68.0`, `v2.69.0`, `v2.70.0` → Vivado hangs ~55 s after synth start

Only commit touching `Gearbox.vhd` / `AsyncGearbox.vhd` / related files in that window: 9ccc0f48 *"resolved GHDL error: cannot extract same variable part for dynamic slice"*. Reverting just that file on `v2.68.0` makes Vivado synthesis complete.

## Why this is a compromise between Vivado and GHDL

The write operation is a *variable-base, constant-width* slice into a shift register. Three forms were considered; each trades off differently between Vivado synthesis and GHDL `--synth`:

### (A) Inline slice — the pre-9ccc0f48 form

```vhdl
v.shiftReg(v.writeIndex+SLAVE_WIDTH_G-1 downto v.writeIndex) := slaveData;
```

- **Vivado:** clean. Recognized as a variable-base / constant-width slice write and synthesized as a single barrel-shifted masked store.
- **GHDL `--synth`:** fails with `cannot extract same variable part for dynamic slice`. GHDL's synthesis front-end requires both slice bounds to statically resolve to the same base expression plus constant offsets. The inline form `(v.writeIndex+SLAVE_WIDTH_G-1 downto v.writeIndex)` is two distinct AST sub-expressions that GHDL's matcher cannot unify, even though they are mathematically equivalent. This is the GHDL error 9ccc0f48 was trying to resolve.

### (B) Per-bit for loop — the 9ccc0f48 form

```vhdl
for i in 0 to SLAVE_WIDTH_G-1 loop
   v.shiftReg(v.writeIndex + i) := slaveData(i);
end loop;
```

- **GHDL `--synth`:** accepted. Each bit assignment is a simple dynamic-index write that GHDL handles via a small mux per iteration.
- **Vivado:** hangs. Vivado does not collapse the unrolled loop back into a slice write. It treats each of the `SLAVE_WIDTH_G` iterations as an independent variable-index bit-level assignment into an `SHIFT_WIDTH_C`-wide register, then tries to prove write disjointness and mux selection for every bit. For `SLAVE_WIDTH_G=768`, `SHIFT_WIDTH_C=2305` the analysis space explodes to ~1.77M mux paths and synthesis never terminates. Narrow gearbox instances happen to survive because the numbers are small enough for Vivado to grind through, but wide ones like `Ssr12ToSsr16Gearbox` with `NUM_CH_G=4` fall off the cliff.

### (C) Helper-variable slice — this PR

```vhdl
if (slaveBitOrder = '1') then
   dataIn := bitReverse(slaveData);
else
   dataIn := slaveData;
end if;
lo                       := v.writeIndex;
hi                       := lo + SLAVE_WIDTH_G - 1;
v.shiftReg(hi downto lo) := dataIn;
```

- **Vivado:** still sees the `v.shiftReg(hi downto lo)` slice form. Vivado's propagation resolves `hi - lo` to the constant `SLAVE_WIDTH_G - 1` at synthesis time and generates the same single barrel-shifted store as form (A). Confirmed experimentally: `Simple-rfsoc-4x2-Example` synthesis completes past the previous hang point.
- **GHDL `--synth`:** passes its "same variable part" check. Because `lo` and `hi` are plain locals with `hi := lo + constant`, GHDL's matcher directly recognizes both bounds as the same base (`lo`) plus a static offset. No inline arithmetic to untangle, no per-bit loop to unroll.
- **Cost:** two scalar locals (`lo`, `hi`) and one `slv(SLAVE_WIDTH_G-1 downto 0)` local (`dataIn`) in the process. `dataIn` hoists `bitReverse(slaveData)` out of the slice RHS for the same reason — both tools track plain signal writes more reliably than writes whose RHS is a function call inside a dynamic slice.

### Simulation equivalence

All three forms produce bit-identical behavior in VHDL simulation (vsim / xsim / GHDL), so the choice is purely a synthesis-path concession. The `test_Gearbox` and `test_AsyncGearbox` cocotb tests exercise both the straight and `bitReverse` (`slaveBitOrder='1'`) paths and pass unchanged — see test plan below.

### Alternatives considered and rejected

- **Revert to form (A) and suppress GHDL `--synth` for `Gearbox.vhd`:** fragile and would regress the purpose of 9ccc0f48 (keeping surf analyzable under GHDL `--synth` for downstream tooling).
- **Shift-and-mask rewrite** (`v.shiftReg := (v.shiftReg and not mask) or shifted` with two `shift_left` barrel shifters): works in both tools but adds a second wide barrel shifter and an extra mask term, bloating logic relative to the original slice write. No reason to pay that cost when form (C) matches form (A)'s resource footprint.
- **Wrap the slice in a function `writeSliceAt(reg, data, idx)`:** viable fallback if form (C) ever regresses in a future GHDL release — kept as a backup option, not applied here because form (C) already passes both tools today.

## Test plan

- [x] `make analysis` (GHDL `-a` VHDL syntax checking) passes — `Gearbox.vhd`, `AsyncGearbox.vhd`, all `AxiStreamGearbox*`, `GearboxTb.vhd`, `Pgp3RxGearboxAligner`, `SelectIoRxGearboxAligner` all analyze cleanly
- [x] `pytest tests/base/general/test_Gearbox.py tests/base/general/test_AsyncGearbox.py` → 5/5 passed, including `test_Gearbox[bit_reverse_async_reset]` which exercises the `slaveBitOrder = '1'` branch with the hoisted `bitReverse()`
- [x] Vivado synthesis of `Simple-rfsoc-4x2-Example` completes past the previous hang point with this fix applied
- [x] CI run on this PR should re-confirm both analysis and regression tests
