### PR TITLE
Deepen base regression coverage

### DIFF
--- a/base/delay/rtl/SlvDelayRam.vhd
+++ b/base/delay/rtl/SlvDelayRam.vhd
@@ -1,13 +1,34 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Shift Register Delay module for std_logic_vector
---              Uses a counter and single port RAM (distributed, block, ultra)
---              Single port RAM setup in read first mode
---              Counter counts 0...maxCount
---              Optional data out register (DO_REG_G) on the RAM
+-- Description: Runtime-configurable delay line for std_logic_vector data.
 --
---              delay = maxCount + ite(DO_REG_G, 3, 2)
+--              SlvDelayRam stores each accepted din sample in an inferred
+--              single-port RAM and reads back the sample located at the
+--              current circular address.  The RAM is used in read-before-write
+--              mode, so the visible output is the sample captured on an
+--              earlier visit to the same address.  The address counter wraps
+--              when it reaches the registered maxCount value, which sets the
+--              requested delay depth.  The en input freezes the address
+--              counter, maxCount register, RAM write, and output update.
+--
+--              DO_REG_G adds an output register after the RAM read data.
+--              With the current implementation, the observable delay is:
+--
+--                 delay = maxCount + ite(DO_REG_G, 3, 2)
+--
+--              maxCount is sampled while en is asserted and is intended to be
+--              programmed during initialization or while the module is held in
+--              reset.  If maxCount is changed while traffic is flowing, the
+--              circular address phase is not automatically realigned.  The
+--              transition samples are therefore undefined, and shrinking
+--              maxCount below the current address can violate the internal
+--              counter range in simulation.  Software or firmware that changes
+--              maxCount at runtime must assert rst afterward and should discard
+--              any pre-reset output history before relying on dout again.  In
+--              practice, allow at least one newly configured delay interval
+--              after reset release before treating dout as aligned to the new
+--              maxCount setting.
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the

--- a/scripts/build_rtl_instantiation_graph.py
+++ b/scripts/build_rtl_instantiation_graph.py
@@ -17,6 +17,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from pathlib import Path
 import re
+import tempfile
 
 
 RE_ENTITY_DECL = re.compile(r"\bentity\s+(?P<name>[A-Za-z][A-Za-z0-9_]*)\s+is\b", re.IGNORECASE)
@@ -71,6 +72,10 @@ class EntityDefinition:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
+
+
+def _default_output_dir() -> Path:
+    return Path(tempfile.gettempdir()) / "surf_rtl_instantiation_graph"
 
 
 def _strip_comments(text: str) -> str:
@@ -957,6 +962,10 @@ def _write_phase1_queue_artifacts(
     layers = _bottom_up_layers(phase1_graph, phase1_defs)
     queue = [node_id for layer in layers for node_id in layer]
     queue, applied_overrides = _apply_order_overrides(queue, phase1_graph, phase1_defs, overrides)
+    try:
+        displayed_override_path = override_path.relative_to(repo_root)
+    except ValueError:
+        displayed_override_path = override_path
 
     layer_by_node = {
         node_id: layer_index
@@ -967,7 +976,7 @@ def _write_phase1_queue_artifacts(
     _write_phase1_queue_json(
         output_dir / "rtl_phase1_queue.json",
         scan_dirs=scan_dirs,
-        override_path=override_path.relative_to(repo_root),
+        override_path=displayed_override_path,
         overrides=overrides,
         definitions=phase1_defs,
         graph=phase1_graph,
@@ -980,7 +989,7 @@ def _write_phase1_queue_artifacts(
     _write_phase1_queue_markdown(
         output_dir / "rtl_phase1_queue.md",
         scan_dirs=scan_dirs,
-        override_path=override_path.relative_to(repo_root),
+        override_path=displayed_override_path,
         overrides=overrides,
         definitions=phase1_defs,
         graph=phase1_graph,
@@ -1016,8 +1025,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--output-dir",
-        default=str(_repo_root() / "docs" / "_meta"),
-        help="Directory for generated graph and queue artifacts.",
+        default=str(_default_output_dir()),
+        help=(
+            "Directory for generated graph and queue artifacts. Defaults to a temporary "
+            "directory so generated analysis does not become normal docs context."
+        ),
     )
     parser.add_argument(
         "--scan-dir",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,22 +1,180 @@
-# Regression Test Layout
+# SURF Cocotb Regression Style Guide
 
-New SURF regressions should be organized by subsystem under `tests/`.
+This directory holds Python-authored regressions for synthesizable SURF RTL.
+The default stack is `pytest + cocotb + GHDL + ruckus`; VHDL should only be
+used for thin wrappers, shims, or required simulation models.
 
 ## Layout
-- `tests/common/`: shared Python regression helpers
-- `tests/legacy/`: archived flat tests that are superseded by subsystem tests and excluded from default pytest collection
-- `tests/base/`: regressions for `base/*`
-- `tests/axi/`: regressions for `axi/*`
-- `tests/protocols/`: regressions for `protocols/*`
-- `tests/ethernet/`: regressions for `ethernet/*`
-- `tests/devices/`: regressions for `devices/*`
-- `tests/xilinx/`: regressions for `xilinx/*`
 
-Within each subsystem, keep tests grouped by functional area when useful, such as
-`tests/base/fifo/` or `tests/axi/axi_stream/`.
+- Keep executable tests under subsystem packages, such as `tests/base/fifo/`,
+  `tests/axi/axi_stream/`, `tests/protocols/srp/`, or
+  `tests/ethernet/UdpEngine/`.
+- Do not add new flat `tests/test_*.py` files.
+- Move superseded flat tests to `tests/legacy/` when they are replaced by
+  subsystem tests. Uncovered legacy tests may stay at the root until migrated.
+- Put reusable helpers in the nearest suitable helper module before adding
+  another local copy of transaction code:
+  - `tests/common/regression_utils.py` for repo-wide runner and environment
+    helpers.
+  - `tests/axi/utils.py` for AXI-family primitives shared across subsystems.
+  - `*_test_utils.py` files beside subsystem tests for protocol-specific
+    frames, scoreboards, setup, and source/sink helpers.
+- Keep checked-in cocotb-facing VHDL wrappers beside the RTL family they adapt,
+  usually in a local `wrappers/` or `ip_integrator/` directory. Do not hide
+  durable wrappers under `tests/`.
 
-## Policy
-- All executable regression logic belongs in Python.
-- VHDL is only for thin wrappers, shims, or required simulation models.
-- New regressions should not be added as flat `tests/test_*.py` files.
-- Flat tests with subsystem replacements should move to `tests/legacy/`; uncovered legacy tests can remain at the root until they are replaced.
+## Python Test Files
+
+Every checked-in cocotb test file should start with the standard SLAC/SURF
+license header followed immediately by a module-specific `Test methodology`
+block:
+
+```python
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## ...
+##############################################################################
+
+# Test methodology:
+# - Sweep: Describe the curated parameter/configuration cases this file runs.
+# - Stimulus: Describe the actual input sequences driven into the DUT.
+# - Checks: Describe the outputs, state changes, sidebands, or errors asserted.
+# - Timing: Describe latency, reset, handshake, backpressure, pulse, or timeout
+#   behavior that the bench depends on or verifies.
+```
+
+Do not use generic methodology text. The block should tell a reader what this
+specific bench proves and what it intentionally does not prove.
+
+Use in-body comments at the major coroutine steps: clock startup, reset,
+stimulus phases, backpressure, trigger waits, and result checks. Keep comments
+tutorial-level for module tests, assuming the reader may not know cocotb well.
+Shared helper modules may be denser, but non-obvious protocol or timing behavior
+still needs a short explanation.
+
+Common structure:
+
+- Imports: standard library, cocotb/pytest, third-party helpers such as
+  `cocotbext.axi`, then repo helpers.
+- A small `TB` class when setup/reset/clocking is nontrivial.
+- One or more `@cocotb.test()` coroutine entrypoints that each prove a clear
+  behavior.
+- A `PARAMETER_SWEEP` list using `pytest.param(..., id="readable_case_name")`
+  or `parameter_case()`.
+- A final pytest wrapper named for the RTL target, calling
+  `run_surf_vhdl_test(test_file=__file__, ...)`.
+
+## Parameter Sweeps
+
+Prefer curated matrices over broad Cartesian products. A good sweep covers
+representative behavior: default path, one or two interesting generic branches,
+reset polarity/asynchronous reset when relevant, a narrow/wide data path if that
+changes packing, and a backpressure or staged case when timing is part of the
+contract.
+
+Keep sweep IDs short and meaningful because they become pytest IDs and sim-build
+directory names. Use `sim_build_key` when a case has enough metadata to create
+fragile or overly long build paths.
+
+Pass only HDL generics as `parameters`. Put Python-only case metadata in
+`extra_env`, or use `hdl_parameters_from(parameters)` when a case dictionary
+contains both.
+
+## Reuse And Helpers
+
+Before writing transaction code, search nearby helpers and related subsystems.
+Existing patterns include:
+
+- AXI-Lite register helpers and common runner utilities in `tests/axi/utils.py`
+  and `tests/common/regression_utils.py`.
+- SSI beat/frame helpers in `tests/protocols/ssi/ssi_test_utils.py`.
+- SRPv3 request/response models in `tests/protocols/srp/srp_test_utils.py`.
+- Ethernet, UDP, IPv4, RawEth, PGP, and CoaXPress frame builders in their
+  local `*_test_utils.py` files.
+
+Prefer extending a helper with one narrow reusable primitive over duplicating
+ready/valid loops, packet builders, register accesses, or frame receivers in a
+new test file.
+
+For AXI Stream, SSI, and other flattened ready/valid sources, hold the current
+beat stable until a sampled accepting clock edge. Use
+`wait_sampled_ready()` when a `cocotbext.axi` source is not appropriate. After
+`wait_sampled_ready()` returns, the transfer has already completed; advance or
+deassert the source immediately.
+
+Use `start_lockstep_clocks()` for `COMMON_CLK_G` or similar wrappers that expect
+truly shared clock edges. Do not start two independent same-period clock
+coroutines when the DUT contract is common-clock behavior.
+
+## Assertions And Timing
+
+Assert externally visible behavior, not implementation accidents. Good checks
+usually include payload bytes, `TKEEP`, `TLAST`, `TUSER`/SOF/EOFE bits, address
+or ID sidebands, response codes, counters, or accepted-handshake timing.
+
+Use bounded waits and explicit timeouts for protocol progress. Avoid
+open-ended `while True` loops unless they are wrapped by `with_timeout()` or a
+helper that has a cycle limit.
+
+When a contract includes backpressure, burst length, sideband propagation, or
+arbitration order, monitor accepted handshakes directly. Final memory contents
+alone are not enough for timing-visible behavior.
+
+Account for `TPD_G`, registered outputs, and GHDL scheduling. Sampling exactly
+on a clock edge can create false failures; most helpers settle with a short
+`Timer` after `RisingEdge()`.
+
+Known RTL issues or intentionally open coverage should be explicit. If a bench
+is checked in skipped or opt-in, document the condition and gate it with a clear
+environment variable such as `RUN_KNOWN_ISSUE_TESTS`.
+
+## Running Tests
+
+Use the repo virtualenv interpreter unless the virtualenv is already activated:
+
+```bash
+make MODULES="$PWD" import
+./.venv/bin/python -m pytest -n auto --dist=worksteal -q tests/<subsystem>
+```
+
+Run `make ... import` when the imported HDL source cache is missing or stale.
+Use `-n 0` for focused debug runs when serial simulator logs matter.
+
+After any command that launches pytest, cocotb, GHDL, or another simulator
+runner, check for stale simulator child processes before starting another run.
+
+## VHDL Wrappers
+
+Checked-in cocotb-facing wrappers are repo HDL and should be readable in the
+same style as surrounding SURF files:
+
+- Start with the standard SLAC/SURF VHDL banner and a concise description.
+- Keep wrappers thin. They should flatten records, expose simulator-friendly
+  generics, tie off unused fields deterministically, compose existing shim
+  layers, or instantiate a small integration topology.
+- Prefer `SlaveAxiStreamIpIntegrator`, `MasterAxiStreamIpIntegrator`,
+  `SlaveAxiLiteIpIntegrator`, and `MasterAxiLiteIpIntegrator` for SURF record
+  ports instead of hand-writing standard bus packing.
+- Add short section comments for the major adapter regions. Typical sections
+  are input flattening, output/status flattening, shim layer, DUT instantiation,
+  and wrapper-specific topology.
+- Name the real RTL instance `U_DUT` unless the wrapper intentionally contains
+  more than one peer instance.
+- Do not put executable stimulus, scoreboards, or test sequencing in VHDL.
+  That belongs in Python.
+
+For any VHDL file created or edited, run the same linter configuration used by
+CI before considering the wrapper done:
+
+```bash
+./.venv/bin/vsg -c vsg-linter.yml path/to/Wrapper.vhd
+```
+
+If `vsg` reports fixable issues, run with `--fix` first, then rerun the lint
+command to confirm the file is clean.
+
+## Coverage Scope
+
+VHDL packages are usually covered transitively through modules that use them.
+Add a dedicated package wrapper only when a behavioral function or procedure is
+important and not reached naturally through existing DUT coverage.

--- a/tests/base/delay/test_SlvDelayFifo.py
+++ b/tests/base/delay/test_SlvDelayFifo.py
@@ -14,7 +14,8 @@
 #   across both storage styles.
 # - Stimulus: Issue short and mixed-delay requests with explicit timestamps so
 #   multiple delayed outputs are queued and released out of order in wall-clock
-#   time but in programmed-delay order.
+#   time but in programmed-delay order, then optionally reset while delayed
+#   entries are pending.
 # - Checks: Returned data must match the request payload associated with each
 #   timestamp and emerge in the same order implied by the requested delay
 #   schedule.
@@ -119,6 +120,27 @@ async def timestamped_outputs_preserve_programmed_order_test(dut):
     assert await tb.wait_for_output() == 0x22
 
 
+@cocotb.test()
+async def reset_flushes_pending_entries_test(dut):
+    if not env_flag("CHECK_RESET_FLUSH", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+
+    # Queue several delayed entries, reset before any requested timestamp can
+    # mature, and then confirm that only post-reset traffic is observable.
+    for delay, value in [(10, 0x77), (12, 0x88), (14, 0x55)]:
+        await tb.load_delay(delay)
+        await tb.write_word(value)
+    await tb.cycle(2)
+    await tb.reset()
+
+    await tb.load_delay(1)
+    await tb.write_word(0x99)
+    assert await tb.wait_for_output() == 0x99
+
+
 PARAMETER_SWEEP = [
     parameter_case(
         "block_sync_reset",
@@ -137,6 +159,16 @@ PARAMETER_SWEEP = [
         FIFO_ADDR_WIDTH_G="4",
         FIFO_MEMORY_TYPE_G="distributed",
         CLK_PERIOD_NS="7",
+    ),
+    parameter_case(
+        "reset_flush_pending",
+        RST_ASYNC_G="true",
+        DATA_WIDTH_G="8",
+        DELAY_BITS_G="6",
+        FIFO_ADDR_WIDTH_G="4",
+        FIFO_MEMORY_TYPE_G="distributed",
+        CHECK_RESET_FLUSH="1",
+        CLK_PERIOD_NS="5",
     ),
 ]
 

--- a/tests/base/delay/test_SlvDelayRam.py
+++ b/tests/base/delay/test_SlvDelayRam.py
@@ -13,10 +13,11 @@
 #   unregistered active-low reset case to cover the RAM-backed delay line
 #   across its two main shapes.
 # - Stimulus: Drive known input patterns while programming delay, hold the
-#   enable low to freeze the output, and assert reset after the RAM has
-#   buffered data.
+#   enable low to freeze the output, assert reset after the RAM has buffered
+#   data, and optionally change `maxCount` followed by the required reset.
 # - Checks: The output must reproduce the delayed sample selected by the
-#   programmed latency, hold steady while disabled, and clear after reset.
+#   programmed latency, reproduce the new delay after a reset-aligned
+#   reprogramming event, hold steady while disabled, and clear after reset.
 # - Timing: Checks are cycle-accurate against the programmed delay, with one
 #   extra observable cycle for the registered-output configuration before the
 #   delayed sample appears.
@@ -100,6 +101,12 @@ class TB:
         await self.cycle()
         await self.cycle()
 
+    async def set_max_count(self, value: int) -> None:
+        self.dut.maxCount.value = value
+        self.max_count = value
+        self.effective_delay = self.max_count + (2 if self.do_reg else 1)
+        await self.cycle(en=1)
+
 
 @cocotb.test()
 async def configured_delay_test(dut):
@@ -143,6 +150,59 @@ async def enable_hold_test(dut):
 
 
 @cocotb.test()
+async def dynamic_delay_change_requires_reset_test(dut):
+    if not env_flag("CHECK_DYNAMIC_DELAY_CHANGE", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+
+    # Start with a short delay and prove live traffic emerges normally.
+    await tb.set_max_count(1)
+    short_delay_values = [0x10 + index for index in range(8)]
+    short_observed = []
+    for value in short_delay_values:
+        observed = await tb.cycle(din=value, en=1)
+        if observed is not None:
+            short_observed.append(observed)
+    for _ in range(tb.effective_delay):
+        observed = await tb.cycle(din=0x00, en=1)
+        if observed is not None:
+            short_observed.append(observed)
+    assert short_observed[-len(short_delay_values) :] == short_delay_values
+
+    # The RTL contract requires reset after reprogramming maxCount. Apply the
+    # new value, reset the circular address phase, and then start fresh traffic
+    # against the new delay setting.
+    tb.dut.maxCount.value = 4
+    tb.max_count = 4
+    tb.effective_delay = tb.max_count + (2 if tb.do_reg else 1)
+    await tb.reset()
+    for _ in range(tb.effective_delay):
+        await tb.cycle(din=0x00, en=1)
+
+    long_delay_values = [0x80 + index for index in range(10)]
+    long_observed = []
+    for value in long_delay_values:
+        observed = await tb.cycle(din=value, en=1)
+        if observed is not None:
+            long_observed.append(observed)
+    for _ in range(tb.effective_delay + 2):
+        observed = await tb.cycle(din=0x00, en=1)
+        if observed is not None:
+            long_observed.append(observed)
+
+    # The first few post-reset samples are still part of the documented output
+    # history discard interval. Once that interval has passed, later traffic
+    # must follow the newly configured delay.
+    stable_values = long_delay_values[2:]
+    assert any(
+        long_observed[index : index + len(stable_values)] == stable_values
+        for index in range(len(long_observed) - len(stable_values) + 1)
+    )
+
+
+@cocotb.test()
 async def reset_behavior_test(dut):
     tb = TB(dut)
     await tb.reset()
@@ -168,6 +228,17 @@ PARAMETER_SWEEP = [
         DELAY_G="8",
         WIDTH_G="8",
         MAX_COUNT="3",
+        CLK_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "block_dynamic_delay_change",
+        RST_POLARITY_G="'1'",
+        MEMORY_TYPE_G="block",
+        DO_REG_G="true",
+        DELAY_G="8",
+        WIDTH_G="8",
+        MAX_COUNT="1",
+        CHECK_DYNAMIC_DELAY_CHANGE="1",
         CLK_PERIOD_NS="5",
     ),
     parameter_case(

--- a/tests/base/fifo/test_FifoAsync.py
+++ b/tests/base/fifo/test_FifoAsync.py
@@ -14,8 +14,10 @@
 #   threshold placements with a small curated matrix instead of a Cartesian
 #   explosion.
 # - Stimulus: Drive burst writes and reads on independent clocks so the FIFO
-#   fills, drains, crosses programmable threshold points, and encounters both
-#   empty and full boundaries.
+#   fills, drains, crosses programmable threshold points, encounters both
+#   empty and full boundaries, optionally turns over near full with concurrent
+#   reads and writes, and optionally resets while traffic history is still
+#   present.
 # - Checks: The bench checks end-to-end ordering, `full`/`empty` behavior,
 #   programmable threshold flags, deeper and wider geometry variants, and the
 #   behavioral difference between `FWFT` and standard read mode.
@@ -89,6 +91,11 @@ class TB:
         # Let FWFT outputs settle before the next operation samples status.
         await Timer(2, unit="ns")
 
+    async def cycle_rd(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.rd_clk)
+            await Timer(2, unit="ns")
+
     async def read_word(self) -> int:
         if self.fwft_enabled:
             await with_timeout(self._wait_valid(), 5, "us")
@@ -137,6 +144,14 @@ class TB:
     async def _wait_prog_empty(self, expected: int) -> None:
         while int(self.dut.prog_empty.value) != expected:
             await RisingEdge(self.dut.rd_clk)
+
+    async def assert_reset_clears_visible_state(self) -> None:
+        # Apply reset after data has moved into the FIFO. The storage contents
+        # themselves are not part of the contract, but the public status must
+        # return to an empty/no-valid state before new traffic is accepted.
+        await self.reset()
+        assert int(self.dut.valid.value) == 0
+        await with_timeout(self._wait_empty(), 5, "us")
 
 
 @cocotb.test()
@@ -224,6 +239,100 @@ async def threshold_flag_test(dut):
         for _ in range(refill_count):
             await tb.read_word()
         await with_timeout(tb._wait_prog_empty(1), 5, "us")
+
+
+@cocotb.test()
+async def burst_backpressure_and_reset_test(dut):
+    if not env_flag("CHECK_STRESS_BEHAVIOR", default=False):
+        return
+
+    tb = TB(
+        dut,
+        wr_clk_period_ns=float(os.environ["WR_CLK_PERIOD_NS"]),
+        rd_clk_period_ns=float(os.environ["RD_CLK_PERIOD_NS"]),
+    )
+    await tb.reset()
+
+    # Fill enough entries to let FWFT prefetch and pointer synchronization
+    # settle, then drain only part of the burst to emulate a read side that
+    # periodically withholds service.
+    first_burst = [0x20 + index for index in range(8)]
+    for value in first_burst:
+        await tb.write_word(value)
+
+    observed = []
+    for _ in range(3):
+        observed.append(await tb.read_word())
+    assert observed == first_burst[:3]
+
+    # Keep writing while the read side is intentionally idle. This stresses the
+    # near-full bookkeeping path without depending on one exact CDC count.
+    second_burst = [0x80 + index for index in range(6)]
+    for value in second_burst:
+        await tb.write_word(value)
+        await tb.cycle_rd(2)
+
+    expected_tail = first_burst[3:] + second_burst
+    for expected in expected_tail[:5]:
+        assert await tb.read_word() == expected
+
+    await tb.assert_reset_clears_visible_state()
+
+    # After reset, new traffic must not be contaminated by the discarded
+    # pre-reset tail.
+    post_reset = [0xA0, 0xA1, 0xA2]
+    for value in post_reset:
+        await tb.write_word(value)
+    for expected in post_reset:
+        assert await tb.read_word() == expected
+
+
+@cocotb.test()
+async def near_full_turnover_test(dut):
+    if not env_flag("CHECK_NEAR_FULL_TURNOVER", default=False):
+        return
+
+    tb = TB(
+        dut,
+        wr_clk_period_ns=float(os.environ["WR_CLK_PERIOD_NS"]),
+        rd_clk_period_ns=float(os.environ["RD_CLK_PERIOD_NS"]),
+    )
+    await tb.reset()
+
+    # Fill the FIFO close to capacity, but leave enough margin that the writer
+    # can make progress as the slower read clock begins popping data. This
+    # stresses pointer synchronization and full deassertion during sustained
+    # boundary turnover without relying on one exact gray-pointer latency.
+    capacity = 2 ** int(os.environ["ADDR_WIDTH_G"])
+    seed_values = [0x100 + index for index in range(capacity - 2)]
+    replacement_values = [0x180 + index for index in range(6)]
+    for value in seed_values:
+        await tb.write_word(value)
+
+    observed = []
+
+    async def reader() -> None:
+        for _ in range(10):
+            observed.append(await tb.read_word())
+            await tb.cycle_rd(1)
+
+    async def writer() -> None:
+        for value in replacement_values:
+            await tb.write_word(value)
+
+    read_task = cocotb.start_soon(reader())
+    write_task = cocotb.start_soon(writer())
+    await read_task
+    await write_task
+
+    expected_stream = seed_values + replacement_values
+    assert observed == expected_stream[: len(observed)]
+
+    # Drain the rest to prove the near-full turnover did not reorder or drop
+    # the new tail words that arrived while the read side was active.
+    for expected in expected_stream[len(observed) :]:
+        assert await tb.read_word() == expected
+    await with_timeout(tb._wait_empty(), 5, "us")
 
 
 PARAMETER_SWEEP = [
@@ -445,6 +554,26 @@ PARAMETER_SWEEP = [
         CHECK_THRESHOLD_FLAGS="1",
         WR_CLK_PERIOD_NS="5",
         RD_CLK_PERIOD_NS="13",
+        RST_ACTIVE_HIGH="1",
+    ),
+    parameter_case(
+        "fwft_adversarial_backpressure",
+        DATA_WIDTH_G="16",
+        ADDR_WIDTH_G="4",
+        FWFT_EN_G="true",
+        MEMORY_TYPE_G="block",
+        PIPE_STAGES_G="0",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        SYNC_STAGES_G="3",
+        FULL_THRES_G="12",
+        EMPTY_THRES_G="2",
+        CHECK_FULL_EMPTY="0",
+        CHECK_THRESHOLD_FLAGS="0",
+        CHECK_STRESS_BEHAVIOR="1",
+        CHECK_NEAR_FULL_TURNOVER="1",
+        WR_CLK_PERIOD_NS="3",
+        RD_CLK_PERIOD_NS="17",
         RST_ACTIVE_HIGH="1",
     ),
 ]

--- a/tests/base/fifo/test_FifoCascade.py
+++ b/tests/base/fifo/test_FifoCascade.py
@@ -12,9 +12,9 @@
 # - Sweep: Sweep a single-stage cascade and a three-stage cascade with an
 #   asynchronous tail so the bench covers both the minimal wrapper case and a
 #   real multi-stage chain.
-# - Stimulus: Push an ordered burst through the cascade and then inspect both
-#   the final output stream and the exported per-stage vector signals during
-#   movement.
+# - Stimulus: Push ordered bursts through the cascade, intermittently pause the
+#   read side so stage boundaries fill and drain, and then inspect both the
+#   final output stream and exported per-stage vector signals during movement.
 # - Checks: The final stream must preserve ordering across all stages, and the
 #   stage vector mapping must reflect the expected stage-local occupancy/data
 #   plumbing for the selected cascade depth.
@@ -166,6 +166,37 @@ async def stage_vector_mapping_test(dut):
     assert top_prog_full == int(dut.prog_full.value)
 
 
+@cocotb.test()
+async def staged_pressure_recovery_test(dut):
+    if not env_flag("CHECK_STAGE_PRESSURE", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+
+    first_burst = [0x40 + index for index in range(6)]
+    for value in first_burst:
+        await tb.write_word(value)
+
+    # Let internal FWFT stages move data while the public consumer is paused.
+    await tb.cycle_wr(8)
+    await tb.cycle_rd(4)
+
+    observed = []
+    for _ in range(3):
+        observed.append(await tb.read_word())
+
+    assert observed == first_burst[:3]
+
+    second_burst = [0x80 + index for index in range(4)]
+    for value in second_burst:
+        await tb.write_word(value)
+
+    expected_tail = first_burst[3:] + second_burst
+    for expected in expected_tail:
+        assert await tb.read_word() == expected
+
+
 PARAMETER_SWEEP = [
     parameter_case(
         "single_stage_async",
@@ -196,6 +227,22 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="4",
         WR_CLK_PERIOD_NS="5",
         RD_CLK_PERIOD_NS="9",
+    ),
+    parameter_case(
+        "three_stage_pressure",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CASCADE_SIZE_G="3",
+        LAST_STAGE_ASYNC_G="true",
+        GEN_SYNC_FIFO_G="false",
+        FWFT_EN_G="true",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="distributed",
+        DATA_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        CHECK_STAGE_PRESSURE="1",
+        WR_CLK_PERIOD_NS="5",
+        RD_CLK_PERIOD_NS="11",
     ),
 ]
 

--- a/tests/base/fifo/test_FifoMux.py
+++ b/tests/base/fifo/test_FifoMux.py
@@ -9,11 +9,12 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Keep one explicit `split_to_narrow_little_endian` case so this file
-#   stays focused on the stable width-conversion path the wrapper is meant to
-#   expose.
+# - Sweep: Keep explicit split-to-narrow and pack-to-wide cases so both sides
+#   of the FifoMux width-conversion logic are covered without turning the
+#   wrapper test into a broad FIFO matrix.
 # - Stimulus: Write wider words that must be unpacked into several narrower
-#   output beats, then reset the write packer while it still holds partial
+#   output beats, write narrower words that must be packed into one wider
+#   output beat, then reset the write packer while it still holds partial
 #   state.
 # - Checks: The output beat order and byte ordering must match the
 #   little-endian split model, and reset must discard any partially assembled
@@ -142,6 +143,11 @@ class TB:
         while int(self.dut.valid.value) == 0:
             await RisingEdge(self.dut.rd_clk)
 
+    async def assert_no_valid(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle_rd(1)
+            assert int(self.dut.valid.value) == 0
+
 
 @cocotb.test()
 async def width_conversion_test(dut):
@@ -186,6 +192,7 @@ async def write_packer_reset_test(dut):
     # pre-reset fragments leak into the next output word.
     await tb.write_word(0xAA)
     await tb.reset()
+    await tb.assert_no_valid(4)
 
     post_reset_words = [0x11, 0x22]
     expected = _expected_reads(
@@ -222,6 +229,23 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="4",
         WR_CLK_PERIOD_NS="5",
         RD_CLK_PERIOD_NS="9",
+    ),
+    parameter_case(
+        "pack_to_wide_big_endian",
+        RST_ASYNC_G="true",
+        RST_POLARITY_G="'1'",
+        CASCADE_SIZE_G="1",
+        LAST_STAGE_ASYNC_G="true",
+        GEN_SYNC_FIFO_G="false",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="distributed",
+        FWFT_EN_G="true",
+        WR_DATA_WIDTH_G="8",
+        RD_DATA_WIDTH_G="16",
+        LITTLE_ENDIAN_G="false",
+        ADDR_WIDTH_G="4",
+        WR_CLK_PERIOD_NS="7",
+        RD_CLK_PERIOD_NS="11",
     ),
 ]
 

--- a/tests/base/fifo/test_FifoSync.py
+++ b/tests/base/fifo/test_FifoSync.py
@@ -12,8 +12,9 @@
 # - Sweep: Sweep memory type, `FWFT` vs standard mode, output pipeline depth,
 #   reset polarity/style, width/depth scaling, and threshold placements under a
 #   single common clock.
-# - Stimulus: Drive burst writes and reads to fill, drain, and hover around the
-#   threshold points while the same clock advances both sides of the FIFO.
+# - Stimulus: Drive burst writes and reads to fill, drain, hover around the
+#   threshold points, and optionally perform simultaneous read/write cycles at
+#   near-boundary occupancies while the same clock advances both sides.
 # - Checks: The bench verifies ordering, `full`/`empty` transitions,
 #   programmable threshold behavior, and the latency difference between `FWFT`
 #   and standard read operation.
@@ -128,6 +129,23 @@ class TB:
         while int(self.dut.prog_empty.value) != expected:
             await RisingEdge(self.dut.clk)
 
+    async def simultaneous_cycle(self, write_value: int) -> int:
+        # FWFT mode presents the current head word before the pop. Sampling
+        # before the edge lets the test prove that the same edge can consume the
+        # old head while accepting a new tail word.
+        await with_timeout(self._wait_valid(), 5, "us")
+        read_value = int(self.dut.dout.value)
+        await with_timeout(self._wait_not_full(), 5, "us")
+        self.dut.din.value = write_value
+        self.dut.wr_en.value = 1
+        self.dut.rd_en.value = 1
+        await RisingEdge(self.dut.clk)
+        self.dut.wr_en.value = 0
+        self.dut.rd_en.value = 0
+        await RisingEdge(self.dut.clk)
+        await Timer(2, unit="ns")
+        return read_value
+
 
 @cocotb.test()
 async def basic_ordering_test(dut):
@@ -205,6 +223,36 @@ async def threshold_flag_test(dut):
         for expected in refill_values:
             assert await tb.read_word() == expected
         await with_timeout(tb._wait_prog_empty(1), 5, "us")
+
+
+@cocotb.test()
+async def simultaneous_boundary_test(dut):
+    if not env_flag("CHECK_SIMULTANEOUS_BOUNDARY", default=False):
+        return
+
+    tb = TB(dut, clk_period_ns=float(os.environ["CLK_PERIOD_NS"]))
+    await tb.reset()
+
+    if not tb.fwft_enabled:
+        return
+
+    capacity = 2 ** int(os.environ["ADDR_WIDTH_G"])
+    seed_values = [0x30 + index for index in range(capacity - 1)]
+    for value in seed_values:
+        await tb.write_word(value)
+
+    observed = []
+    replacement_values = [0x90, 0x91, 0x92, 0x93]
+    for value in replacement_values:
+        observed.append(await tb.simultaneous_cycle(value))
+
+    assert observed == seed_values[: len(replacement_values)]
+
+    expected_tail = seed_values[len(replacement_values) :] + replacement_values
+    for expected in expected_tail:
+        assert await tb.read_word() == expected
+
+    await with_timeout(tb._wait_empty(), 5, "us")
 
 
 PARAMETER_SWEEP = [
@@ -383,6 +431,23 @@ PARAMETER_SWEEP = [
         EMPTY_THRES_G="2",
         CHECK_FULL_EMPTY="1",
         CHECK_THRESHOLD_FLAGS="1",
+        CLK_PERIOD_NS="5",
+        RST_ACTIVE_HIGH="1",
+    ),
+    parameter_case(
+        "fwft_simultaneous_near_full",
+        DATA_WIDTH_G="16",
+        ADDR_WIDTH_G="4",
+        FWFT_EN_G="true",
+        MEMORY_TYPE_G="block",
+        PIPE_STAGES_G="0",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        FULL_THRES_G="12",
+        EMPTY_THRES_G="2",
+        CHECK_FULL_EMPTY="0",
+        CHECK_THRESHOLD_FLAGS="0",
+        CHECK_SIMULTANEOUS_BOUNDARY="1",
         CLK_PERIOD_NS="5",
         RST_ACTIVE_HIGH="1",
     ),

--- a/tests/base/general/test_Arbiter.py
+++ b/tests/base/general/test_Arbiter.py
@@ -13,7 +13,8 @@
 #   active-low reset case so the round-robin logic is exercised beyond a single
 #   fixed width.
 # - Stimulus: Present competing request patterns, keep the current requester
-#   asserted to exercise hold behavior, and then rotate the contenders.
+#   asserted to exercise hold behavior, repeatedly rotate contenders to check
+#   starvation resistance, and then reset the pointer history.
 # - Checks: The grant must rotate in round-robin order, the hold case must keep
 #   serving the same requester, and reset must clear the selection history.
 # - Timing: Grant updates are checked on arbitration boundaries only, and the
@@ -162,6 +163,41 @@ async def reset_behavior_test(dut):
         assert int(dut.valid.value) == 0
 
 
+@cocotb.test()
+async def starvation_rotation_test(dut):
+    if not env_flag("CHECK_STARVATION_ROTATION", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+
+    # Keep all requesters asserted, but drop the current winner for one cycle
+    # after every grant. Over several rounds every requester should be selected
+    # instead of the arbiter sticking to one low-index or high-index source.
+    seen = set()
+    all_requesters = (1 << tb.req_size) - 1
+    request_mask = all_requesters
+    for _ in range(tb.req_size * 3):
+        tb.dut.req.value = request_mask
+        await tb.cycle(1)
+        assert int(dut.valid.value) == 1
+        winner = int(dut.selected.value)
+        seen.add(winner)
+
+        request_mask = all_requesters & ~(1 << winner)
+        tb.dut.req.value = request_mask
+        await tb.cycle(1)
+        assert int(dut.valid.value) == 1
+        next_winner = int(dut.selected.value)
+        assert next_winner != winner
+        assert (request_mask >> next_winner) & 0x1
+        seen.add(next_winner)
+
+        request_mask = all_requesters
+
+    assert seen == set(range(tb.req_size))
+
+
 PARAMETER_SWEEP = [
     parameter_case(
         "size4_baseline",
@@ -183,6 +219,14 @@ PARAMETER_SWEEP = [
         RST_ASYNC_G="true",
         RST_POLARITY_G="'0'",
         CLK_PERIOD_NS="7",
+    ),
+    parameter_case(
+        "size5_starvation_rotation",
+        REQ_SIZE_G="5",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CHECK_STARVATION_ROTATION="1",
+        CLK_PERIOD_NS="5",
     ),
 ]
 

--- a/tests/base/general/test_WatchDogRst.py
+++ b/tests/base/general/test_WatchDogRst.py
@@ -13,10 +13,11 @@
 #   active-low output case so both input and output polarity handling are
 #   covered.
 # - Stimulus: Allow the watchdog to expire once with no keepalive activity,
-#   then periodically kick it before timeout to prove the non-expiring path.
+#   periodically kick it before timeout, and drive a chatter sequence that
+#   repeatedly approaches the timeout boundary before recovering.
 # - Checks: The timeout pulse or reset output must assert only after the
 #   configured idle window and remain suppressed while keepalive pulses arrive
-#   in time.
+#   in time, including after multiple near-timeout noise bursts.
 # - Timing: The bench counts the timeout interval in exact cycles and checks
 #   that each keepalive restarts the watchdog window rather than merely
 #   delaying the already-expiring event.
@@ -96,6 +97,30 @@ async def keepalive_prevents_timeout_test(dut):
     dut.monIn.value = tb.input_active_value()
     await tb.cycle(3)
     assert int(dut.rstOut.value) == tb.output_inactive_value()
+
+
+@cocotb.test()
+async def chattered_keepalive_sequence_test(dut):
+    tb = TB(dut)
+    await tb.cycle(4)
+
+    # Exercise a noisier software/firmware keepalive pattern: each inactive
+    # stretch gets close to the programmed timeout, then a short active pulse
+    # must fully restart the watchdog window.
+    for inactive_cycles in [1, max(tb.duration - 1, 1), max(tb.duration - 2, 1), tb.duration // 2]:
+        dut.monIn.value = tb.input_inactive_value()
+        await tb.cycle(inactive_cycles)
+        assert int(dut.rstOut.value) == tb.output_inactive_value()
+
+        dut.monIn.value = tb.input_active_value()
+        await tb.cycle(2)
+        assert int(dut.rstOut.value) == tb.output_inactive_value()
+
+    # After the chatter sequence, a genuinely missing keepalive still needs to
+    # time out normally rather than leaving the watchdog wedged idle.
+    dut.monIn.value = tb.input_inactive_value()
+    await tb.cycle(tb.duration + 3)
+    assert int(dut.rstOut.value) == tb.output_active_value()
 
 
 PARAMETER_SWEEP = [

--- a/tests/base/ram/test_DualPortRam.py
+++ b/tests/base/ram/test_DualPortRam.py
@@ -14,8 +14,9 @@
 #   active-high vs active-low reset so the wrapper-facing RAM modes are all
 #   touched once.
 # - Stimulus: Write and read through both ports, create same-address read/write
-#   interactions to expose mode semantics, apply partial byte masks, and then
-#   assert reset on the B side.
+#   interactions to expose mode semantics, apply partial byte masks, optionally
+#   collide port-A writes with port-B reads, and then assert reset on the B
+#   side.
 # - Checks: The bench checks cross-port readback, port-A read-during-write
 #   behavior, byte-lane merging, the extra hold behavior from `DOB_REG_G`, and
 #   reset clearing of the registered output.
@@ -174,6 +175,34 @@ async def byte_write_and_reset_test(dut):
     assert await tb.read_b(4) == 0xCAFE
 
 
+@cocotb.test()
+async def cross_port_collision_test(dut):
+    if not env_flag("CHECK_CROSS_PORT_COLLISION", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.warmup()
+
+    await tb.write_a(5, 0x1357)
+    assert await tb.read_b(5) == 0x1357
+
+    # Schedule a port-A write and a port-B read to the same address on the same
+    # clock edge. The exact collision mode is backend dependent, so the durable
+    # contract for this portable inferred wrapper is that the new value is
+    # visible after the collision has settled.
+    tb.dut.addra.value = 5
+    tb.dut.dina.value = 0x2468
+    tb.dut.wea.value = 1
+    tb.dut.weaByte.value = tb.full_byte_mask("weaByte")
+    tb.dut.addrb.value = 5
+    await RisingEdge(dut.clka)
+    await tb.settle()
+    tb.dut.wea.value = 0
+    tb.dut.weaByte.value = 0
+
+    assert await tb.read_b(5) == 0x2468
+
+
 PARAMETER_SWEEP = [
     parameter_case(
         "block_read_first",
@@ -220,6 +249,23 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="4",
         RST_ASYNC_G="false",
         RST_POLARITY_G="'0'",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "block_same_clock_collision",
+        MEMORY_TYPE_G="block",
+        REG_EN_G="true",
+        DOA_REG_G="false",
+        DOB_REG_G="false",
+        MODE_G="read-first",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CHECK_CROSS_PORT_COLLISION="1",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="5",
     ),

--- a/tests/base/ram/test_SimpleDualPortRam.py
+++ b/tests/base/ram/test_SimpleDualPortRam.py
@@ -13,7 +13,8 @@
 #   registration, byte-write enable, and asynchronous plus active-low reset
 #   behavior.
 # - Stimulus: Write through port A and read through port B, apply partial byte
-#   masks to an existing word, and then reset after a registered output has
+#   masks to an existing word, optionally hold port-B enable low in direct and
+#   registered-output modes, and then reset after a registered output has
 #   captured data.
 # - Checks: The bench checks basic dual-port readback, byte-write merging, hold
 #   behavior of the optional B output register, and reset clearing of that
@@ -114,6 +115,56 @@ async def byte_write_enable_test(dut):
 
 
 @cocotb.test()
+async def read_enable_hold_test(dut):
+    if not env_flag("CHECK_READ_ENABLE_HOLD", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.cycle_a(1)
+    await tb.cycle_b(1)
+
+    await tb.write_word(0, 0x1111)
+    await tb.write_word(1, 0x2222)
+    assert await tb.read_word(0) == 0x1111
+
+    # Port B should hold its previous output while `enb` is low, even if the
+    # address changes underneath it.
+    dut.enb.value = 0
+    dut.addrb.value = 1
+    await tb.cycle_b(2)
+    assert int(dut.doutb.value) == 0x1111
+
+    dut.enb.value = 1
+    assert await tb.read_word(1) == 0x2222
+
+
+@cocotb.test()
+async def registered_read_enable_hold_test(dut):
+    if not env_flag("CHECK_REGISTERED_ENB_HOLD", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.cycle_a(1)
+    await tb.cycle_b(1)
+    assert tb.dob_reg_enabled
+
+    await tb.write_word(0, 0x1111)
+    await tb.write_word(1, 0x2222)
+    assert await tb.read_word(0) == 0x1111
+
+    # With DOB_REG_G enabled, `enb=0` should hold the registered B output even
+    # while the address changes and port A updates the addressed memory word.
+    dut.enb.value = 0
+    dut.addrb.value = 1
+    await tb.write_word(1, 0x3333)
+    await tb.cycle_b(3)
+    assert int(dut.doutb.value) == 0x1111
+
+    dut.enb.value = 1
+    assert await tb.read_word(1) == 0x3333
+
+
+@cocotb.test()
 async def registered_output_hold_test(dut):
     tb = TB(dut)
     if not tb.dob_reg_enabled:
@@ -193,6 +244,7 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="4",
         RST_ASYNC_G="false",
         RST_POLARITY_G="'1'",
+        CHECK_REGISTERED_ENB_HOLD="1",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="5",
     ),
@@ -232,6 +284,20 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="4",
         RST_ASYNC_G="false",
         RST_POLARITY_G="'0'",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "read_enable_hold",
+        MEMORY_TYPE_G="block",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CHECK_READ_ENABLE_HOLD="1",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="5",
     ),

--- a/tests/base/ram/test_TrueDualPortRam.py
+++ b/tests/base/ram/test_TrueDualPortRam.py
@@ -13,8 +13,8 @@
 #   byte-write plus `DOB`-registered case, and include an asynchronous
 #   active-low reset case.
 # - Stimulus: Alternate reads and writes on both ports, create same-address
-#   interactions to expose mode semantics, apply partial byte writes, and then
-#   reset after a registered capture.
+#   interactions to expose mode semantics, optionally collide both write ports,
+#   apply partial byte writes, and then reset after a registered capture.
 # - Checks: The bench verifies cross-port visibility, mode-specific
 #   read-during-write results, byte-lane masking, registered-output hold
 #   behavior, and reset recovery.
@@ -174,6 +174,46 @@ async def byte_write_enable_test(dut):
 
 
 @cocotb.test()
+async def dual_write_collision_test(dut):
+    if not env_flag("CHECK_DUAL_WRITE_COLLISION", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.warmup()
+
+    await tb.write_a(5, 0x1111)
+    assert await tb.read_a(5) == 0x1111
+
+    # Drive simultaneous same-address writes from both ports on a shared clock.
+    # The final winner is not a portable contract for inferred dual-write RAMs,
+    # but the collision must not poison adjacent addresses or prevent later
+    # deterministic writes to the collided address.
+    dut.addra.value = 5
+    dut.dina.value = 0xAAAA
+    dut.wea.value = 1
+    dut.weaByte.value = tb.full_byte_mask("weaByte")
+    dut.addrb.value = 5
+    dut.dinb.value = 0x5555
+    dut.web.value = 1
+    dut.webByte.value = tb.full_byte_mask("webByte")
+    await RisingEdge(dut.clka)
+    await tb.settle()
+    dut.wea.value = 0
+    dut.weaByte.value = 0
+    dut.web.value = 0
+    dut.webByte.value = 0
+
+    observed = await tb.read_a(5)
+    assert observed in (0xAAAA, 0x5555)
+
+    await tb.write_b(6, 0x3333)
+    assert await tb.read_a(6) == 0x3333
+
+    await tb.write_a(5, 0x7777)
+    assert await tb.read_b(5) == 0x7777
+
+
+@cocotb.test()
 async def registered_output_hold_test(dut):
     tb = TB(dut)
     await tb.warmup()
@@ -289,6 +329,21 @@ PARAMETER_SWEEP = [
         RST_POLARITY_G="'0'",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="7",
+    ),
+    parameter_case(
+        "same_clock_dual_write_collision",
+        MODE_G="read-first",
+        DOA_REG_G="false",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CHECK_DUAL_WRITE_COLLISION="1",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
     ),
 ]
 

--- a/tests/base/sync/test_SynchronizerFifo.py
+++ b/tests/base/sync/test_SynchronizerFifo.py
@@ -13,7 +13,9 @@
 #   reset case so the small CDC FIFO is covered both in its fast path and in
 #   real CDC mode.
 # - Stimulus: Send an ordered data stream through the FIFO, run a common-clock
-#   bypass transfer, and then assert reset while data history exists.
+#   bypass transfer, optionally pause the read side between bursty writes,
+#   optionally reset while FWFT data is pending, and then assert reset while
+#   data history exists.
 # - Checks: Data ordering must be preserved, the common-clock path must bypass
 #   the deeper CDC behavior, and reset must restore the configured initial
 #   output value.
@@ -132,6 +134,21 @@ class TB:
         await self.cycle_rd(1)
         return value
 
+    async def read_with_pause(self) -> int:
+        assert not self.common_clk
+
+        # Most SynchronizerFifo users tie rd_en high, but the FIFO still has a
+        # real read-enable input. This helper models a consumer that explicitly
+        # pauses between pops, so valid can rise and hold before the pop edge.
+        self.dut.rd_en.value = 0
+        await with_timeout(self._wait_valid(), 5, "us")
+        value = int(self.dut.dout.value)
+        self.dut.rd_en.value = 1
+        await self.cycle_rd(1)
+        self.dut.rd_en.value = 0
+        await self.cycle_rd(1)
+        return value
+
     async def _wait_valid(self) -> None:
         # Poll on the read clock because valid is generated in that domain and
         # can appear several cycles after the write that filled the FIFO.
@@ -187,6 +204,67 @@ async def reset_value_test(dut):
         assert observed == tb.init_value
 
 
+@cocotb.test()
+async def async_burst_read_gap_test(dut):
+    if not env_flag("CHECK_ASYNC_BURST_GAPS", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+    assert not tb.common_clk
+    dut.rd_en.value = 0
+
+    first_burst = [0x10 + index for index in range(5)]
+    for value in first_burst:
+        await tb.write(value)
+
+    # Hold the read side idle long enough for pointer synchronization and FWFT
+    # prefetch to settle, then consume only part of the burst.
+    await tb.cycle_rd(8)
+    for expected in first_burst:
+        assert await tb.read_with_pause() == expected
+
+    # After a paused burst drains, a second burst should still cross correctly.
+    # This keeps the test focused on explicit read-enable gaps rather than
+    # overflow behavior, because SynchronizerFifo intentionally exposes no
+    # source-side backpressure.
+    second_burst = [0x40 + index for index in range(4)]
+    for value in second_burst:
+        await tb.write(value)
+    for expected in second_burst:
+        assert await tb.read_with_pause() == expected
+
+
+@cocotb.test()
+async def reset_while_prefetched_test(dut):
+    if not env_flag("CHECK_RESET_WHILE_PREFETCHED", default=False):
+        return
+
+    tb = TB(dut)
+    await tb.reset()
+    assert not tb.common_clk
+    dut.rd_en.value = 0
+
+    # Let a burst cross into the read domain while the consumer is paused. In
+    # FWFT mode that can leave a visible word waiting at dout before the pop
+    # edge, which is the reset crossing this case is meant to guard.
+    for value in [0x20, 0x21, 0x22]:
+        await tb.write(value)
+    await with_timeout(tb._wait_valid(), 5, "us")
+
+    await tb.reset()
+    dut.rd_en.value = 0
+    assert int(dut.valid.value) == 0
+
+    # Post-reset data should transfer cleanly with no stale pre-reset word
+    # leaking through the paused read path.
+    post_reset = [0x60, 0x61]
+    for value in post_reset:
+        await tb.write(value)
+    for expected in post_reset:
+        assert await tb.read_with_pause() == expected
+
+
 PARAMETER_SWEEP = [
     parameter_case(
         "common_clock_bypass",
@@ -209,6 +287,19 @@ PARAMETER_SWEEP = [
         ADDR_WIDTH_G="3",
         WR_CLK_PERIOD_NS="5",
         RD_CLK_PERIOD_NS="9",
+    ),
+    parameter_case(
+        "async_bursty_read_gaps",
+        RST_ASYNC_G="true",
+        RST_POLARITY_G="'1'",
+        COMMON_CLK_G="false",
+        MEMORY_TYPE_G="distributed",
+        DATA_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        CHECK_ASYNC_BURST_GAPS="1",
+        CHECK_RESET_WHILE_PREFETCHED="1",
+        WR_CLK_PERIOD_NS="3",
+        RD_CLK_PERIOD_NS="13",
     ),
 ]
 

--- a/tests/protocols/coaxpress/README.md
+++ b/tests/protocols/coaxpress/README.md
@@ -57,7 +57,7 @@ intentional limitation, not as silent proof of complete spec compliance.
 | `test_CoaXPressEventAckMsg.py` | `CoaXPressEventAckMsg` | Event acknowledgment wire format, section `9.8.3`, Table 30 | Near-normative subset |
 | `test_CoaXPressTxLsFsm.py` | `CoaXPressTxLsFsm` | Low-speed idle cadence and default trigger serialization, section `9.3.1.1` / Table 15 | Partial protocol |
 | `test_CoaXPressTx.py` | `CoaXPressTx` | Control/event-acknowledgment arbitration and software-trigger path across the TX assembly | RTL-contract with spec packet classes |
-| `test_CoaXPressConfig.py` | `CoaXPressConfig` | Control command packet formatting and tag handling, section `9.6.1.2` / `9.6.2` | Checked in but skipped |
+| `test_CoaXPressConfig.py` | `CoaXPressConfig` | Control command packet formatting, CRC generation, tag handling, and SRPv3 response completion through the real `SrpV3AxiLite` ingress path, section `9.6.1.2` / `9.6.2` | Near-normative subset |
 | `test_CoaXPressCore.py` | `CoaXPressCore` | AXI-Lite control of tagged config request generation plus software-visible `RxOverflowCnt` / `RxFsmErrorCnt` status behavior at the full-core boundary | RTL-contract with spec request prefix and top-level error-status checks |
 | `test_CoaXPressOverFiberBridgeTx.py` | `CoaXPressOverFiberBridgeTx` | CXPoF start/control/payload/terminate words, section `6.3.1` to `6.3.6` in `CXPR-008-2021` | Near-normative subset |
 | `test_CoaXPressOverFiberBridgeRx.py` | `CoaXPressOverFiberBridgeRx` | CXPoF start-word decode back into CoaXPress packet and `IO_ACK` words | Partial protocol |
@@ -105,10 +105,11 @@ exposed by the current checked-in RTL.
 The current checked-in coverage is split:
 
 - `test_CoaXPressConfig.py`
-  - intended normative request-format coverage for section `9.6.1.2` and
-    `9.6.2`
-  - currently skipped because the real `CoaXPressConfig` / `SrpV3AxiLite`
-    ingress path does not complete in the bench
+  - checks untagged read and tagged write control-command formatting for
+    section `9.6.1.2` and `9.6.2`
+  - drives requests through the real `CoaXPressConfig` / `SrpV3AxiLite`
+    ingress path and validates both the serialized config packet and the
+    completed SRPv3 response
 - `test_CoaXPressRxLane.py` and `test_CoaXPressRx.py`
   - now drive fuller control-ack shapes on the wire: code, size, reply data,
     CRC placeholder, and `EOP`
@@ -212,10 +213,12 @@ Current checked-in coverage:
   - `/T/` plus `/I/` termination
 - `test_CoaXPressOverFiberBridgeRx.py`
   - RX start-word decode for normal packets and `IO_ACK`
-  - HKP forwarding, including a housekeeping-to-payload transition
+  - embedded EOP K-code reconstruction for stream marker and packet-end words
+  - HKP forwarding, including a housekeeping-to-payload transition and an
+    HKP-carried CXP EOP word
   - negative lane-placement checks for `/S/`, `/Q/`, `/T/`, and `/E/`
-  - lane-0 `/Q/` no-output guardrail, `/E/` packet abort behavior, and recovery
-    to a following valid low-speed packet
+  - lane-0 `/Q/` no-output guardrail, `/E/` packet abort behavior before and
+    after payload, and recovery to a following valid low-speed packet
 - `test_CoaXPressOverFiberBridge.py`
   - top-level 32b/64b gearbox integration around the bridge leaves
   - RX-side 64b gearbox coverage for `/E/` abort/recovery, HKP-to-payload
@@ -228,6 +231,20 @@ Still open on the bridge side:
 - full housekeeping protocol semantics beyond raw HKP forwarding and the current
   HKP-to-payload transition check
 
+Current RTL support limits observed while expanding the bridge tests:
+
+- `/Q/` ordered sets are not decoded into any bridge-visible state, sequence
+  tracker, status output, or CXP-side indication. The current contract is only
+  that `/Q/` in the interpacket gap is suppressed and later valid traffic
+  recovers.
+- `/E/` has no bridge-visible status output. When it appears during a packet,
+  the RX bridge aborts the active nGMII packet and returns to idle; if the start
+  word was already accepted, the CXP `SOP` and packet-type words may already
+  have been emitted, but no synthetic CXP `EOP` is generated.
+- HKP handling is raw forwarding. The RX bridge does not validate HKP content
+  semantics or expose a separate housekeeping parser; it reconstructs K-coded
+  words and then returns to normal payload/EOP handling.
+
 ## Known Limitations
 
 The current checked-in CoaXPress suite should not be described as full protocol
@@ -235,7 +252,6 @@ compliance coverage.
 
 The most important open limits are:
 
-- `CoaXPressConfig` is still skipped
 - `CoaXPressRxHsFsm` still has an open bonded-receive issue on back-to-back
   short four-lane image frames: later one-word tails can miss `TLAST`, which
   merges or truncates adjacent frames

--- a/tests/protocols/coaxpress/test_CoaXPressConfig.py
+++ b/tests/protocols/coaxpress/test_CoaXPressConfig.py
@@ -11,17 +11,18 @@
 # Test methodology:
 # - Sweep: Cover the two request-serialization branches that are unique to
 #   `CoaXPressConfig`: untagged reads and tagged writes.
-# - Stimulus: Drive one-beat SRPv3 request frames into `cfgIb` and capture the
-#   emitted CoaXPress low-speed byte stream on `cfgTx`.
+# - Stimulus: Drive wide SRPv3 request frames into `cfgIb`, capture the emitted
+#   CoaXPress low-speed byte stream on `cfgTx`, and feed the completion side
+#   with one config receive acknowledgment.
 # - Checks: The DUT must emit the spec-shaped request prefix/suffix, select the
 #   correct tagged or untagged packet type, preserve the address and write-data
-#   fields, and increment the tagged packet counter across transactions.
+#   fields, calculate the command CRC, increment the tagged packet counter, and
+#   complete the SRPv3 response frame.
 # - Timing: Requests are accepted through the real `TREADY` handshake and the
-#   test waits on the serialized CoaXPress bytes rather than assuming an ideal
-#   one-cycle transfer through the assembly.
+#   test waits on both serialized CoaXPress bytes and the returned SRPv3 frame
+#   rather than assuming an ideal one-cycle transfer through the assembly.
 
 import cocotb
-import pytest
 from cocotb.triggers import RisingEdge, Timer, with_timeout
 
 from tests.common.regression_utils import run_surf_vhdl_test
@@ -29,32 +30,22 @@ from tests.protocols.coaxpress.coaxpress_test_utils import (
     CXP_EOP,
     CXP_SOP,
     collect_stream_bytes,
+    cxp_crc_word,
     endian_swap32,
-    pack_u32_words_le,
+    repeat_byte,
     reset_signals,
-    send_axis_payload,
     set_initial_values,
     start_clock,
     word_to_bytes,
 )
-
-pytestmark = pytest.mark.skip(
-    reason=(
-        "Blocked by a suspected CoaXPressConfig/SrpV3AxiLite integration issue: "
-        "the real SRP-driven request path does not complete within the current bench timeout."
-    )
+from tests.protocols.srp.srp_test_utils import (
+    FlatSrpAxis,
+    SRP_READ,
+    SRP_WRITE,
+    SrpV3Request,
+    assert_srpv3_response,
+    srpv3_frame,
 )
-
-
-READ_OPCODE = 0x0
-WRITE_OPCODE = 0x1
-
-
-def _srp_request_words(*, opcode: int, tid: int, addr: int, req_size: int, write_data: int | None = None) -> list[int]:
-    words = [0x00000003 | (opcode << 8), tid, addr & 0xFFFFFFFF, 0x00000000, req_size]
-    if write_data is not None:
-        words.append(write_data & 0xFFFFFFFF)
-    return words
 
 
 async def _drive_cfg_rx_completion(dut, value: int, *, hold_cycles: int = 8) -> None:
@@ -67,8 +58,7 @@ async def _drive_cfg_rx_completion(dut, value: int, *, hold_cycles: int = 8) -> 
     dut.cfgRxTData.value = 0
 
 
-@cocotb.test()
-async def coaxpress_config_untagged_read_request_test(dut):
+async def _setup_config_bench(dut, *, config_pkt_tag: int) -> FlatSrpAxis:
     start_clock(dut.cfgClk, period_ns=4.0)
     set_initial_values(
         dut,
@@ -84,17 +74,36 @@ async def coaxpress_config_untagged_read_request_test(dut):
             "cfgRxTData": 0,
             "configTimerSize": 4096,
             "configErrResp": 1,
-            "configPktTag": 0,
+            "configPktTag": config_pkt_tag,
         },
     )
-    await reset_signals(dut, clk=dut.cfgClk, reset_names=("cfgRst",), assert_cycles=10, release_cycles=5)
+    await reset_signals(
+        dut,
+        clk=dut.cfgClk,
+        reset_names=("cfgRst",),
+        assert_cycles=10,
+        release_cycles=5,
+    )
+    axis = FlatSrpAxis(
+        dut,
+        clk=dut.cfgClk,
+        source_prefix="S_CFG_IB",
+        sink_prefix="M_CFG_OB",
+        data_bytes=32,
+    )
+    axis.init_source()
+    axis.init_sink()
+    return axis
+
+
+@cocotb.test()
+async def coaxpress_config_untagged_read_request_test(dut):
+    axis = await _setup_config_bench(dut, config_pkt_tag=0)
 
     tid = 0x12345678
     addr = 0x00000040
     read_data = 0xDDAA5501
-    request_payload = pack_u32_words_le(
-        _srp_request_words(opcode=READ_OPCODE, tid=tid, addr=addr, req_size=0x00000003)
-    )
+    request = SrpV3Request(SRP_READ, tid, addr, 4)
 
     tx_task = cocotb.start_soon(
         collect_stream_bytes(
@@ -107,7 +116,8 @@ async def coaxpress_config_untagged_read_request_test(dut):
             timeout_cycles=8000,
         )
     )
-    await send_axis_payload(dut, clk=dut.cfgClk, prefix="S_CFG_IB", payload=request_payload, width_bytes=32, tuser=0x2)
+    response_task = cocotb.start_soon(axis.recv_response(timeout_time=20))
+    await axis.send_words(srpv3_frame(request))
 
     tx_bytes = await with_timeout(tx_task, 20, "us")
 
@@ -117,33 +127,22 @@ async def coaxpress_config_untagged_read_request_test(dut):
         + bytes(word_to_bytes(0x04000000))
         + bytes(word_to_bytes(endian_swap32(addr)))
     )
+    expected_crc = cxp_crc_word([0x04000000, endian_swap32(addr)])
     assert tx_bytes.startswith(expected_prefix)
+    assert tx_bytes[16:20] == bytes(word_to_bytes(expected_crc))
     assert tx_bytes[-4:] == bytes(word_to_bytes(CXP_EOP))
-    assert tx_bytes[16:20] != b"\x00\x00\x00\x00"
+
     await _drive_cfg_rx_completion(dut, read_data << 32)
+    assert_srpv3_response(
+        await response_task,
+        request,
+        [read_data],
+    )
 
 
 @cocotb.test()
 async def coaxpress_config_tagged_write_tag_increment_test(dut):
-    start_clock(dut.cfgClk, period_ns=4.0)
-    set_initial_values(
-        dut,
-        {
-            "S_CFG_IB_TVALID": 0,
-            "S_CFG_IB_TDATA": 0,
-            "S_CFG_IB_TKEEP": 0,
-            "S_CFG_IB_TLAST": 0,
-            "S_CFG_IB_TUSER": 0,
-            "M_CFG_OB_TREADY": 1,
-            "M_CFG_TX_TREADY": 0,
-            "cfgRxTValid": 0,
-            "cfgRxTData": 0,
-            "configTimerSize": 4096,
-            "configErrResp": 1,
-            "configPktTag": 1,
-        },
-    )
-    await reset_signals(dut, clk=dut.cfgClk, reset_names=("cfgRst",), assert_cycles=10, release_cycles=5)
+    axis = await _setup_config_bench(dut, config_pkt_tag=1)
 
     requests = [
         (0x0BADB002, 0x00000020, 0x11223344, 0x00),
@@ -151,9 +150,7 @@ async def coaxpress_config_tagged_write_tag_increment_test(dut):
     ]
 
     for tid, addr, write_data, expected_tag in requests:
-        request_payload = pack_u32_words_le(
-            _srp_request_words(opcode=WRITE_OPCODE, tid=tid, addr=addr, req_size=0x00000003, write_data=write_data)
-        )
+        request = SrpV3Request(SRP_WRITE, tid, addr, 4)
 
         tx_task = cocotb.start_soon(
             collect_stream_bytes(
@@ -166,7 +163,8 @@ async def coaxpress_config_tagged_write_tag_increment_test(dut):
                 timeout_cycles=8000,
             )
         )
-        await send_axis_payload(dut, clk=dut.cfgClk, prefix="S_CFG_IB", payload=request_payload, width_bytes=32, tuser=0x2)
+        response_task = cocotb.start_soon(axis.recv_response(timeout_time=20))
+        await axis.send_words(srpv3_frame(request, [write_data]))
 
         tx_bytes = await with_timeout(tx_task, 20, "us")
         assert tx_bytes[:4] == bytes(word_to_bytes(CXP_SOP))
@@ -175,9 +173,18 @@ async def coaxpress_config_tagged_write_tag_increment_test(dut):
         assert tx_bytes[12:16] == bytes(word_to_bytes(0x04000001))
         assert tx_bytes[16:20] == bytes(word_to_bytes(endian_swap32(addr)))
         assert tx_bytes[20:24] == bytes(word_to_bytes(write_data))
+        expected_crc = cxp_crc_word(
+            [repeat_byte(expected_tag), 0x04000001, endian_swap32(addr), write_data]
+        )
+        assert tx_bytes[24:28] == bytes(word_to_bytes(expected_crc))
         assert tx_bytes[-4:] == bytes(word_to_bytes(CXP_EOP))
 
         await _drive_cfg_rx_completion(dut, 0)
+        assert_srpv3_response(
+            await response_task,
+            request,
+            [write_data],
+        )
 
 
 def test_CoaXPressConfig():

--- a/tests/protocols/coaxpress/test_CoaXPressOverFiberBridgeRx.py
+++ b/tests/protocols/coaxpress/test_CoaXPressOverFiberBridgeRx.py
@@ -9,15 +9,18 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Exercise bridge RX low-speed packet decode, `IO_ACK`, HKP forwarding,
-#   HKP-to-payload transition, misplaced control-character guardrails, `/Q/`
-#   no-output behavior, `/E/` abort behavior, and recovery to a later packet.
+# - Sweep: Exercise bridge RX low-speed packet decode, `IO_ACK`, embedded EOP
+#   K-code reconstruction, HKP forwarding, HKP-to-payload transition, misplaced
+#   control-character guardrails, `/Q/` no-output behavior, `/E/` abort behavior,
+#   and recovery to a later packet.
 # - Stimulus: Drive CXPoF start/payload/terminate sequences, housekeeping start
-#   words, lane-misplaced `/S/`, `/Q/`, `/T/`, and `/E/` controls, lane-0 `/Q/`,
-#   and an explicit `/E/` during an active low-speed packet.
+#   words, embedded marker/EOP K-codes, lane-misplaced `/S/`, `/Q/`, `/T/`, and
+#   `/E/` controls, lane-0 `/Q/`, and explicit `/E/` aborts during active
+#   low-speed packets.
 # - Checks: The bridge must reconstruct repeated-byte `SOP`, packet-type,
-#   payload, and `EOP` words for valid packets, emit standalone `IO_ACK`, forward
-#   raw HKP words, suppress malformed control traffic, and recover cleanly.
+#   payload, marker, and `EOP` words for valid packets, emit standalone `IO_ACK`,
+#   forward raw HKP words, suppress malformed control traffic, and recover
+#   cleanly.
 # - Timing: The bench samples the reconstructed CXP word stream every cycle so
 #   it checks the bridge's real shift-register latency and output ordering.
 
@@ -29,6 +32,7 @@ from tests.protocols.coaxpress.coaxpress_test_utils import (
     CXP_IDLE,
     CXP_IDLE_K,
     CXP_IO_ACK,
+    CXP_MARKER,
     CXP_PKT_EVENT_ACK,
     CXP_SOP,
     CXPOF_ERROR,
@@ -192,6 +196,140 @@ async def coaxpress_over_fiber_bridge_rx_sequence_error_and_recovery_test(dut):
         (CXP_SOP, 0xF),
         (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
         (0x55667788, 0x0),
+        (CXP_EOP, 0xF),
+    ]
+
+
+@cocotb.test()
+async def coaxpress_over_fiber_bridge_rx_embedded_eop_kcode_test(dut):
+    # A high-speed CXP-PHY EOP can carry an embedded CoaXPress K-code in
+    # EopData0. Cover the marker and packet-end cases explicitly so this bridge
+    # is not only checked against the common K29.7 packet-end path.
+    start_clock(dut.clk)
+    dut.rst.setimmediatevalue(1)
+    dut.xgmiiRxd.setimmediatevalue(0x07070707)
+    dut.xgmiiRxc.setimmediatevalue(0xF)
+    await reset_dut(dut, clk_name="clk", reset_names=("rst",))
+
+    observed: list[tuple[int, int]] = []
+
+    async def drive(rxd: int, rxc: int) -> None:
+        dut.xgmiiRxd.value = rxd
+        dut.xgmiiRxc.value = rxc
+        await cycle(dut.clk, 1)
+        sample = (int(dut.rxData.value), int(dut.rxDataK.value))
+        if sample != (CXP_IDLE, CXP_IDLE_K):
+            observed.append(sample)
+
+    # First packet ends with embedded K28.3, which should reconstruct a CXP
+    # stream-marker word rather than a packet-end word.
+    await drive(_cxp_start_word(CXP_PKT_EVENT_ACK), 0x1)
+    await drive(0x11223344, 0x0)
+    await drive(0x07FD007C, 0xC)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    # A later packet using embedded K29.7 should still reconstruct the normal
+    # CXP EOP word and prove the marker split did not corrupt state.
+    await drive(_cxp_start_word(CXP_PKT_EVENT_ACK), 0x1)
+    await drive(0x55667788, 0x0)
+    await drive(0x07FD00FD, 0xC)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    assert observed == [
+        (CXP_SOP, 0xF),
+        (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
+        (0x11223344, 0x0),
+        (CXP_MARKER, 0xF),
+        (CXP_SOP, 0xF),
+        (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
+        (0x55667788, 0x0),
+        (CXP_EOP, 0xF),
+    ]
+
+
+@cocotb.test()
+async def coaxpress_over_fiber_bridge_rx_hkp_eop_kcode_test(dut):
+    # A high-speed HKP packet can carry a CoaXPress K-code word that is not
+    # represented with XGMII control bits. The current bridge forwards that HKP
+    # word on the CXP side with all K bits asserted and terminates cleanly when
+    # the HKP word itself is the CXP EOP code.
+    start_clock(dut.clk)
+    dut.rst.setimmediatevalue(1)
+    dut.xgmiiRxd.setimmediatevalue(0x07070707)
+    dut.xgmiiRxc.setimmediatevalue(0xF)
+    await reset_dut(dut, clk_name="clk", reset_names=("rst",))
+
+    observed: list[tuple[int, int]] = []
+
+    async def drive(rxd: int, rxc: int) -> None:
+        dut.xgmiiRxd.value = rxd
+        dut.xgmiiRxc.value = rxc
+        await cycle(dut.clk, 1)
+        sample = (int(dut.rxData.value), int(dut.rxDataK.value))
+        if sample != (CXP_IDLE, CXP_IDLE_K):
+            observed.append(sample)
+
+    await drive(CXPOF_START | (0x81 << 8), 0x1)
+    await drive(CXP_EOP, 0x0)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    await drive(_cxp_start_word(CXP_PKT_EVENT_ACK), 0x1)
+    await drive(0x99AABBCC, 0x0)
+    await drive(0x07FD00FD, 0xC)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    assert observed == [
+        (CXP_EOP, 0xF),
+        (CXP_SOP, 0xF),
+        (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
+        (0x99AABBCC, 0x0),
+        (CXP_EOP, 0xF),
+    ]
+
+
+@cocotb.test()
+async def coaxpress_over_fiber_bridge_rx_error_after_sop_recovery_test(dut):
+    # `/E/` immediately after the SOP/type phase is another abort placement that
+    # matters for recovery. The bridge may already have emitted the CXP SOP and
+    # type words queued by the start word, but it must not invent an EOP for the
+    # aborted packet and must accept the next clean packet.
+    start_clock(dut.clk)
+    dut.rst.setimmediatevalue(1)
+    dut.xgmiiRxd.setimmediatevalue(0x07070707)
+    dut.xgmiiRxc.setimmediatevalue(0xF)
+    await reset_dut(dut, clk_name="clk", reset_names=("rst",))
+
+    observed: list[tuple[int, int]] = []
+
+    async def drive(rxd: int, rxc: int) -> None:
+        dut.xgmiiRxd.value = rxd
+        dut.xgmiiRxc.value = rxc
+        await cycle(dut.clk, 1)
+        sample = (int(dut.rxData.value), int(dut.rxDataK.value))
+        if sample != (CXP_IDLE, CXP_IDLE_K):
+            observed.append(sample)
+
+    await drive(_cxp_start_word(CXP_PKT_EVENT_ACK), 0x1)
+    await drive(CXPOF_ERROR | (CXPOF_IDLE << 8) | (CXPOF_IDLE << 16) | (CXPOF_IDLE << 24), 0x1)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    await drive(_cxp_start_word(CXP_PKT_EVENT_ACK), 0x1)
+    await drive(0x12345678, 0x0)
+    await drive(0x07FD00FD, 0xC)
+    await drive(0x07070707, 0xF)
+    await drive(0x07070707, 0xF)
+
+    assert observed == [
+        (CXP_SOP, 0xF),
+        (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
+        (CXP_SOP, 0xF),
+        (repeat_byte(CXP_PKT_EVENT_ACK), 0x0),
+        (0x12345678, 0x0),
         (CXP_EOP, 0xF),
     ]
 


### PR DESCRIPTION
### Description

Deepen the simulator-friendly `base/` regression coverage with targeted FIFO, RAM, synchronizer, arbitration, watchdog, and delay-line stress cases.

This update adds directed cocotb coverage for FIFO pressure and recovery behavior, RAM collision and enable semantics, synchronizer FIFO read-enable gaps, arbiter starvation rotation, watchdog near-timeout keepalive noise, and delay reset/runtime-delay behavior. It also documents the `SlvDelayRam` runtime `maxCount` contract in the RTL description header.

### Details

The branch keeps the remaining non-dummy `base/` gap, `LutFixedDelay`, deferred because it still depends on the vendor-backed `SinglePortRamPrimitive` path.

Relative to `pre-release`, this PR also carries the already accumulated regression-maintenance work on this branch line: generated graph and phase-1 queue artifacts are removed from `docs/_meta`, the planning docs now treat those artifacts as temporary analysis output, and the current CoaXPress regression documentation/test refinements are preserved.