### PR TITLE
[CI validation – do not merge to pre-release] selective-test run on BoxcarFilter touch (D-05)

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -159,6 +159,7 @@ jobs:
 
   gen_release:
     needs: [lint, test, docs]
+    if: github.event_name != 'pull_request'
     uses: slaclab/ruckus/.github/workflows/gen_release.yml@main
     with:
       version: '1.0.0'
@@ -169,6 +170,7 @@ jobs:
 
   conda_build_lib:
     needs: [lint, test, docs]
+    if: github.event_name != 'pull_request'
     uses: slaclab/ruckus/.github/workflows/conda_build_lib.yml@main
     with:
       version: '1.0.0'

--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -14,7 +14,11 @@
 # secrets.CONDA_UPLOAD_TOKEN_TAG
 
 name: CI
-on: [push]
+on:
+  push:
+    branches: [main, pre-release]
+    tags: ['**']
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -84,6 +88,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -104,10 +110,20 @@ jobs:
           fi
           python -m pip install -r ruckus/scripts/pip_requirements.txt
 
+      - name: Build dependency index
+        run: |
+          make MODULES=$PWD analysis
+          python scripts/build_test_dependency_index.py
+
       - name: Parallel Regression Tests
         run: |
           make MODULES=$PWD import
-          python -m pytest --cov -v -n auto --dist=worksteal tests/axi tests/base tests/dsp tests/protocols
+          pytest_cmd=$(python scripts/select_tests.py)
+          if [ -z "$pytest_cmd" ]; then
+            echo "No tests selected — skipping pytest (SEL-07)"
+            exit 0
+          fi
+          eval "$pytest_cmd"
 
       - name: Code Coverage
         run: |

--- a/dsp/generic/fixed/BoxcarFilter.vhd
+++ b/dsp/generic/fixed/BoxcarFilter.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Simple boxcar filter
+-- Description: Simple boxcar filter (N-tap moving average with power-of-2 divisor)
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the


### PR DESCRIPTION
Phase 3 / 03-02 D-05 validation PR. Head carries the new surf_ci.yml (selective-test selector) + a one-line non-functional BoxcarFilter.vhd comment touch. Base is the non-integration branch ci/selective-base so classify_ref routes to SELECTIVE. Purpose: demonstrate the selector picks only the BoxcarFilter-dependent test set. This PR is a throwaway validation artifact — not for merge into pre-release/main.