### PR TITLE
Add CODEOWNERS review requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub requests reviews from CODEOWNERS when matching files change.
+# If path-specific rules are added later, include one of these owners on each
+# rule to keep code-owner review required for every PR into pre-release.
+
+* @bengineerd @slacrherbst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # If path-specific rules are added later, include one of these owners on each
 # rule to keep code-owner review required for every PR into pre-release.
 
-* @bengineerd @slacrherbst
+* @bengineerd @slacrherbst @ruck314


### PR DESCRIPTION
### Description
Add a `.github/CODEOWNERS` file so GitHub can require one of the designated code owners to approve pull requests into `pre-release`.
