### PR TITLE
Add batcher cocotb regression coverage

### DIFF
--- a/protocols/batcher/wrappers/AxiStreamBatcherAxilWrapper.vhd
+++ b/protocols/batcher/wrappers/AxiStreamBatcherAxilWrapper.vhd
@@ -1,0 +1,216 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for surf.AxiStreamBatcherAxil
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+
+entity AxiStreamBatcherAxilWrapper is
+   generic (
+      TPD_G                        : time                  := 1 ns;
+      VERSION_G                    : positive range 1 to 2 := 2;
+      DATA_BYTES_G                 : positive range 2 to 8 := 8;
+      MAX_NUMBER_SUB_FRAMES_G      : positive              := 32;
+      SUPER_FRAME_BYTE_THRESHOLD_G : natural               := 8192;
+      MAX_CLK_GAP_G                : natural               := 256;
+      COMMON_CLOCK_G               : boolean               := true;
+      INPUT_PIPE_STAGES_G          : natural               := 0;
+      OUTPUT_PIPE_STAGES_G         : natural               := 1;
+      AXIL_ADDR_WIDTH_G            : positive              := 12);
+   port (
+      axisClk       : in  sl;
+      axisRst       : in  sl;
+      axilClkIn     : in  sl := '0';
+      axilRstIn     : in  sl := '1';
+      idle          : out sl;
+      S_AXIS_TVALID : in  sl;
+      S_AXIS_TDATA  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S_AXIS_TKEEP  : in  slv(DATA_BYTES_G-1 downto 0);
+      S_AXIS_TLAST  : in  sl;
+      S_AXIS_TDEST  : in  slv(7 downto 0);
+      S_AXIS_TID    : in  slv(7 downto 0);
+      S_AXIS_TUSER  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S_AXIS_TREADY : out sl;
+      M_AXIS_TVALID : out sl;
+      M_AXIS_TDATA  : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP  : out slv(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST  : out sl;
+      M_AXIS_TDEST  : out slv(7 downto 0);
+      M_AXIS_TID    : out slv(7 downto 0);
+      M_AXIS_TUSER  : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TREADY : in  sl;
+      S_AXI_AWADDR  : in  slv(AXIL_ADDR_WIDTH_G-1 downto 0);
+      S_AXI_AWPROT  : in  slv(2 downto 0);
+      S_AXI_AWVALID : in  sl;
+      S_AXI_AWREADY : out sl;
+      S_AXI_WDATA   : in  slv(31 downto 0);
+      S_AXI_WSTRB   : in  slv(3 downto 0);
+      S_AXI_WVALID  : in  sl;
+      S_AXI_WREADY  : out sl;
+      S_AXI_BRESP   : out slv(1 downto 0);
+      S_AXI_BVALID  : out sl;
+      S_AXI_BREADY  : in  sl;
+      S_AXI_ARADDR  : in  slv(AXIL_ADDR_WIDTH_G-1 downto 0);
+      S_AXI_ARPROT  : in  slv(2 downto 0);
+      S_AXI_ARVALID : in  sl;
+      S_AXI_ARREADY : out sl;
+      S_AXI_RDATA   : out slv(31 downto 0);
+      S_AXI_RRESP   : out slv(1 downto 0);
+      S_AXI_RVALID  : out sl;
+      S_AXI_RREADY  : in  sl);
+end entity AxiStreamBatcherAxilWrapper;
+
+architecture rtl of AxiStreamBatcherAxilWrapper is
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => false,
+      TDATA_BYTES_C => DATA_BYTES_G,
+      TDEST_BITS_C  => 8,
+      TID_BITS_C    => 0,
+      TKEEP_MODE_C  => TKEEP_NORMAL_C,
+      TUSER_BITS_C  => 8,
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+
+   signal axilHostClk     : sl;
+   signal axilHostRst     : sl;
+   signal axilRstN        : sl;
+   signal axilClk         : sl;
+   signal axilRst         : sl;
+   signal axilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal axilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal axilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+   signal sAxisMaster     : AxiStreamMasterType    := AXI_STREAM_MASTER_INIT_C;
+   signal sAxisSlave      : AxiStreamSlaveType     := AXI_STREAM_SLAVE_INIT_C;
+   signal mAxisMaster     : AxiStreamMasterType    := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave      : AxiStreamSlaveType     := AXI_STREAM_SLAVE_INIT_C;
+
+begin
+
+   axilHostClk <= axisClk when COMMON_CLOCK_G else axilClkIn;
+   axilHostRst <= axisRst when COMMON_CLOCK_G else axilRstIn;
+   axilRstN    <= not axilHostRst;
+
+   ------------------------
+   -- AXI-Lite bus shim  --
+   ------------------------
+   U_AXIL : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         HAS_PROT   => 1,
+         HAS_WSTRB  => 1,
+         ADDR_WIDTH => AXIL_ADDR_WIDTH_G)
+      port map (
+         S_AXI_ACLK      => axilHostClk,      -- [in]
+         S_AXI_ARESETN   => axilRstN,         -- [in]
+         S_AXI_AWADDR    => S_AXI_AWADDR,     -- [in]
+         S_AXI_AWPROT    => S_AXI_AWPROT,     -- [in]
+         S_AXI_AWVALID   => S_AXI_AWVALID,    -- [in]
+         S_AXI_AWREADY   => S_AXI_AWREADY,    -- [out]
+         S_AXI_WDATA     => S_AXI_WDATA,      -- [in]
+         S_AXI_WSTRB     => S_AXI_WSTRB,      -- [in]
+         S_AXI_WVALID    => S_AXI_WVALID,     -- [in]
+         S_AXI_WREADY    => S_AXI_WREADY,     -- [out]
+         S_AXI_BRESP     => S_AXI_BRESP,      -- [out]
+         S_AXI_BVALID    => S_AXI_BVALID,     -- [out]
+         S_AXI_BREADY    => S_AXI_BREADY,     -- [in]
+         S_AXI_ARADDR    => S_AXI_ARADDR,     -- [in]
+         S_AXI_ARPROT    => S_AXI_ARPROT,     -- [in]
+         S_AXI_ARVALID   => S_AXI_ARVALID,    -- [in]
+         S_AXI_ARREADY   => S_AXI_ARREADY,    -- [out]
+         S_AXI_RDATA     => S_AXI_RDATA,      -- [out]
+         S_AXI_RRESP     => S_AXI_RRESP,      -- [out]
+         S_AXI_RVALID    => S_AXI_RVALID,     -- [out]
+         S_AXI_RREADY    => S_AXI_RREADY,     -- [in]
+         axilClk         => axilClk,          -- [out]
+         axilRst         => axilRst,          -- [out]
+         axilReadMaster  => axilReadMaster,   -- [out]
+         axilReadSlave   => axilReadSlave,    -- [in]
+         axilWriteMaster => axilWriteMaster,  -- [out]
+         axilWriteSlave  => axilWriteSlave);  -- [in]
+
+   ------------------------
+   -- AXI Stream shims  --
+   ------------------------
+   comb : process (M_AXIS_TREADY, S_AXIS_TDATA, S_AXIS_TDEST, S_AXIS_TID,
+                   S_AXIS_TKEEP, S_AXIS_TLAST, S_AXIS_TUSER, S_AXIS_TVALID,
+                   mAxisMaster, sAxisSlave) is
+      variable vS : AxiStreamMasterType;
+      variable vM : AxiStreamSlaveType;
+   begin
+      vS                                   := AXI_STREAM_MASTER_INIT_C;
+      vS.tValid                           := S_AXIS_TVALID;
+      vS.tData                            := (others => '0');
+      vS.tData(8*DATA_BYTES_G-1 downto 0) := S_AXIS_TDATA;
+      vS.tStrb                            := (others => '0');
+      vS.tStrb(DATA_BYTES_G-1 downto 0)   := S_AXIS_TKEEP;
+      vS.tKeep                            := (others => '0');
+      vS.tKeep(DATA_BYTES_G-1 downto 0)   := S_AXIS_TKEEP;
+      vS.tLast                            := S_AXIS_TLAST;
+      vS.tDest                            := (others => '0');
+      vS.tDest(7 downto 0)                := S_AXIS_TDEST;
+      vS.tId                              := (others => '0');
+      vS.tId(7 downto 0)                  := S_AXIS_TID;
+      vS.tUser                            := (others => '0');
+      vS.tUser(8*DATA_BYTES_G-1 downto 0) := S_AXIS_TUSER;
+
+      vM        := AXI_STREAM_SLAVE_INIT_C;
+      vM.tReady := M_AXIS_TREADY;
+
+      sAxisMaster <= vS;
+      mAxisSlave  <= vM;
+
+      S_AXIS_TREADY <= sAxisSlave.tReady;
+      M_AXIS_TVALID <= mAxisMaster.tValid;
+      M_AXIS_TDATA  <= mAxisMaster.tData(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP  <= mAxisMaster.tKeep(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST  <= mAxisMaster.tLast;
+      M_AXIS_TDEST  <= mAxisMaster.tDest(7 downto 0);
+      M_AXIS_TID    <= mAxisMaster.tId(7 downto 0);
+      M_AXIS_TUSER  <= mAxisMaster.tUser(8*DATA_BYTES_G-1 downto 0);
+   end process comb;
+
+   ---------------------
+   -- DUT instancing  --
+   ---------------------
+   U_DUT : entity surf.AxiStreamBatcherAxil
+      generic map (
+         TPD_G                        => TPD_G,
+         VERSION_G                    => VERSION_G,
+         COMMON_CLOCK_G               => COMMON_CLOCK_G,
+         MAX_NUMBER_SUB_FRAMES_G      => MAX_NUMBER_SUB_FRAMES_G,
+         SUPER_FRAME_BYTE_THRESHOLD_G => SUPER_FRAME_BYTE_THRESHOLD_G,
+         MAX_CLK_GAP_G                => MAX_CLK_GAP_G,
+         AXIS_CONFIG_G                => AXIS_CONFIG_C,
+         INPUT_PIPE_STAGES_G          => INPUT_PIPE_STAGES_G,
+         OUTPUT_PIPE_STAGES_G         => OUTPUT_PIPE_STAGES_G)
+      port map (
+         axisClk         => axisClk,           -- [in]
+         axisRst         => axisRst,           -- [in]
+         idle            => idle,              -- [out]
+         sAxisMaster     => sAxisMaster,       -- [in]
+         sAxisSlave      => sAxisSlave,        -- [out]
+         mAxisMaster     => mAxisMaster,       -- [out]
+         mAxisSlave      => mAxisSlave,        -- [in]
+         axilClk         => axilClk,           -- [in]
+         axilRst         => axilRst,           -- [in]
+         axilReadMaster  => axilReadMaster,    -- [in]
+         axilReadSlave   => axilReadSlave,     -- [out]
+         axilWriteMaster => axilWriteMaster,   -- [in]
+         axilWriteSlave  => axilWriteSlave);   -- [out]
+
+end architecture rtl;

--- a/protocols/batcher/wrappers/AxiStreamBatcherEventBuilderWrapper.vhd
+++ b/protocols/batcher/wrappers/AxiStreamBatcherEventBuilderWrapper.vhd
@@ -1,0 +1,252 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for surf.AxiStreamBatcherEventBuilder
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+
+entity AxiStreamBatcherEventBuilderWrapper is
+   generic (
+      TPD_G                 : time                   := 1 ns;
+      VERSION_G             : positive range 1 to 2  := 2;
+      MODE_G                : string                 := "INDEXED";
+      DATA_BYTES_G          : positive range 8 to 8  := 8;
+      ROUTE_MODE_G          : natural range 0 to 1   := 0;
+      INPUT_PIPE_STAGES_G   : natural                := 0;
+      OUTPUT_PIPE_STAGES_G  : natural                := 1;
+      AXIL_ADDR_WIDTH_G     : positive               := 12;
+      TRANS_TDEST_G         : natural range 0 to 255 := 255);
+   port (
+      axisClk        : in  sl;
+      axisRst        : in  sl;
+      blowoffExt     : in  sl;
+      blowoffInt     : out sl;
+      S0_AXIS_TVALID : in  sl;
+      S0_AXIS_TDATA  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S0_AXIS_TKEEP  : in  slv(DATA_BYTES_G-1 downto 0);
+      S0_AXIS_TLAST  : in  sl;
+      S0_AXIS_TDEST  : in  slv(7 downto 0);
+      S0_AXIS_TID    : in  slv(7 downto 0);
+      S0_AXIS_TUSER  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S0_AXIS_TREADY : out sl;
+      S1_AXIS_TVALID : in  sl;
+      S1_AXIS_TDATA  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S1_AXIS_TKEEP  : in  slv(DATA_BYTES_G-1 downto 0);
+      S1_AXIS_TLAST  : in  sl;
+      S1_AXIS_TDEST  : in  slv(7 downto 0);
+      S1_AXIS_TID    : in  slv(7 downto 0);
+      S1_AXIS_TUSER  : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S1_AXIS_TREADY : out sl;
+      M_AXIS_TVALID  : out sl;
+      M_AXIS_TDATA   : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP   : out slv(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST   : out sl;
+      M_AXIS_TDEST   : out slv(7 downto 0);
+      M_AXIS_TID     : out slv(7 downto 0);
+      M_AXIS_TUSER   : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TREADY  : in  sl;
+      S_AXI_AWADDR   : in  slv(AXIL_ADDR_WIDTH_G-1 downto 0);
+      S_AXI_AWPROT   : in  slv(2 downto 0);
+      S_AXI_AWVALID  : in  sl;
+      S_AXI_AWREADY  : out sl;
+      S_AXI_WDATA    : in  slv(31 downto 0);
+      S_AXI_WSTRB    : in  slv(3 downto 0);
+      S_AXI_WVALID   : in  sl;
+      S_AXI_WREADY   : out sl;
+      S_AXI_BRESP    : out slv(1 downto 0);
+      S_AXI_BVALID   : out sl;
+      S_AXI_BREADY   : in  sl;
+      S_AXI_ARADDR   : in  slv(AXIL_ADDR_WIDTH_G-1 downto 0);
+      S_AXI_ARPROT   : in  slv(2 downto 0);
+      S_AXI_ARVALID  : in  sl;
+      S_AXI_ARREADY  : out sl;
+      S_AXI_RDATA    : out slv(31 downto 0);
+      S_AXI_RRESP    : out slv(1 downto 0);
+      S_AXI_RVALID   : out sl;
+      S_AXI_RREADY   : in  sl);
+end entity AxiStreamBatcherEventBuilderWrapper;
+
+architecture rtl of AxiStreamBatcherEventBuilderWrapper is
+
+   constant NUM_SLAVES_C : positive := 2;
+
+   function route1 (mode : natural) return slv is
+   begin
+      if mode = 0 then
+         return "0101----";
+      else
+         return "1010--11";
+      end if;
+   end function route1;
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => false,
+      TDATA_BYTES_C => DATA_BYTES_G,
+      TDEST_BITS_C  => 8,
+      TID_BITS_C    => 0,
+      TKEEP_MODE_C  => TKEEP_NORMAL_C,
+      TUSER_BITS_C  => 8,
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+
+   constant TDEST_ROUTES_C : Slv8Array(NUM_SLAVES_C-1 downto 0) := (
+      0 => "--------",
+      1 => route1(ROUTE_MODE_G));
+
+   signal axilRstN        : sl;
+   signal axilClk         : sl;
+   signal axilRst         : sl;
+   signal axilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal axilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal axilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+   signal sAxisMasters    : AxiStreamMasterArray(NUM_SLAVES_C-1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal sAxisSlaves     : AxiStreamSlaveArray(NUM_SLAVES_C-1 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+   signal mAxisMaster     : AxiStreamMasterType                           := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave      : AxiStreamSlaveType                            := AXI_STREAM_SLAVE_INIT_C;
+
+begin
+
+   axilRstN <= not axisRst;
+
+   ------------------------
+   -- AXI-Lite bus shim  --
+   ------------------------
+   U_AXIL : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         HAS_PROT   => 1,
+         HAS_WSTRB  => 1,
+         ADDR_WIDTH => AXIL_ADDR_WIDTH_G)
+      port map (
+         S_AXI_ACLK      => axisClk,          -- [in]
+         S_AXI_ARESETN   => axilRstN,         -- [in]
+         S_AXI_AWADDR    => S_AXI_AWADDR,     -- [in]
+         S_AXI_AWPROT    => S_AXI_AWPROT,     -- [in]
+         S_AXI_AWVALID   => S_AXI_AWVALID,    -- [in]
+         S_AXI_AWREADY   => S_AXI_AWREADY,    -- [out]
+         S_AXI_WDATA     => S_AXI_WDATA,      -- [in]
+         S_AXI_WSTRB     => S_AXI_WSTRB,      -- [in]
+         S_AXI_WVALID    => S_AXI_WVALID,     -- [in]
+         S_AXI_WREADY    => S_AXI_WREADY,     -- [out]
+         S_AXI_BRESP     => S_AXI_BRESP,      -- [out]
+         S_AXI_BVALID    => S_AXI_BVALID,     -- [out]
+         S_AXI_BREADY    => S_AXI_BREADY,     -- [in]
+         S_AXI_ARADDR    => S_AXI_ARADDR,     -- [in]
+         S_AXI_ARPROT    => S_AXI_ARPROT,     -- [in]
+         S_AXI_ARVALID   => S_AXI_ARVALID,    -- [in]
+         S_AXI_ARREADY   => S_AXI_ARREADY,    -- [out]
+         S_AXI_RDATA     => S_AXI_RDATA,      -- [out]
+         S_AXI_RRESP     => S_AXI_RRESP,      -- [out]
+         S_AXI_RVALID    => S_AXI_RVALID,     -- [out]
+         S_AXI_RREADY    => S_AXI_RREADY,     -- [in]
+         axilClk         => axilClk,          -- [out]
+         axilRst         => axilRst,          -- [out]
+         axilReadMaster  => axilReadMaster,   -- [out]
+         axilReadSlave   => axilReadSlave,    -- [in]
+         axilWriteMaster => axilWriteMaster,  -- [out]
+         axilWriteSlave  => axilWriteSlave);  -- [in]
+
+   ------------------------
+   -- AXI Stream shims  --
+   ------------------------
+   comb : process (M_AXIS_TREADY, S0_AXIS_TDATA, S0_AXIS_TDEST, S0_AXIS_TID,
+                   S0_AXIS_TKEEP, S0_AXIS_TLAST, S0_AXIS_TUSER, S0_AXIS_TVALID,
+                   S1_AXIS_TDATA, S1_AXIS_TDEST, S1_AXIS_TID, S1_AXIS_TKEEP,
+                   S1_AXIS_TLAST, S1_AXIS_TUSER, S1_AXIS_TVALID, mAxisMaster,
+                   sAxisSlaves) is
+      variable vS : AxiStreamMasterArray(NUM_SLAVES_C-1 downto 0);
+      variable vM : AxiStreamSlaveType;
+   begin
+      vS := (others => AXI_STREAM_MASTER_INIT_C);
+
+      vS(0).tValid                           := S0_AXIS_TVALID;
+      vS(0).tData                            := (others => '0');
+      vS(0).tData(8*DATA_BYTES_G-1 downto 0) := S0_AXIS_TDATA;
+      vS(0).tStrb                            := (others => '0');
+      vS(0).tStrb(DATA_BYTES_G-1 downto 0)   := S0_AXIS_TKEEP;
+      vS(0).tKeep                            := (others => '0');
+      vS(0).tKeep(DATA_BYTES_G-1 downto 0)   := S0_AXIS_TKEEP;
+      vS(0).tLast                            := S0_AXIS_TLAST;
+      vS(0).tDest                            := (others => '0');
+      vS(0).tDest(7 downto 0)                := S0_AXIS_TDEST;
+      vS(0).tId                              := (others => '0');
+      vS(0).tId(7 downto 0)                  := S0_AXIS_TID;
+      vS(0).tUser                            := (others => '0');
+      vS(0).tUser(8*DATA_BYTES_G-1 downto 0) := S0_AXIS_TUSER;
+
+      vS(1).tValid                           := S1_AXIS_TVALID;
+      vS(1).tData                            := (others => '0');
+      vS(1).tData(8*DATA_BYTES_G-1 downto 0) := S1_AXIS_TDATA;
+      vS(1).tStrb                            := (others => '0');
+      vS(1).tStrb(DATA_BYTES_G-1 downto 0)   := S1_AXIS_TKEEP;
+      vS(1).tKeep                            := (others => '0');
+      vS(1).tKeep(DATA_BYTES_G-1 downto 0)   := S1_AXIS_TKEEP;
+      vS(1).tLast                            := S1_AXIS_TLAST;
+      vS(1).tDest                            := (others => '0');
+      vS(1).tDest(7 downto 0)                := S1_AXIS_TDEST;
+      vS(1).tId                              := (others => '0');
+      vS(1).tId(7 downto 0)                  := S1_AXIS_TID;
+      vS(1).tUser                            := (others => '0');
+      vS(1).tUser(8*DATA_BYTES_G-1 downto 0) := S1_AXIS_TUSER;
+
+      vM        := AXI_STREAM_SLAVE_INIT_C;
+      vM.tReady := M_AXIS_TREADY;
+
+      sAxisMasters <= vS;
+      mAxisSlave   <= vM;
+
+      S0_AXIS_TREADY <= sAxisSlaves(0).tReady;
+      S1_AXIS_TREADY <= sAxisSlaves(1).tReady;
+      M_AXIS_TVALID  <= mAxisMaster.tValid;
+      M_AXIS_TDATA   <= mAxisMaster.tData(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP   <= mAxisMaster.tKeep(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST   <= mAxisMaster.tLast;
+      M_AXIS_TDEST   <= mAxisMaster.tDest(7 downto 0);
+      M_AXIS_TID     <= mAxisMaster.tId(7 downto 0);
+      M_AXIS_TUSER   <= mAxisMaster.tUser(8*DATA_BYTES_G-1 downto 0);
+   end process comb;
+
+   ---------------------
+   -- DUT instancing  --
+   ---------------------
+   U_DUT : entity surf.AxiStreamBatcherEventBuilder
+      generic map (
+         TPD_G                => TPD_G,
+         VERSION_G            => VERSION_G,
+         NUM_SLAVES_G         => NUM_SLAVES_C,
+         MODE_G               => MODE_G,
+         TDEST_ROUTES_G       => TDEST_ROUTES_C,
+         TDEST_LOW_G          => 0,
+         TRANS_TDEST_G        => toSlv(TRANS_TDEST_G, 8),
+         AXIS_CONFIG_G        => AXIS_CONFIG_C,
+         INPUT_PIPE_STAGES_G  => INPUT_PIPE_STAGES_G,
+         OUTPUT_PIPE_STAGES_G => OUTPUT_PIPE_STAGES_G)
+      port map (
+         axisClk         => axisClk,          -- [in]
+         axisRst         => axisRst,          -- [in]
+         blowoffExt      => blowoffExt,       -- [in]
+         blowoffInt      => blowoffInt,       -- [out]
+         axilReadMaster  => axilReadMaster,   -- [in]
+         axilReadSlave   => axilReadSlave,    -- [out]
+         axilWriteMaster => axilWriteMaster,  -- [in]
+         axilWriteSlave  => axilWriteSlave,   -- [out]
+         sAxisMasters    => sAxisMasters,     -- [in]
+         sAxisSlaves     => sAxisSlaves,      -- [out]
+         mAxisMaster     => mAxisMaster,      -- [out]
+         mAxisSlave      => mAxisSlave);      -- [in]
+
+end architecture rtl;

--- a/protocols/batcher/wrappers/AxiStreamBatcherWrapper.vhd
+++ b/protocols/batcher/wrappers/AxiStreamBatcherWrapper.vhd
@@ -1,0 +1,143 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for surf.AxiStreamBatcher
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+entity AxiStreamBatcherWrapper is
+   generic (
+      TPD_G                        : time                  := 1 ns;
+      VERSION_G                    : positive range 1 to 2 := 2;
+      DATA_BYTES_G                 : positive range 2 to 8 := 8;
+      MAX_NUMBER_SUB_FRAMES_G      : positive              := 32;
+      SUPER_FRAME_BYTE_THRESHOLD_G : natural               := 8192;
+      MAX_CLK_GAP_G                : natural               := 256;
+      INPUT_PIPE_STAGES_G          : natural               := 0;
+      OUTPUT_PIPE_STAGES_G         : natural               := 1);
+   port (
+      axisClk                 : in  sl;
+      axisRst                 : in  sl;
+      forceTerm               : in  sl;
+      superFrameByteThreshold : in  slv(31 downto 0);
+      maxSubFrames            : in  slv(15 downto 0);
+      maxClkGap               : in  slv(31 downto 0);
+      idle                    : out sl;
+      S_AXIS_TVALID           : in  sl;
+      S_AXIS_TDATA            : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S_AXIS_TKEEP            : in  slv(DATA_BYTES_G-1 downto 0);
+      S_AXIS_TLAST            : in  sl;
+      S_AXIS_TDEST            : in  slv(7 downto 0);
+      S_AXIS_TID              : in  slv(7 downto 0);
+      S_AXIS_TUSER            : in  slv(8*DATA_BYTES_G-1 downto 0);
+      S_AXIS_TREADY           : out sl;
+      M_AXIS_TVALID           : out sl;
+      M_AXIS_TDATA            : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP            : out slv(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST            : out sl;
+      M_AXIS_TDEST            : out slv(7 downto 0);
+      M_AXIS_TID              : out slv(7 downto 0);
+      M_AXIS_TUSER            : out slv(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TREADY           : in  sl);
+end entity AxiStreamBatcherWrapper;
+
+architecture rtl of AxiStreamBatcherWrapper is
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => false,
+      TDATA_BYTES_C => DATA_BYTES_G,
+      TDEST_BITS_C  => 8,
+      TID_BITS_C    => 0,
+      TKEEP_MODE_C  => TKEEP_NORMAL_C,
+      TUSER_BITS_C  => 8,
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+
+   signal sAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal sAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal mAxisMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal mAxisSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+begin
+
+   ---------------
+   -- Bus shims --
+   ---------------
+   comb : process (M_AXIS_TREADY, S_AXIS_TDATA, S_AXIS_TDEST, S_AXIS_TID,
+                   S_AXIS_TKEEP, S_AXIS_TLAST, S_AXIS_TUSER, S_AXIS_TVALID,
+                   mAxisMaster, sAxisSlave) is
+      variable vS : AxiStreamMasterType;
+      variable vM : AxiStreamSlaveType;
+   begin
+      vS                                      := AXI_STREAM_MASTER_INIT_C;
+      vS.tValid                              := S_AXIS_TVALID;
+      vS.tData                               := (others => '0');
+      vS.tData(8*DATA_BYTES_G-1 downto 0)    := S_AXIS_TDATA;
+      vS.tStrb                               := (others => '0');
+      vS.tStrb(DATA_BYTES_G-1 downto 0)      := S_AXIS_TKEEP;
+      vS.tKeep                               := (others => '0');
+      vS.tKeep(DATA_BYTES_G-1 downto 0)      := S_AXIS_TKEEP;
+      vS.tLast                               := S_AXIS_TLAST;
+      vS.tDest                               := (others => '0');
+      vS.tDest(7 downto 0)                   := S_AXIS_TDEST;
+      vS.tId                                 := (others => '0');
+      vS.tId(7 downto 0)                     := S_AXIS_TID;
+      vS.tUser                               := (others => '0');
+      vS.tUser(8*DATA_BYTES_G-1 downto 0)    := S_AXIS_TUSER;
+
+      vM        := AXI_STREAM_SLAVE_INIT_C;
+      vM.tReady := M_AXIS_TREADY;
+
+      sAxisMaster <= vS;
+      mAxisSlave  <= vM;
+
+      S_AXIS_TREADY <= sAxisSlave.tReady;
+      M_AXIS_TVALID <= mAxisMaster.tValid;
+      M_AXIS_TDATA  <= mAxisMaster.tData(8*DATA_BYTES_G-1 downto 0);
+      M_AXIS_TKEEP  <= mAxisMaster.tKeep(DATA_BYTES_G-1 downto 0);
+      M_AXIS_TLAST  <= mAxisMaster.tLast;
+      M_AXIS_TDEST  <= mAxisMaster.tDest(7 downto 0);
+      M_AXIS_TID    <= mAxisMaster.tId(7 downto 0);
+      M_AXIS_TUSER  <= mAxisMaster.tUser(8*DATA_BYTES_G-1 downto 0);
+   end process comb;
+
+   ---------------------
+   -- DUT instancing  --
+   ---------------------
+   U_DUT : entity surf.AxiStreamBatcher
+      generic map (
+         TPD_G                        => TPD_G,
+         VERSION_G                    => VERSION_G,
+         MAX_NUMBER_SUB_FRAMES_G      => MAX_NUMBER_SUB_FRAMES_G,
+         SUPER_FRAME_BYTE_THRESHOLD_G => SUPER_FRAME_BYTE_THRESHOLD_G,
+         MAX_CLK_GAP_G                => MAX_CLK_GAP_G,
+         AXIS_CONFIG_G                => AXIS_CONFIG_C,
+         INPUT_PIPE_STAGES_G          => INPUT_PIPE_STAGES_G,
+         OUTPUT_PIPE_STAGES_G         => OUTPUT_PIPE_STAGES_G)
+      port map (
+         axisClk                 => axisClk,                    -- [in]
+         axisRst                 => axisRst,                    -- [in]
+         forceTerm               => forceTerm,                  -- [in]
+         superFrameByteThreshold => superFrameByteThreshold,    -- [in]
+         maxSubFrames            => maxSubFrames,               -- [in]
+         maxClkGap               => maxClkGap,                  -- [in]
+         idle                    => idle,                       -- [out]
+         sAxisMaster             => sAxisMaster,                -- [in]
+         sAxisSlave              => sAxisSlave,                 -- [out]
+         mAxisMaster             => mAxisMaster,                -- [out]
+         mAxisSlave              => mAxisSlave);                -- [in]
+
+end architecture rtl;

--- a/tests/protocols/batcher/__init__.py
+++ b/tests/protocols/batcher/__init__.py
@@ -1,0 +1,9 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################

--- a/tests/protocols/batcher/batcher_test_utils.py
+++ b/tests/protocols/batcher/batcher_test_utils.py
@@ -1,0 +1,262 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import FallingEdge, RisingEdge, Timer
+
+from tests.axi.utils import wait_sampled_ready
+
+
+@dataclass
+class AxisBeat:
+    data: int
+    keep: int = 0xFF
+    last: int = 0
+    dest: int = 0
+    tid: int = 0
+    user: int = 0
+
+
+class FlatAxisEndpoint:
+    def __init__(self, dut, *, prefix: str):
+        self.dut = dut
+        self.prefix = prefix
+
+    def _sig(self, suffix: str):
+        return getattr(self.dut, f"{self.prefix}_{suffix}")
+
+    def set_idle(self) -> None:
+        for suffix, value in (
+            ("TVALID", 0),
+            ("TDATA", 0),
+            ("TKEEP", 0),
+            ("TLAST", 0),
+            ("TDEST", 0),
+            ("TID", 0),
+            ("TUSER", 0),
+        ):
+            if hasattr(self.dut, f"{self.prefix}_{suffix}"):
+                self._sig(suffix).value = value
+
+    def drive(self, beat: AxisBeat) -> None:
+        self._sig("TVALID").value = 1
+        self._sig("TDATA").value = beat.data
+        self._sig("TKEEP").value = beat.keep
+        self._sig("TLAST").value = beat.last
+        self._sig("TDEST").value = beat.dest
+        self._sig("TID").value = beat.tid
+        self._sig("TUSER").value = beat.user
+
+    def snapshot(self) -> AxisBeat:
+        return AxisBeat(
+            data=int(self._sig("TDATA").value),
+            keep=int(self._sig("TKEEP").value),
+            last=int(self._sig("TLAST").value),
+            dest=int(self._sig("TDEST").value),
+            tid=int(self._sig("TID").value),
+            user=int(self._sig("TUSER").value),
+        )
+
+    async def send(self, beat: AxisBeat, *, clk) -> None:
+        self.drive(beat)
+        await wait_sampled_ready(self._sig("TREADY"), clk=clk)
+        self.set_idle()
+
+    async def wait_valid(self, *, clk, timeout_cycles: int = 256) -> AxisBeat:
+        await Timer(1, unit="ns")
+        if int(self._sig("TVALID").value) == 1:
+            return self.snapshot()
+        for _ in range(timeout_cycles):
+            await FallingEdge(clk)
+            await Timer(1, unit="ns")
+            if int(self._sig("TVALID").value) == 1:
+                return self.snapshot()
+            await RisingEdge(clk)
+            await Timer(1, unit="ns")
+            if int(self._sig("TVALID").value) == 1:
+                return self.snapshot()
+        raise AssertionError(f"Timed out waiting for {self.prefix} valid")
+
+    async def recv(self, *, clk, keep_ready: bool = False) -> AxisBeat:
+        self._sig("TREADY").value = 1
+        beat = await self.wait_valid(clk=clk)
+        await RisingEdge(clk)
+        await Timer(1, unit="ns")
+        if not keep_ready:
+            self._sig("TREADY").value = 0
+        return beat
+
+
+def start_batcher_clock(dut, *, period_ns: float = 5.0) -> None:
+    cocotb.start_soon(Clock(dut.axisClk, period_ns, unit="ns").start())
+
+
+async def cycle(clk, count: int = 1) -> None:
+    for _ in range(count):
+        await RisingEdge(clk)
+        await Timer(1, unit="ns")
+
+
+async def reset_batcher_dut(dut, *, cycles: int = 4) -> None:
+    dut.axisRst.setimmediatevalue(1)
+    await cycle(dut.axisClk, cycles)
+    dut.axisRst.value = 0
+    await cycle(dut.axisClk, 2)
+
+
+def word_from_bytes(data: bytes) -> int:
+    return int.from_bytes(data.ljust(8, b"\x00"), "little")
+
+
+def bytes_from_word(word: int, *, keep: int = 0xFF) -> bytes:
+    raw = word.to_bytes(8, "little")
+    return bytes(raw[index] for index in range(8) if keep & (1 << index))
+
+
+def keep_count(keep: int) -> int:
+    return sum(1 for lane in range(8) if keep & (1 << lane))
+
+
+def user_from_lanes(values: list[int]) -> int:
+    user = 0
+    for lane, value in enumerate(values):
+        user |= (value & 0xFF) << (8 * lane)
+    return user
+
+
+def payload_to_beats(payload: bytes, *, dest: int, first_user: int, last_user: int) -> list[AxisBeat]:
+    beats = []
+    for offset in range(0, len(payload), 8):
+        chunk = payload[offset : offset + 8]
+        is_first = offset == 0
+        is_last = offset + 8 >= len(payload)
+        user_values = [0] * len(chunk)
+        if is_first:
+            user_values[0] = first_user
+        if is_last:
+            user_values[-1] = last_user
+        beats.append(
+            AxisBeat(
+                data=word_from_bytes(chunk),
+                keep=(1 << len(chunk)) - 1,
+                last=int(is_last),
+                dest=dest,
+                user=user_from_lanes(user_values),
+            )
+        )
+    return beats
+
+
+def batcher_v2_header(*, seq: int = 0, data_bytes: int = 8) -> bytes:
+    width = (data_bytes // 2).bit_length() - 1
+    return bytes([0x2 | ((width & 0xF) << 4), seq & 0xFF])
+
+
+def batcher_subframe_tail(*, byte_count: int, dest: int, first_user: int, last_user: int) -> bytes:
+    return (
+        byte_count.to_bytes(4, "little")
+        + bytes([dest & 0xFF, first_user & 0xFF, last_user & 0xFF])
+    )
+
+
+def expected_batched_bytes(frames: list[tuple[bytes, int, int, int]], *, seq: int = 0) -> bytes:
+    stream = bytearray(batcher_v2_header(seq=seq))
+    for payload, dest, first_user, last_user in frames:
+        stream.extend(payload)
+        stream.extend(
+            batcher_subframe_tail(
+                byte_count=len(payload),
+                dest=dest,
+                first_user=first_user,
+                last_user=last_user,
+            )
+        )
+    return bytes(stream)
+
+
+async def send_frame(endpoint: FlatAxisEndpoint, beats: list[AxisBeat], *, clk) -> None:
+    for beat in beats:
+        await endpoint.send(beat, clk=clk)
+
+
+async def send_frames_concurrently(
+    frames: list[tuple[FlatAxisEndpoint, list[AxisBeat]]],
+    *,
+    clk,
+) -> None:
+    tasks = [cocotb.start_soon(send_frame(endpoint, beats, clk=clk)) for endpoint, beats in frames]
+    for task in tasks:
+        await task
+
+
+async def recv_until_last(endpoint: FlatAxisEndpoint, *, clk, max_beats: int = 32) -> list[AxisBeat]:
+    beats = []
+    for _ in range(max_beats):
+        beat = await endpoint.recv(clk=clk, keep_ready=True)
+        beats.append(beat)
+        if beat.last:
+            endpoint._sig("TREADY").value = 0
+            return beats
+    endpoint._sig("TREADY").value = 0
+    raise AssertionError("Timed out waiting for terminal batcher beat")
+
+
+async def recv_beats(endpoint: FlatAxisEndpoint, *, clk, count: int) -> list[AxisBeat]:
+    beats = []
+    for _ in range(count):
+        beats.append(await endpoint.recv(clk=clk, keep_ready=True))
+    endpoint._sig("TREADY").value = 0
+    return beats
+
+
+async def expect_no_valid(endpoint: FlatAxisEndpoint, *, clk, cycles: int) -> None:
+    endpoint._sig("TREADY").value = 1
+    for _ in range(cycles):
+        await RisingEdge(clk)
+        await Timer(1, unit="ns")
+        assert int(endpoint._sig("TVALID").value) == 0
+    endpoint._sig("TREADY").value = 0
+
+
+async def recv_until_last_with_backpressure(
+    endpoint: FlatAxisEndpoint,
+    *,
+    clk,
+    hold_cycles: int = 2,
+    max_beats: int = 32,
+) -> list[AxisBeat]:
+    beats = []
+    endpoint._sig("TREADY").value = 0
+    for _ in range(max_beats):
+        beat = await endpoint.wait_valid(clk=clk)
+        for _ in range(hold_cycles):
+            await RisingEdge(clk)
+            await Timer(1, unit="ns")
+            assert endpoint.snapshot() == beat
+        endpoint._sig("TREADY").value = 1
+        await RisingEdge(clk)
+        await Timer(1, unit="ns")
+        endpoint._sig("TREADY").value = 0
+        beats.append(beat)
+        if beat.last:
+            return beats
+    raise AssertionError("Timed out waiting for terminal batcher beat")
+
+
+def beats_to_bytes(beats: list[AxisBeat]) -> bytes:
+    payload = bytearray()
+    for beat in beats:
+        payload.extend(bytes_from_word(beat.data, keep=beat.keep))
+    return bytes(payload)

--- a/tests/protocols/batcher/test_AxiStreamBatcher.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcher.py
@@ -1,0 +1,318 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Use a standalone `AxiStreamBatcher` wrapper in V2 mode with an
+#   8-byte AXI Stream width so the regression checks the compacted output path
+#   implemented through `AxiStreamGearbox`.
+# - Stimulus: Drive one or more input subframes with varied payload lengths,
+#   `TKEEP`, `TDEST`, first-byte `TUSER`, and last-byte `TUSER`, then terminate
+#   superframes by subframe count, idle gap, byte threshold, and sink
+#   backpressure.
+# - Checks: The emitted byte stream must match the V2 superframe header,
+#   payload bytes, and subframe tail metadata exactly, with `TLAST` only on the
+#   terminal superframe beat.
+# - Timing: Source and sink use ready/valid handshakes, including a held-not-
+#   ready sink case that asserts the DUT holds every output beat stable.
+
+import cocotb
+import pytest
+from cocotb.triggers import with_timeout
+
+from tests.common.regression_utils import run_surf_vhdl_test
+from tests.protocols.batcher.batcher_test_utils import (
+    AxisBeat,
+    FlatAxisEndpoint,
+    beats_to_bytes,
+    cycle,
+    expected_batched_bytes,
+    keep_count,
+    payload_to_beats,
+    recv_beats,
+    recv_until_last,
+    recv_until_last_with_backpressure,
+    reset_batcher_dut,
+    send_frame,
+    start_batcher_clock,
+)
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.source = FlatAxisEndpoint(dut, prefix="S_AXIS")
+        self.sink = FlatAxisEndpoint(dut, prefix="M_AXIS")
+
+        start_batcher_clock(dut)
+        dut.axisRst.setimmediatevalue(1)
+        dut.forceTerm.setimmediatevalue(0)
+        dut.superFrameByteThreshold.setimmediatevalue(0)
+        dut.maxSubFrames.setimmediatevalue(1)
+        dut.maxClkGap.setimmediatevalue(256)
+        dut.M_AXIS_TREADY.setimmediatevalue(0)
+        self.source.set_idle()
+
+    async def reset(self):
+        await reset_batcher_dut(self.dut)
+
+
+@cocotb.test()
+async def single_subframe_terminates_on_count_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # A five-byte frame exercises the V2 gearbox because the two-byte
+    # superframe header, payload, and seven-byte tail do not align to an
+    # eight-byte output boundary.
+    payload = bytes(range(0x10, 0x15))
+    frame = (payload, 0x3, 0x22, 0x41)
+    input_beats = payload_to_beats(
+        payload,
+        dest=frame[1],
+        first_user=frame[2],
+        last_user=frame[3],
+    )
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(tb.source, input_beats, clk=dut.axisClk)
+    rx_beats = await with_timeout(rx_task, 3, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([frame])
+    assert rx_beats[-1].last == 1
+    await cycle(dut.axisClk, 2)
+    assert int(dut.idle.value) == 1
+
+
+@cocotb.test()
+async def two_subframes_share_one_superframe_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 2
+
+    # Two subframes should share one superframe when the runtime subframe limit
+    # is raised.  The second frame is deliberately not word-aligned so the tail
+    # metadata lands in a compacted output beat.
+    first = (bytes(range(0x20, 0x28)), 0x4, 0x11, 0x91)
+    second = (bytes(range(0x40, 0x45)), 0x7, 0x33, 0xA5)
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    for payload, dest, first_user, last_user in (first, second):
+        await send_frame(
+            tb.source,
+            payload_to_beats(
+                payload,
+                dest=dest,
+                first_user=first_user,
+                last_user=last_user,
+            ),
+            clk=dut.axisClk,
+        )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([first, second])
+    assert [beat.last for beat in rx_beats[:-1]] == [0] * (len(rx_beats) - 1)
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def idle_gap_terminates_pending_tail_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 8
+    dut.maxClkGap.value = 3
+
+    # With no second subframe arriving, the small max-clock-gap setting must
+    # close the superframe after the tail has been accepted into the batcher.
+    payload = bytes(range(0x60, 0x6B))
+    frame = (payload, 0x2, 0x44, 0xB1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            payload,
+            dest=frame[1],
+            first_user=frame[2],
+            last_user=frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([frame])
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def byte_threshold_terminates_superframe_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 8
+    dut.maxClkGap.value = 0
+    dut.superFrameByteThreshold.value = 24
+
+    # The threshold check is asserted through externally visible termination
+    # behavior only.  The RTL floors the register value internally to its word
+    # accounting granularity, so the test avoids overfitting that private count.
+    first = (bytes(range(0x70, 0x78)), 0x1, 0x55, 0xC1)
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            first[0],
+            dest=first[1],
+            first_user=first[2],
+            last_user=first[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([first])
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def force_term_marks_terminal_eofe_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 8
+    dut.maxClkGap.value = 256
+
+    # Send one complete subframe, then force the enclosing superframe closed
+    # before the clock-gap timer or subframe count can terminate it naturally.
+    payload = bytes(range(0x80, 0x85))
+    frame = (payload, 0x6, 0x66, 0xE2)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            payload,
+            dest=frame[1],
+            first_user=frame[2],
+            last_user=frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+
+    # `forceTerm` is sampled into the RTL and then applied from the non-header
+    # state, so hold it for a few clocks to avoid making the test sensitive to
+    # the exact state transition cycle.
+    await cycle(dut.axisClk, 4)
+    dut.forceTerm.value = 1
+    await cycle(dut.axisClk, 4)
+    dut.forceTerm.value = 0
+
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats).startswith(expected_batched_bytes([frame]))
+    assert rx_beats[-1].last == 1
+    terminal_lane = keep_count(rx_beats[-1].keep) - 1
+    assert terminal_lane >= 0
+    assert (rx_beats[-1].user >> (8 * terminal_lane)) & 0x1 == 1
+
+
+@cocotb.test()
+async def reset_recovers_after_partial_superframe_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 8
+    dut.maxClkGap.value = 256
+
+    # Present a non-terminal input beat and let the DUT emit at least one
+    # partial output beat.  The following reset should discard that incomplete
+    # superframe state instead of contaminating the next accepted frame.
+    partial = AxisBeat(
+        data=int.from_bytes(bytes(range(0xA0, 0xA8)), "little"),
+        keep=0xFF,
+        last=0,
+        dest=0x2,
+        user=0x19,
+    )
+    await tb.source.send(partial, clk=dut.axisClk)
+    partial_rx = await with_timeout(recv_beats(tb.sink, clk=dut.axisClk, count=1), 2, "us")
+    assert partial_rx[0].last == 0
+
+    await reset_batcher_dut(dut)
+    assert int(dut.idle.value) == 1
+    dut.maxSubFrames.value = 1
+    await cycle(dut.axisClk, 1)
+
+    payload = bytes(range(0xB0, 0xB5))
+    frame = (payload, 0x1, 0x22, 0xC3)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            payload,
+            dest=frame[1],
+            first_user=frame[2],
+            last_user=frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([frame])
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def output_backpressure_holds_each_beat_stable_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    payload = bytes(range(0x90, 0x9A))
+    frame = (payload, 0x5, 0x77, 0xD4)
+    rx_task = cocotb.start_soon(
+        recv_until_last_with_backpressure(tb.sink, clk=dut.axisClk, hold_cycles=3)
+    )
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            payload,
+            dest=frame[1],
+            first_user=frame[2],
+            last_user=frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([frame])
+    assert rx_beats[-1].last == 1
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "DATA_BYTES_G": 8,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="v2_8byte",
+        ),
+    ],
+)
+def test_AxiStreamBatcher(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.axistreambatcherwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/batcher/wrappers/AxiStreamBatcherWrapper.vhd",
+            ],
+        },
+    )

--- a/tests/protocols/batcher/test_AxiStreamBatcherAxil.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherAxil.py
@@ -1,0 +1,342 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Use the `AxiStreamBatcherAxil` wrapper in V2 mode with common and
+#   independent AXI-Lite/stream clocks, matching the control-surface targets
+#   from the batcher regression plan.
+# - Stimulus: Program the runtime threshold, max-subframe, max-clock-gap,
+#   `softRst`, and `blowoff` registers through a cocotb AXI-Lite master while
+#   driving flat AXI Stream subframes through the wrapped batcher.
+# - Checks: Register reset values and readback must match the RTL/PyRogue map,
+#   and control writes must change stream-side termination or drop/reset behavior
+#   without re-proving every batcher payload byte beyond the leaf helper model.
+# - Timing: The common-clock case keeps readback strict, while the async case
+#   waits for the expected register value through the CDC bridge before using
+#   writes to steer stream-side behavior.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import with_timeout
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster
+
+from tests.axi.utils import axil_read_u32, axil_write_u32
+from tests.common.regression_utils import run_surf_vhdl_test
+from tests.protocols.batcher.batcher_test_utils import (
+    AxisBeat,
+    FlatAxisEndpoint,
+    beats_to_bytes,
+    cycle,
+    expect_no_valid,
+    expected_batched_bytes,
+    payload_to_beats,
+    recv_beats,
+    recv_until_last,
+    reset_batcher_dut,
+    send_frame,
+    start_batcher_clock,
+)
+
+SUPER_FRAME_BYTE_THRESHOLD_ADDR = 0x00
+MAX_SUB_FRAMES_ADDR = 0x04
+MAX_CLK_GAP_ADDR = 0x08
+STATUS_ADDR = 0x0C
+BLOWOFF_ADDR = 0xF8
+SOFT_RST_ADDR = 0xFC
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.common_clock = os.environ.get("COMMON_CLOCK_G", "True").lower() == "true"
+        self.source = FlatAxisEndpoint(dut, prefix="S_AXIS")
+        self.sink = FlatAxisEndpoint(dut, prefix="M_AXIS")
+
+        start_batcher_clock(dut)
+        dut.axisRst.setimmediatevalue(1)
+        dut.axilClkIn.setimmediatevalue(0)
+        dut.axilRstIn.setimmediatevalue(1)
+        if self.common_clock:
+            self.axil_clk = dut.axisClk
+            self.axil_rst = dut.axisRst
+        else:
+            cocotb.start_soon(Clock(dut.axilClkIn, 7.0, unit="ns").start())
+            self.axil_clk = dut.axilClkIn
+            self.axil_rst = dut.axilRstIn
+        self.axil = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "S_AXI"), self.axil_clk, self.axil_rst)
+
+        dut.M_AXIS_TREADY.setimmediatevalue(0)
+        self.source.set_idle()
+
+    async def reset(self):
+        if self.common_clock:
+            await reset_batcher_dut(self.dut)
+        else:
+            self.dut.axisRst.setimmediatevalue(1)
+            self.dut.axilRstIn.setimmediatevalue(1)
+            await cycle(self.dut.axisClk, 8)
+            await cycle(self.dut.axilClkIn, 8)
+            self.dut.axisRst.value = 0
+            await cycle(self.dut.axisClk, 16)
+            self.dut.axilRstIn.value = 0
+            await cycle(self.dut.axisClk, 64)
+            await cycle(self.dut.axilClkIn, 64)
+
+    async def read(self, address: int) -> int:
+        return await with_timeout(axil_read_u32(self.axil, address), 2, "us")
+
+    async def read_eventually(self, address: int, expected: int) -> None:
+        # The async bridge can return reset/CDC-latency responses before the
+        # target register response reaches the AXI-Lite side.
+        observed = []
+        for _ in range(8):
+            observed.append(await self.read(address))
+            if observed[-1] == expected:
+                return
+            await cycle(self.axil_clk, 4)
+        raise AssertionError(
+            f"AXI-Lite readback at 0x{address:02X} never reached "
+            f"0x{expected:08X}; observed {observed}"
+        )
+
+    async def write(self, address: int, value: int) -> None:
+        await with_timeout(axil_write_u32(self.axil, address, value), 2, "us")
+        if not self.common_clock:
+            await cycle(self.dut.axisClk, 16)
+
+
+@cocotb.test()
+async def register_reset_and_readback_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # The reset values mirror `AxiStreamBatcherAxil` generics and the PyRogue
+    # register map.  Status bit 0 is idle and bits 27:24 report VERSION_G.
+    if tb.common_clock:
+        assert await tb.read(SUPER_FRAME_BYTE_THRESHOLD_ADDR) == 8192
+        assert await tb.read(MAX_SUB_FRAMES_ADDR) == 32
+        assert await tb.read(MAX_CLK_GAP_ADDR) == 256
+        assert await tb.read(STATUS_ADDR) == 0x02000001
+    else:
+        await tb.read_eventually(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 8192)
+        await tb.read_eventually(MAX_SUB_FRAMES_ADDR, 32)
+        await tb.read_eventually(MAX_CLK_GAP_ADDR, 256)
+        await tb.read_eventually(STATUS_ADDR, 0x02000001)
+
+    # Write/readback checks keep the control register map pinned before the
+    # stream-side tests rely on these fields to steer termination behavior.
+    await tb.write(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 24)
+    await tb.write(MAX_SUB_FRAMES_ADDR, 2)
+    await tb.write(MAX_CLK_GAP_ADDR, 5)
+    if tb.common_clock:
+        assert await tb.read(SUPER_FRAME_BYTE_THRESHOLD_ADDR) == 24
+        assert await tb.read(MAX_SUB_FRAMES_ADDR) == 2
+        assert await tb.read(MAX_CLK_GAP_ADDR) == 5
+    else:
+        await tb.read_eventually(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 24)
+        await tb.read_eventually(MAX_SUB_FRAMES_ADDR, 2)
+        await tb.read_eventually(MAX_CLK_GAP_ADDR, 5)
+
+
+@cocotb.test()
+async def max_subframe_register_controls_termination_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # A register write to MaxSubFrames should be enough to make the wrapper
+    # combine two leaf subframes into one superframe.
+    await tb.write(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 0)
+    await tb.write(MAX_SUB_FRAMES_ADDR, 2)
+    await tb.write(MAX_CLK_GAP_ADDR, 256)
+
+    first = (bytes(range(0x10, 0x18)), 0x1, 0x21, 0x81)
+    second = (bytes(range(0x20, 0x25)), 0x2, 0x31, 0x91)
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    for payload, dest, first_user, last_user in (first, second):
+        await send_frame(
+            tb.source,
+            payload_to_beats(
+                payload,
+                dest=dest,
+                first_user=first_user,
+                last_user=last_user,
+            ),
+            clk=dut.axisClk,
+        )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([first, second])
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def threshold_and_gap_registers_control_termination_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Use the AXI-Lite register path to exercise the two other termination
+    # families without duplicating all of the leaf byte grammar assertions.
+    await tb.write(MAX_SUB_FRAMES_ADDR, 8)
+    await tb.write(MAX_CLK_GAP_ADDR, 0)
+    await tb.write(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 24)
+
+    threshold_frame = (bytes(range(0x40, 0x48)), 0x3, 0x41, 0xA1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            threshold_frame[0],
+            dest=threshold_frame[1],
+            first_user=threshold_frame[2],
+            last_user=threshold_frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([threshold_frame])
+
+    await tb.write(SUPER_FRAME_BYTE_THRESHOLD_ADDR, 0)
+    await tb.write(MAX_CLK_GAP_ADDR, 3)
+
+    gap_frame = (bytes(range(0x50, 0x55)), 0x4, 0x51, 0xB1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            gap_frame[0],
+            dest=gap_frame[1],
+            first_user=gap_frame[2],
+            last_user=gap_frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([gap_frame], seq=1)
+
+
+@cocotb.test()
+async def soft_reset_discards_pending_superframe_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(MAX_SUB_FRAMES_ADDR, 8)
+    await tb.write(MAX_CLK_GAP_ADDR, 256)
+
+    # Start, but do not finish, a subframe.  The soft reset register should
+    # return the stream path to idle before the next valid frame is accepted.
+    partial = AxisBeat(
+        data=int.from_bytes(bytes(range(0x60, 0x68)), "little"),
+        keep=0xFF,
+        last=0,
+        dest=0x5,
+        user=0x12,
+    )
+    await tb.source.send(partial, clk=dut.axisClk)
+    partial_rx = await with_timeout(recv_beats(tb.sink, clk=dut.axisClk, count=1), 2, "us")
+    assert partial_rx[0].last == 0
+
+    await tb.write(SOFT_RST_ADDR, 1)
+    await cycle(dut.axisClk, 4)
+    assert int(dut.idle.value) == 1
+
+    await tb.write(MAX_SUB_FRAMES_ADDR, 1)
+    recovery = (bytes(range(0x70, 0x75)), 0x6, 0x61, 0xC1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            recovery[0],
+            dest=recovery[1],
+            first_user=recovery[2],
+            last_user=recovery[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([recovery])
+
+
+@cocotb.test()
+async def blowoff_drops_accepted_input_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(MAX_SUB_FRAMES_ADDR, 1)
+    await tb.write(BLOWOFF_ADDR, 1)
+
+    # Blowoff should keep accepting inbound stream beats while resetting the
+    # batcher path, so accepted traffic must not create a malformed output frame.
+    dropped = bytes(range(0x80, 0x85))
+    await send_frame(
+        tb.source,
+        payload_to_beats(dropped, dest=0x7, first_user=0x71, last_user=0xD1),
+        clk=dut.axisClk,
+    )
+    await expect_no_valid(tb.sink, clk=dut.axisClk, cycles=12)
+
+    await tb.write(BLOWOFF_ADDR, 0)
+    await cycle(dut.axisClk, 4)
+
+    recovery = (bytes(range(0x90, 0x95)), 0x1, 0x81, 0xE1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            recovery[0],
+            dest=recovery[1],
+            first_user=recovery[2],
+            last_user=recovery[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes([recovery])
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "DATA_BYTES_G": 8,
+                "COMMON_CLOCK_G": True,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="v2_8byte_common_clock",
+        ),
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "DATA_BYTES_G": 8,
+                "COMMON_CLOCK_G": False,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="v2_8byte_async_axil",
+        ),
+    ],
+)
+def test_AxiStreamBatcherAxil(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.axistreambatcheraxilwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "axi/axi-lite/ip_integrator/SlaveAxiLiteIpIntegrator.vhd",
+                "protocols/batcher/wrappers/AxiStreamBatcherAxilWrapper.vhd",
+            ],
+        },
+    )

--- a/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
@@ -1,0 +1,435 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Use a two-input `AxiStreamBatcherEventBuilder` wrapper in INDEXED,
+#   ROUTED, and one alternate routed table/transition-TDEST configuration.  This
+#   keeps event-builder policy visible without building an exhaustive
+#   source-count matrix.
+# - Stimulus: Drive small AXI Stream frames on one or both inputs, program the
+#   event-builder AXI-Lite bypass/timeout controls, and use transition TDEST
+#   cases in routed modes.
+# - Checks: Assert source-selection policy, TDEST remap, null/transition/timeout
+#   counters, bypass/drop behavior, and the final batcher byte stream shape
+#   through the shared leaf byte helpers.
+# - Timing: Inputs are driven concurrently where the event builder requires all
+#   active sources to be present, and timeout/bypass cases verify progress when
+#   one source is absent or intentionally skipped.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.triggers import with_timeout
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster
+
+from tests.axi.utils import axil_read_u32, axil_write_u32
+from tests.common.regression_utils import run_surf_vhdl_test
+from tests.protocols.batcher.batcher_test_utils import (
+    AxisBeat,
+    FlatAxisEndpoint,
+    beats_to_bytes,
+    cycle,
+    expect_no_valid,
+    expected_batched_bytes,
+    payload_to_beats,
+    recv_until_last_with_backpressure,
+    recv_until_last,
+    reset_batcher_dut,
+    send_frame,
+    send_frames_concurrently,
+    start_batcher_clock,
+    word_from_bytes,
+)
+
+DATA_CNT_BASE = 0x000
+NULL_CNT_BASE = 0x100
+TIMEOUT_DROP_CNT_BASE = 0x200
+TRANS_CNT_ADDR = 0xFC0
+TRANS_TDEST_ADDR = 0xFC4
+BYPASS_ADDR = 0xFD0
+TIMEOUT_ADDR = 0xFF0
+STATUS_ADDR = 0xFF4
+BLOWOFF_ADDR = 0xFF8
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.mode = os.environ.get("MODE_G", "INDEXED").strip("'").strip('"')
+        self.route_mode = int(os.environ.get("ROUTE_MODE_G", "0"))
+        self.trans_tdest = int(os.environ.get("TRANS_TDEST_G", "255"))
+        self.source0 = FlatAxisEndpoint(dut, prefix="S0_AXIS")
+        self.source1 = FlatAxisEndpoint(dut, prefix="S1_AXIS")
+        self.sink = FlatAxisEndpoint(dut, prefix="M_AXIS")
+        self.axil = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "S_AXI"), dut.axisClk, dut.axisRst)
+
+        start_batcher_clock(dut)
+        dut.axisRst.setimmediatevalue(1)
+        dut.blowoffExt.setimmediatevalue(0)
+        dut.M_AXIS_TREADY.setimmediatevalue(0)
+        self.source0.set_idle()
+        self.source1.set_idle()
+
+    async def reset(self):
+        await reset_batcher_dut(self.dut)
+
+    async def read(self, address: int) -> int:
+        return await with_timeout(axil_read_u32(self.axil, address), 2, "us")
+
+    async def write(self, address: int, value: int) -> None:
+        await with_timeout(axil_write_u32(self.axil, address, value), 2, "us")
+
+    def remapped_dest(self, index: int, original: int) -> int:
+        if self.mode == "ROUTED":
+            if index == 1:
+                if self.route_mode == 0:
+                    return 0x50 | (original & 0x0F)
+                return 0xA0 | (original & 0x0C) | 0x03
+            return original & 0xFF
+        return index
+
+
+def _frame(payload: bytes, *, dest: int, first_user: int, last_user: int):
+    return (payload, dest, first_user, last_user)
+
+
+def _null_beat(*, dest: int = 0) -> AxisBeat:
+    return AxisBeat(
+        data=word_from_bytes(b"\x00"),
+        keep=0x01,
+        last=1,
+        dest=dest,
+        user=0x01,
+    )
+
+
+@cocotb.test()
+async def register_status_and_remap_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Pin down the management map before relying on counters later in the file.
+    assert await tb.read(TRANS_TDEST_ADDR) == tb.trans_tdest
+    assert await tb.read(STATUS_ADDR) == 0x02000002
+    assert await tb.read(BYPASS_ADDR) == 0
+    assert await tb.read(TIMEOUT_ADDR) == 0
+
+    first = _frame(bytes(range(0x10, 0x15)), dest=0x03, first_user=0x21, last_user=0x81)
+    second = _frame(bytes(range(0x20, 0x25)), dest=0x07, first_user=0x31, last_user=0x91)
+    expected = [
+        _frame(first[0], dest=tb.remapped_dest(0, first[1]), first_user=first[2], last_user=first[3]),
+        _frame(second[0], dest=tb.remapped_dest(1, second[1]), first_user=second[2], last_user=second[3]),
+    ]
+
+    # Both channels must be valid together before the event builder can form a
+    # complete event, so drive the two source coroutines concurrently.
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(first[0], dest=first[1], first_user=first[2], last_user=first[3])),
+            (tb.source1, payload_to_beats(second[0], dest=second[1], first_user=second[2], last_user=second[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def null_source_is_counted_and_not_forwarded_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    data = _frame(bytes(range(0x30, 0x35)), dest=0x04, first_user=0x41, last_user=0xA1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(0, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3])),
+            (tb.source1, [_null_beat(dest=0x05)]),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(NULL_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def timeout_drops_missing_source_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(TIMEOUT_ADDR, 4)
+
+    data = _frame(bytes(range(0x40, 0x45)), dest=0x06, first_user=0x51, last_user=0xB1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(0, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    # Only source 0 is present.  The timeout register should let the builder
+    # emit source 0 and count source 1 as a timeout drop instead of deadlocking.
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source0,
+        payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3]),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(TIMEOUT_DROP_CNT_BASE + 4) == 1
+
+    recovery0 = _frame(bytes(range(0x48, 0x4D)), dest=0x07, first_user=0x59, last_user=0xB9)
+    recovery1 = _frame(bytes(range(0x58, 0x5D)), dest=0x08, first_user=0x69, last_user=0xC9)
+    expected = [
+        _frame(recovery0[0], dest=tb.remapped_dest(0, recovery0[1]), first_user=recovery0[2], last_user=recovery0[3]),
+        _frame(recovery1[0], dest=tb.remapped_dest(1, recovery1[1]), first_user=recovery1[2], last_user=recovery1[3]),
+    ]
+
+    # A later complete event should still be framed correctly after the timeout
+    # event and should advance the underlying batcher sequence normally.
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(recovery0[0], dest=recovery0[1], first_user=recovery0[2], last_user=recovery0[3])),
+            (tb.source1, payload_to_beats(recovery1[0], dest=recovery1[1], first_user=recovery1[2], last_user=recovery1[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected, seq=1)
+    assert await tb.read(DATA_CNT_BASE + 0) == 2
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+    assert await tb.read(TIMEOUT_DROP_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def output_backpressure_holds_complete_event_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    first = _frame(bytes(range(0x90, 0x95)), dest=0x0B, first_user=0x24, last_user=0x84)
+    second = _frame(bytes(range(0xA0, 0xA5)), dest=0x0C, first_user=0x34, last_user=0x94)
+    expected = [
+        _frame(first[0], dest=tb.remapped_dest(0, first[1]), first_user=first[2], last_user=first[3]),
+        _frame(second[0], dest=tb.remapped_dest(1, second[1]), first_user=second[2], last_user=second[3]),
+    ]
+
+    # Hold each output beat while both sources have contributed to the event.
+    # The shared helper asserts that TVALID-side fields stay stable under
+    # backpressure before accepting the beat.
+    rx_task = cocotb.start_soon(
+        recv_until_last_with_backpressure(tb.sink, clk=dut.axisClk, hold_cycles=3)
+    )
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(first[0], dest=first[1], first_user=first[2], last_user=first[3])),
+            (tb.source1, payload_to_beats(second[0], dest=second[1], first_user=second[2], last_user=second[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 5, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def blowoff_drops_inputs_and_recovers_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(BLOWOFF_ADDR, 1)
+    await cycle(dut.axisClk, 4)
+    assert int(dut.blowoffInt.value) == 1
+
+    dropped0 = bytes(range(0xB0, 0xB5))
+    dropped1 = bytes(range(0xC0, 0xC5))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(dropped0, dest=0x0D, first_user=0x44, last_user=0xA4)),
+            (tb.source1, payload_to_beats(dropped1, dest=0x0E, first_user=0x54, last_user=0xB4)),
+        ],
+        clk=dut.axisClk,
+    )
+    await expect_no_valid(tb.sink, clk=dut.axisClk, cycles=12)
+    assert await tb.read(DATA_CNT_BASE + 0) == 0
+    assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+    await tb.write(BLOWOFF_ADDR, 0)
+    await cycle(dut.axisClk, 4)
+    assert int(dut.blowoffInt.value) == 0
+
+    recovery0 = _frame(bytes(range(0xD0, 0xD5)), dest=0x0F, first_user=0x64, last_user=0xC4)
+    recovery1 = _frame(bytes(range(0xE0, 0xE5)), dest=0x10, first_user=0x74, last_user=0xD4)
+    expected = [
+        _frame(recovery0[0], dest=tb.remapped_dest(0, recovery0[1]), first_user=recovery0[2], last_user=recovery0[3]),
+        _frame(recovery1[0], dest=tb.remapped_dest(1, recovery1[1]), first_user=recovery1[2], last_user=recovery1[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(recovery0[0], dest=recovery0[1], first_user=recovery0[2], last_user=recovery0[3])),
+            (tb.source1, payload_to_beats(recovery1[0], dest=recovery1[1], first_user=recovery1[2], last_user=recovery1[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected, seq=0)
+
+
+@cocotb.test()
+async def bypass_skips_source_and_recovers_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(BYPASS_ADDR, 0b10)
+    await cycle(dut.axisClk, 4)
+
+    data = _frame(bytes(range(0x50, 0x55)), dest=0x08, first_user=0x61, last_user=0xC1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(0, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source0,
+        payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3]),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+    await tb.write(BYPASS_ADDR, 0)
+    await cycle(dut.axisClk, 4)
+
+    recovery0 = _frame(bytes(range(0x60, 0x65)), dest=0x09, first_user=0x71, last_user=0xD1)
+    recovery1 = _frame(bytes(range(0x70, 0x75)), dest=0x0A, first_user=0x81, last_user=0xE1)
+    expected = [
+        _frame(recovery0[0], dest=tb.remapped_dest(0, recovery0[1]), first_user=recovery0[2], last_user=recovery0[3]),
+        _frame(recovery1[0], dest=tb.remapped_dest(1, recovery1[1]), first_user=recovery1[2], last_user=recovery1[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(recovery0[0], dest=recovery0[1], first_user=recovery0[2], last_user=recovery0[3])),
+            (tb.source1, payload_to_beats(recovery1[0], dest=recovery1[1], first_user=recovery1[2], last_user=recovery1[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected, seq=0)
+
+
+@cocotb.test()
+async def routed_transition_frame_preempts_event_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    if tb.mode != "ROUTED":
+        return
+
+    transition = _frame(bytes(range(0x80, 0x85)), dest=tb.trans_tdest, first_user=0x91, last_user=0xF1)
+    blocked = AxisBeat(
+        data=word_from_bytes(bytes(range(0x90, 0x98))),
+        keep=0xFF,
+        last=1,
+        dest=0x01,
+        user=0xA1,
+    )
+    expected = [
+        _frame(transition[0], dest=tb.trans_tdest, first_user=transition[2], last_user=transition[3]),
+    ]
+
+    # Hold source 1 valid to prove the transition path selects only the source
+    # with TRANS_TDEST_G and skips the other input for this event.
+    tb.source1.drive(blocked)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source0,
+        payload_to_beats(transition[0], dest=transition[1], first_user=transition[2], last_user=transition[3]),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+    tb.source1.set_idle()
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(TRANS_CNT_ADDR) == 1
+    assert await tb.read(DATA_CNT_BASE + 0) == 0
+    assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "MODE_G": "INDEXED",
+                "ROUTE_MODE_G": 0,
+                "TRANS_TDEST_G": 255,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="indexed_v2_2src",
+        ),
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "MODE_G": "ROUTED",
+                "ROUTE_MODE_G": 0,
+                "TRANS_TDEST_G": 255,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="routed_v2_2src",
+        ),
+        pytest.param(
+            {
+                "VERSION_G": 2,
+                "MODE_G": "ROUTED",
+                "ROUTE_MODE_G": 1,
+                "TRANS_TDEST_G": 165,
+                "INPUT_PIPE_STAGES_G": 0,
+                "OUTPUT_PIPE_STAGES_G": 1,
+            },
+            id="routed_alt_route_trans",
+        ),
+    ],
+)
+def test_AxiStreamBatcherEventBuilder(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.axistreambatchereventbuilderwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "axi/axi-lite/ip_integrator/SlaveAxiLiteIpIntegrator.vhd",
+                "protocols/batcher/wrappers/AxiStreamBatcherEventBuilderWrapper.vhd",
+            ],
+        },
+    )


### PR DESCRIPTION
### Description
Adds focused cocotb regression coverage for the AXI Stream batcher family, including the batcher data path, AXI-Lite control/status interface, event-builder path, and common/async clock configurations.

### Details
This batcher-focused slice adds thin VHDL wrappers under `protocols/batcher/wrappers/` so cocotb can drive and observe the existing RTL through flattened AXI Stream and AXI-Lite interfaces. The wrappers cover:

- `AxiStreamBatcher`
- `AxiStreamBatcherAxil`
- `AxiStreamBatcherEventBuilder`

The new Python regression support under `tests/protocols/batcher/` adds shared batcher helpers and directed tests for:

- batch formatting, frame boundaries, sequence/count behavior, and payload preservation;
- ready/valid behavior and output frame checking for the core batcher path;
- AXI-Lite register access, control/status behavior, and software-visible batcher configuration;
- event-builder routing/formatting behavior through the wrapper topology;
- common-clock and asynchronous-clock configurations used by the batcher/event-builder paths.

The branch also adds batcher regression planning and handoff notes under `docs/plans/batcher-regression/` and updates the shared RTL regression notes with the batcher progress.

This PR is stacked after #1425 and should be merged after `packetizer-tests` and before `rssi-tests`.

### Related
Depends on #1425. Follow-up stack: #1427.