### PR TITLE
CI: validate selective test selection (BoxcarFilter leaf, D-05)

### DIFF
--- a/dsp/generic/fixed/BoxcarFilter.vhd
+++ b/dsp/generic/fixed/BoxcarFilter.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Simple boxcar filter
+-- Description: Simple boxcar filter (CI selective-test validation touch)
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the


### PR DESCRIPTION
Phase 03-02 live validation of selective CI test execution.

A single non-functional comment touch to `dsp/generic/fixed/BoxcarFilter.vhd` is the only production `.vhd` change vs the non-integration base `ci/selective-base`, so `select_tests.py` should resolve it to the BoxcarFilter-dependent test set and run a **narrow** suite.

Expected on the `test` job:
- Triggered by `pull_request`
- `make analysis` -> build dependency index -> `make import` -> selector, no base-unreachable error (fetch-depth:0)
- Selector picks only the BoxcarFilter set (incl. `tests/dsp/generic/test_BoxcarFilter.py`), NOT the full suite
- pytest invocation preserves `--cov -v -n auto --dist=worksteal`
- `gen_release` / `conda_build_lib` do NOT run (PR event gate)
- Job green

Validates SEL-01, SEL-09, and Success Criteria 1/3/4. Do not merge into protected refs as-is.