### PR TITLE
AxiStreamConcat: assert TKEEP_MODE_C = TKEEP_FIXED_C at elaboration

### DIFF
--- a/axi/axi-stream/rtl/AxiStreamConcat.vhd
+++ b/axi/axi-stream/rtl/AxiStreamConcat.vhd
@@ -125,6 +125,12 @@ architecture rtl of AxiStreamConcat is
 
 begin
 
+   -- AxiStreamConcat only supports TKEEP_FIXED_C (see header note).
+   -- Use AxiStreamBatcher for TKEEP_NORMAL_C, TKEEP_COMP_C, or TKEEP_COUNT_C.
+   assert (AXIS_CONFIG_G.TKEEP_MODE_C = TKEEP_FIXED_C)
+      report "AxiStreamConcat: AXIS_CONFIG_G.TKEEP_MODE_C must be TKEEP_FIXED_C. Use AxiStreamBatcher for other TKEEP modes."
+      severity failure;
+
    -----------------
    -- Input pipeline
    -----------------


### PR DESCRIPTION
## Summary

`AxiStreamConcat` strips TLAST between sub-frames and emits a single super-frame with `tKeep` hardcoded full-width (see `axi/axi-stream/rtl/AxiStreamConcat.vhd:320`). For that to be lossless, every input word must already be full-width. Otherwise the partial-keep bytes at the end of one sub-frame would need to be re-packed against the first word of the next sub-frame, and this module does no such repacking. Hence the existing header note that only `TKEEP_FIXED_C` is supported.

Misconfiguring with `TKEEP_NORMAL_C` / `TKEEP_COMP_C` / `TKEEP_COUNT_C` today produces a corrupted stream silently. This adds an elaboration-time assert so the build/sim fails immediately, matching the pattern in `AxiStreamFifoV2`, `AxiStreamGearbox`, and `AxiStreamResize`.

## Test plan

- [x] vsg-linter clean
- [x] Existing `test_AxiStreamConcat.py` unaffected (IP integrator wrapper uses `TKEEP_FIXED_C`)