### PR TITLE
Add SIMULATION_G to SugoiManagerRx hierarchy to bypass IDELAYE3

### DIFF
--- a/protocols/sugoi/rtl/SugoiManagerCore.vhd
+++ b/protocols/sugoi/rtl/SugoiManagerCore.vhd
@@ -141,6 +141,7 @@ begin
    U_Rx : entity surf.SugoiManagerRx
       generic map (
          TPD_G           => TPD_G,
+         SIMULATION_G    => SIMULATION_G,
          DIFF_PAIR_G     => DIFF_PAIR_G,
          DEVICE_FAMILY_G => DEVICE_FAMILY_G,
          IODELAY_GROUP_G => IODELAY_GROUP_G,

--- a/protocols/sugoi/rtl/SugoiManagerRx.vhd
+++ b/protocols/sugoi/rtl/SugoiManagerRx.vhd
@@ -25,6 +25,7 @@ use surf.StdRtlPkg.all;
 entity SugoiManagerRx is
    generic (
       TPD_G           : time    := 1 ns;
+      SIMULATION_G    : boolean := false;
       DIFF_PAIR_G     : boolean := true;
       DEVICE_FAMILY_G : string  := "ULTRASCALE";
       IODELAY_GROUP_G : string  := "DESER_GROUP";  -- IDELAYCTRL not used in COUNT mode
@@ -72,6 +73,7 @@ begin
       U_SugoiManagerRx_1 : entity surf.SugoiManagerRxUltrascale
          generic map (
             TPD_G           => TPD_G,
+            SIMULATION_G    => SIMULATION_G,
             DIFF_PAIR_G     => DIFF_PAIR_G,
             DEVICE_FAMILY_G => DEVICE_FAMILY_G,
             IODELAY_GROUP_G => IODELAY_GROUP_G,

--- a/protocols/sugoi/rtl/UltraScale/SugoiManagerRxUltrascale.vhd
+++ b/protocols/sugoi/rtl/UltraScale/SugoiManagerRxUltrascale.vhd
@@ -28,6 +28,7 @@ use unisim.vcomponents.all;
 entity SugoiManagerRxUltrascale is
    generic (
       TPD_G           : time    := 1 ns;
+      SIMULATION_G    : boolean := false;
       DIFF_PAIR_G     : boolean := true;
       DEVICE_FAMILY_G : string  := "ULTRASCALE";
       IODELAY_GROUP_G : string  := "DESER_GROUP";  -- IDELAYCTRL not used in COUNT mode
@@ -71,29 +72,36 @@ begin
             O => rxIn);
    end generate;
 
-   U_DELAY : entity surf.Idelaye3Wrapper
-      generic map (
-         DELAY_FORMAT     => "COUNT",
-         SIM_DEVICE       => DEVICE_FAMILY_G,
-         DELAY_VALUE      => 0,
-         REFCLK_FREQUENCY => REF_FREQ_G,  -- IDELAYCTRL not used in COUNT mode
-         UPDATE_MODE      => "ASYNC",
-         CASCADE          => "NONE",
-         DELAY_SRC        => "IDATAIN",
-         DELAY_TYPE       => "VAR_LOAD")
-      port map(
-         DATAIN      => '0',
-         IDATAIN     => rxIn,
-         DATAOUT     => rxDly,
-         CLK         => clk,
-         RST         => rst,
-         CE          => '0',
-         INC         => '0',
-         LOAD        => dlyLoad,
-         EN_VTC      => '0',
-         CASC_IN     => '0',
-         CASC_RETURN => '0',
-         CNTVALUEIN  => dlyCfg);
+   GEN_REAL : if (SIMULATION_G = false) generate
+      U_DELAY : entity surf.Idelaye3Wrapper
+         generic map (
+            DELAY_FORMAT     => "COUNT",
+            SIM_DEVICE       => DEVICE_FAMILY_G,
+            DELAY_VALUE      => 0,
+            REFCLK_FREQUENCY => REF_FREQ_G,  -- IDELAYCTRL not used in COUNT mode
+            UPDATE_MODE      => "ASYNC",
+            CASCADE          => "NONE",
+            DELAY_SRC        => "IDATAIN",
+            DELAY_TYPE       => "VAR_LOAD")
+         port map(
+            DATAIN      => '0',
+            IDATAIN     => rxIn,
+            DATAOUT     => rxDly,
+            CLK         => clk,
+            RST         => rst,
+            CE          => '0',
+            INC         => '0',
+            LOAD        => dlyLoad,
+            EN_VTC      => '0',
+            CASC_IN     => '0',
+            CASC_RETURN => '0',
+            CNTVALUEIN  => dlyCfg);
+   end generate GEN_REAL;
+
+   GEN_SIM : if (SIMULATION_G = true) generate
+      -- Bypass IDELAYE3 in simulation to avoid Unisim model assertion warnings
+      rxDly <= rxIn;
+   end generate GEN_SIM;
 
    U_IDDR : IDDRE1
       generic map (

--- a/protocols/sugoi/rtl/dummy/SugoiManagerRxUltrascaleDummy.vhd
+++ b/protocols/sugoi/rtl/dummy/SugoiManagerRxUltrascaleDummy.vhd
@@ -25,6 +25,7 @@ use surf.StdRtlPkg.all;
 entity SugoiManagerRxUltrascale is
    generic (
       TPD_G           : time    := 1 ns;
+      SIMULATION_G    : boolean := false;
       DIFF_PAIR_G     : boolean := true;
       DEVICE_FAMILY_G : string  := "ULTRASCALE";
       IODELAY_GROUP_G : string  := "DESER_GROUP";  -- IDELAYCTRL not used in COUNT mode


### PR DESCRIPTION
## Summary

The Xilinx Unisim `IDELAYE3` simulation model emits `[Unisim IDELAYE3-4] Invalid Scenario LOAD = X CE = 0 INC = 0` warnings every clock cycle when `LOAD` is `X` during initialization (e.g. before reset propagates). These flood the simulation log.

This adds a `SIMULATION_G` generic to `SugoiManagerRxUltrascale` and `SugoiManagerRx` so the existing `SugoiManagerCore.SIMULATION_G` can propagate down and bypass the `IDELAYE3` instance during simulation:

```vhdl
GEN_REAL : if (SIMULATION_G = false) generate
   U_DELAY : entity surf.Idelaye3Wrapper ...
end generate GEN_REAL;

GEN_SIM : if (SIMULATION_G = true) generate
   rxDly <= rxIn;
end generate GEN_SIM;
```

For real hardware builds (`SIMULATION_G = false`, the default) the `IDELAYE3` is instantiated as before — this is purely a simulation-time bypass.

## Files changed

- `protocols/sugoi/rtl/UltraScale/SugoiManagerRxUltrascale.vhd` — add `SIMULATION_G`; wrap `U_DELAY` in `GEN_REAL`; `GEN_SIM` bypasses with `rxDly <= rxIn`
- `protocols/sugoi/rtl/dummy/SugoiManagerRxUltrascaleDummy.vhd` — add `SIMULATION_G` to keep entity port consistent
- `protocols/sugoi/rtl/SugoiManagerRx.vhd` — add `SIMULATION_G`; pass through to `SugoiManagerRxUltrascale`
- `protocols/sugoi/rtl/SugoiManagerCore.vhd` — wire existing entity-level `SIMULATION_G` to `SugoiManagerRx`

## Test plan
- [x] VHDL syntax check passes (`make MODULES=$PWD analysis`)
- [x] VSG linter passes
- [x] Verify no IDELAYE3 warnings during VCS co-simulation with `SIMULATION_G = true`
- [x] Verify synthesis behavior unchanged with `SIMULATION_G = false` (default)