### PR TITLE
Use newline delimiter in Si5394/Si5345 CSV-to-MEM scripts for Vivado 2026.1 $readmemh

### DIFF
--- a/scripts/Si5345ConvertCsvToMem.py
+++ b/scripts/Si5345ConvertCsvToMem.py
@@ -47,7 +47,7 @@ cnt = 0
 ofd = open(args.memPath, 'w')
 
 # Power down during the configuration load
-ofd.write('001E' + '01' + ',')
+ofd.write('001E' + '01' + '\n')
 cnt = cnt + 1
 
 # Open the .CSV file
@@ -59,25 +59,25 @@ with open(args.csvFile) as csvfile:
         if (row[0]!='Address'):
             offset = row[0]
             data   = row[1]
-            ofd.write(offset[2:] + data[2:] + ',')
+            ofd.write(offset[2:] + data[2:] + '\n')
             cnt = cnt + 1
 
 # Execute the Page5.BW_UPDATE_PLL command
-ofd.write('0514' + '01' + ',')
-ofd.write('0514' + '00' + ',')
+ofd.write('0514' + '01' + '\n')
+ofd.write('0514' + '00' + '\n')
 cnt = cnt + 2
 
 # Power Up after the configuration load
-ofd.write('001E' + '00' + ',')
+ofd.write('001E' + '00' + '\n')
 cnt = cnt + 1
 
 # Clear the internal error flags
-ofd.write('0011' + '01' + ',')
+ofd.write('0011' + '01' + '\n')
 cnt = cnt + 1
 
 # Fill the reset of the BRAM with zeros
 for i in range(1024-cnt):
-    ofd.write('0000' + '00' + ',')
+    ofd.write('0000' + '00' + '\n')
     cnt = cnt + 1
 
 # Close the file

--- a/scripts/Si5394ConvertCsvToMem.py
+++ b/scripts/Si5394ConvertCsvToMem.py
@@ -50,9 +50,9 @@ ofd = open(args.memPath, 'w')
 # 0x0B25,0x00
 # 0x0540,0x01
 ##############################
-ofd.write('0B24' + 'C0' + ',')
-ofd.write('0B25' + '00' + ',')
-ofd.write('0540' + '01' + ',')
+ofd.write('0B24' + 'C0' + '\n')
+ofd.write('0B25' + '00' + '\n')
+ofd.write('0540' + '01' + '\n')
 cnt = 3 # Init the counter
 
 #######################################################################
@@ -64,7 +64,7 @@ cnt = 3 # Init the counter
 #######################################################################
 #    0xFFFFFF is special code in firmware boot ROM to wait 625 ms
 #######################################################################
-ofd.write('FFFFFF' + ',')
+ofd.write('FFFFFF' + '\n')
 cnt = cnt + 1
 
 # Open the .CSV file
@@ -76,7 +76,7 @@ with open(args.csvFile) as csvfile:
         if (row[0]!='Address'):
             offset = row[0]
             data   = row[1]
-            ofd.write(offset[2:] + data[2:] + ',')
+            ofd.write(offset[2:] + data[2:] + '\n')
             cnt = cnt + 1
 
 ###############################
@@ -88,16 +88,16 @@ with open(args.csvFile) as csvfile:
 # 0x0B24,0xC3
 # 0x0B25,0x02
 ###############################
-ofd.write('0514' + '01' + ',')
-ofd.write('001C' + '01' + ',')
-ofd.write('0540' + '00' + ',')
-ofd.write('0B24' + 'C3' + ',')
-ofd.write('0B25' + '02' + ',')
+ofd.write('0514' + '01' + '\n')
+ofd.write('001C' + '01' + '\n')
+ofd.write('0540' + '00' + '\n')
+ofd.write('0B24' + 'C3' + '\n')
+ofd.write('0B25' + '02' + '\n')
 cnt = cnt + 5
 
 # Fill the reset of the BRAM with zeros
 for i in range(1024-cnt):
-    ofd.write('0000' + '00' + ',')
+    ofd.write('0000' + '00' + '\n')
 
 # Close the file
 ofd.close()


### PR DESCRIPTION
## Problem
Vivado 2026.1's `$readmemh` parser (used by `xpm_memory` to initialize BRAM via `MEMORY_INIT_FILE`) is stricter than prior versions and rejects the comma separator in the generated `.mem` files as an illegal hex digit:

```
error in $readmem data: usage of illegal digit [.../xpm/xpm_memory/hdl/xpm_memory.sv:1226]
failed synthesizing module 'xpm_memory_base'
failed synthesizing module 'SimpleDualPortRamXpm'
failed synthesizing module 'Si5394I2cCore'
```

Older Vivado (≤2025.1) tolerated the commas; 2026.1 does not.

## Fix
`Si5394ConvertCsvToMem.py` and `Si5345ConvertCsvToMem.py` now emit one token per line (IEEE 1800 whitespace-delimited) instead of a single comma-separated line. This loads correctly across all Vivado versions. The token contents are unchanged, so regenerated `.mem` files are byte-identical except for the delimiter.

Downstream `.mem` files (e.g. in axi-pcie-core) must be regenerated from their `.csv` sources with these updated scripts.
