### PR TITLE
Add PGP4 RX K-code CSC checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ sim_build/
 .planning/
 planning/
 CLAUDE.md
+.DS_Store

--- a/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4AxiL.vhd
@@ -198,11 +198,11 @@ begin
    ---------------------
    -- AXI-Lite Registers
    ---------------------
-   comb : process (axilReadMaster, axilRst, axilWriteMaster, locData, locOverflowCnt,
-                   locPause, locPauseCnt, phyFec, phyFecCnt, r, remLinkData,
-                   remRxOverflowCnt, remRxPause, remRxPauseCnt, rxClkFreq, rxError,
-                   rxErrorCnt, rxOpCodeData, rxStatusCnt, txClkFreq, txError,
-                   txErrorCnt, txOpCodeData, txStatusCnt) is
+   comb : process (axilReadMaster, axilRst, axilWriteMaster, locData,
+                   locOverflowCnt, locPause, locPauseCnt, phyFec, phyFecCnt, r,
+                   remLinkData, remRxOverflowCnt, remRxPause, remRxPauseCnt,
+                   rxClkFreq, rxError, rxErrorCnt, rxOpCodeData, rxStatusCnt,
+                   txClkFreq, txError, txErrorCnt, txOpCodeData, txStatusCnt) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndpointType;
    begin

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -155,45 +155,29 @@ begin
          checkedHeader => checkedHeader,      -- [out]
          linkError     => kCodeLinkError);    -- [out]
 
-   U_linkError : entity surf.SynchronizerOneShot
+   -- Elastic Buffer or same-clock bypass path
+   U_Pgp4RxEb_1 : entity surf.Pgp4RxEb
       generic map (
-         TPD_G       => TPD_G,
-         RST_ASYNC_G => RST_ASYNC_G)
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G,
+         BYPASS_G       => not SKIP_EN_G)
       port map (
-         clk     => pgpRxClk,
-         dataIn  => kCodeLinkError,
-         dataOut => linkError);
-
-   GEN_EB : if (SKIP_EN_G = true) generate
-      -- Elastic Buffer
-      U_Pgp4RxEb_1 : entity surf.Pgp4RxEb
-         generic map (
-            TPD_G          => TPD_G,
-            RST_POLARITY_G => RST_POLARITY_G,
-            RST_ASYNC_G    => RST_ASYNC_G)
-         port map (
-            phyRxClk    => phyRxClk,           -- [in]
-            phyRxRst    => phyRxRst,           -- [in]
-            phyRxValid  => checkedValid,       -- [in]
-            phyRxData   => checkedData,        -- [in]
-            phyRxHeader => checkedHeader,      -- [in]
-            pgpRxClk    => pgpRxClk,           -- [in]
-            pgpRxRst    => pgpRxRst,           -- [in]
-            pgpRxValid  => ebValid,            -- [out]
-            pgpRxData   => ebData,             -- [out]
-            pgpRxHeader => ebHeader,           -- [out]
-            remLinkData => remLinkData,        -- [out]
-            overflow    => ebOverflow,         -- [out]
-            status      => ebStatus);          -- [out]
-   end generate GEN_EB;
-   NO_EB : if (SKIP_EN_G = false) generate
-      ebValid     <= checkedValid;
-      ebData      <= checkedData;
-      ebHeader    <= checkedHeader;
-      remLinkData <= (others => '0');
-      ebOverflow  <= '0';
-      ebStatus    <= (others => '0');
-   end generate NO_EB;
+         phyRxClk       => phyRxClk,           -- [in]
+         phyRxRst       => phyRxRst,           -- [in]
+         phyRxValid     => checkedValid,       -- [in]
+         phyRxData      => checkedData,        -- [in]
+         phyRxHeader    => checkedHeader,      -- [in]
+         phyRxLinkError => kCodeLinkError,     -- [in]
+         pgpRxClk       => pgpRxClk,           -- [in]
+         pgpRxRst       => pgpRxRst,           -- [in]
+         pgpRxValid     => ebValid,            -- [out]
+         pgpRxData      => ebData,             -- [out]
+         pgpRxHeader    => ebHeader,           -- [out]
+         remLinkData    => remLinkData,        -- [out]
+         overflow       => ebOverflow,         -- [out]
+         linkError      => linkError,          -- [out]
+         status         => ebStatus);          -- [out]
 
    -- Main RX protocol logic
    U_Pgp4RxProtocol_1 : entity surf.Pgp4RxProtocol

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -71,6 +71,10 @@ architecture rtl of Pgp4Rx is
    signal unscrambledValid       : sl;
    signal unscrambledData        : slv(63 downto 0);
    signal unscrambledHeader      : slv(1 downto 0);
+   signal checkedValid           : sl;
+   signal checkedData            : slv(63 downto 0);
+   signal checkedHeader          : slv(1 downto 0);
+   signal kCodeLinkError         : sl;
    signal remLinkData            : slv(47 downto 0);
    signal ebValid                : sl;
    signal ebData                 : slv(63 downto 0);
@@ -134,6 +138,32 @@ begin
          outputData     => unscrambledData,     -- [out]
          outputSideband => unscrambledHeader);  -- [out]
 
+   -- Check K-code checksum before the elastic buffer or no-EB bypass path
+   U_Pgp4RxKCodeChecker_1 : entity surf.Pgp4RxKCodeChecker
+      generic map (
+         TPD_G          => TPD_G,
+         RST_POLARITY_G => RST_POLARITY_G,
+         RST_ASYNC_G    => RST_ASYNC_G)
+      port map (
+         phyRxClk      => phyRxClk,           -- [in]
+         phyRxRst      => phyRxRst,           -- [in]
+         phyRxValid    => unscrambledValid,   -- [in]
+         phyRxData     => unscrambledData,    -- [in]
+         phyRxHeader   => unscrambledHeader,  -- [in]
+         checkedValid  => checkedValid,       -- [out]
+         checkedData   => checkedData,        -- [out]
+         checkedHeader => checkedHeader,      -- [out]
+         linkError     => kCodeLinkError);    -- [out]
+
+   U_linkError : entity surf.SynchronizerOneShot
+      generic map (
+         TPD_G       => TPD_G,
+         RST_ASYNC_G => RST_ASYNC_G)
+      port map (
+         clk     => pgpRxClk,
+         dataIn  => kCodeLinkError,
+         dataOut => linkError);
+
    GEN_EB : if (SKIP_EN_G = true) generate
       -- Elastic Buffer
       U_Pgp4RxEb_1 : entity surf.Pgp4RxEb
@@ -144,9 +174,9 @@ begin
          port map (
             phyRxClk    => phyRxClk,           -- [in]
             phyRxRst    => phyRxRst,           -- [in]
-            phyRxValid  => unscrambledValid,   -- [in]
-            phyRxData   => unscrambledData,    -- [in]
-            phyRxHeader => unscrambledHeader,  -- [in]
+            phyRxValid  => checkedValid,       -- [in]
+            phyRxData   => checkedData,        -- [in]
+            phyRxHeader => checkedHeader,      -- [in]
             pgpRxClk    => pgpRxClk,           -- [in]
             pgpRxRst    => pgpRxRst,           -- [in]
             pgpRxValid  => ebValid,            -- [out]
@@ -154,16 +184,14 @@ begin
             pgpRxHeader => ebHeader,           -- [out]
             remLinkData => remLinkData,        -- [out]
             overflow    => ebOverflow,         -- [out]
-            linkError   => linkError,          -- [out]
             status      => ebStatus);          -- [out]
    end generate GEN_EB;
    NO_EB : if (SKIP_EN_G = false) generate
-      ebValid     <= unscrambledValid;
-      ebData      <= unscrambledData;
-      ebHeader    <= unscrambledHeader;
+      ebValid     <= checkedValid;
+      ebData      <= checkedData;
+      ebHeader    <= checkedHeader;
       remLinkData <= (others => '0');
       ebOverflow  <= '0';
-      linkError   <= '0';
       ebStatus    <= (others => '0');
    end generate NO_EB;
 

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -161,7 +161,7 @@ begin
          TPD_G          => TPD_G,
          RST_POLARITY_G => RST_POLARITY_G,
          RST_ASYNC_G    => RST_ASYNC_G,
-         BYPASS_G       => not SKIP_EN_G)
+         SKIP_EN_G      => SKIP_EN_G)
       port map (
          phyRxClk       => phyRxClk,           -- [in]
          phyRxRst       => phyRxRst,           -- [in]

--- a/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4Rx.vhd
@@ -163,21 +163,21 @@ begin
          RST_ASYNC_G    => RST_ASYNC_G,
          SKIP_EN_G      => SKIP_EN_G)
       port map (
-         phyRxClk       => phyRxClk,           -- [in]
-         phyRxRst       => phyRxRst,           -- [in]
-         phyRxValid     => checkedValid,       -- [in]
-         phyRxData      => checkedData,        -- [in]
-         phyRxHeader    => checkedHeader,      -- [in]
-         phyRxLinkError => kCodeLinkError,     -- [in]
-         pgpRxClk       => pgpRxClk,           -- [in]
-         pgpRxRst       => pgpRxRst,           -- [in]
-         pgpRxValid     => ebValid,            -- [out]
-         pgpRxData      => ebData,             -- [out]
-         pgpRxHeader    => ebHeader,           -- [out]
-         remLinkData    => remLinkData,        -- [out]
-         overflow       => ebOverflow,         -- [out]
-         linkError      => linkError,          -- [out]
-         status         => ebStatus);          -- [out]
+         phyRxClk       => phyRxClk,        -- [in]
+         phyRxRst       => phyRxRst,        -- [in]
+         phyRxValid     => checkedValid,    -- [in]
+         phyRxData      => checkedData,     -- [in]
+         phyRxHeader    => checkedHeader,   -- [in]
+         phyRxLinkError => kCodeLinkError,  -- [in]
+         pgpRxClk       => pgpRxClk,        -- [in]
+         pgpRxRst       => pgpRxRst,        -- [in]
+         pgpRxValid     => ebValid,         -- [out]
+         pgpRxData      => ebData,          -- [out]
+         pgpRxHeader    => ebHeader,        -- [out]
+         remLinkData    => remLinkData,     -- [out]
+         overflow       => ebOverflow,      -- [out]
+         linkError      => linkError,       -- [out]
+         status         => ebStatus);       -- [out]
 
    -- Main RX protocol logic
    U_Pgp4RxProtocol_1 : entity surf.Pgp4RxProtocol

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -51,7 +51,6 @@ end entity Pgp4RxEb;
 architecture rtl of Pgp4RxEb is
 
    type RegType is record
-      holdoff     : sl;
       dataValid   : sl;
       remLinkData : slv(47 downto 0);
       fifoIn      : slv(65 downto 0);
@@ -63,7 +62,6 @@ architecture rtl of Pgp4RxEb is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      holdoff     => '0',
       dataValid   => '0',
       remLinkData => (others => '0'),
       fifoIn      => (others => '0'),
@@ -97,11 +95,10 @@ begin
       v.fifoWrEn             := phyRxValid;
 
       -- Map to same-clock bypass output
-      v.pgpRxValid  := phyRxValid and not r.holdoff and not phyRxLinkError;
+      v.pgpRxValid  := phyRxValid;
       v.pgpRxData   := phyRxData;
       v.pgpRxHeader := phyRxHeader;
       v.linkError   := phyRxLinkError;
-      v.holdoff     := phyRxLinkError;
 
       -- Check for valid k-code
       if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) then
@@ -124,7 +121,6 @@ begin
       if (RST_ASYNC_G = false and phyRxRst = RST_POLARITY_G) then
          -- Maintain save behavior before the remLinkData update (not reseting fifoIn or fifoWrEn)
          v.remLinkData := (others => '0');
-         v.holdoff     := '0';
          v.pgpRxValid  := '0';
          v.pgpRxData   := (others => '0');
          v.pgpRxHeader := (others => '0');

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -28,7 +28,7 @@ entity Pgp4RxEb is
       TPD_G          : time    := 1 ns;
       RST_POLARITY_G : sl      := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G    : boolean := false;
-      BYPASS_G       : boolean := false);
+      SKIP_EN_G      : boolean := true);
    port (
       phyRxClk       : in  sl;
       phyRxRst       : in  sl;
@@ -145,7 +145,7 @@ begin
       end if;
    end process seq;
 
-   GEN_EB : if (BYPASS_G = false) generate
+   GEN_EB : if (SKIP_EN_G = true) generate
 
       U_remLinkData : entity surf.SynchronizerFifo
          generic map (
@@ -208,7 +208,7 @@ begin
 
    end generate GEN_EB;
 
-   GEN_BYPASS : if (BYPASS_G = true) generate
+   GEN_BYPASS : if (SKIP_EN_G = false) generate
 
       pgpRxValid  <= r.pgpRxValid;
       pgpRxData   <= r.pgpRxData;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -42,14 +42,12 @@ entity Pgp4RxEb is
       pgpRxHeader : out slv(1 downto 0);
       remLinkData : out slv(47 downto 0);
       overflow    : out sl;
-      linkError   : out sl;
       status      : out slv(8 downto 0));
 end entity Pgp4RxEb;
 
 architecture rtl of Pgp4RxEb is
 
    type RegType is record
-      linkError   : sl;
       dataValid   : sl;
       remLinkData : slv(47 downto 0);
       fifoIn      : slv(65 downto 0);
@@ -57,7 +55,6 @@ architecture rtl of Pgp4RxEb is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      linkError   => '0',
       dataValid   => '0',
       remLinkData => (others => '0'),
       fifoIn      => (others => '0'),
@@ -79,7 +76,6 @@ begin
       v := r;
 
       -- Reset strobes
-      v.linkError := '0';
       v.dataValid := '0';
 
       -- Map to FIFO write
@@ -87,19 +83,11 @@ begin
       v.fifoIn(65 downto 64) := phyRxHeader;
       v.fifoWrEn             := phyRxValid;
 
-      -- Check for k-code
-      if (phyRxHeader = PGP4_K_HEADER_C) then
+      -- Check for valid k-code
+      if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) then
 
-         -- Check for invalid K-code CRC
-         if (phyRxData(PGP4_K_CODE_CRC_FIELD_C) /= pgp4KCodeCrc(phyRxData)) then
-
-            -- Don't write words into the FIFO
-            v.fifoWrEn := '0';
-
-            -- Set the error flag
-            v.linkError := '1';
-
-         elsif (phyRxData(PGP4_BTF_FIELD_C) = PGP4_SKP_C) then
+         -- Check for SKP words
+         if (phyRxData(PGP4_BTF_FIELD_C) = PGP4_SKP_C) then
 
             -- Don't write SKP words into the FIFO
             v.fifoWrEn := '0';
@@ -181,14 +169,5 @@ begin
          clk     => pgpRxClk,
          dataIn  => overflowInt,
          dataOut => overflow);
-
-   U_linkError : entity surf.SynchronizerOneShot
-      generic map (
-         TPD_G       => TPD_G,
-         RST_ASYNC_G => RST_ASYNC_G)
-      port map (
-         clk     => pgpRxClk,
-         dataIn  => r.linkError,
-         dataOut => linkError);
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -55,21 +55,13 @@ architecture rtl of Pgp4RxEb is
       remLinkData : slv(47 downto 0);
       fifoIn      : slv(65 downto 0);
       fifoWrEn    : sl;
-      pgpRxValid  : sl;
-      pgpRxData   : slv(63 downto 0);
-      pgpRxHeader : slv(1 downto 0);
-      linkError   : sl;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
       dataValid   => '0',
       remLinkData => (others => '0'),
       fifoIn      => (others => '0'),
-      fifoWrEn    => '0',
-      pgpRxValid  => '0',
-      pgpRxData   => (others => '0'),
-      pgpRxHeader => (others => '0'),
-      linkError   => '0');
+      fifoWrEn    => '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -80,7 +72,7 @@ architecture rtl of Pgp4RxEb is
 
 begin
 
-   comb : process (phyRxData, phyRxHeader, phyRxLinkError, phyRxRst, phyRxValid, r) is
+   comb : process (phyRxData, phyRxHeader, phyRxRst, phyRxValid, r) is
       variable v : RegType;
    begin
       -- Latch the current value
@@ -89,29 +81,27 @@ begin
       -- Reset strobes
       v.dataValid := '0';
 
-      -- Map to FIFO write
-      v.fifoIn(63 downto 0)  := phyRxData;
-      v.fifoIn(65 downto 64) := phyRxHeader;
-      v.fifoWrEn             := phyRxValid;
+      if (SKIP_EN_G = true) then
 
-      -- Map to same-clock bypass output
-      v.pgpRxValid  := phyRxValid;
-      v.pgpRxData   := phyRxData;
-      v.pgpRxHeader := phyRxHeader;
-      v.linkError   := phyRxLinkError;
+         -- Map to FIFO write
+         v.fifoIn(63 downto 0)  := phyRxData;
+         v.fifoIn(65 downto 64) := phyRxHeader;
+         v.fifoWrEn             := phyRxValid;
 
-      -- Check for valid k-code
-      if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) then
+         -- Check for valid k-code
+         if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) then
 
-         -- Check for SKP words
-         if (phyRxData(PGP4_BTF_FIELD_C) = PGP4_SKP_C) then
+            -- Check for SKP words
+            if (phyRxData(PGP4_BTF_FIELD_C) = PGP4_SKP_C) then
 
-            -- Don't write SKP words into the FIFO
-            v.fifoWrEn := '0';
+               -- Don't write SKP words into the FIFO
+               v.fifoWrEn := '0';
 
-            -- Save the remote data bus
-            v.dataValid   := '1';
-            v.remLinkData := phyRxData(PGP4_SKIP_DATA_FIELD_C);
+               -- Save the remote data bus
+               v.dataValid   := '1';
+               v.remLinkData := phyRxData(PGP4_SKIP_DATA_FIELD_C);
+
+            end if;
 
          end if;
 
@@ -121,10 +111,6 @@ begin
       if (RST_ASYNC_G = false and phyRxRst = RST_POLARITY_G) then
          -- Maintain save behavior before the remLinkData update (not reseting fifoIn or fifoWrEn)
          v.remLinkData := (others => '0');
-         v.pgpRxValid  := '0';
-         v.pgpRxData   := (others => '0');
-         v.pgpRxHeader := (others => '0');
-         v.linkError   := '0';
       end if;
 
       -- Register the variable for next clock cycle
@@ -206,12 +192,12 @@ begin
 
    GEN_BYPASS : if (SKIP_EN_G = false) generate
 
-      pgpRxValid  <= r.pgpRxValid;
-      pgpRxData   <= r.pgpRxData;
-      pgpRxHeader <= r.pgpRxHeader;
+      pgpRxValid  <= phyRxValid;
+      pgpRxData   <= phyRxData;
+      pgpRxHeader <= phyRxHeader;
       remLinkData <= (others => '0');
       overflow    <= '0';
-      linkError   <= r.linkError;
+      linkError   <= phyRxLinkError;
       status      <= (others => '0');
 
    end generate GEN_BYPASS;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxEb.vhd
@@ -27,38 +27,51 @@ entity Pgp4RxEb is
    generic (
       TPD_G          : time    := 1 ns;
       RST_POLARITY_G : sl      := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
-      RST_ASYNC_G    : boolean := false);
+      RST_ASYNC_G    : boolean := false;
+      BYPASS_G       : boolean := false);
    port (
-      phyRxClk    : in  sl;
-      phyRxRst    : in  sl;
-      phyRxValid  : in  sl;
-      phyRxData   : in  slv(63 downto 0);  -- Unscrambled data from the PHY
-      phyRxHeader : in  slv(1 downto 0);
+      phyRxClk       : in  sl;
+      phyRxRst       : in  sl;
+      phyRxValid     : in  sl;
+      phyRxData      : in  slv(63 downto 0);  -- Unscrambled data from the PHY
+      phyRxHeader    : in  slv(1 downto 0);
+      phyRxLinkError : in  sl := '0';
       -- User Transmit interface
-      pgpRxClk    : in  sl;
-      pgpRxRst    : in  sl;
-      pgpRxValid  : out sl;
-      pgpRxData   : out slv(63 downto 0);
-      pgpRxHeader : out slv(1 downto 0);
-      remLinkData : out slv(47 downto 0);
-      overflow    : out sl;
-      status      : out slv(8 downto 0));
+      pgpRxClk       : in  sl;
+      pgpRxRst       : in  sl;
+      pgpRxValid     : out sl;
+      pgpRxData      : out slv(63 downto 0);
+      pgpRxHeader    : out slv(1 downto 0);
+      remLinkData    : out slv(47 downto 0);
+      overflow       : out sl;
+      linkError      : out sl;
+      status         : out slv(8 downto 0));
 end entity Pgp4RxEb;
 
 architecture rtl of Pgp4RxEb is
 
    type RegType is record
+      holdoff     : sl;
       dataValid   : sl;
       remLinkData : slv(47 downto 0);
       fifoIn      : slv(65 downto 0);
       fifoWrEn    : sl;
+      pgpRxValid  : sl;
+      pgpRxData   : slv(63 downto 0);
+      pgpRxHeader : slv(1 downto 0);
+      linkError   : sl;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
+      holdoff     => '0',
       dataValid   => '0',
       remLinkData => (others => '0'),
       fifoIn      => (others => '0'),
-      fifoWrEn    => '0');
+      fifoWrEn    => '0',
+      pgpRxValid  => '0',
+      pgpRxData   => (others => '0'),
+      pgpRxHeader => (others => '0'),
+      linkError   => '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -69,7 +82,7 @@ architecture rtl of Pgp4RxEb is
 
 begin
 
-   comb : process (phyRxData, phyRxHeader, phyRxRst, phyRxValid, r) is
+   comb : process (phyRxData, phyRxHeader, phyRxLinkError, phyRxRst, phyRxValid, r) is
       variable v : RegType;
    begin
       -- Latch the current value
@@ -82,6 +95,13 @@ begin
       v.fifoIn(63 downto 0)  := phyRxData;
       v.fifoIn(65 downto 64) := phyRxHeader;
       v.fifoWrEn             := phyRxValid;
+
+      -- Map to same-clock bypass output
+      v.pgpRxValid  := phyRxValid and not r.holdoff and not phyRxLinkError;
+      v.pgpRxData   := phyRxData;
+      v.pgpRxHeader := phyRxHeader;
+      v.linkError   := phyRxLinkError;
+      v.holdoff     := phyRxLinkError;
 
       -- Check for valid k-code
       if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) then
@@ -104,6 +124,11 @@ begin
       if (RST_ASYNC_G = false and phyRxRst = RST_POLARITY_G) then
          -- Maintain save behavior before the remLinkData update (not reseting fifoIn or fifoWrEn)
          v.remLinkData := (others => '0');
+         v.holdoff     := '0';
+         v.pgpRxValid  := '0';
+         v.pgpRxData   := (others => '0');
+         v.pgpRxHeader := (others => '0');
+         v.linkError   := '0';
       end if;
 
       -- Register the variable for next clock cycle
@@ -120,54 +145,79 @@ begin
       end if;
    end process seq;
 
-   U_remLinkData : entity surf.SynchronizerFifo
-      generic map (
-         TPD_G          => TPD_G,
-         RST_POLARITY_G => RST_POLARITY_G,
-         RST_ASYNC_G    => RST_ASYNC_G,
-         DATA_WIDTH_G   => 48)
-      port map (
-         rst    => phyRxRst,
-         wr_clk => phyRxClk,
-         wr_en  => r.dataValid,
-         din    => r.remLinkData,
-         rd_clk => pgpRxClk,
-         dout   => remLinkData);
+   GEN_EB : if (BYPASS_G = false) generate
 
-   U_FifoAsync_1 : entity surf.FifoAsync
-      generic map (
-         TPD_G          => TPD_G,
-         RST_POLARITY_G => RST_POLARITY_G,
-         RST_ASYNC_G    => RST_ASYNC_G,
-         MEMORY_TYPE_G  => "block",
-         FWFT_EN_G      => true,
-         PIPE_STAGES_G  => 0,
-         DATA_WIDTH_G   => 66,
-         ADDR_WIDTH_G   => 9)
-      port map (
-         rst                => phyRxRst,
-         -- Write Interface
-         wr_clk             => phyRxClk,
-         wr_en              => r.fifoWrEn,
-         din                => r.fifoIn,
-         overflow           => overflowInt,
-         -- Read Interface
-         rd_clk             => pgpRxClk,
-         rd_en              => valid,
-         dout(63 downto 0)  => pgpRxData,
-         dout(65 downto 64) => pgpRxHeader,
-         rd_data_count      => status,
-         valid              => valid);
+      U_remLinkData : entity surf.SynchronizerFifo
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            DATA_WIDTH_G   => 48)
+         port map (
+            rst    => phyRxRst,
+            wr_clk => phyRxClk,
+            wr_en  => r.dataValid,
+            din    => r.remLinkData,
+            rd_clk => pgpRxClk,
+            dout   => remLinkData);
 
-   pgpRxValid <= valid;
+      U_FifoAsync_1 : entity surf.FifoAsync
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            MEMORY_TYPE_G  => "block",
+            FWFT_EN_G      => true,
+            PIPE_STAGES_G  => 0,
+            DATA_WIDTH_G   => 66,
+            ADDR_WIDTH_G   => 9)
+         port map (
+            rst                => phyRxRst,
+            -- Write Interface
+            wr_clk             => phyRxClk,
+            wr_en              => r.fifoWrEn,
+            din                => r.fifoIn,
+            overflow           => overflowInt,
+            -- Read Interface
+            rd_clk             => pgpRxClk,
+            rd_en              => valid,
+            dout(63 downto 0)  => pgpRxData,
+            dout(65 downto 64) => pgpRxHeader,
+            rd_data_count      => status,
+            valid              => valid);
 
-   U_overflow : entity surf.SynchronizerOneShot
-      generic map (
-         TPD_G       => TPD_G,
-         RST_ASYNC_G => RST_ASYNC_G)
-      port map (
-         clk     => pgpRxClk,
-         dataIn  => overflowInt,
-         dataOut => overflow);
+      pgpRxValid <= valid;
+
+      U_overflow : entity surf.SynchronizerOneShot
+         generic map (
+            TPD_G       => TPD_G,
+            RST_ASYNC_G => RST_ASYNC_G)
+         port map (
+            clk     => pgpRxClk,
+            dataIn  => overflowInt,
+            dataOut => overflow);
+
+      U_linkError : entity surf.SynchronizerOneShot
+         generic map (
+            TPD_G       => TPD_G,
+            RST_ASYNC_G => RST_ASYNC_G)
+         port map (
+            clk     => pgpRxClk,
+            dataIn  => phyRxLinkError,
+            dataOut => linkError);
+
+   end generate GEN_EB;
+
+   GEN_BYPASS : if (BYPASS_G = true) generate
+
+      pgpRxValid  <= r.pgpRxValid;
+      pgpRxData   <= r.pgpRxData;
+      pgpRxHeader <= r.pgpRxHeader;
+      remLinkData <= (others => '0');
+      overflow    <= '0';
+      linkError   <= r.linkError;
+      status      <= (others => '0');
+
+   end generate GEN_BYPASS;
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
@@ -43,6 +43,7 @@ end entity Pgp4RxKCodeChecker;
 architecture rtl of Pgp4RxKCodeChecker is
 
    type RegType is record
+      holdoff       : sl;
       checkedValid  : sl;
       checkedData   : slv(63 downto 0);
       checkedHeader : slv(1 downto 0);
@@ -50,6 +51,7 @@ architecture rtl of Pgp4RxKCodeChecker is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
+      holdoff       => '0',
       checkedValid  => '0',
       checkedData   => (others => '0'),
       checkedHeader => (others => '0'),
@@ -61,22 +63,30 @@ architecture rtl of Pgp4RxKCodeChecker is
 begin
 
    comb : process (phyRxData, phyRxHeader, phyRxRst, phyRxValid, r) is
-      variable v : RegType;
+      variable v        : RegType;
+      variable badKCode : sl;
    begin
       -- Latch the current value
       v := r;
 
+      badKCode := '0';
+      if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) and
+         (phyRxData(PGP4_K_CODE_CRC_FIELD_C) /= pgp4KCodeCrc(phyRxData)) then
+         badKCode := '1';
+      end if;
+
       -- Map to output register
-      v.checkedValid  := phyRxValid;
+      v.checkedValid  := phyRxValid and not r.holdoff;
       v.checkedData   := phyRxData;
       v.checkedHeader := phyRxHeader;
       v.linkError     := '0';
+      v.holdoff       := '0';
 
       -- Drop K-codes with invalid checksum
-      if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) and
-         (phyRxData(PGP4_K_CODE_CRC_FIELD_C) /= pgp4KCodeCrc(phyRxData)) then
+      if (badKCode = '1') then
          v.checkedValid := '0';
          v.linkError    := '1';
+         v.holdoff      := '1';
       end if;
 
       -- Reset

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
@@ -97,6 +97,12 @@ begin
       -- Register the variable for next clock cycle
       rin <= v;
 
+      -- Drive outputs
+      checkedValid  <= r.checkedValid;
+      checkedData   <= r.checkedData;
+      checkedHeader <= r.checkedHeader;
+      linkError     <= r.linkError;
+
    end process comb;
 
    seq : process (phyRxClk, phyRxRst) is
@@ -107,10 +113,5 @@ begin
          r <= rin after TPD_G;
       end if;
    end process seq;
-
-   checkedValid  <= r.checkedValid;
-   checkedData   <= r.checkedData;
-   checkedHeader <= r.checkedHeader;
-   linkError     <= r.linkError;
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
@@ -1,0 +1,106 @@
+-------------------------------------------------------------------------------
+-- Title      : PGPv4: https://confluence.slac.stanford.edu/x/1dzgEQ
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: PGPv4 Rx K-code Checksum Checker
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4RxKCodeChecker is
+   generic (
+      TPD_G          : time    := 1 ns;
+      RST_POLARITY_G : sl      := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
+      RST_ASYNC_G    : boolean := false);
+   port (
+      phyRxClk     : in  sl;
+      phyRxRst     : in  sl;
+      phyRxValid   : in  sl;
+      phyRxData    : in  slv(63 downto 0);
+      phyRxHeader  : in  slv(1 downto 0);
+      checkedValid  : out sl;
+      checkedData   : out slv(63 downto 0);
+      checkedHeader : out slv(1 downto 0);
+      linkError     : out sl);
+end entity Pgp4RxKCodeChecker;
+
+architecture rtl of Pgp4RxKCodeChecker is
+
+   type RegType is record
+      checkedValid  : sl;
+      checkedData   : slv(63 downto 0);
+      checkedHeader : slv(1 downto 0);
+      linkError     : sl;
+   end record RegType;
+
+   constant REG_INIT_C : RegType := (
+      checkedValid  => '0',
+      checkedData   => (others => '0'),
+      checkedHeader => (others => '0'),
+      linkError     => '0');
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+begin
+
+   comb : process (phyRxData, phyRxHeader, phyRxRst, phyRxValid, r) is
+      variable v : RegType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Map to output register
+      v.checkedValid  := phyRxValid;
+      v.checkedData   := phyRxData;
+      v.checkedHeader := phyRxHeader;
+      v.linkError     := '0';
+
+      -- Drop K-codes with invalid checksum
+      if (phyRxValid = '1') and (phyRxHeader = PGP4_K_HEADER_C) and
+         (phyRxData(PGP4_K_CODE_CRC_FIELD_C) /= pgp4KCodeCrc(phyRxData)) then
+         v.checkedValid := '0';
+         v.linkError    := '1';
+      end if;
+
+      -- Reset
+      if (RST_ASYNC_G = false and phyRxRst = RST_POLARITY_G) then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (phyRxClk, phyRxRst) is
+   begin
+      if (RST_ASYNC_G) and (phyRxRst = RST_POLARITY_G) then
+         r <= REG_INIT_C after TPD_G;
+      elsif rising_edge(phyRxClk) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+   checkedValid  <= r.checkedValid;
+   checkedData   <= r.checkedData;
+   checkedHeader <= r.checkedHeader;
+   linkError     <= r.linkError;
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
+++ b/protocols/pgp/pgp4/core/rtl/Pgp4RxKCodeChecker.vhd
@@ -29,11 +29,11 @@ entity Pgp4RxKCodeChecker is
       RST_POLARITY_G : sl      := '1';  -- '1' for active HIGH reset, '0' for active LOW reset
       RST_ASYNC_G    : boolean := false);
    port (
-      phyRxClk     : in  sl;
-      phyRxRst     : in  sl;
-      phyRxValid   : in  sl;
-      phyRxData    : in  slv(63 downto 0);
-      phyRxHeader  : in  slv(1 downto 0);
+      phyRxClk      : in  sl;
+      phyRxRst      : in  sl;
+      phyRxValid    : in  sl;
+      phyRxData     : in  slv(63 downto 0);
+      phyRxHeader   : in  slv(1 downto 0);
       checkedValid  : out sl;
       checkedData   : out slv(63 downto 0);
       checkedHeader : out slv(1 downto 0);

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4AxiLDirectWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4AxiLDirectWrapper.vhd
@@ -22,32 +22,32 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4AxiLDirectWrapper is
    port (
-      S_AXI_ACLK      : in  std_logic                     := '0';
-      S_AXI_ARESETN   : in  std_logic                     := '0';
-      S_AXI_AWADDR    : in  std_logic_vector(11 downto 0) := (others => '0');
-      S_AXI_AWPROT    : in  std_logic_vector(2 downto 0)  := (others => '0');
-      S_AXI_AWVALID   : in  std_logic                     := '0';
-      S_AXI_AWREADY   : out std_logic;
-      S_AXI_WDATA     : in  std_logic_vector(31 downto 0) := (others => '0');
-      S_AXI_WSTRB     : in  std_logic_vector(3 downto 0)  := (others => '1');
-      S_AXI_WVALID    : in  std_logic                     := '0';
-      S_AXI_WREADY    : out std_logic;
-      S_AXI_BRESP     : out std_logic_vector(1 downto 0);
-      S_AXI_BVALID    : out std_logic;
-      S_AXI_BREADY    : in  std_logic                     := '0';
-      S_AXI_ARADDR    : in  std_logic_vector(11 downto 0) := (others => '0');
-      S_AXI_ARPROT    : in  std_logic_vector(2 downto 0)  := (others => '0');
-      S_AXI_ARVALID   : in  std_logic                     := '0';
-      S_AXI_ARREADY   : out std_logic;
-      S_AXI_RDATA     : out std_logic_vector(31 downto 0);
-      S_AXI_RRESP     : out std_logic_vector(1 downto 0);
-      S_AXI_RVALID    : out std_logic;
-      S_AXI_RREADY    : in  std_logic                     := '0';
-      txDisableOut    : out std_logic;
-      flowCntlDisOut  : out std_logic;
-      resetTxOut      : out std_logic;
-      resetRxOut      : out std_logic;
-      loopbackOut     : out std_logic_vector(2 downto 0));
+      S_AXI_ACLK     : in  std_logic                     := '0';
+      S_AXI_ARESETN  : in  std_logic                     := '0';
+      S_AXI_AWADDR   : in  std_logic_vector(11 downto 0) := (others => '0');
+      S_AXI_AWPROT   : in  std_logic_vector(2 downto 0)  := (others => '0');
+      S_AXI_AWVALID  : in  std_logic                     := '0';
+      S_AXI_AWREADY  : out std_logic;
+      S_AXI_WDATA    : in  std_logic_vector(31 downto 0) := (others => '0');
+      S_AXI_WSTRB    : in  std_logic_vector(3 downto 0)  := (others => '1');
+      S_AXI_WVALID   : in  std_logic                     := '0';
+      S_AXI_WREADY   : out std_logic;
+      S_AXI_BRESP    : out std_logic_vector(1 downto 0);
+      S_AXI_BVALID   : out std_logic;
+      S_AXI_BREADY   : in  std_logic                     := '0';
+      S_AXI_ARADDR   : in  std_logic_vector(11 downto 0) := (others => '0');
+      S_AXI_ARPROT   : in  std_logic_vector(2 downto 0)  := (others => '0');
+      S_AXI_ARVALID  : in  std_logic                     := '0';
+      S_AXI_ARREADY  : out std_logic;
+      S_AXI_RDATA    : out std_logic_vector(31 downto 0);
+      S_AXI_RRESP    : out std_logic_vector(1 downto 0);
+      S_AXI_RVALID   : out std_logic;
+      S_AXI_RREADY   : in  std_logic                     := '0';
+      txDisableOut   : out std_logic;
+      flowCntlDisOut : out std_logic;
+      resetTxOut     : out std_logic;
+      resetRxOut     : out std_logic;
+      loopbackOut    : out std_logic_vector(2 downto 0));
 end entity Pgp4AxiLDirectWrapper;
 
 architecture rtl of Pgp4AxiLDirectWrapper is

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4CoreLiteWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4CoreLiteWrapper.vhd
@@ -49,27 +49,27 @@ end entity Pgp4CoreLiteWrapper;
 
 architecture rtl of Pgp4CoreLiteWrapper is
 
-   constant TUSER_WIDTH_C     : positive := 1;
-   constant TID_WIDTH_C       : positive := 1;
-   constant TDEST_WIDTH_C     : positive := 1;
-   constant TDATA_NUM_BYTES_C : positive := 8;
-   signal axisClk : sl := '0';
-   signal axisRst : sl := '0';
-   signal sAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal sAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal pgpTxIn  : Pgp4TxInType := PGP4_TX_IN_INIT_C;
-   signal pgpTxOut : Pgp4TxOutType;
-   signal phyValid  : sl               := '0';
-   signal phyData   : slv(63 downto 0) := (others => '0');
-   signal phyHeader : slv(1 downto 0)  := (others => '0');
-   signal pgpRxIn  : Pgp4RxInType := PGP4_RX_IN_INIT_C;
-   signal pgpRxOut : Pgp4RxOutType;
-   signal pgpRxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpRxCtrl   : AxiStreamCtrlType   := AXI_STREAM_CTRL_INIT_C;
-   signal mAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal mAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   constant TUSER_WIDTH_C     : positive            := 1;
+   constant TID_WIDTH_C       : positive            := 1;
+   constant TDEST_WIDTH_C     : positive            := 1;
+   constant TDATA_NUM_BYTES_C : positive            := 8;
+   signal axisClk             : sl                  := '0';
+   signal axisRst             : sl                  := '0';
+   signal sAxisMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal sAxisSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal pgpTxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal pgpTxIn             : Pgp4TxInType        := PGP4_TX_IN_INIT_C;
+   signal pgpTxOut            : Pgp4TxOutType;
+   signal phyValid            : sl                  := '0';
+   signal phyData             : slv(63 downto 0)    := (others => '0');
+   signal phyHeader           : slv(1 downto 0)     := (others => '0');
+   signal pgpRxIn             : Pgp4RxInType        := PGP4_RX_IN_INIT_C;
+   signal pgpRxOut            : Pgp4RxOutType;
+   signal pgpRxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpRxCtrl           : AxiStreamCtrlType   := AXI_STREAM_CTRL_INIT_C;
+   signal mAxisMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
 
 begin
 

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4CoreWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4CoreWrapper.vhd
@@ -49,27 +49,27 @@ end entity Pgp4CoreWrapper;
 
 architecture rtl of Pgp4CoreWrapper is
 
-   constant TUSER_WIDTH_C     : positive := 1;
-   constant TID_WIDTH_C       : positive := 1;
-   constant TDEST_WIDTH_C     : positive := 1;
-   constant TDATA_NUM_BYTES_C : positive := 8;
-   signal axisClk : sl := '0';
-   signal axisRst : sl := '0';
-   signal sAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal sAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal pgpTxIn  : Pgp4TxInType := PGP4_TX_IN_INIT_C;
-   signal pgpTxOut : Pgp4TxOutType;
-   signal phyValid  : sl               := '0';
-   signal phyData   : slv(63 downto 0) := (others => '0');
-   signal phyHeader : slv(1 downto 0)  := (others => '0');
-   signal pgpRxIn  : Pgp4RxInType := PGP4_RX_IN_INIT_C;
-   signal pgpRxOut : Pgp4RxOutType;
-   signal pgpRxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpRxCtrl   : AxiStreamCtrlType   := AXI_STREAM_CTRL_INIT_C;
-   signal mAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal mAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   constant TUSER_WIDTH_C     : positive            := 1;
+   constant TID_WIDTH_C       : positive            := 1;
+   constant TDEST_WIDTH_C     : positive            := 1;
+   constant TDATA_NUM_BYTES_C : positive            := 8;
+   signal axisClk             : sl                  := '0';
+   signal axisRst             : sl                  := '0';
+   signal sAxisMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal sAxisSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal pgpTxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal pgpTxIn             : Pgp4TxInType        := PGP4_TX_IN_INIT_C;
+   signal pgpTxOut            : Pgp4TxOutType;
+   signal phyValid            : sl                  := '0';
+   signal phyData             : slv(63 downto 0)    := (others => '0');
+   signal phyHeader           : slv(1 downto 0)     := (others => '0');
+   signal pgpRxIn             : Pgp4RxInType        := PGP4_RX_IN_INIT_C;
+   signal pgpRxOut            : Pgp4RxOutType;
+   signal pgpRxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpRxCtrl           : AxiStreamCtrlType   := AXI_STREAM_CTRL_INIT_C;
+   signal mAxisMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
 
 begin
 

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4LiteRxLowSpeedWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4LiteRxLowSpeedWrapper.vhd
@@ -70,17 +70,17 @@ architecture rtl of Pgp4LiteRxLowSpeedWrapper is
    signal axilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
    signal axilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
 
-   signal pgpTxIn      : Pgp4TxInType := PGP4_TX_IN_INIT_C;
-   signal pgpTxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave   : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal phyTxValid   : sl;
-   signal phyTxData    : slv(63 downto 0);
-   signal phyTxHeader  : slv(1 downto 0);
-   signal serWord      : slv(65 downto 0);
-   signal deserData    : Slv8Array(0 downto 0);
-   signal dlyLoads     : slv(0 downto 0);
-   signal dlyCfgs      : Slv9Array(0 downto 0);
-   signal rxMasters    : AxiStreamMasterArray(0 downto 0);
+   signal pgpTxIn     : Pgp4TxInType        := PGP4_TX_IN_INIT_C;
+   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal phyTxValid  : sl;
+   signal phyTxData   : slv(63 downto 0);
+   signal phyTxHeader : slv(1 downto 0);
+   signal serWord     : slv(65 downto 0);
+   signal deserData   : Slv8Array(0 downto 0);
+   signal dlyLoads    : slv(0 downto 0);
+   signal dlyCfgs     : Slv9Array(0 downto 0);
+   signal rxMasters   : AxiStreamMasterArray(0 downto 0);
 
 begin
 

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -20,8 +20,7 @@ use surf.StdRtlPkg.all;
 
 entity Pgp4RxEbWrapper is
    generic (
-      SKIP_EN_G      : boolean := true;
-      CHECK_K_CODE_G : boolean := false);
+      SKIP_EN_G : boolean := true);
    port (
       phyClk         : in  sl;
       pgpClk         : in  sl;
@@ -41,44 +40,19 @@ end entity Pgp4RxEbWrapper;
 
 architecture rtl of Pgp4RxEbWrapper is
 
-   signal checkedValid  : sl;
-   signal checkedData   : slv(63 downto 0);
-   signal checkedHeader : slv(1 downto 0);
-   signal checkedError  : sl;
-
 begin
 
-   GEN_CHECK_K_CODE : if (CHECK_K_CODE_G = true) generate
-      U_Checker : entity surf.Pgp4RxKCodeChecker
-         port map (
-            phyRxClk      => phyClk,
-            phyRxRst      => rst,
-            phyRxValid    => phyRxValid,
-            phyRxData     => phyRxData,
-            phyRxHeader   => phyRxHeader,
-            checkedValid  => checkedValid,
-            checkedData   => checkedData,
-            checkedHeader => checkedHeader,
-            linkError     => checkedError);
-   end generate GEN_CHECK_K_CODE;
-
-   GEN_NO_CHECK_K_CODE : if (CHECK_K_CODE_G = false) generate
-      checkedValid  <= phyRxValid;
-      checkedData   <= phyRxData;
-      checkedHeader <= phyRxHeader;
-      checkedError  <= phyRxLinkError;
-   end generate GEN_NO_CHECK_K_CODE;
-
+   -- DUT instantiation
    U_DUT : entity surf.Pgp4RxEb
       generic map (
          SKIP_EN_G => SKIP_EN_G)
       port map (
          phyRxClk       => phyClk,
          phyRxRst       => rst,
-         phyRxValid     => checkedValid,
-         phyRxData      => checkedData,
-         phyRxHeader    => checkedHeader,
-         phyRxLinkError => checkedError,
+         phyRxValid     => phyRxValid,
+         phyRxData      => phyRxData,
+         phyRxHeader    => phyRxHeader,
+         phyRxLinkError => phyRxLinkError,
          pgpRxClk       => pgpClk,
          pgpRxRst       => rst,
          pgpRxValid     => pgpRxValid,

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -31,7 +31,6 @@ entity Pgp4RxEbWrapper is
       pgpRxHeader : out slv(1 downto 0);
       remLinkData : out slv(47 downto 0);
       overflow    : out sl;
-      linkError   : out sl;
       status      : out slv(8 downto 0));
 end entity Pgp4RxEbWrapper;
 
@@ -53,7 +52,6 @@ begin
          pgpRxHeader => pgpRxHeader,
          remLinkData => remLinkData,
          overflow    => overflow,
-         linkError   => linkError,
          status      => status);
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -20,7 +20,7 @@ use surf.StdRtlPkg.all;
 
 entity Pgp4RxEbWrapper is
    generic (
-      BYPASS_G : boolean := false);
+      SKIP_EN_G : boolean := true);
    port (
       phyClk         : in  sl;
       pgpClk         : in  sl;
@@ -44,7 +44,7 @@ begin
 
    U_DUT : entity surf.Pgp4RxEb
       generic map (
-         BYPASS_G => BYPASS_G)
+         SKIP_EN_G => SKIP_EN_G)
       port map (
          phyRxClk       => phyClk,
          phyRxRst       => rst,

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -19,19 +19,23 @@ library surf;
 use surf.StdRtlPkg.all;
 
 entity Pgp4RxEbWrapper is
+   generic (
+      BYPASS_G : boolean := false);
    port (
-      phyClk      : in  sl;
-      pgpClk      : in  sl;
-      rst         : in  sl;
-      phyRxValid  : in  sl;
-      phyRxData   : in  slv(63 downto 0);
-      phyRxHeader : in  slv(1 downto 0);
-      pgpRxValid  : out sl;
-      pgpRxData   : out slv(63 downto 0);
-      pgpRxHeader : out slv(1 downto 0);
-      remLinkData : out slv(47 downto 0);
-      overflow    : out sl;
-      status      : out slv(8 downto 0));
+      phyClk         : in  sl;
+      pgpClk         : in  sl;
+      rst            : in  sl;
+      phyRxValid     : in  sl;
+      phyRxData      : in  slv(63 downto 0);
+      phyRxHeader    : in  slv(1 downto 0);
+      phyRxLinkError : in  sl := '0';
+      pgpRxValid     : out sl;
+      pgpRxData      : out slv(63 downto 0);
+      pgpRxHeader    : out slv(1 downto 0);
+      remLinkData    : out slv(47 downto 0);
+      overflow       : out sl;
+      linkError      : out sl;
+      status         : out slv(8 downto 0));
 end entity Pgp4RxEbWrapper;
 
 architecture rtl of Pgp4RxEbWrapper is
@@ -39,19 +43,23 @@ architecture rtl of Pgp4RxEbWrapper is
 begin
 
    U_DUT : entity surf.Pgp4RxEb
+      generic map (
+         BYPASS_G => BYPASS_G)
       port map (
-         phyRxClk    => phyClk,
-         phyRxRst    => rst,
-         phyRxValid  => phyRxValid,
-         phyRxData   => phyRxData,
-         phyRxHeader => phyRxHeader,
-         pgpRxClk    => pgpClk,
-         pgpRxRst    => rst,
-         pgpRxValid  => pgpRxValid,
-         pgpRxData   => pgpRxData,
-         pgpRxHeader => pgpRxHeader,
-         remLinkData => remLinkData,
-         overflow    => overflow,
-         status      => status);
+         phyRxClk       => phyClk,
+         phyRxRst       => rst,
+         phyRxValid     => phyRxValid,
+         phyRxData      => phyRxData,
+         phyRxHeader    => phyRxHeader,
+         phyRxLinkError => phyRxLinkError,
+         pgpRxClk       => pgpClk,
+         pgpRxRst       => rst,
+         pgpRxValid     => pgpRxValid,
+         pgpRxData      => pgpRxData,
+         pgpRxHeader    => pgpRxHeader,
+         remLinkData    => remLinkData,
+         overflow       => overflow,
+         linkError      => linkError,
+         status         => status);
 
 end architecture rtl;

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -20,7 +20,8 @@ use surf.StdRtlPkg.all;
 
 entity Pgp4RxEbWrapper is
    generic (
-      SKIP_EN_G : boolean := true);
+      SKIP_EN_G       : boolean := true;
+      CHECK_K_CODE_G  : boolean := false);
    port (
       phyClk         : in  sl;
       pgpClk         : in  sl;
@@ -40,7 +41,33 @@ end entity Pgp4RxEbWrapper;
 
 architecture rtl of Pgp4RxEbWrapper is
 
+   signal checkedValid  : sl;
+   signal checkedData   : slv(63 downto 0);
+   signal checkedHeader : slv(1 downto 0);
+   signal checkedError  : sl;
+
 begin
+
+   GEN_CHECK_K_CODE : if (CHECK_K_CODE_G = true) generate
+      U_Checker : entity surf.Pgp4RxKCodeChecker
+         port map (
+            phyRxClk      => phyClk,
+            phyRxRst      => rst,
+            phyRxValid    => phyRxValid,
+            phyRxData     => phyRxData,
+            phyRxHeader   => phyRxHeader,
+            checkedValid  => checkedValid,
+            checkedData   => checkedData,
+            checkedHeader => checkedHeader,
+            linkError     => checkedError);
+   end generate GEN_CHECK_K_CODE;
+
+   GEN_NO_CHECK_K_CODE : if (CHECK_K_CODE_G = false) generate
+      checkedValid  <= phyRxValid;
+      checkedData   <= phyRxData;
+      checkedHeader <= phyRxHeader;
+      checkedError  <= phyRxLinkError;
+   end generate GEN_NO_CHECK_K_CODE;
 
    U_DUT : entity surf.Pgp4RxEb
       generic map (
@@ -48,10 +75,10 @@ begin
       port map (
          phyRxClk       => phyClk,
          phyRxRst       => rst,
-         phyRxValid     => phyRxValid,
-         phyRxData      => phyRxData,
-         phyRxHeader    => phyRxHeader,
-         phyRxLinkError => phyRxLinkError,
+         phyRxValid     => checkedValid,
+         phyRxData      => checkedData,
+         phyRxHeader    => checkedHeader,
+         phyRxLinkError => checkedError,
          pgpRxClk       => pgpClk,
          pgpRxRst       => rst,
          pgpRxValid     => pgpRxValid,

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd
@@ -20,8 +20,8 @@ use surf.StdRtlPkg.all;
 
 entity Pgp4RxEbWrapper is
    generic (
-      SKIP_EN_G       : boolean := true;
-      CHECK_K_CODE_G  : boolean := false);
+      SKIP_EN_G      : boolean := true;
+      CHECK_K_CODE_G : boolean := false);
    port (
       phyClk         : in  sl;
       pgpClk         : in  sl;

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxLiteLowSpeedLaneWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxLiteLowSpeedLaneWrapper.vhd
@@ -23,36 +23,36 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4RxLiteLowSpeedLaneWrapper is
    port (
-      clk       : in  sl;
-      rst       : in  sl;
-      txValid   : in  sl;
-      txReady   : out sl;
-      txData    : in  slv(63 downto 0);
-      txSof     : in  sl;
-      txEof     : in  sl;
-      txEofe    : in  sl;
-      locked    : out sl;
-      bitSlip   : out sl;
-      dlyLoad   : out sl;
-      dlyCfg    : out slv(8 downto 0);
-      rxValid   : out sl;
-      rxLast    : out sl;
-      rxData    : out slv(63 downto 0);
-      rxDest    : out slv(7 downto 0);
-      rxUser    : out slv(15 downto 0));
+      clk     : in  sl;
+      rst     : in  sl;
+      txValid : in  sl;
+      txReady : out sl;
+      txData  : in  slv(63 downto 0);
+      txSof   : in  sl;
+      txEof   : in  sl;
+      txEofe  : in  sl;
+      locked  : out sl;
+      bitSlip : out sl;
+      dlyLoad : out sl;
+      dlyCfg  : out slv(8 downto 0);
+      rxValid : out sl;
+      rxLast  : out sl;
+      rxData  : out slv(63 downto 0);
+      rxDest  : out slv(7 downto 0);
+      rxUser  : out slv(15 downto 0));
 end entity Pgp4RxLiteLowSpeedLaneWrapper;
 
 architecture rtl of Pgp4RxLiteLowSpeedLaneWrapper is
 
-   signal pgpTxIn      : Pgp4TxInType := PGP4_TX_IN_INIT_C;
-   signal pgpTxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave   : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal phyTxValid   : sl;
-   signal phyTxData    : slv(63 downto 0);
-   signal phyTxHeader  : slv(1 downto 0);
-   signal serWord      : slv(65 downto 0);
-   signal deserData    : slv(7 downto 0);
-   signal rxMaster     : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxIn     : Pgp4TxInType        := PGP4_TX_IN_INIT_C;
+   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal phyTxValid  : sl;
+   signal phyTxData   : slv(63 downto 0);
+   signal phyTxHeader : slv(1 downto 0);
+   signal serWord     : slv(65 downto 0);
+   signal deserData   : slv(7 downto 0);
+   signal rxMaster    : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
 
 begin
 

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxLiteLowSpeedRegWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxLiteLowSpeedRegWrapper.vhd
@@ -56,8 +56,8 @@ end entity Pgp4RxLiteLowSpeedRegWrapper;
 
 architecture rtl of Pgp4RxLiteLowSpeedRegWrapper is
 
-   signal eyeWidth        : Slv9Array(1 downto 0) := (others => (others => '0'));
-   signal dlyConfig       : Slv9Array(1 downto 0) := (others => (others => '0'));
+   signal eyeWidth        : Slv9Array(1 downto 0)  := (others => (others => '0'));
+   signal dlyConfig       : Slv9Array(1 downto 0)  := (others => (others => '0'));
    signal usrDlyCfg       : Slv9Array(1 downto 0);
    signal axilClk         : sl;
    signal axilRst         : sl;

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolDepacketizerWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolDepacketizerWrapper.vhd
@@ -43,15 +43,15 @@ end entity Pgp4RxProtocolDepacketizerWrapper;
 
 architecture rtl of Pgp4RxProtocolDepacketizerWrapper is
 
-   signal pgpRxOut              : Pgp4RxOutType       := PGP4_RX_OUT_INIT_C;
-   signal pgpRawRxMaster        : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpRawRxSlave         : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
-   signal depacketizedRxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal depacketizedRxSlave   : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
-   signal depacketizerDebug     : Packetizer2DebugType;
-   signal remRxFifoCtrl         : AxiStreamCtrlArray(0 downto 0);
-   signal remRxLinkReady        : sl;
-   signal locRxLinkReady        : sl;
+   signal pgpRxOut             : Pgp4RxOutType       := PGP4_RX_OUT_INIT_C;
+   signal pgpRawRxMaster       : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpRawRxSlave        : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal depacketizedRxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal depacketizedRxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal depacketizerDebug    : Packetizer2DebugType;
+   signal remRxFifoCtrl        : AxiStreamCtrlArray(0 downto 0);
+   signal remRxLinkReady       : sl;
+   signal locRxLinkReady       : sl;
 
 begin
 

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolDepacketizerWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolDepacketizerWrapper.vhd
@@ -1,0 +1,109 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for PGP4 RX protocol and depacketizer
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiStreamPacketizer2Pkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp4Pkg.all;
+
+entity Pgp4RxProtocolDepacketizerWrapper is
+   port (
+      clk          : in  sl;
+      rst          : in  sl;
+      phyRxActive  : in  sl := '1';
+      protRxValid  : in  sl;
+      protRxHeader : in  slv(1 downto 0);
+      protRxData   : in  slv(63 downto 0);
+      rxReady      : in  sl := '1';
+      linkReady    : out sl;
+      frameRx      : out sl;
+      frameRxErr   : out sl;
+      linkError    : out sl;
+      rxValid      : out sl;
+      rxLast       : out sl;
+      rxData       : out slv(63 downto 0);
+      rxUser       : out slv(15 downto 0));
+end entity Pgp4RxProtocolDepacketizerWrapper;
+
+architecture rtl of Pgp4RxProtocolDepacketizerWrapper is
+
+   signal pgpRxOut              : Pgp4RxOutType       := PGP4_RX_OUT_INIT_C;
+   signal pgpRawRxMaster        : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpRawRxSlave         : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal depacketizedRxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal depacketizedRxSlave   : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal depacketizerDebug     : Packetizer2DebugType;
+   signal remRxFifoCtrl         : AxiStreamCtrlArray(0 downto 0);
+   signal remRxLinkReady        : sl;
+   signal locRxLinkReady        : sl;
+
+begin
+
+   linkReady  <= pgpRxOut.linkReady;
+   linkError  <= pgpRxOut.linkError;
+   frameRx    <= depacketizerDebug.eof;
+   frameRxErr <= depacketizerDebug.eofe;
+   rxValid    <= depacketizedRxMaster.tValid;
+   rxLast     <= depacketizedRxMaster.tLast;
+   rxData     <= depacketizedRxMaster.tData(63 downto 0);
+   rxUser     <= depacketizedRxMaster.tUser(15 downto 0);
+
+   depacketizedRxSlave.tReady <= rxReady;
+
+   U_Pgp4RxProtocol : entity surf.Pgp4RxProtocol
+      generic map (
+         NUM_VC_G => 1)
+      port map (
+         pgpRxClk       => clk,
+         pgpRxRst       => rst,
+         pgpRxIn        => PGP4_RX_IN_INIT_C,
+         pgpRxOut       => pgpRxOut,
+         pgpRxMaster    => pgpRawRxMaster,
+         pgpRxSlave     => pgpRawRxSlave,
+         remRxFifoCtrl  => remRxFifoCtrl,
+         remRxLinkReady => remRxLinkReady,
+         locRxLinkReady => locRxLinkReady,
+         linkError      => '0',
+         phyRxActive    => phyRxActive,
+         protRxValid    => protRxValid,
+         protRxPhyInit  => open,
+         protRxData     => protRxData,
+         protRxHeader   => protRxHeader);
+
+   U_AxiStreamDepacketizer2 : entity surf.AxiStreamDepacketizer2
+      generic map (
+         MEMORY_TYPE_G       => "distributed",
+         REG_EN_G            => false,
+         CRC_PIPELINE_G      => 0,
+         CRC_MODE_G          => "DATA",
+         CRC_POLY_G          => PGP4_CRC_POLY_C,
+         SEQ_CNT_SIZE_G      => 12,
+         TDEST_BITS_G        => 0,
+         INPUT_PIPE_STAGES_G => 0)
+      port map (
+         axisClk     => clk,
+         axisRst     => rst,
+         linkGood    => locRxLinkReady,
+         debug       => depacketizerDebug,
+         sAxisMaster => pgpRawRxMaster,
+         sAxisSlave  => pgpRawRxSlave,
+         mAxisMaster => depacketizedRxMaster,
+         mAxisSlave  => depacketizedRxSlave);
+
+end architecture rtl;

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolWrapper.vhd
@@ -24,13 +24,13 @@ entity Pgp4RxProtocolWrapper is
    port (
       clk            : in  sl;
       rst            : in  sl;
-      phyRxActive    : in  sl               := '1';
-      linkErrorIn    : in  sl               := '0';
-      resetRx        : in  sl               := '0';
+      phyRxActive    : in  sl := '1';
+      linkErrorIn    : in  sl := '0';
+      resetRx        : in  sl := '0';
       protRxValid    : in  sl;
       protRxHeader   : in  slv(1 downto 0);
       protRxData     : in  slv(63 downto 0);
-      pktReady       : in  sl               := '1';
+      pktReady       : in  sl := '1';
       linkReady      : out sl;
       linkDown       : out sl;
       linkErrorOut   : out sl;
@@ -49,8 +49,8 @@ end entity Pgp4RxProtocolWrapper;
 
 architecture rtl of Pgp4RxProtocolWrapper is
 
-   signal pgpRxIn       : Pgp4RxInType       := PGP4_RX_IN_INIT_C;
-   signal pgpRxOut      : Pgp4RxOutType      := PGP4_RX_OUT_INIT_C;
+   signal pgpRxIn       : Pgp4RxInType        := PGP4_RX_IN_INIT_C;
+   signal pgpRxOut      : Pgp4RxOutType       := PGP4_RX_OUT_INIT_C;
    signal pgpRxMaster   : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
    signal pgpRxSlave    : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
    signal remRxFifoCtrl : AxiStreamCtrlArray(0 downto 0);

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxWrapper.vhd
@@ -22,41 +22,37 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4RxWrapper is
    port (
-      clk          : in  sl;
-      rst          : in  sl;
-      txValid      : in  sl;
-      txReady      : out sl;
-      txData       : in  slv(63 downto 0);
-      txSof        : in  sl;
-      txEof        : in  sl;
-      txEofe       : in  sl;
-      opCodeEn     : in  sl               := '0';
-      opCodeData   : in  slv(47 downto 0) := (others => '0');
-      corruptArm   : in  sl               := '0';
-      corruptMask  : in  slv(63 downto 0) := (others => '0');
-      corruptBusy  : out sl;
-      linkReady    : out sl;
-      frameRx      : out sl;
-      frameRxErr   : out sl;
-      rxOpCodeEn   : out sl;
-      rxOpCodeData : out slv(47 downto 0);
-      rxValid      : out sl;
-      rxLast       : out sl;
-      rxData       : out slv(63 downto 0);
-      rxDest       : out slv(7 downto 0);
-      rxUser       : out slv(15 downto 0));
+      clk              : in  sl;
+      rst              : in  sl;
+      txValid          : in  sl;
+      txReady          : out sl;
+      txData           : in  slv(63 downto 0);
+      txSof            : in  sl;
+      txEof            : in  sl;
+      txEofe           : in  sl;
+      opCodeEn         : in  sl               := '0';
+      opCodeData       : in  slv(47 downto 0) := (others => '0');
+      linkReady        : out sl;
+      linkError        : out sl;
+      frameRx          : out sl;
+      frameRxErr       : out sl;
+      rxOpCodeEn       : out sl;
+      rxOpCodeData     : out slv(47 downto 0);
+      rxValid          : out sl;
+      rxLast           : out sl;
+      rxData           : out slv(63 downto 0);
+      rxDest           : out slv(7 downto 0);
+      rxUser           : out slv(15 downto 0));
 end entity Pgp4RxWrapper;
 
 architecture rtl of Pgp4RxWrapper is
 
-   signal pgpTxIn      : Pgp4TxInType := PGP4_TX_IN_INIT_C;
-   signal pgpTxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave   : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal phyTxValid   : sl;
-   signal phyTxData    : slv(63 downto 0);
-   signal phyTxHeader  : slv(1 downto 0);
-   signal loopPhyData  : slv(63 downto 0);
-   signal corruptBusyInt : sl := '0';
+   signal pgpTxIn             : Pgp4TxInType       := PGP4_TX_IN_INIT_C;
+   signal pgpTxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal phyTxValid          : sl;
+   signal phyTxData           : slv(63 downto 0);
+   signal phyTxHeader         : slv(1 downto 0);
 
    signal pgpRxOut     : Pgp4RxOutType := PGP4_RX_OUT_INIT_C;
    signal pgpRxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
@@ -81,9 +77,9 @@ begin
    pgpTxMaster.tLast              <= txEof;
 
    linkReady    <= pgpRxOut.linkReady;
+   linkError    <= pgpRxOut.linkError;
    frameRx      <= pgpRxOut.frameRx;
    frameRxErr   <= pgpRxOut.frameRxErr;
-   corruptBusy  <= corruptBusyInt;
    rxOpCodeEn   <= pgpRxOut.opCodeEn;
    rxOpCodeData <= pgpRxOut.opCodeData;
    rxValid      <= pgpRxMaster.tValid;
@@ -91,21 +87,6 @@ begin
    rxData       <= pgpRxMaster.tData(63 downto 0);
    rxDest       <= pgpRxMaster.tDest(7 downto 0);
    rxUser       <= pgpRxMaster.tUser(15 downto 0);
-
-   loopPhyData <= phyTxData xor corruptMask when (corruptBusyInt = '1' and phyTxValid = '1' and phyTxHeader = PGP4_D_HEADER_C) else phyTxData;
-
-   process (clk) is
-   begin
-      if rising_edge(clk) then
-         if rst = '1' then
-            corruptBusyInt <= '0';
-         elsif corruptArm = '1' then
-            corruptBusyInt <= '1';
-         elsif corruptBusyInt = '1' and phyTxValid = '1' and phyTxHeader = PGP4_D_HEADER_C then
-            corruptBusyInt <= '0';
-         end if;
-      end if;
-   end process;
 
    U_TX : entity surf.Pgp4Tx
       generic map (
@@ -154,7 +135,7 @@ begin
          phyRxInit      => open,
          phyRxActive    => '1',
          phyRxValid     => phyTxValid,
-         phyRxData      => loopPhyData,
+         phyRxData      => phyTxData,
          phyRxHeader    => phyTxHeader,
          phyRxStartSeq  => '0',
          phyRxSlip      => open);

--- a/protocols/pgp/pgp4/core/wrappers/Pgp4RxWrapper.vhd
+++ b/protocols/pgp/pgp4/core/wrappers/Pgp4RxWrapper.vhd
@@ -22,40 +22,40 @@ use surf.Pgp4Pkg.all;
 
 entity Pgp4RxWrapper is
    port (
-      clk              : in  sl;
-      rst              : in  sl;
-      txValid          : in  sl;
-      txReady          : out sl;
-      txData           : in  slv(63 downto 0);
-      txSof            : in  sl;
-      txEof            : in  sl;
-      txEofe           : in  sl;
-      opCodeEn         : in  sl               := '0';
-      opCodeData       : in  slv(47 downto 0) := (others => '0');
-      linkReady        : out sl;
-      linkError        : out sl;
-      frameRx          : out sl;
-      frameRxErr       : out sl;
-      rxOpCodeEn       : out sl;
-      rxOpCodeData     : out slv(47 downto 0);
-      rxValid          : out sl;
-      rxLast           : out sl;
-      rxData           : out slv(63 downto 0);
-      rxDest           : out slv(7 downto 0);
-      rxUser           : out slv(15 downto 0));
+      clk          : in  sl;
+      rst          : in  sl;
+      txValid      : in  sl;
+      txReady      : out sl;
+      txData       : in  slv(63 downto 0);
+      txSof        : in  sl;
+      txEof        : in  sl;
+      txEofe       : in  sl;
+      opCodeEn     : in  sl               := '0';
+      opCodeData   : in  slv(47 downto 0) := (others => '0');
+      linkReady    : out sl;
+      linkError    : out sl;
+      frameRx      : out sl;
+      frameRxErr   : out sl;
+      rxOpCodeEn   : out sl;
+      rxOpCodeData : out slv(47 downto 0);
+      rxValid      : out sl;
+      rxLast       : out sl;
+      rxData       : out slv(63 downto 0);
+      rxDest       : out slv(7 downto 0);
+      rxUser       : out slv(15 downto 0));
 end entity Pgp4RxWrapper;
 
 architecture rtl of Pgp4RxWrapper is
 
-   signal pgpTxIn             : Pgp4TxInType       := PGP4_TX_IN_INIT_C;
-   signal pgpTxMaster         : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
-   signal pgpTxSlave          : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
-   signal phyTxValid          : sl;
-   signal phyTxData           : slv(63 downto 0);
-   signal phyTxHeader         : slv(1 downto 0);
+   signal pgpTxIn     : Pgp4TxInType        := PGP4_TX_IN_INIT_C;
+   signal pgpTxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpTxSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+   signal phyTxValid  : sl;
+   signal phyTxData   : slv(63 downto 0);
+   signal phyTxHeader : slv(1 downto 0);
 
-   signal pgpRxOut     : Pgp4RxOutType := PGP4_RX_OUT_INIT_C;
-   signal pgpRxMaster  : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal pgpRxOut    : Pgp4RxOutType       := PGP4_RX_OUT_INIT_C;
+   signal pgpRxMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
 
 begin
 
@@ -121,23 +121,23 @@ begin
          SKIP_EN_G         => false,
          RX_CRC_PIPELINE_G => 0)
       port map (
-         pgpRxClk       => clk,
-         pgpRxRst       => rst,
-         pgpRxIn        => PGP4_RX_IN_INIT_C,
-         pgpRxOut       => pgpRxOut,
+         pgpRxClk        => clk,
+         pgpRxRst        => rst,
+         pgpRxIn         => PGP4_RX_IN_INIT_C,
+         pgpRxOut        => pgpRxOut,
          pgpRxMasters(0) => pgpRxMaster,
-         pgpRxCtrl(0)   => AXI_STREAM_CTRL_UNUSED_C,
-         remRxFifoCtrl  => open,
-         remRxLinkReady => open,
-         locRxLinkReady => open,
-         phyRxClk       => clk,
-         phyRxRst       => rst,
-         phyRxInit      => open,
-         phyRxActive    => '1',
-         phyRxValid     => phyTxValid,
-         phyRxData      => phyTxData,
-         phyRxHeader    => phyTxHeader,
-         phyRxStartSeq  => '0',
-         phyRxSlip      => open);
+         pgpRxCtrl(0)    => AXI_STREAM_CTRL_UNUSED_C,
+         remRxFifoCtrl   => open,
+         remRxLinkReady  => open,
+         locRxLinkReady  => open,
+         phyRxClk        => clk,
+         phyRxRst        => rst,
+         phyRxInit       => open,
+         phyRxActive     => '1',
+         phyRxValid      => phyTxValid,
+         phyRxData       => phyTxData,
+         phyRxHeader     => phyTxHeader,
+         phyRxStartSeq   => '0',
+         phyRxSlip       => open);
 
 end architecture rtl;

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxCrcError.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxCrcError.py
@@ -9,56 +9,83 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Keep one checked-in `Pgp4Rx` wrapper with the integrated `Pgp4Tx`
-#   traffic source and the new one-shot corruption hook disabled by default.
-# - Stimulus: Arm the corruption hook, then send one valid single-word frame so
-#   one 64-bit data beat is flipped after TX formatting but before RX checking.
-# - Checks: The integrated receive path must flag `frameRxErr` while staying
-#   link-up, which proves CRC-style rejection beyond the standalone CRC blocks.
-# - Timing: The corruption hook only touches the first transmitted data word of
-#   the next frame, so the injected error is deterministic.
+# - Sweep: Run a raw `Pgp4RxProtocol` plus `AxiStreamDepacketizer2` wrapper.
+# - Stimulus: Train the protocol link with valid IDLE words, then send one
+#   SOF/data/EOF cell whose EOF carries an intentionally wrong frame CRC.
+# - Checks: The depacketizer must report an errored frame end while the PGP4
+#   link itself remains up, proving that payload CRC errors are handled at the
+#   frame/cell layer instead of as link alignment errors.
+# - Timing: The bench drives complete 64-bit protocol words directly, so no
+#   test-only corruption ports are needed on the integrated RX loopback wrapper.
 
 import cocotb
 import pytest
 
 from tests.common.regression_utils import parameter_case
 from tests.protocols.pgp.pgp4.pgp4_test_utils import (
+    PGP4_D_HEADER,
+    PGP4_K_HEADER,
     Pgp4FlatTB,
-    initialize_flat_tx_inputs,
     initialize_signals,
-    send_single_word_frame,
+    pgp4_eof_word,
+    pgp4_idle_word,
+    pgp4_sof_word,
+    signal_int,
     wait_for_signal,
 )
 from tests.protocols.pgp.pgp_test_utils import run_pgp_wrapper_test
+
+PAYLOAD_WORD = 0x0123456789ABCDEF
+BAD_CELL_CRC = 0x11223344
+
+
+async def send_protocol_word(tb: Pgp4FlatTB, *, header: int, data: int):
+    tb.dut.protRxHeader.value = header
+    tb.dut.protRxData.value = data
+    tb.dut.protRxValid.value = 1
+    await tb.cycle()
+
+
+async def train_rx_protocol_link(tb: Pgp4FlatTB, *, cycles: int = 1002):
+    idle_word = pgp4_idle_word(rem_link_ready=1)
+    for _ in range(cycles):
+        await send_protocol_word(tb, header=PGP4_K_HEADER, data=idle_word)
+    tb.dut.protRxValid.value = 0
+    await wait_for_signal(tb, "linkReady", cycles=8)
 
 
 @cocotb.test()
 async def pgp4_rx_crc_error_test(dut):
     tb = Pgp4FlatTB(dut)
-    initialize_flat_tx_inputs(dut, include_opcode=True)
-    initialize_signals(dut, corruptArm=0, corruptMask=0)
+    initialize_signals(
+        dut,
+        phyRxActive=1,
+        protRxValid=0,
+        protRxHeader=0,
+        protRxData=0,
+        rxReady=1,
+    )
     await tb.reset()
-    await wait_for_signal(tb, "linkReady", cycles=2600)
+    await train_rx_protocol_link(tb)
 
-    dut.corruptMask.value = 0x1
-    dut.corruptArm.value = 1
-    await tb.cycle()
-    dut.corruptArm.value = 0
+    await send_protocol_word(tb, header=PGP4_K_HEADER, data=pgp4_sof_word(vc=0, seq=0))
+    await send_protocol_word(tb, header=PGP4_D_HEADER, data=PAYLOAD_WORD)
+    await send_protocol_word(tb, header=PGP4_K_HEADER, data=pgp4_eof_word(bytes_last=8, crc=BAD_CELL_CRC))
+    dut.protRxValid.value = 0
 
-    await send_single_word_frame(tb, payload=0x0123456789ABCDEF)
-    await wait_for_signal(tb, "corruptBusy", value=0, cycles=64)
     await wait_for_signal(tb, "frameRxErr", cycles=512)
-    assert int(dut.linkReady.value) == 1
+    assert signal_int(dut, "linkReady") == 1
+    assert signal_int(dut, "linkError") == 0
 
 
-PARAMETER_SWEEP = [parameter_case("integrated_scrambled_rx_wrapper_crc_error")]
+PARAMETER_SWEEP = [parameter_case("raw_protocol_depacketizer_crc_error")]
 
 
 @pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
 def test_Pgp4RxCrcError(parameters):
     run_pgp_wrapper_test(
         test_file=__file__,
-        toplevel="surf.pgp4rxwrapper",
-        wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxWrapper.vhd",
+        toplevel="surf.pgp4rxprotocoldepacketizerwrapper",
+        wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxProtocolDepacketizerWrapper.vhd",
         extra_env=parameters,
     )

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
@@ -10,11 +10,11 @@
 
 # Test methodology:
 # - Sweep: Run the direct `Pgp4RxEb` wrapper in three asynchronous clock modes
-#   plus one same-clock, skip-disabled mode with the K-code checker enabled.
+#   plus one same-clock, skip-disabled passthrough mode.
 # - Stimulus: Drive ordered mixes of data words, valid K-words, SKP words, and
 #   reset/overflow stress bursts directly into the PHY side of the elastic
-#   buffer.  The skip-disabled mode drives a malformed K-word followed
-#   immediately by data to cover the no-elastic-buffer link-error corner case.
+#   buffer.  The skip-disabled mode drives a data word with an external link
+#   error pulse to cover the no-elastic-buffer passthrough contract.
 # - Checks: The DUT must forward non-SKP traffic in order, suppress SKP while
 #   still updating `remLinkData`, flush buffered data on reset, and pulse
 #   `overflow` when sustained write pressure outruns the read domain.
@@ -39,18 +39,12 @@ from tests.common.regression_utils import (
 from tests.protocols.pgp.pgp4.pgp4_test_utils import (
     PGP4_D_HEADER,
     PGP4_K_HEADER,
-    PGP4_USER,
     initialize_signals,
     pgp4_idle_word,
-    pgp4_kword,
     pgp4_skip_word,
-    pgp4_user_word,
     signal_int,
 )
 from tests.protocols.pgp.pgp_test_utils import run_pgp_wrapper_test
-
-K_CODE_CSC_LSB = 48
-USER_OPCODE_PAYLOAD = 0x0000CAFEBABE
 
 
 class Pgp4RxEbTB:
@@ -156,27 +150,21 @@ def initialize_phy_inputs(dut):
     initialize_signals(dut, phyRxValid=0, phyRxData=0, phyRxHeader=0, phyRxLinkError=0)
 
 
-async def send_phy_word(tb: Pgp4RxEbTB, *, header: int, data: int):
+async def send_phy_word(tb: Pgp4RxEbTB, *, header: int, data: int, link_error: int = 0):
     """Launch one PHY-side word for exactly one recovered-clock cycle."""
 
     tb.dut.phyRxHeader.value = header
     tb.dut.phyRxData.value = data
+    tb.dut.phyRxLinkError.value = link_error
     tb.dut.phyRxValid.value = 1
     await tb.cycle_phy()
     tb.dut.phyRxValid.value = 0
+    tb.dut.phyRxLinkError.value = 0
 
 
 async def send_phy_words(tb: Pgp4RxEbTB, words: list[tuple[int, int]]):
     for header, data in words:
         await send_phy_word(tb, header=header, data=data)
-
-
-def bad_kcode_checksum_word() -> int:
-    """Build a real USER K-word and corrupt only its checksum field."""
-
-    good_user_word = pgp4_user_word(USER_OPCODE_PAYLOAD)
-    assert good_user_word == pgp4_kword(PGP4_USER, USER_OPCODE_PAYLOAD)
-    return good_user_word ^ (1 << K_CODE_CSC_LSB)
 
 
 def env_parameters_from(parameters: dict[str, object]) -> dict[str, object]:
@@ -313,7 +301,7 @@ async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
 
 
 @cocotb.test()
-async def pgp4_rx_eb_skip_disabled_bubbles_after_link_error(dut):
+async def pgp4_rx_eb_skip_disabled_passes_stream_and_link_error(dut):
     tb = Pgp4RxEbTB(dut)
     if not env_flag("EXPECT_SKIP_DISABLED", default=False):
         return
@@ -331,21 +319,11 @@ async def pgp4_rx_eb_skip_disabled_bubbles_after_link_error(dut):
     cocotb.start_soon(collector.run())
     cocotb.start_soon(link_error_monitor.run())
 
-    data_word_a = 0x1111222233334444
-    bad_user_word = bad_kcode_checksum_word()
-    suppressed_word = 0x5555666677778888
-    data_word_b = 0x9999AAAABBBBCCCC
+    data_word = 0x123456789ABCDEF0
+    await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word, link_error=1)
 
-    await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_a)
-    await send_phy_word(tb, header=PGP4_K_HEADER, data=bad_user_word)
-    await send_phy_word(tb, header=PGP4_D_HEADER, data=suppressed_word)
-    await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_b)
-
-    words = await wait_for_collected_beats(collector, count=2, step=tb.cycle_pgp, cycles=64)
-    assert words == [
-        (PGP4_D_HEADER, data_word_a),
-        (PGP4_D_HEADER, data_word_b),
-    ]
+    words = await wait_for_collected_beats(collector, count=1, step=tb.cycle_pgp, cycles=64)
+    assert words == [(PGP4_D_HEADER, data_word)]
     assert link_error_monitor.seen
 
 
@@ -371,7 +349,6 @@ PARAMETER_SWEEP = [
     parameter_case(
         "same_clock_skip_disabled",
         SKIP_EN_G=False,
-        CHECK_K_CODE_G=True,
         PHY_CLK_PERIOD_NS="4.000",
         PGP_CLK_PERIOD_NS="4.000",
         COMMON_CLK="1",

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
@@ -14,12 +14,11 @@
 #   not equal, a near-empty case where the local read clock is faster than the
 #   recovered write clock, and a deliberate overflow-stress case where the
 #   write side is much faster than the read side.
-# - Stimulus: Drive ordered mixes of data words, valid K-words, SKP words, bad
-#   K-word CRC cases, and reset/overflow stress bursts directly into the PHY
-#   side of the elastic buffer.
+# - Stimulus: Drive ordered mixes of data words, valid K-words, SKP words, and
+#   reset/overflow stress bursts directly into the PHY side of the elastic
+#   buffer.
 # - Checks: The DUT must forward non-SKP traffic in order, suppress SKP while
-#   still updating `remLinkData`, reject bad K-word CRC traffic with a
-#   synchronized `linkError` pulse, flush buffered data on reset, and pulse
+#   still updating `remLinkData`, flush buffered data on reset, and pulse
 #   `overflow` when sustained write pressure outruns the read domain.
 # - Timing: All output checks are sampled on `pgpRxClk`, while input traffic is
 #   launched on `phyRxClk`, so the bench reflects the intended recovered-clock
@@ -230,52 +229,6 @@ async def pgp4_rx_eb_filters_skip_and_preserves_stream_order(dut):
         (PGP4_D_HEADER, data_word_b),
     ]
     await wait_for_signal_in_domain(tb, "remLinkData", value=skip_data, cycles=64)
-    assert signal_int(tb.dut, "linkError") == 0
-
-
-@cocotb.test()
-async def pgp4_rx_eb_rejects_bad_kcode_crc_without_poisoning_fifo(dut):
-    tb = Pgp4RxEbTB(dut)
-    if env_flag("EXPECT_OVERFLOW", default=False):
-        return
-
-    initialize_phy_inputs(dut)
-    await tb.reset()
-
-    # A bad K-code CRC should be dropped before the FIFO write side and should
-    # produce a synchronized `linkError` pulse in the read domain.  Surrounding
-    # traffic should still be delivered in order.
-    collector = ValidBeatCollector(
-        dut,
-        step=tb.sample_pgp_cycle,
-        valid_name="pgpRxValid",
-        field_names=("pgpRxHeader", "pgpRxData"),
-    )
-    cocotb.start_soon(collector.run())
-    link_error_monitor = PulseMonitor(dut, "linkError", step=tb.cycle_pgp)
-    cocotb.start_soon(link_error_monitor.run())
-
-    data_word_a = 0x0011223344556677
-    data_word_b = 0x8899AABBCCDDEEFF
-    bad_idle = pgp4_idle_word(rem_link_ready=1) ^ (1 << 48)
-
-    await send_phy_words(
-        tb,
-        [
-            (PGP4_D_HEADER, data_word_a),
-            (PGP4_K_HEADER, bad_idle),
-            (PGP4_D_HEADER, data_word_b),
-        ],
-    )
-
-    words = await wait_for_collected_beats(collector, count=2, step=tb.cycle_pgp, cycles=256)
-    assert words == [
-        (PGP4_D_HEADER, data_word_a),
-        (PGP4_D_HEADER, data_word_b),
-    ]
-    await tb.cycle_pgp(32)
-    assert link_error_monitor.seen
-
 
 @cocotb.test()
 async def pgp4_rx_eb_reset_flushes_buffered_words(dut):
@@ -322,7 +275,6 @@ async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
 
     await tb.cycle_pgp(64)
     assert overflow_monitor.seen
-    assert signal_int(tb.dut, "linkError") == 0
 
 
 PARAMETER_SWEEP = [

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
@@ -31,7 +31,7 @@ import pytest
 from cocotb.clock import Clock
 from cocotb.triggers import FallingEdge, RisingEdge, Timer
 
-from tests.common.regression_utils import env_flag, env_float, parameter_case
+from tests.common.regression_utils import env_flag, env_float, parameter_case, start_lockstep_clocks
 from tests.protocols.pgp.pgp4.pgp4_test_utils import (
     PGP4_D_HEADER,
     PGP4_K_HEADER,
@@ -54,8 +54,11 @@ class Pgp4RxEbTB:
         self.dut = dut
         self.phy_period_ns = env_float("PHY_CLK_PERIOD_NS", default=4.0)
         self.pgp_period_ns = env_float("PGP_CLK_PERIOD_NS", default=4.125)
-        cocotb.start_soon(Clock(dut.phyClk, self.phy_period_ns, unit="ns").start())
-        cocotb.start_soon(Clock(dut.pgpClk, self.pgp_period_ns, unit="ns").start())
+        if env_flag("COMMON_CLK", default=False):
+            start_lockstep_clocks(dut.phyClk, dut.pgpClk, period_ns=self.phy_period_ns)
+        else:
+            cocotb.start_soon(Clock(dut.phyClk, self.phy_period_ns, unit="ns").start())
+            cocotb.start_soon(Clock(dut.pgpClk, self.pgp_period_ns, unit="ns").start())
 
     async def cycle_phy(self, count: int = 1):
         for _ in range(count):
@@ -140,7 +143,7 @@ async def wait_for_collected_beats(collector: ValidBeatCollector, *, count: int,
 def initialize_phy_inputs(dut):
     """Drive the direct PHY-side wrapper inputs to a known idle state."""
 
-    initialize_signals(dut, phyRxValid=0, phyRxData=0, phyRxHeader=0)
+    initialize_signals(dut, phyRxValid=0, phyRxData=0, phyRxHeader=0, phyRxLinkError=0)
 
 
 async def send_phy_word(tb: Pgp4RxEbTB, *, header: int, data: int):
@@ -156,6 +159,15 @@ async def send_phy_word(tb: Pgp4RxEbTB, *, header: int, data: int):
 async def send_phy_words(tb: Pgp4RxEbTB, words: list[tuple[int, int]]):
     for header, data in words:
         await send_phy_word(tb, header=header, data=data)
+
+
+async def send_phy_link_error(tb: Pgp4RxEbTB):
+    """Pulse the checker-to-EB link error without presenting a valid word."""
+
+    tb.dut.phyRxValid.value = 0
+    tb.dut.phyRxLinkError.value = 1
+    await tb.cycle_phy()
+    tb.dut.phyRxLinkError.value = 0
 
 
 async def collect_output_words(tb: Pgp4RxEbTB, *, count: int, cycles: int = 256) -> list[tuple[int, int]]:
@@ -190,7 +202,7 @@ async def assert_no_output_words(tb: Pgp4RxEbTB, *, cycles: int):
 @cocotb.test()
 async def pgp4_rx_eb_filters_skip_and_preserves_stream_order(dut):
     tb = Pgp4RxEbTB(dut)
-    if env_flag("EXPECT_OVERFLOW", default=False):
+    if env_flag("EXPECT_BYPASS", default=False) or env_flag("EXPECT_OVERFLOW", default=False):
         return
 
     initialize_phy_inputs(dut)
@@ -233,6 +245,9 @@ async def pgp4_rx_eb_filters_skip_and_preserves_stream_order(dut):
 @cocotb.test()
 async def pgp4_rx_eb_reset_flushes_buffered_words(dut):
     tb = Pgp4RxEbTB(dut)
+    if env_flag("EXPECT_BYPASS", default=False):
+        return
+
     initialize_phy_inputs(dut)
     await tb.reset()
 
@@ -255,6 +270,9 @@ async def pgp4_rx_eb_reset_flushes_buffered_words(dut):
 @cocotb.test()
 async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
     tb = Pgp4RxEbTB(dut)
+    if env_flag("EXPECT_BYPASS", default=False):
+        return
+
     initialize_phy_inputs(dut)
     await tb.reset()
 
@@ -275,6 +293,42 @@ async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
 
     await tb.cycle_pgp(64)
     assert overflow_monitor.seen
+
+
+@cocotb.test()
+async def pgp4_rx_eb_bypass_bubbles_after_link_error(dut):
+    tb = Pgp4RxEbTB(dut)
+    if not env_flag("EXPECT_BYPASS", default=False):
+        return
+
+    initialize_phy_inputs(dut)
+    await tb.reset()
+
+    collector = ValidBeatCollector(
+        dut,
+        step=tb.sample_pgp_cycle,
+        valid_name="pgpRxValid",
+        field_names=("pgpRxHeader", "pgpRxData"),
+    )
+    link_error_monitor = PulseMonitor(dut, "linkError", step=tb.sample_pgp_cycle)
+    cocotb.start_soon(collector.run())
+    cocotb.start_soon(link_error_monitor.run())
+
+    data_word_a = 0x1111222233334444
+    suppressed_word = 0x5555666677778888
+    data_word_b = 0x9999AAAABBBBCCCC
+
+    await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_a)
+    await send_phy_link_error(tb)
+    await send_phy_word(tb, header=PGP4_D_HEADER, data=suppressed_word)
+    await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_b)
+
+    words = await wait_for_collected_beats(collector, count=2, step=tb.cycle_pgp, cycles=64)
+    assert words == [
+        (PGP4_D_HEADER, data_word_a),
+        (PGP4_D_HEADER, data_word_b),
+    ]
+    assert link_error_monitor.seen
 
 
 PARAMETER_SWEEP = [
@@ -306,4 +360,30 @@ def test_Pgp4RxEb(parameters):
         toplevel="surf.pgp4rxebwrapper",
         wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd",
         extra_env=parameters,
+    )
+
+
+BYPASS_PARAMETER_SWEEP = [
+    pytest.param(
+        {"BYPASS_G": True},
+        {
+            "PHY_CLK_PERIOD_NS": "4.000",
+            "PGP_CLK_PERIOD_NS": "4.000",
+            "COMMON_CLK": "1",
+            "EXPECT_BYPASS": "1",
+            "EXPECT_OVERFLOW": "0",
+        },
+        id="same_clock_bypass",
+    ),
+]
+
+
+@pytest.mark.parametrize("parameters, extra_env", BYPASS_PARAMETER_SWEEP)
+def test_Pgp4RxEbBypass(parameters, extra_env):
+    run_pgp_wrapper_test(
+        test_file=__file__,
+        toplevel="surf.pgp4rxebwrapper",
+        wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd",
+        parameters=parameters,
+        extra_env=extra_env,
     )

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
@@ -9,14 +9,12 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Run the direct `Pgp4RxEb` wrapper in three asynchronous clock modes:
-#   a realistic slight-drift case where `phyRxClk` and `pgpRxClk` are close but
-#   not equal, a near-empty case where the local read clock is faster than the
-#   recovered write clock, and a deliberate overflow-stress case where the
-#   write side is much faster than the read side.
+# - Sweep: Run the direct `Pgp4RxEb` wrapper in three asynchronous clock modes
+#   plus one same-clock, skip-disabled mode with the K-code checker enabled.
 # - Stimulus: Drive ordered mixes of data words, valid K-words, SKP words, and
 #   reset/overflow stress bursts directly into the PHY side of the elastic
-#   buffer.
+#   buffer.  The skip-disabled mode drives a malformed K-word followed
+#   immediately by data to cover the no-elastic-buffer link-error corner case.
 # - Checks: The DUT must forward non-SKP traffic in order, suppress SKP while
 #   still updating `remLinkData`, flush buffered data on reset, and pulse
 #   `overflow` when sustained write pressure outruns the read domain.
@@ -31,16 +29,28 @@ import pytest
 from cocotb.clock import Clock
 from cocotb.triggers import FallingEdge, RisingEdge, Timer
 
-from tests.common.regression_utils import env_flag, env_float, parameter_case, start_lockstep_clocks
+from tests.common.regression_utils import (
+    env_flag,
+    env_float,
+    hdl_parameters_from,
+    parameter_case,
+    start_lockstep_clocks,
+)
 from tests.protocols.pgp.pgp4.pgp4_test_utils import (
     PGP4_D_HEADER,
     PGP4_K_HEADER,
+    PGP4_USER,
     initialize_signals,
     pgp4_idle_word,
+    pgp4_kword,
     pgp4_skip_word,
+    pgp4_user_word,
     signal_int,
 )
 from tests.protocols.pgp.pgp_test_utils import run_pgp_wrapper_test
+
+K_CODE_CSC_LSB = 48
+USER_OPCODE_PAYLOAD = 0x0000CAFEBABE
 
 
 class Pgp4RxEbTB:
@@ -161,13 +171,20 @@ async def send_phy_words(tb: Pgp4RxEbTB, words: list[tuple[int, int]]):
         await send_phy_word(tb, header=header, data=data)
 
 
-async def send_phy_link_error(tb: Pgp4RxEbTB):
-    """Pulse the checker-to-EB link error without presenting a valid word."""
+def bad_kcode_checksum_word() -> int:
+    """Build a real USER K-word and corrupt only its checksum field."""
 
-    tb.dut.phyRxValid.value = 0
-    tb.dut.phyRxLinkError.value = 1
-    await tb.cycle_phy()
-    tb.dut.phyRxLinkError.value = 0
+    good_user_word = pgp4_user_word(USER_OPCODE_PAYLOAD)
+    assert good_user_word == pgp4_kword(PGP4_USER, USER_OPCODE_PAYLOAD)
+    return good_user_word ^ (1 << K_CODE_CSC_LSB)
+
+
+def env_parameters_from(parameters: dict[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in parameters.items()
+        if not key.endswith("_G")
+    }
 
 
 async def collect_output_words(tb: Pgp4RxEbTB, *, count: int, cycles: int = 256) -> list[tuple[int, int]]:
@@ -315,11 +332,12 @@ async def pgp4_rx_eb_skip_disabled_bubbles_after_link_error(dut):
     cocotb.start_soon(link_error_monitor.run())
 
     data_word_a = 0x1111222233334444
+    bad_user_word = bad_kcode_checksum_word()
     suppressed_word = 0x5555666677778888
     data_word_b = 0x9999AAAABBBBCCCC
 
     await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_a)
-    await send_phy_link_error(tb)
+    await send_phy_word(tb, header=PGP4_K_HEADER, data=bad_user_word)
     await send_phy_word(tb, header=PGP4_D_HEADER, data=suppressed_word)
     await send_phy_word(tb, header=PGP4_D_HEADER, data=data_word_b)
 
@@ -350,6 +368,16 @@ PARAMETER_SWEEP = [
         PGP_CLK_PERIOD_NS="12.000",
         EXPECT_OVERFLOW="1",
     ),
+    parameter_case(
+        "same_clock_skip_disabled",
+        SKIP_EN_G=False,
+        CHECK_K_CODE_G=True,
+        PHY_CLK_PERIOD_NS="4.000",
+        PGP_CLK_PERIOD_NS="4.000",
+        COMMON_CLK="1",
+        EXPECT_SKIP_DISABLED="1",
+        EXPECT_OVERFLOW="0",
+    ),
 ]
 
 
@@ -359,31 +387,6 @@ def test_Pgp4RxEb(parameters):
         test_file=__file__,
         toplevel="surf.pgp4rxebwrapper",
         wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd",
-        extra_env=parameters,
-    )
-
-
-SKIP_DISABLED_PARAMETER_SWEEP = [
-    pytest.param(
-        {"SKIP_EN_G": False},
-        {
-            "PHY_CLK_PERIOD_NS": "4.000",
-            "PGP_CLK_PERIOD_NS": "4.000",
-            "COMMON_CLK": "1",
-            "EXPECT_SKIP_DISABLED": "1",
-            "EXPECT_OVERFLOW": "0",
-        },
-        id="same_clock_skip_disabled",
-    ),
-]
-
-
-@pytest.mark.parametrize("parameters, extra_env", SKIP_DISABLED_PARAMETER_SWEEP)
-def test_Pgp4RxEbSkipDisabled(parameters, extra_env):
-    run_pgp_wrapper_test(
-        test_file=__file__,
-        toplevel="surf.pgp4rxebwrapper",
-        wrapper_source="protocols/pgp/pgp4/core/wrappers/Pgp4RxEbWrapper.vhd",
-        parameters=parameters,
-        extra_env=extra_env,
+        parameters=hdl_parameters_from(parameters),
+        extra_env=env_parameters_from(parameters),
     )

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxEb.py
@@ -202,7 +202,7 @@ async def assert_no_output_words(tb: Pgp4RxEbTB, *, cycles: int):
 @cocotb.test()
 async def pgp4_rx_eb_filters_skip_and_preserves_stream_order(dut):
     tb = Pgp4RxEbTB(dut)
-    if env_flag("EXPECT_BYPASS", default=False) or env_flag("EXPECT_OVERFLOW", default=False):
+    if env_flag("EXPECT_SKIP_DISABLED", default=False) or env_flag("EXPECT_OVERFLOW", default=False):
         return
 
     initialize_phy_inputs(dut)
@@ -245,7 +245,7 @@ async def pgp4_rx_eb_filters_skip_and_preserves_stream_order(dut):
 @cocotb.test()
 async def pgp4_rx_eb_reset_flushes_buffered_words(dut):
     tb = Pgp4RxEbTB(dut)
-    if env_flag("EXPECT_BYPASS", default=False):
+    if env_flag("EXPECT_SKIP_DISABLED", default=False):
         return
 
     initialize_phy_inputs(dut)
@@ -270,7 +270,7 @@ async def pgp4_rx_eb_reset_flushes_buffered_words(dut):
 @cocotb.test()
 async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
     tb = Pgp4RxEbTB(dut)
-    if env_flag("EXPECT_BYPASS", default=False):
+    if env_flag("EXPECT_SKIP_DISABLED", default=False):
         return
 
     initialize_phy_inputs(dut)
@@ -296,9 +296,9 @@ async def pgp4_rx_eb_overflow_pulses_when_phy_outpaces_local_clock(dut):
 
 
 @cocotb.test()
-async def pgp4_rx_eb_bypass_bubbles_after_link_error(dut):
+async def pgp4_rx_eb_skip_disabled_bubbles_after_link_error(dut):
     tb = Pgp4RxEbTB(dut)
-    if not env_flag("EXPECT_BYPASS", default=False):
+    if not env_flag("EXPECT_SKIP_DISABLED", default=False):
         return
 
     initialize_phy_inputs(dut)
@@ -363,23 +363,23 @@ def test_Pgp4RxEb(parameters):
     )
 
 
-BYPASS_PARAMETER_SWEEP = [
+SKIP_DISABLED_PARAMETER_SWEEP = [
     pytest.param(
-        {"BYPASS_G": True},
+        {"SKIP_EN_G": False},
         {
             "PHY_CLK_PERIOD_NS": "4.000",
             "PGP_CLK_PERIOD_NS": "4.000",
             "COMMON_CLK": "1",
-            "EXPECT_BYPASS": "1",
+            "EXPECT_SKIP_DISABLED": "1",
             "EXPECT_OVERFLOW": "0",
         },
-        id="same_clock_bypass",
+        id="same_clock_skip_disabled",
     ),
 ]
 
 
-@pytest.mark.parametrize("parameters, extra_env", BYPASS_PARAMETER_SWEEP)
-def test_Pgp4RxEbBypass(parameters, extra_env):
+@pytest.mark.parametrize("parameters, extra_env", SKIP_DISABLED_PARAMETER_SWEEP)
+def test_Pgp4RxEbSkipDisabled(parameters, extra_env):
     run_pgp_wrapper_test(
         test_file=__file__,
         toplevel="surf.pgp4rxebwrapper",

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxKCodeChecker.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxKCodeChecker.py
@@ -14,7 +14,8 @@
 #   cycles, and reset directly into the checker input.
 # - Checks: Data words pass regardless of K-code checksum contents, valid
 #   K-words pass unchanged, invalid K-words are suppressed with a one-cycle
-#   `linkError`, and reset clears the registered outputs.
+#   `linkError`, the word immediately following an invalid K-word is also
+#   suppressed, and reset clears the registered outputs.
 # - Timing: The checker is registered, so each input word is sampled one clock
 #   cycle after it is driven.
 
@@ -38,6 +39,8 @@ from tests.protocols.pgp.pgp4.pgp4_test_utils import (
 
 K_CODE_CSC_LSB = 48
 DATA_PASS_THROUGH_WORD = 0x0123456789ABCDEF
+DATA_AFTER_ERROR_WORD = 0xFEDCBA9876543210
+DATA_RECOVERY_WORD = 0x55AA55AA55AA55AA
 IDLE_PAUSE_MASK = 0x1234
 IDLE_OVERFLOW_MASK = 0x00A5
 USER_OPCODE_PAYLOAD = 0x0000CAFEBABE
@@ -129,8 +132,21 @@ async def pgp4_rx_kcode_checker_test(dut):
         1,
     )
 
-    await drive_checker_word(tb, header=PGP4_K_HEADER, data=bad_user_word, valid=0)
-    assert checker_outputs(dut) == (0, PGP4_K_HEADER, bad_user_word, 0)
+    # The checker also suppresses the immediately following word so downstream
+    # link-error state can take effect before any more protocol words arrive.
+    assert await drive_checker_word(tb, header=PGP4_D_HEADER, data=DATA_AFTER_ERROR_WORD) == (
+        0,
+        PGP4_D_HEADER,
+        DATA_AFTER_ERROR_WORD,
+        0,
+    )
+
+    assert await drive_checker_word(tb, header=PGP4_D_HEADER, data=DATA_RECOVERY_WORD) == (
+        1,
+        PGP4_D_HEADER,
+        DATA_RECOVERY_WORD,
+        0,
+    )
 
     tb.dut.phyRxValid.value = 1
     tb.dut.phyRxHeader.value = PGP4_D_HEADER

--- a/tests/protocols/pgp/pgp4/test_Pgp4RxKCodeChecker.py
+++ b/tests/protocols/pgp/pgp4/test_Pgp4RxKCodeChecker.py
@@ -1,0 +1,152 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Run the single-clock `Pgp4RxKCodeChecker` RTL directly.
+# - Stimulus: Drive ordinary data words, valid K-words, invalid K-words, idle
+#   cycles, and reset directly into the checker input.
+# - Checks: Data words pass regardless of K-code checksum contents, valid
+#   K-words pass unchanged, invalid K-words are suppressed with a one-cycle
+#   `linkError`, and reset clears the registered outputs.
+# - Timing: The checker is registered, so each input word is sampled one clock
+#   cycle after it is driven.
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+
+from tests.common.regression_utils import parameter_case, run_surf_vhdl_test
+from tests.protocols.pgp.pgp4.pgp4_test_utils import (
+    PGP4_D_HEADER,
+    PGP4_K_HEADER,
+    PGP4_IDLE,
+    PGP4_USER,
+    Pgp4FlatTB,
+    initialize_signals,
+    pgp4_idle_word,
+    pgp4_kword,
+    pgp4_user_word,
+    signal_int,
+)
+
+K_CODE_CSC_LSB = 48
+DATA_PASS_THROUGH_WORD = 0x0123456789ABCDEF
+IDLE_PAUSE_MASK = 0x1234
+IDLE_OVERFLOW_MASK = 0x00A5
+USER_OPCODE_PAYLOAD = 0x0000CAFEBABE
+
+
+def checker_outputs(dut) -> tuple[int, int, int, int]:
+    return (
+        signal_int(dut, "checkedValid"),
+        signal_int(dut, "checkedHeader"),
+        signal_int(dut, "checkedData"),
+        signal_int(dut, "linkError"),
+    )
+
+
+async def cycle_and_sample(tb: Pgp4FlatTB):
+    await tb.cycle()
+    await Timer(1, unit="ns")
+
+
+async def drive_checker_word(tb: Pgp4FlatTB, *, header: int, data: int, valid: int = 1) -> tuple[int, int, int, int]:
+    tb.dut.phyRxValid.value = valid
+    tb.dut.phyRxHeader.value = header
+    tb.dut.phyRxData.value = data
+    await Timer(1, unit="ps")
+    await cycle_and_sample(tb)
+    return checker_outputs(tb.dut)
+
+
+def bad_kcode_checksum_word() -> int:
+    """Build a real USER K-word and corrupt only its checksum field.
+
+    `pgp4_user_word()` delegates to `pgp4_kword()`, which fills bits 55:48
+    with the correct PGP4 control-word checksum.  Flipping bit 48 leaves the
+    block type and 48-bit USER payload intact while making the checksum fail.
+    """
+
+    return pgp4_user_word(USER_OPCODE_PAYLOAD) ^ (1 << K_CODE_CSC_LSB)
+
+
+@cocotb.test()
+async def pgp4_rx_kcode_checker_test(dut):
+    tb = Pgp4FlatTB(dut, clk_name="phyRxClk", rst_name="phyRxRst")
+    initialize_signals(
+        dut,
+        phyRxValid=0,
+        phyRxHeader=0,
+        phyRxData=0,
+    )
+    await tb.reset()
+    assert checker_outputs(dut) == (0, 0, 0, 0)
+
+    # Data words do not carry a PGP4 K-code checksum.  This value is chosen
+    # only to prove that ordinary data is registered and passed through
+    # unchanged when the 64b/66b header marks it as data.
+    assert await drive_checker_word(tb, header=PGP4_D_HEADER, data=DATA_PASS_THROUGH_WORD) == (
+        1,
+        PGP4_D_HEADER,
+        DATA_PASS_THROUGH_WORD,
+        0,
+    )
+
+    # `pgp4_idle_word()` builds the BTF, LINKINFO payload, and correct
+    # checksum.  Rebuilding the same word with `pgp4_kword()` documents the
+    # intended payload fields without relying on a raw 64-bit literal.
+    idle_link_info = 0x104 | (IDLE_PAUSE_MASK << 16) | (IDLE_OVERFLOW_MASK << 32)
+    idle_word = pgp4_idle_word(
+        rem_link_ready=1,
+        pause_mask=IDLE_PAUSE_MASK,
+        overflow_mask=IDLE_OVERFLOW_MASK,
+    )
+    assert idle_word == pgp4_kword(PGP4_IDLE, idle_link_info)
+    assert await drive_checker_word(tb, header=PGP4_K_HEADER, data=idle_word) == (
+        1,
+        PGP4_K_HEADER,
+        idle_word,
+        0,
+    )
+
+    # This USER word has a valid block type and opcode payload, but one
+    # checksum bit is flipped so the checker should drop it and pulse
+    # `linkError` for exactly this registered output cycle.
+    good_user_word = pgp4_user_word(USER_OPCODE_PAYLOAD)
+    assert good_user_word == pgp4_kword(PGP4_USER, USER_OPCODE_PAYLOAD)
+    bad_user_word = bad_kcode_checksum_word()
+    assert await drive_checker_word(tb, header=PGP4_K_HEADER, data=bad_user_word) == (
+        0,
+        PGP4_K_HEADER,
+        bad_user_word,
+        1,
+    )
+
+    await drive_checker_word(tb, header=PGP4_K_HEADER, data=bad_user_word, valid=0)
+    assert checker_outputs(dut) == (0, PGP4_K_HEADER, bad_user_word, 0)
+
+    tb.dut.phyRxValid.value = 1
+    tb.dut.phyRxHeader.value = PGP4_D_HEADER
+    tb.dut.phyRxData.value = DATA_PASS_THROUGH_WORD
+    tb.dut.phyRxRst.value = 1
+    await cycle_and_sample(tb)
+    assert checker_outputs(dut) == (0, 0, 0, 0)
+
+
+PARAMETER_SWEEP = [parameter_case("direct_wrapper")]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_Pgp4RxKCodeChecker(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.pgp4rxkcodechecker",
+        extra_env=parameters,
+    )


### PR DESCRIPTION
## Summary

This fixes a serious PGP4 RX bug: implementations that do not instantiate the RX elastic buffer, such as configurations with SKIP codes disabled, were not checking control-word/header CSCs. Bad K-codes could therefore pass into the receive protocol path instead of being rejected as link errors.

- Add a shared `Pgp4RxKCodeChecker` stage after descrambling so control-word CSC is checked before both the elastic-buffer and no-EB receive paths.
- Remove K-code CSC handling from `Pgp4RxEb`, leaving it responsible for SKP filtering, remote LINKINFO extraction, clock crossing, and overflow.
- Add focused regressions for the K-code checker, RX elastic buffer behavior, and raw protocol/depacketizer CRC error handling.
- Remove test-only corruption controls from the integrated `Pgp4RxWrapper` and add `.DS_Store` to `.gitignore`.
