### PR TITLE
Fixing CoaXPress disconnected signal

### DIFF
--- a/protocols/coaxpress/core/rtl/CoaXPressAxiL.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressAxiL.vhd
@@ -500,6 +500,7 @@ begin
          WIDTH_G => 32)
       port map (
          clk     => cfgClk,
+         rst     => cfgRst,
          dataIn  => r.configTimerSize,
          dataOut => configTimerSize);
 
@@ -508,6 +509,7 @@ begin
          TPD_G => TPD_G)
       port map (
          clk     => cfgClk,
+         rst     => cfgRst,
          dataIn  => r.configErrResp,
          dataOut => configErrResp);
 
@@ -516,6 +518,7 @@ begin
          TPD_G => TPD_G)
       port map (
          clk     => cfgClk,
+         rst     => cfgRst,
          dataIn  => r.configPktTag,
          dataOut => configPktTag);
 

--- a/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
+++ b/protocols/coaxpress/core/rtl/CoaXPressCore.vhd
@@ -230,7 +230,7 @@ begin
          rxFsmError      => rxFsmError,
          -- Config Interface (cfgClk domain)
          cfgClk          => cfgClk,
-         cfgRst          => cfgClk,
+         cfgRst          => cfgRst,
          configTimerSize => configTimerSize,
          configErrResp   => configErrResp,
          configPktTag    => configPktTag,


### PR DESCRIPTION
Fixed an improperly connected reset signal in the CoaXPress modules

### Description
The reset was not used within the CoaXPressAxiL module and it was connected to a clock signal. I connected it to the proper signal and used it to reset the synchronizers.
