### PR TITLE
BittWare QSFP/SFP I2C stabilization: retry+sentinel + CMIS QsfpDd class

### DIFF
--- a/python/surf/devices/transceivers/_Qsfp.py
+++ b/python/surf/devices/transceivers/_Qsfp.py
@@ -14,7 +14,9 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import logging
 import pyrogue as pr
+import rogue
 import rogue.interfaces.memory as rim
 
 import threading
@@ -22,9 +24,24 @@ import queue
 
 from surf.devices import transceivers
 
+# Exception types to catch and mask in _pollWorker.  Mirrors _RETRY_EXC_TYPES
+# from __init__.py but defined here to avoid a circular import (this module is
+# loaded by __init__.py before _RETRY_EXC_TYPES is defined there).
+_POLL_EXC = (rogue.GeneralError, pr.MemoryError) if hasattr(pr, 'MemoryError') else (rogue.GeneralError,)
+
+_log = logging.getLogger(__name__)
+
 class Qsfp(pr.Device):
     def __init__(self, advDebug=False, **kwargs):
         super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name        = 'ErrorCount',
+            description = 'I2C read failures after retry exhaustion (cumulative since Rogue start)',
+            mode        = 'RO',
+            value       = 0,
+            typeStr     = 'UInt32',
+        ))
 
         ################
         # Lower Page 00h
@@ -37,6 +54,24 @@ class Qsfp(pr.Device):
             bitSize     = 5,
             mode        = 'RO',
             enum        = transceivers.IdentifierDict,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'Flat_mem',
+            description = 'Upper memory flat or paged',
+            offset      = (2 << 2),
+            bitSize     = 1,
+            bitOffset   = 2,
+            mode        = 'RO',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'Data_Not_Ready',
+            description = 'Indicates free-side does not yet have valid monitor data. The bit remains high until valid data can be read at which time the bit goes low.',
+            offset      = (2 << 2),
+            bitSize     = 1,
+            bitOffset   = 0,
+            mode        = 'RO',
         ))
 
         if advDebug:
@@ -62,29 +97,11 @@ class Qsfp(pr.Device):
             ))
 
             self.add(pr.RemoteVariable(
-                name        = 'Flat_mem',
-                description = 'Upper memory flat or paged',
-                offset      = (2 << 2),
-                bitSize     = 1,
-                bitOffset   = 2,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
                 name        = 'IntL',
                 description = 'Digital state of the IntL Interrupt output pin',
                 offset      = (2 << 2),
                 bitSize     = 1,
                 bitOffset   = 1,
-                mode        = 'RO',
-            ))
-
-            self.add(pr.RemoteVariable(
-                name        = 'Data_Not_Ready',
-                description = 'Indicates free-side does not yet have valid monitor data. The bit remains high until valid data can be read at which time the bit goes low.',
-                offset      = (2 << 2),
-                bitSize     = 1,
-                bitOffset   = 0,
                 mode        = 'RO',
             ))
 
@@ -855,6 +872,12 @@ class _UpperPageProxy(pr.Device):
     def proxyTransaction(self, transaction):
         self._queue.put(transaction)
 
+    def _writePageSelect(self, pageSelect):
+        """Write the page-select byte if it differs from the cached value, or if the proxy was just armed. _CmisUpperPageProxy overrides this to write the bank-select byte first."""
+        if (self.PageSelectByte.value() != pageSelect) or not self._armed:
+            self._armed = True
+            self.PageSelectByte.set(value=pageSelect, write=True)
+
     def _pollWorker(self):
         while True:
             #print('Main thread loop start')
@@ -862,46 +885,81 @@ class _UpperPageProxy(pr.Device):
             if transaction is None:
                 return
             with self._memLock, transaction.lock():
+                try:
+                    # Determine the page select and register index
+                    pageSelect = ((transaction.address()>>10)&0xFF)-1
+                    regIndex   = ((transaction.address()>>2)&0xFF)-128
 
-                # Determine the page select and register index
-                pageSelect = ((transaction.address()>>10)&0xFF)-1
-                regIndex   = ((transaction.address()>>2)&0xFF)-128
+                    # Gate: suppress upper pages 1-3 if Flat_mem=1 (SFF-8636 flat memory)
+                    # Page 0 (upper page 00h) is always present per spec.
+                    if pageSelect >= 1:
+                        try:
+                            flat = self.parent.Flat_mem.value()
+                        except Exception:
+                            flat = 0
+                        if flat:
+                            tt = transaction.type()
+                            if (tt == rim.Write) or (tt == rim.Post):
+                                transaction.done()
+                            else:
+                                dataBa = bytearray(4)
+                                transaction.setData(dataBa, 0)
+                                transaction.done()
+                            continue
 
-                # Check if the page select has changed
-                if (self.PageSelectByte.value() != pageSelect) or not self._armed:
+                    self._writePageSelect(pageSelect)
 
-                    # Set the flag
-                    self._armed = True
+                    # Check for a write or post TXN
+                    if (transaction.type() == rim.Write) or (transaction.type() == rim.Post):
 
-                    # Perform the hardware write
-                    self.PageSelectByte.set(value=pageSelect, write=True)
+                        # Convert from TXN.data to the write byte array
+                        dataBa = bytearray(4)
+                        transaction.getData(dataBa, 0)
+                        data = int.from_bytes(dataBa, 'little', signed=False)
 
-                # Check for a write or post TXN
-                if (transaction.type() == rim.Write) or (transaction.type() == rim.Post):
+                        # Perform the hardware write
+                        self.UpperPage.set(index=regIndex, value=data, write=True)
 
-                    # Convert from TXN.data to the write byte array
-                    dataBa = bytearray(4)
-                    transaction.getData(dataBa, 0)
-                    data = int.from_bytes(dataBa, 'little', signed=False)
+                        # Close out the transaction
+                        transaction.done()
 
-                    # Perform the hardware write
-                    self.UpperPage.set(index=regIndex, value=data, write=True)
+                    # Else this is a read or verify TXN
+                    else:
 
-                    # Close out the transaction
-                    transaction.done()
+                        # Perform the hardware read
+                        data = self.UpperPage.get(index=regIndex, read=True)
 
-                # Else this is a read or verify TXN
-                else:
+                        # Convert from write byte array to TXN.data to the
+                        dataBa = bytearray(data.to_bytes(4, 'little', signed=False))
+                        transaction.setData(dataBa, 0)
 
-                    # Perform the hardware read
-                    data = self.UpperPage.get(index=regIndex, read=True)
+                        # Close out the transaction
+                        transaction.done()
 
-                    # Convert from write byte array to TXN.data to the
-                    dataBa = bytearray(data.to_bytes(4, 'little', signed=False))
-                    transaction.setData(dataBa, 0)
-
-                    # Close out the transaction
-                    transaction.done()
+                except _POLL_EXC as _exc:
+                    try:
+                        tt = transaction.type()
+                        if (tt == rim.Write) or (tt == rim.Post):
+                            transaction.done()
+                        else:
+                            dataBa = bytearray(4)
+                            transaction.setData(dataBa, 0)
+                            transaction.done()
+                    except Exception:
+                        pass
+                    try:
+                        self.parent.ErrorCount.set(
+                            self.parent.ErrorCount.value() + 1, write=False)
+                    except Exception:
+                        pass
+                    try:
+                        _log.warning(
+                            f"_UpperPageProxy._pollWorker masked I2C failure "
+                            f"at addr=0x{transaction.address():08x} type={transaction.type()}: "
+                            f"{type(_exc).__name__}: {_exc}"
+                        )
+                    except Exception:
+                        pass
 
     def _stop(self):
         self._queue.put(None)

--- a/python/surf/devices/transceivers/_QsfpDd.py
+++ b/python/surf/devices/transceivers/_QsfpDd.py
@@ -1,0 +1,285 @@
+#-----------------------------------------------------------------------------
+# Description:
+#
+# Based on CMIS (Common Management Interface Specification) Rev 5.0 (May 2021)
+# http://www.qsfp-dd.com/wp-content/uploads/2021/05/CMIS5p0.pdf
+#
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+from surf.devices import transceivers
+from surf.devices.transceivers._Qsfp import _UpperPageProxy, _ProxySlave, _POLL_EXC, _log  # noqa: F401
+
+##############################################################################
+# CMIS-specific enum dictionaries
+##############################################################################
+
+# CMIS spec revision compliance (lower page byte 1).  Upper nibble = major,
+# lower nibble = minor.  Only published revisions are mapped explicitly; every
+# other byte value resolves to 'Undefined' so the GUI cannot misreport an
+# unrecognized revision as a known one (D4).
+CmisRevisionDict = {
+    0x30: 'CMIS 3.0',
+    0x40: 'CMIS 4.0',
+    0x50: 'CMIS 5.0',
+    0x51: 'CMIS 5.1',
+    0x52: 'CMIS 5.2',
+}
+
+for _code in range(0x100):
+    CmisRevisionDict.setdefault(_code, 'Undefined')
+
+# CMIS Module State Machine (lower page byte 3 bits 3:1) per CMIS §6.3.
+ModuleStateDict = {
+    0b001: 'ModuleLowPwr',
+    0b010: 'ModulePwrUp',
+    0b011: 'ModuleReady',
+    0b100: 'ModulePwrDn',
+    0b101: 'ModuleFault',
+}
+
+
+class QsfpDd(pr.Device):
+    def __init__(self, advDebug=False, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name        = 'ErrorCount',
+            description = 'I2C read failures after retry exhaustion (cumulative since Rogue start)',
+            mode        = 'RO',
+            value       = 0,
+            typeStr     = 'UInt32',
+        ))
+
+        ################
+        # Lower Page 00h
+        ################
+
+        self.add(pr.RemoteVariable(
+            name        = 'Identifier',
+            description = 'Type of serial transceiver (SFF-8024 form-factor code)',
+            offset      = (0 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            enum        = transceivers.IdentifierDict,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'CmisRevision',
+            description = 'CMIS spec revision compliance (upper nibble = major, lower nibble = minor)',
+            offset      = (1 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            enum        = CmisRevisionDict,
+        ))
+
+        if advDebug:
+            self.add(pr.RemoteVariable(
+                name        = 'ModuleState',
+                description = 'CMIS Module State Machine state (lower page byte 3 bits 3:1)',
+                offset      = (3 << 2),
+                bitSize     = 3,
+                bitOffset   = 1,
+                mode        = 'RO',
+                enum        = ModuleStateDict,
+            ))
+
+        self.addRemoteVariables(
+            name        = 'TemperatureRaw',
+            description = 'Module temperature (signed 16-bit, 1/256 degC)',
+            offset      = (14 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            number      = 2,  # BYTE14:BYTE15
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'Temperature',
+            description  = 'Internally measured module temperature',
+            mode         = 'RO',
+            linkedGet    = transceivers.getTemp,
+            dependencies = [self.TemperatureRaw[0], self.TemperatureRaw[1]],
+            units        = 'degC',
+            disp         = '{:1.3f}',
+        ))
+
+        self.addRemoteVariables(
+            name        = 'VccRaw',
+            description = 'Module supply voltage (unsigned 16-bit, 100 uV)',
+            offset      = (16 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            number      = 2,  # BYTE16:BYTE17
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'Vcc',
+            description  = 'Internally measured supply voltage in transceiver',
+            mode         = 'RO',
+            linkedGet    = transceivers.getVolt,
+            dependencies = [self.VccRaw[0], self.VccRaw[1]],
+            units        = 'V',
+            disp         = '{:1.3f}',
+        ))
+
+        ##############################
+        # Upper Page Proxy + children
+        ##############################
+
+        self.add(_CmisUpperPageProxy(
+            name    = 'UpperPageProxy',
+            memBase = self,
+            offset  = 0x0000,
+            hidden  = True,
+        ))
+        self.proxy = _ProxySlave(self.UpperPageProxy)
+
+        # Note: the analog SFF-8636 class _QsfpUpperPage00h.py accepts an advDebug kwarg to
+        # expose the byte-128 'UppperIdentifier' echo (a duplicate of lower-page byte 0
+        # kept around for legacy diagnostics). CMIS does not have an analogous echo and
+        # v1 has no other upper-page debug-only field, so we drop the kwarg. If a future
+        # CMIS upper-page debug field needs gating, re-introduce advDebug then.
+        self.add(QsfpDdUpperPage00h(
+            name    = 'UpperPage00h',
+            memBase = self.proxy,
+            offset  = (0+1) << 10,
+        ))
+
+    def add(self, node):
+        pr.Node.add(self, node)
+
+        if isinstance(node, pr.Device):
+            if node._memBase is None:
+                node._setSlave(self.proxy)
+
+
+class _CmisUpperPageProxy(_UpperPageProxy):
+    """CMIS variant that writes bank-select byte 126 before page-select byte 127.
+
+    v1 always writes bank=0 (no banked pages are wired in this version; D1 keeps
+    the write unconditional per CMIS §8.2.2 + RES-08 mask).
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.RemoteVariable(
+            name        = 'BankSelectByte',
+            description = 'CMIS byte 126: bank select (always 0 in v1)',
+            offset      = (126 << 2),
+            bitSize     = 8,
+            mode        = 'WO',
+            hidden      = True,
+            groups      = ['NoStream', 'NoState', 'NoConfig'],
+        ))
+
+        self._bankArmed = False
+
+    def _writePageSelect(self, pageSelect):
+        """CMIS §8.2.2: BankSelect MUST be applied before PageSelect.
+
+        v1 always writes bank=0 once at first transaction; the parent's RES-08
+        mask absorbs any module NACK (D1).
+        """
+        if not self._bankArmed:
+            self._bankArmed = True
+            self.BankSelectByte.set(value=0, write=True)
+        super()._writePageSelect(pageSelect)
+
+
+class QsfpDdUpperPage00h(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.addRemoteVariables(
+            name        = 'VendorNameRaw',
+            description = 'CMIS vendor name (ASCII)',
+            offset      = (129 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            base        = pr.String,
+            number      = 16,  # BYTE129:BYTE144
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorName',
+            description  = 'CMIS vendor name (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorNameRaw[x] for x in range(16)],
+        ))
+
+        self.addRemoteVariables(
+            name        = 'VendorPnRaw',
+            description = 'CMIS vendor part number (ASCII)',
+            offset      = (148 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            base        = pr.String,
+            number      = 16,  # BYTE148:BYTE163
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorPn',
+            description  = 'CMIS vendor part number (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorPnRaw[x] for x in range(16)],
+        ))
+
+        self.addRemoteVariables(
+            name        = 'VendorSnRaw',
+            description = 'CMIS vendor serial number (ASCII)',
+            offset      = (166 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            base        = pr.String,
+            number      = 16,  # BYTE166:BYTE181
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'VendorSn',
+            description  = 'CMIS vendor serial number (ASCII)',
+            mode         = 'RO',
+            linkedGet    = transceivers.parseStrArrayByte,
+            dependencies = [self.VendorSnRaw[x] for x in range(16)],
+        ))
+
+        self.addRemoteVariables(
+            name        = 'DateCode',
+            description = "Vendor's manufacturing date code (ASCII YYMMDD; CMIS lot code bytes 188-189 dropped in v1)",
+            offset      = (182 << 2),
+            bitSize     = 8,
+            mode        = 'RO',
+            base        = pr.String,
+            number      = 6,  # BYTE182:BYTE187 (YYMMDD only; CMIS LL lot code bytes 188-189 dropped)
+            stride      = 4,
+            hidden      = True,
+        )
+
+        self.add(pr.LinkVariable(
+            name         = 'ManufactureDate',
+            description  = "Vendor's manufacturing date code (ASCII)",
+            mode         = 'RO',
+            linkedGet    = transceivers.getDate,
+            dependencies = [self.DateCode[x] for x in [0, 1, 4, 5, 2, 3]],
+        ))

--- a/python/surf/devices/transceivers/_Sfp.py
+++ b/python/surf/devices/transceivers/_Sfp.py
@@ -22,6 +22,14 @@ class Sfp(pr.Device):
     def __init__(self,**kwargs):
         super().__init__(**kwargs)
 
+        self.add(pr.LocalVariable(
+            name        = 'ErrorCount',
+            description = 'I2C read failures after retry exhaustion (cumulative since Rogue start)',
+            mode        = 'RO',
+            value       = 0,
+            typeStr     = 'UInt32',
+        ))
+
         #####################################################
         #       Serial ID: Data Fields – Address A0h        #
         #####################################################

--- a/python/surf/devices/transceivers/__init__.py
+++ b/python/surf/devices/transceivers/__init__.py
@@ -11,8 +11,47 @@ from surf.devices.transceivers._Sfp  import *
 from surf.devices.transceivers._QsfpUpperPage00h import *
 from surf.devices.transceivers._QsfpUpperPage03h import *
 from surf.devices.transceivers._Qsfp import *
+from surf.devices.transceivers._QsfpDd import *
 
 import math
+import rogue
+import pyrogue as pr
+
+# Retry constants for I2C read failures.
+_RETRY_MAX = 3
+_RETRY_SENTINEL = object()  # unique sentinel; compare with 'is', never '=='
+
+# Build exception tuple at import time so the except clause stays cheap.
+# pr.MemoryError is present in Rogue >= 6.x builds (confirmed v6.12.0).
+_RETRY_EXC_TYPES = (rogue.GeneralError, pr.MemoryError) if hasattr(pr, 'MemoryError') else (rogue.GeneralError,)
+
+
+def _retryGet(var, dep, read):
+    """Attempt dep.get(read=read) up to _RETRY_MAX times.
+
+    On success (any attempt), return the value immediately.
+    On _RETRY_EXC_TYPES exhaustion, log a single WARN, increment
+    ErrorCount on the parent device (best-effort, wrapped in try/except),
+    and return _RETRY_SENTINEL so the caller can substitute a safe default.
+    Any other exception type propagates out unchanged.
+    """
+    last_exc = None
+    for attempt in range(_RETRY_MAX):
+        try:
+            return dep.get(read=read)
+        except _RETRY_EXC_TYPES as exc:
+            last_exc = exc
+    # All retries exhausted.
+    var._log.warning('I2C read failed after %d retries for %s: %s', _RETRY_MAX, dep.path, last_exc)
+    try:
+        dev = var.parent
+        if not hasattr(dev, 'ErrorCount'):
+            dev = dev.parent
+        dev.ErrorCount.set(dev.ErrorCount.value() + 1, write=False)
+    except Exception:
+        pass
+    return _RETRY_SENTINEL
+
 
 # Can't use SparseString + bulk memory read if there is a AXI-Lite Proxy
 # So recoded using 4 byte transactions + this get function
@@ -20,47 +59,80 @@ def parseStrArrayByte(dev, var, read):
     with dev.root.updateGroup():
         retVar = ''
         for x in range(len(var.dependencies)):
-            retVar += var.dependencies[x].get(read=read)
+            val = _retryGet(var, var.dependencies[x], read)
+            if val is not _RETRY_SENTINEL:
+                retVar += val
     return retVar
 
 # Used to decode the "dateCode" variable
 def getDate(dev, var, read):
     with dev.root.updateGroup():
-        year  = '20' + var.dependencies[0].get(read=read) + var.dependencies[1].get(read=read)
-        month = var.dependencies[2].get(read=read) + var.dependencies[3].get(read=read)
-        day   = var.dependencies[4].get(read=read) + var.dependencies[5].get(read=read)
+        vals = [_retryGet(var, var.dependencies[i], read) for i in range(6)]
+        if any(v is _RETRY_SENTINEL for v in vals):
+            return None
+        year  = '20' + vals[0] + vals[1]
+        month = vals[2] + vals[3]
+        day   = vals[4] + vals[5]
         # Check if not empty or blank string
         if month.strip() and day.strip():
             return f'{month}/{day}/{year}'
 
 def getTemp(dev, var, read):
     with dev.root.updateGroup():
-        msb = var.dependencies[0].get(read=read)
-        lsb = var.dependencies[1].get(read=read)
+        try:
+            if var.parent.Data_Not_Ready.value():
+                return float('nan')
+        except Exception:
+            pass
+        msb = _retryGet(var, var.dependencies[0], read)
+        lsb = _retryGet(var, var.dependencies[1], read)
+        if msb is _RETRY_SENTINEL or lsb is _RETRY_SENTINEL:
+            return float('nan')
         raw = (msb << 8) | lsb
         # Return value in units of degC
         return float(raw)/256.0
 
 def getVolt(dev, var, read):
     with dev.root.updateGroup():
-        msb = var.dependencies[0].get(read=read)
-        lsb = var.dependencies[1].get(read=read)
+        try:
+            if var.parent.Data_Not_Ready.value():
+                return float('nan')
+        except Exception:
+            pass
+        msb = _retryGet(var, var.dependencies[0], read)
+        lsb = _retryGet(var, var.dependencies[1], read)
+        if msb is _RETRY_SENTINEL or lsb is _RETRY_SENTINEL:
+            return float('nan')
         raw = (msb << 8) | lsb
         # Return value in units of Volts
         return float(raw)*100.0E-6
 
 def getTxBias(dev, var, read):
     with dev.root.updateGroup():
-        msb = var.dependencies[0].get(read=read)
-        lsb = var.dependencies[1].get(read=read)
+        try:
+            if var.parent.Data_Not_Ready.value():
+                return float('nan')
+        except Exception:
+            pass
+        msb = _retryGet(var, var.dependencies[0], read)
+        lsb = _retryGet(var, var.dependencies[1], read)
+        if msb is _RETRY_SENTINEL or lsb is _RETRY_SENTINEL:
+            return float('nan')
         raw = (msb << 8) | lsb
         # Return value in units of mA
         return float(raw)*0.002
 
 def getOpticalPwr(dev, var, read):
     with dev.root.updateGroup():
-        msb = var.dependencies[0].get(read=read)
-        lsb = var.dependencies[1].get(read=read)
+        try:
+            if var.parent.Data_Not_Ready.value():
+                return float('nan')
+        except Exception:
+            pass
+        msb = _retryGet(var, var.dependencies[0], read)
+        lsb = _retryGet(var, var.dependencies[1], read)
+        if msb is _RETRY_SENTINEL or lsb is _RETRY_SENTINEL:
+            return float('nan')
         raw = (msb << 8) | lsb
         if raw == 0:
             pwrWatts = 0.1e-6 # Prevent log10(zero) case by forcing 0.1 µW if raw=0
@@ -71,8 +143,15 @@ def getOpticalPwr(dev, var, read):
 
 def getTec(dev, var, read):
     with dev.root.updateGroup():
-        msb = var.dependencies[0].get(read=read)
-        lsb = var.dependencies[1].get(read=read)
+        try:
+            if var.parent.Data_Not_Ready.value():
+                return float('nan')
+        except Exception:
+            pass
+        msb = _retryGet(var, var.dependencies[0], read)
+        lsb = _retryGet(var, var.dependencies[1], read)
+        if msb is _RETRY_SENTINEL or lsb is _RETRY_SENTINEL:
+            return float('nan')
         raw = (msb << 8) | lsb
         # Return value in units of mA
         return float(raw)*0.1


### PR DESCRIPTION
## Scope

BittWare XupVv8Vu13p QSFP/SFP I2C stabilization. Adds CMIS `QsfpDd` device class and a shared retry+sentinel layer across all transceiver classes so I2C failures never kill the Rogue update/proxy-poll threads.

Base: `pre-release` ← Head: `bittware-qsfp-i2c-dev`

## Changes

**Phase 1 — Retry + sentinel hardening** (`__init__.py`, `_Sfp.py`, `_Qsfp.py`):
- Shared `_retryGet` helper: 3 attempts on `rogue.GeneralError` / `pr.MemoryError`, then logs `WARNING`, increments `ErrorCount`, returns sentinel (`''` for strings, `NaN` for numerics).
- All `parseStrArrayByte`, `getDate`, `getTemp`, `getVolt`, `getTxBias`, `getOpticalPwr`, `getTec` use it.
- Per-device `ErrorCount` `LocalVariable` (`UInt32`, RO) on `Sfp`/`Qsfp`/`QsfpDd`.
- SFF-8636 `Flat_mem` suppresses upper pages 01h–03h; `Data_Not_Ready` gates DOM reads.
- `_UpperPageProxy._pollWorker` masks AXIL exceptions and always calls `transaction.done()` — fixes pre-existing surf gap where `PageSelectByte.set()` failures killed the poll thread.

**Phase 2 — CMIS `QsfpDd` class** (`_QsfpDd.py`):
- Models CMIS lower-page 00h + upper-page 00h (identity, vendor name/PN/SN/date, module type, temperature, Vcc, `CmisRevision`).
- `_CmisUpperPageProxy` writes bank-select byte 126 + page-select byte 127 (banked pages 10h–2Fh deferred to v2).
- Exported from `surf.devices.transceivers`.

KCU1500 path unchanged — `Sfp`/`Qsfp` `__init__` signatures untouched; `QsfpDd` is a sibling class. Per-slot dispatch lands in the companion `axi-pcie-core` PR via `transceiverClass`.

## Known limitations

- Byte-level `RemoteVariable` update path (`_doUpdate`) is **not** covered by `_retryGet`. An I2C failure there still produces a `Thread-7` `Block::getStringPy` traceback and stops auto-refresh on the affected slot. Non-blocking for headless scripts; carried per planning CONTEXT.md A6.
- CMIS banked pages 10h–1Fh / VDM 20h–2Fh deferred to v2 (proxy is architecturally ready).

## Bench validation

`rdsrv403.slac.stanford.edu`, `/dev/datadev_0`, surf `b008bb0d`. Slot 0 (`QSFP-SR4-100G`) and Slot 3 (`QSFPDD-SR8-400G`) read identity + UpperPage00h vendor/PN/SN with `ErrorCount` Δ = 0. Slots 1+2 (silent modules) produced 68 `_pollWorker masked I2C failure` WARNINGs and **0** `Block::getStringPy` exceptions — `_updateWorker` and `_pollWorker` survived. Sweep script: `software/scripts/QsfpI2cSweep.py` in the companion `pgp-pcie-apps` PR.

**Key proof:** Slot 3 (400G CMIS) reads UpperPage00h vendor/PN/SN via the new `QsfpDd` class with `ErrorCount` Δ = 0 — end-to-end confirmation of CMIS proxy + retry + sentinel against real hardware.
