### PR TITLE
Fix AxiStreamDmaRingWrite elaboration for >32-bit AXI address widths

### DIFF
--- a/axi/dma/ip_integrator/AxiStreamDmaRingReadIpIntegrator.vhd
+++ b/axi/dma/ip_integrator/AxiStreamDmaRingReadIpIntegrator.vhd
@@ -23,6 +23,8 @@ use surf.AxiStreamPkg.all;
 use surf.SsiPkg.all;
 
 entity AxiStreamDmaRingReadIpIntegrator is
+   generic (
+      AXI_ADDR_WIDTH_G : positive range 12 to 64 := 16);
    port (
       axilClk         : in  sl;
       axilRst         : in  sl;
@@ -62,7 +64,7 @@ entity AxiStreamDmaRingReadIpIntegrator is
       M_AXIS_TUSER    : out slv(1 downto 0);
       M_AXIS_TREADY   : in  sl;
       M_AXI_ARID      : out slv(0 downto 0);
-      M_AXI_ARADDR    : out slv(15 downto 0);
+      M_AXI_ARADDR    : out slv(AXI_ADDR_WIDTH_G-1 downto 0);
       M_AXI_ARLEN     : out slv(7 downto 0);
       M_AXI_ARSIZE    : out slv(2 downto 0);
       M_AXI_ARBURST   : out slv(1 downto 0);
@@ -101,7 +103,7 @@ architecture rtl of AxiStreamDmaRingReadIpIntegrator is
       tIdBits   => 0);
 
    constant AXI_CONFIG_C : AxiConfigType := axiConfig(
-      ADDR_WIDTH_C => 16,
+      ADDR_WIDTH_C => AXI_ADDR_WIDTH_G,
       DATA_BYTES_C => 4,
       ID_BITS_C    => 1,
       LEN_BITS_C   => 8);
@@ -226,7 +228,7 @@ begin
       generic map (
          EN_ERROR_RESP => true,
          ID_WIDTH      => 1,
-         ADDR_WIDTH    => 16,
+         ADDR_WIDTH    => AXI_ADDR_WIDTH_G,
          DATA_WIDTH    => 32)
       port map (
          M_AXI_ACLK     => axiClk,

--- a/axi/dma/ip_integrator/AxiStreamDmaRingWriteIpIntegrator.vhd
+++ b/axi/dma/ip_integrator/AxiStreamDmaRingWriteIpIntegrator.vhd
@@ -23,6 +23,8 @@ use surf.AxiStreamPkg.all;
 use surf.SsiPkg.all;
 
 entity AxiStreamDmaRingWriteIpIntegrator is
+   generic (
+      AXI_ADDR_WIDTH_G : positive range 12 to 64 := 16);
    port (
       axilClk         : in  sl;
       axilRst         : in  sl;
@@ -69,7 +71,7 @@ entity AxiStreamDmaRingWriteIpIntegrator is
       bufferTriggered : out slv(1 downto 0);
       bufferError     : out slv(1 downto 0);
       M_AXI_AWID      : out slv(0 downto 0);
-      M_AXI_AWADDR    : out slv(15 downto 0);
+      M_AXI_AWADDR    : out slv(AXI_ADDR_WIDTH_G-1 downto 0);
       M_AXI_AWLEN     : out slv(7 downto 0);
       M_AXI_AWSIZE    : out slv(2 downto 0);
       M_AXI_AWBURST   : out slv(1 downto 0);
@@ -112,7 +114,7 @@ architecture rtl of AxiStreamDmaRingWriteIpIntegrator is
       tIdBits   => 0);
 
    constant AXI_CONFIG_C : AxiConfigType := axiConfig(
-      ADDR_WIDTH_C => 16,
+      ADDR_WIDTH_C => AXI_ADDR_WIDTH_G,
       DATA_BYTES_C => 4,
       ID_BITS_C    => 1,
       LEN_BITS_C   => 8);
@@ -239,7 +241,7 @@ begin
       generic map (
          EN_ERROR_RESP => true,
          ID_WIDTH      => 1,
-         ADDR_WIDTH    => 16,
+         ADDR_WIDTH    => AXI_ADDR_WIDTH_G,
          DATA_WIDTH    => 32)
       port map (
          M_AXI_ACLK     => axiClk,

--- a/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
+++ b/axi/dma/rtl/v1/AxiStreamDmaRingWrite.vhd
@@ -487,7 +487,7 @@ begin
                    statusRamDout, trigRamDout) is
       variable v            : RegType;
       variable axilEndpoint : AxiLiteEndpointType;
-      variable endRamSize   : integer;
+      variable endRamSize   : slv(RAM_DATA_WIDTH_C-1 downto 0);
    begin
       v := r;
 
@@ -571,9 +571,11 @@ begin
             -- Writes always start on a BURST_SIZE_BYTES_G boundary, so can drive low dmaReq.address
             -- bits to zero for optimization.
             v.dmaReq.address(AXI_WRITE_CONFIG_G.ADDR_WIDTH_C-1 downto 0) := v.nextAddr;
-            endRamSize                                                   := conv_integer(endRamDout - v.nextAddr);
+            -- Keep the remaining-bytes math in the vector domain: conv_integer
+            -- overflows for address widths wider than 32 bits.
+            endRamSize                                                   := endRamDout - v.nextAddr;
             if FORCE_WRAP_ALIGN_G and endRamSize < BURST_SIZE_BYTES_G then
-               v.dmaReq.maxSize := toSlv(endRamSize, 32);
+               v.dmaReq.maxSize := resize(endRamSize, 32);
             else
                v.dmaReq.maxSize := toSlv(BURST_SIZE_BYTES_G, 32);
             end if;
@@ -596,10 +598,10 @@ begin
                v.ramWe           := '1';  -- write new values into register ram
 
                -- Increment the stored write pointer by the acknowledged byte
-               -- count. Slice the DMA size back down to the local address
-               -- width so the arithmetic stays range-safe for narrower test
-               -- wrappers and smaller address maps.
-               v.nextAddr := r.nextAddr + dmaAck.size(RAM_DATA_WIDTH_C-1 downto 0);
+               -- count. Resize the DMA size to the local address width so the
+               -- arithmetic stays range-safe for both narrower address maps
+               -- (truncate) and wider than 32-bit address maps (zero-pad).
+               v.nextAddr := r.nextAddr + resize(dmaAck.size, RAM_DATA_WIDTH_C);
                if (v.nextAddr = r.endAddr) then
                   v.status(FULL_C) := '1';
                   if (r.mode(DONE_WHEN_FULL_C) = '1') then

--- a/tests/axi/dma/test_AxiStreamDmaRingRead.py
+++ b/tests/axi/dma/test_AxiStreamDmaRingRead.py
@@ -33,7 +33,7 @@ from cocotbext.axi import (
 )
 
 from tests.axi.utils import ring_buffer_axil_addr
-from tests.common.regression_utils import run_surf_vhdl_test, start_lockstep_clocks
+from tests.common.regression_utils import parameter_case, run_surf_vhdl_test, start_lockstep_clocks
 
 
 class TB:
@@ -119,7 +119,15 @@ async def status_driven_ring_read_test(dut):
     assert frame.tdest == 0
 
 
-@pytest.mark.parametrize("parameters", [pytest.param({}, id="buffer0_status_readout")])
+# The wide-address case elaborates the DUT with ADDR_WIDTH_C > 32 so CI catches
+# generic-dependent slice bounds that only fail for wide AXI address maps.
+PARAMETER_SWEEP = [
+    parameter_case("buffer0_status_readout"),
+    parameter_case("wide_addr_33bit", AXI_ADDR_WIDTH_G="33"),
+]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
 def test_AxiStreamDmaRingRead(parameters):
     run_surf_vhdl_test(
         test_file=__file__,

--- a/tests/axi/dma/test_AxiStreamDmaRingWrite.py
+++ b/tests/axi/dma/test_AxiStreamDmaRingWrite.py
@@ -37,7 +37,7 @@ from tests.axi.utils import (
     axil_write_u32,
     ring_buffer_axil_addr,
 )
-from tests.common.regression_utils import run_surf_vhdl_test, start_lockstep_clocks
+from tests.common.regression_utils import parameter_case, run_surf_vhdl_test, start_lockstep_clocks
 
 
 class TB:
@@ -121,7 +121,16 @@ async def configured_buffer_capture_test(dut):
     assert int(dut.bufferTriggered.value) & 0x1
 
 
-@pytest.mark.parametrize("parameters", [pytest.param({}, id="buffer0_capture_done")])
+# The wide-address case elaborates the DUT with ADDR_WIDTH_C > 32, which is the
+# configuration class that exposed generic-dependent slice bounds against the
+# fixed 32-bit dmaAck.size field (Vivado-only failure before this coverage).
+PARAMETER_SWEEP = [
+    parameter_case("buffer0_capture_done"),
+    parameter_case("wide_addr_33bit", AXI_ADDR_WIDTH_G="33"),
+]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
 def test_AxiStreamDmaRingWrite(parameters):
     run_surf_vhdl_test(
         test_file=__file__,


### PR DESCRIPTION
### Description
Fixes a Vivado elaboration failure (`Synth 8-97 array index 32 out of range`) in `AxiStreamDmaRingWrite.vhd` for designs with `AXI_WRITE_CONFIG_G.ADDR_WIDTH_C > 32` (e.g. SMuRF cryo-det with a 33-bit DDR address map), and adds CI coverage so this class of bug fails the GHDL regression in the future.

- `resize(dmaAck.size, RAM_DATA_WIDTH_C)` replaces the slice `dmaAck.size(RAM_DATA_WIDTH_C-1 downto 0)`, which indexed past the fixed 32-bit `dmaAck.size` field whenever the address width exceeded 32 bits.
- `endRamSize` remaining-bytes math now stays in the vector domain: `conv_integer` asserts in simulation when the >32-bit difference exceeds `integer'high` (latent bug exposed by the new wide-address test case).
- `AxiStreamDmaRingWriteIpIntegrator` and `AxiStreamDmaRingReadIpIntegrator` gain an `AXI_ADDR_WIDTH_G` generic (default 16, no behavior change for existing users).
- Both cocotb tests sweep a `wide_addr_33bit` case so GHDL elaborates the `ADDR_WIDTH_C > 32` configuration that previously only Vivado builds reached.

### Details
Generic-dependent slice bounds are legal VHDL at analysis time (`ghdl -a` cannot flag them); they are only checkable at elaboration with the offending generic values. CI previously elaborated the ring DMA wrappers only at `ADDR_WIDTH_C = 16`, so the bug was invisible to the GHDL regression while breaking Vivado builds. The new parameter sweep closes that coverage gap: reverting the RTL fix makes the `wide_addr_33bit` case fail with a bound check at the exact offending line.