### PR TITLE
Removed redundant description attribute causing software to fail

### DIFF
--- a/python/surf/protocols/htsp/_HtspAxiL.py
+++ b/python/surf/protocols/htsp/_HtspAxiL.py
@@ -285,7 +285,6 @@ class HtspAxiLRxStatus(pr.Device):
 
         def addStatusCountVar(**ecvkwargs):
             self.add(pr.RemoteVariable(
-                description  =  'Status count',
                 bitSize      =  statusCountBits,
                 mode         =  'RO',
                 disp         =  '{:d}',
@@ -294,7 +293,6 @@ class HtspAxiLRxStatus(pr.Device):
 
         def addErrorCountVar(**ecvkwargs):
             self.add(pr.RemoteVariable(
-                description  =  'Error count',
                 bitSize      =  errorCountBits,
                 mode         =  'RO',
                 disp         =  '{:d}',
@@ -477,7 +475,6 @@ class HtspAxiLTxStatus(pr.Device):
 
         def addStatusCountVar(**ecvkwargs):
             self.add(pr.RemoteVariable(
-                description  =  'Status count',
                 bitSize      =  statusCountBits,
                 mode         =  'RO',
                 disp         =  '{:d}',
@@ -486,7 +483,6 @@ class HtspAxiLTxStatus(pr.Device):
 
         def addErrorCountVar(**ecvkwargs):
             self.add(pr.RemoteVariable(
-                description  =  'Error count',
                 bitSize      =  errorCountBits,
                 mode         =  'RO',
                 disp         =  '{:d}',


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
Receive the following error when calling addStatusCountVar in _HtspAxiL.py
```
File "/sdf/group/faders/users/dnajjar/epixuhr-3x2-readout-testing/firmware/submodules/surf/python/surf/protocols/htsp/_HtspAxiL.py", line 287, in addStatusCountVar
    self.add(pr.RemoteVariable(
             ^^^^^^^^^^^^^^^^^^
TypeError: pyrogue._Variable.RemoteVariable() got multiple values for keyword argument 'description'
```

