### PR TITLE
[CI validation – do not merge] D-05 selective-test run on BoxcarFilter touch

### DIFF
--- a/dsp/generic/fixed/BoxcarFilter.vhd
+++ b/dsp/generic/fixed/BoxcarFilter.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Simple boxcar filter
+-- Description: Simple boxcar filter (N-tap moving average with power-of-2 divisor)
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the


### PR DESCRIPTION
Phase 3 / 03-02 D-05 validation (rebuilt). Head = ci/selective-base + a single non-functional BoxcarFilter.vhd comment touch. Base ci/selective-base is the feature tip (carries scripts/select_tests.py, scripts/build_test_dependency_index.py, and the rewired surf_ci.yml) on a NON-integration branch so classify_ref → SELECTIVE. Expectation: the test job's selector picks ONLY the BoxcarFilter-dependent test(s). Throwaway validation artifact — do not merge.