### PR TITLE
Reimplement CoaXPress write guard locally (drop rogue addPreWriteListener)

### DIFF
--- a/python/surf/protocols/coaxpress/_Bootstrap.py
+++ b/python/surf/protocols/coaxpress/_Bootstrap.py
@@ -11,9 +11,9 @@
 import pyrogue as pr
 import time
 
-from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+import surf.protocols.coaxpress as cxp
 
-class Bootstrap(WriteGuardMixin, pr.Device):
+class Bootstrap(cxp.WriteGuardMixin, pr.Device):
     def __init__(self, GenDc=False, CoaXPressAxiL=None, **kwargs):
         super().__init__(**kwargs)
 
@@ -24,7 +24,7 @@ class Bootstrap(WriteGuardMixin, pr.Device):
 
         def _write_guard(path, value, state):
             if self._acq_var is not None and self._acq_var.value():
-                raise WriteBlockedError(path, 'cannot write registers during acquisition')
+                raise cxp.WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard)
 

--- a/python/surf/protocols/coaxpress/_Bootstrap.py
+++ b/python/surf/protocols/coaxpress/_Bootstrap.py
@@ -9,24 +9,22 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
-import rogue
 import time
 
-class Bootstrap(pr.Device):
+from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+
+class Bootstrap(WriteGuardMixin, pr.Device):
     def __init__(self, GenDc=False, CoaXPressAxiL=None, **kwargs):
         super().__init__(**kwargs)
-
-        rogue.Version.minVersion('6.13.0')
 
         self.CoaXPressAxiL = CoaXPressAxiL
 
         # Default write guard: no-op until setAcquisitionMonitor() provides a camera.
-        # Uses the pre-write listener API from rogue PR #1229.
         self._acq_var = None
 
         def _write_guard(path, value, state):
             if self._acq_var is not None and self._acq_var.value():
-                raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+                raise WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard)
 
@@ -652,7 +650,7 @@ class Bootstrap(pr.Device):
 
         Call this after the camera device is ready.  The guard checks
         ``camera.IsAcquiring`` before every write and raises
-        ``pr.WriteBlockedError`` if acquisition is in progress.
+        ``WriteBlockedError`` if acquisition is in progress.
         """
         self._acq_var = camera.IsAcquiring
 

--- a/python/surf/protocols/coaxpress/_PhantomS641.py
+++ b/python/surf/protocols/coaxpress/_PhantomS641.py
@@ -10,9 +10,9 @@
 
 import pyrogue as pr
 
-from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+import surf.protocols.coaxpress as cxp
 
-class PhantomS641(WriteGuardMixin, pr.Device):
+class PhantomS641(cxp.WriteGuardMixin, pr.Device):
     def __init__(self, isPhantomS711=False, **kwargs):
         super().__init__(**kwargs)
 
@@ -809,6 +809,6 @@ class PhantomS641(WriteGuardMixin, pr.Device):
             if state.get(self.IsAcquiring.path):
                 name = path.rsplit('.', 1)[-1]
                 if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
-                    raise WriteBlockedError(path, 'cannot write registers during acquisition')
+                    raise cxp.WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_PhantomS641.py
+++ b/python/surf/protocols/coaxpress/_PhantomS641.py
@@ -9,13 +9,13 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
-import rogue
 
-class PhantomS641(pr.Device):
+from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+
+class PhantomS641(WriteGuardMixin, pr.Device):
     def __init__(self, isPhantomS711=False, **kwargs):
         super().__init__(**kwargs)
 
-        rogue.Version.minVersion('6.13.0')
         #############################################################
         # Start of manufacturer-specific register space at 0x00006000
         #############################################################
@@ -805,11 +805,10 @@ class PhantomS641(pr.Device):
 
         # Block all register writes while the camera is acquiring.
         # AcquisitionStart and AcquisitionStop must remain writable to allow stopping.
-        # Uses the pre-write listener API from rogue PR #1229.
         def _write_guard(path, value, state):
             if state.get(self.IsAcquiring.path):
                 name = path.rsplit('.', 1)[-1]
                 if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
-                    raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+                    raise WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_PhantomS991.py
+++ b/python/surf/protocols/coaxpress/_PhantomS991.py
@@ -10,9 +10,9 @@
 
 import pyrogue as pr
 
-from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+import surf.protocols.coaxpress as cxp
 
-class PhantomS991(WriteGuardMixin, pr.Device):
+class PhantomS991(cxp.WriteGuardMixin, pr.Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -662,6 +662,6 @@ class PhantomS991(WriteGuardMixin, pr.Device):
             if state.get(self.IsAcquiring.path):
                 name = path.rsplit('.', 1)[-1]
                 if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
-                    raise WriteBlockedError(path, 'cannot write registers during acquisition')
+                    raise cxp.WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_PhantomS991.py
+++ b/python/surf/protocols/coaxpress/_PhantomS991.py
@@ -9,13 +9,12 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
-import rogue
 
-class PhantomS991(pr.Device):
+from surf.protocols.coaxpress._WriteGuard import WriteGuardMixin, WriteBlockedError
+
+class PhantomS991(WriteGuardMixin, pr.Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        rogue.Version.minVersion('6.13.0')
 
         #############################################################
         # Start of manufacturer-specific register space at 0x00006000
@@ -659,11 +658,10 @@ class PhantomS991(pr.Device):
 
         # Block all register writes while the camera is acquiring.
         # AcquisitionStart and AcquisitionStop must remain writable to allow stopping.
-        # Uses the pre-write listener API from rogue PR #1229.
         def _write_guard(path, value, state):
             if state.get(self.IsAcquiring.path):
                 name = path.rsplit('.', 1)[-1]
                 if name not in ('AcquisitionStart', 'AcquisitionStop', 'IsAcquiring'):
-                    raise pr.WriteBlockedError(path, 'cannot write registers during acquisition')
+                    raise WriteBlockedError(path, 'cannot write registers during acquisition')
 
         self.addPreWriteListener(_write_guard, stateVars=[self.IsAcquiring])

--- a/python/surf/protocols/coaxpress/_WriteGuard.py
+++ b/python/surf/protocols/coaxpress/_WriteGuard.py
@@ -1,0 +1,71 @@
+#-----------------------------------------------------------------------------
+# This file is part of 'SLAC Firmware Standard Library'.
+# It is subject to the license terms in the LICENSE.txt file found in the
+# top-level directory of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of 'SLAC Firmware Standard Library', including this file,
+# may be copied, modified, propagated, or distributed except according to
+# the terms contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+__all__ = ['WriteBlockedError', 'WriteGuardMixin']
+
+class WriteBlockedError(Exception):
+    """Raised by a pre-write listener to block a register write."""
+    def __init__(self, path, msg='cannot write registers during acquisition'):
+        self.path = path
+        super().__init__(f'{path}: {msg}')
+
+
+class WriteGuardMixin:
+    """Device mixin that runs pre-write listeners before interactive register writes.
+
+    Provides device-level pre-write listeners using only the stable
+    Device.writeBlocks() funnel, so it depends on no optional rogue feature and works
+    across rogue releases.
+
+    Mechanism: an interactive ``RemoteVariable.set(write=True)`` routes through
+    ``self._parent.writeBlocks(force=True, recurse=False, variable=self, ...)``. By
+    overriding ``writeBlocks`` we run the registered listeners just before the
+    transaction starts. A listener raises ``WriteBlockedError`` to abort the write.
+
+    Behavior:
+      * Only single interactive writes are guarded (``variable is not None``). Bulk
+        writes (``variable is None``, from writeAll/setYaml/writeBlocks(recurse=True))
+        are NOT guarded, since they do not route through the per-variable
+        set()/setDisp()/post() path.
+      * Posted writes (``RemoteCommand`` via ``cmd.post()``) and ``LocalVariable``
+        writes bypass writeBlocks entirely, so they are inherently allowed. A
+        non-whitelisted posted command issued mid-acquisition is therefore not blocked
+        here; the acquisition start/stop commands are allowed either way, which is the
+        behavior the guard exists to provide.
+
+    Use as the first base class: ``class Foo(WriteGuardMixin, pr.Device)`` so that
+    ``super().writeBlocks(...)`` resolves to ``pr.Device.writeBlocks``.
+    """
+
+    def addPreWriteListener(self, listener, stateVars=None):
+        """Register a pre-write listener.
+
+        Parameters
+        ----------
+        listener : callable
+            Called as ``listener(path, value, state)`` immediately before an
+            interactive write. ``path`` is the variable path, ``value`` is the staged
+            write value, and ``state`` is a dict of ``{var.path: var.value()}`` for
+            each variable in ``stateVars``. Raise ``WriteBlockedError`` to block.
+        stateVars : list, optional
+            Variables whose current values are captured into the ``state`` dict.
+        """
+        if not hasattr(self, '_preWriteListeners'):
+            self._preWriteListeners = []
+        self._preWriteListeners.append((listener, stateVars or []))
+
+    def writeBlocks(self, *, variable=None, **kwargs):
+        listeners = getattr(self, '_preWriteListeners', None)
+        if variable is not None and listeners:
+            value = variable.value()
+            for listener, stateVars in listeners:
+                state = {sv.path: sv.value() for sv in stateVars}
+                listener(variable.path, value, state)
+        super().writeBlocks(variable=variable, **kwargs)

--- a/python/surf/protocols/coaxpress/__init__.py
+++ b/python/surf/protocols/coaxpress/__init__.py
@@ -7,6 +7,7 @@
 ## may be copied, modified, propagated, or distributed except according to
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
+from surf.protocols.coaxpress._WriteGuard    import *
 from surf.protocols.coaxpress._CoaXPressAxiL import *
 from surf.protocols.coaxpress._Bootstrap     import *
 


### PR DESCRIPTION
## Context

rogue is removing `addPreWriteListener()` / `pr.WriteBlockedError` in the next tag cycle ([rogue#1248](https://github.com/slaclab/rogue/pull/1248) reverts [rogue#1229](https://github.com/slaclab/rogue/pull/1229)). The CoaXPress Phantom write guard ([#1417](https://github.com/slaclab/surf/pull/1417)) depends on that API, so it would break (`AttributeError` at device construction) on the upcoming rogue.

This PR reimplements the guard **locally** inside `python/surf/protocols/coaxpress/` so it works on both current and future rogue, with **no behavior change** versus `addPreWriteListener` + rogue v6.13.0.

## What changed

- **New `_WriteGuard.py`**: a local `WriteBlockedError` plus `WriteGuardMixin`, which restores the `addPreWriteListener(cb, stateVars=...)` API by overriding `Device.writeBlocks()` — the funnel through which interactive `RemoteVariable.set(write=True)` routes (`self._parent.writeBlocks(..., variable=self)`).
- **`Bootstrap`, `PhantomS641`, `PhantomS991`** now inherit `WriteGuardMixin`; the `_write_guard(path, value, state)` bodies and `addPreWriteListener(...)` calls are unchanged. `PhantomS711` inherits via `PhantomS641`.
- Removed `rogue.Version.minVersion('6.13.0')` (it gated the now-removed feature) and the orphaned `import rogue`.
- `pr.WriteBlockedError` → local `WriteBlockedError`.

## Behavior parity (matches addPreWriteListener + rogue v6.13.0)

| Write path | Behavior |
|---|---|
| Interactive `var.set()`, non-whitelisted, acquiring | **Blocked** (`variable is not None`) |
| `AcquisitionStart`/`AcquisitionStop` (posted) | Allowed (post bypasses `writeBlocks`) |
| `IsAcquiring` (`LocalVariable`) | Allowed (bypasses `writeBlocks`) |
| Bulk `writeAll` / `setYaml`, acquiring | **Not** guarded |
| Not acquiring | All allowed |