### PR TITLE
Phantom write guard

### DIFF
--- a/python/surf/protocols/coaxpress/_Bootstrap.py
+++ b/python/surf/protocols/coaxpress/_Bootstrap.py
@@ -16,6 +16,16 @@ class Bootstrap(pr.Device):
         super().__init__(**kwargs)
         self.CoaXPressAxiL = CoaXPressAxiL
 
+        # Default write guard: no-op until setAcquisitionMonitor() provides a camera.
+        # Uses the pre-write listener API from rogue PR #1229.
+        self._acq_var = None
+
+        def _write_guard(path, value, state):
+            if self._acq_var is not None and self._acq_var.value():
+                raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+
+        self.addPreWriteListener(_write_guard)
+
         self.add(pr.RemoteVariable(
             name        = 'Standard',
             description = 'This register shall provide a magic number indicating the Device implements the CoaXPress standard. The magic number shall be 0xC0A79AE5.',
@@ -632,6 +642,15 @@ class Bootstrap(pr.Device):
             linkedGet    = lambda: f'v{self.MajorVersionUsed.value()}.{self.MinorVersionUsed.value()}',
             dependencies = [self.MajorVersionUsed,self.MinorVersionUsed],
         ))
+
+    def setAcquisitionMonitor(self, camera):
+        """Block Bootstrap register writes while the given camera is acquiring.
+
+        Call this after the camera device is ready.  The guard checks
+        ``camera.IsAcquiring`` before every write and raises
+        ``pr.WriteBlockedError`` if acquisition is in progress.
+        """
+        self._acq_var = camera.IsAcquiring
 
     def DeviceDiscovery(self, arg=None):
         # Updates all the local device register values

--- a/python/surf/protocols/coaxpress/_Bootstrap.py
+++ b/python/surf/protocols/coaxpress/_Bootstrap.py
@@ -9,11 +9,15 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
+import rogue
 import time
 
 class Bootstrap(pr.Device):
     def __init__(self, GenDc=False, CoaXPressAxiL=None, **kwargs):
         super().__init__(**kwargs)
+
+        rogue.Version.minVersion('6.13.0')
+
         self.CoaXPressAxiL = CoaXPressAxiL
 
         # Default write guard: no-op until setAcquisitionMonitor() provides a camera.

--- a/python/surf/protocols/coaxpress/_PhantomS641.py
+++ b/python/surf/protocols/coaxpress/_PhantomS641.py
@@ -9,10 +9,13 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
+import rogue
 
 class PhantomS641(pr.Device):
     def __init__(self, isPhantomS711=False, **kwargs):
         super().__init__(**kwargs)
+
+        rogue.Version.minVersion('6.13.0')
         #############################################################
         # Start of manufacturer-specific register space at 0x00006000
         #############################################################

--- a/python/surf/protocols/coaxpress/_PhantomS641.py
+++ b/python/surf/protocols/coaxpress/_PhantomS641.py
@@ -249,6 +249,22 @@ class PhantomS641(pr.Device):
             },
         ))
 
+        self.add(pr.LocalVariable(
+            name        = 'IsAcquiring',
+            description = 'True while the camera is acquiring frames.',
+            mode        = 'RO',
+            value       = False,
+            hidden      = True,
+        ))
+
+        def _acq_start(cmd):
+            cmd.post(1)
+            self.IsAcquiring.set(True)
+
+        def _acq_stop(cmd):
+            cmd.post(0)
+            self.IsAcquiring.set(False)
+
         self.add(pr.RemoteCommand(
             name        = 'AcquisitionStart',
             description = 'This feature starts the Acquisition of the device.',
@@ -256,7 +272,7 @@ class PhantomS641(pr.Device):
             base        = pr.UIntBE,
             bitSize     = 8,
             bitOffset   = 24,
-            function    = lambda cmd: cmd.post(1),
+            function    = _acq_start,
         ))
 
         self.add(pr.RemoteCommand(
@@ -266,7 +282,7 @@ class PhantomS641(pr.Device):
             base        = pr.UIntBE,
             bitSize     = 8,
             bitOffset   = 24,
-            function    = lambda cmd: cmd.post(0),
+            function    = _acq_stop,
         ))
 
         self.add(pr.RemoteVariable(
@@ -783,3 +799,14 @@ class PhantomS641(pr.Device):
             mode        = 'RW',
             hidden      = True,
         ))
+
+        # Block all register writes while the camera is acquiring.
+        # AcquisitionStart and AcquisitionStop must remain writable to allow stopping.
+        # Uses the pre-write listener API from rogue PR #1229.
+        def _write_guard(path, value, state):
+            if state.get(self.IsAcquiring.path):
+                name = path.rsplit('.', 1)[-1]
+                if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
+                    raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+
+        self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_PhantomS991.py
+++ b/python/surf/protocols/coaxpress/_PhantomS991.py
@@ -166,6 +166,22 @@ class PhantomS991(pr.Device):
             },
         ))
 
+        self.add(pr.LocalVariable(
+            name        = 'IsAcquiring',
+            description = 'True while the camera is acquiring frames.',
+            mode        = 'RO',
+            value       = False,
+            hidden      = True,
+        ))
+
+        def _acq_start(cmd):
+            cmd.post(1)
+            self.IsAcquiring.set(True)
+
+        def _acq_stop(cmd):
+            cmd.post(0)
+            self.IsAcquiring.set(False)
+
         self.add(pr.RemoteCommand(
             name        = 'AcquisitionStart',
             description = 'This feature starts the Acquisition of the device.',
@@ -173,7 +189,7 @@ class PhantomS991(pr.Device):
             base        = pr.UIntBE,
             bitSize     = 8,
             bitOffset   = 24,
-            function    = lambda cmd: cmd.post(1),
+            function    = _acq_start,
         ))
 
         self.add(pr.RemoteCommand(
@@ -183,7 +199,7 @@ class PhantomS991(pr.Device):
             base        = pr.UIntBE,
             bitSize     = 8,
             bitOffset   = 24,
-            function    = lambda cmd: cmd.post(0),
+            function    = _acq_stop,
         ))
 
         self.add(pr.RemoteVariable(
@@ -636,3 +652,14 @@ class PhantomS991(pr.Device):
             mode        = 'RW',
             hidden      = True,
         ))
+
+        # Block all register writes while the camera is acquiring.
+        # AcquisitionStart and AcquisitionStop must remain writable to allow stopping.
+        # Uses the pre-write listener API from rogue PR #1229.
+        def _write_guard(path, value, state):
+            if state.get(self.IsAcquiring.path):
+                name = path.rsplit('.', 1)[-1]
+                if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
+                    raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+
+        self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_PhantomS991.py
+++ b/python/surf/protocols/coaxpress/_PhantomS991.py
@@ -9,10 +9,14 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
+import rogue
 
 class PhantomS991(pr.Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        rogue.Version.minVersion('6.13.0')
+
         #############################################################
         # Start of manufacturer-specific register space at 0x00006000
         #############################################################


### PR DESCRIPTION
Prevents cameras from getting stuck when registers are written when acquisition is running.

### Description
Based on the new rogue functionality [from this PR](https://github.com/slaclab/rogue/pull/1229).

If a register of the camera is written when the acquisition is running the camera gets stuck and needs a power-cycle.
This PR adds a local variable within the camera to track the acquisition status, and guards to avoid writes when the camera is running.

Moreover, given the run status is owned by the camera, the bootstrap `setAcquisitionMonitor` method is included to link the write guard to the corresponding camera state. 
