### PR TITLE
CI: validate selective-mode test selection (BoxcarFilter leaf diff)

### DIFF
--- a/dsp/generic/fixed/BoxcarFilter.vhd
+++ b/dsp/generic/fixed/BoxcarFilter.vhd
@@ -69,6 +69,6 @@ begin
          obFull   => obFull,
          obPeriod => obPeriod);
 
-   obData <= intData(DATA_WIDTH_G+ADDR_WIDTH_G-1 downto ADDR_WIDTH_G);  -- Truncate the integrator output (power of 2 divide)
+   obData <= intData(DATA_WIDTH_G+ADDR_WIDTH_G-1 downto ADDR_WIDTH_G);  -- Truncate the integrator output (power of 2 divide) [ci-validate]
 
 end mapping;


### PR DESCRIPTION
Temporary validation PR — DO NOT MERGE.

Exercises the Phase 3 selective test selector with a clean single-file leaf diff
(BoxcarFilter.vhd only) against ci/selective-base.

Expected in the 'Regression Tests > Parallel Regression Tests' step (stderr):
  INFO: classify_ref -> selective (event='pull_request' ... base_ref='ci/selective-base')
  INFO: selective: base_ref='ci/selective-base' changed_vhd=1 selected_tests=82

Expected result: selective subset (~82 files: test_BoxcarFilter.py + always_run),
NOT the full 653-item suite, and the two dependency-index proof tests now PASS
(they run via always_run and load the pre-built index instead of rebuilding it
post 'make import').

Validates: fix(03-01) prebuilt-index proof + feat(03-01) selector diagnostics.