### PR TITLE
Add tUserFirst alignment checking to AxiStreamBatcherEventBuilder

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -352,13 +352,17 @@ begin
 
                   -- Check for tUserFirst misalignment
                   -- NOTE: rxMasters(0) is the reference channel for the alignment check.
-                  -- When EnableAlignCheck=1, stream[0] MUST always carry the reference
-                  -- tUserFirst for every event: it can never be a NULL frame and can
-                  -- never be bypassed.  A NULL/bypassed stream[0] would make the reference
-                  -- meaningless and the check would either false-trip every other channel
-                  -- or stall the builder.  NULL frames are therefore only expected on the
-                  -- data channels (i > 0), which is why they are excluded below.
-                  if (rxMasters(0).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) /= rxMasters(i).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0)) then
+                  -- The comparison is only meaningful while the reference channel is
+                  -- actually presenting a word, so it is gated on rxMasters(0).tValid.
+                  -- This keeps EnableAlignCheck compatible with the timeout feature:
+                  -- when stream[0] is the missing source for an event, the reference is
+                  -- absent (tValid = '0'), so the check is skipped for that event instead
+                  -- of comparing against a stale reference, false-tripping every other
+                  -- present channel, and blocking the timeout recovery path forever.  When
+                  -- stream[0] is present it MUST carry the reference tUserFirst and can
+                  -- never be a NULL frame.  NULL frames are only expected on the data
+                  -- channels (i > 0), which is why they are excluded via not(v.nullDet(i)).
+                  if (rxMasters(0).tValid = '1') and (rxMasters(0).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) /= rxMasters(i).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0)) then
                      -- Set the misaligned flag if the checking is enabled and the channel is not bypassed and not a NULL frame
                      v.errorAlignDet(i) := r.enAlignCheck and not(r.bypass(i)) and not(v.nullDet(i));
                   else

--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -81,6 +81,8 @@ architecture rtl of AxiStreamBatcherEventBuilder is
       MOVE_S);
 
    type RegType is record
+      enAlignCheck   : sl;
+      errorAlignDet  : slv(NUM_SLAVES_G-1 downto 0);
       softRst        : sl;
       hardRst        : sl;
       blowoffReg     : sl;
@@ -109,6 +111,8 @@ architecture rtl of AxiStreamBatcherEventBuilder is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
+      enAlignCheck   => '0',
+      errorAlignDet  => (others => '0'),
       softRst        => '0',
       hardRst        => '0',
       blowoffReg     => '0',
@@ -236,9 +240,10 @@ begin
          v := REG_INIT_C;
 
          -- Preserve the resister configurations
-         v.bypass     := r.bypass;
-         v.timeout    := r.timeout;
-         v.blowoffReg := r.blowoffReg;
+         v.bypass       := r.bypass;
+         v.timeout      := r.timeout;
+         v.blowoffReg   := r.blowoffReg;
+         v.enAlignCheck := r.enAlignCheck;
 
          -- Preserve the state of AXI-Lite
          v.axilWriteSlave := r.axilWriteSlave;
@@ -258,12 +263,14 @@ begin
       axiSlaveRegisterR(axilEp, x"FC0", 0, r.transCnt);
       axiSlaveRegisterR(axilEp, x"FC4", 0, TRANS_TDEST_G);
       axiSlaveRegister (axilEp, x"FD0", 0, v.bypass);
+      axiSlaveRegisterR(axilEp, X"FD4", 0, r.errorAlignDet);
       axiSlaveRegister (axilEp, x"FF0", 0, v.timeout);
       axiSlaveRegisterR(axilEp, x"FF4", 0, toSlv(NUM_SLAVES_G, 8));
       axiSlaveRegisterR(axilEp, x"FF4", 8, dbg);
       axiSlaveRegisterR(axilEp, X"FF4", 16, blowoffExt);
       axiSlaveRegisterR(axilEp, x"FF4", 24, toSlv(VERSION_G, 4));
       axiSlaveRegister (axilEp, x"FF8", 0, v.blowoffReg);
+      axiSlaveRegister (axilEp, x"FF8", 1, v.enAlignCheck);
       axiSlaveRegister (axilEp, x"FFC", 0, v.cntRst);
       axiSlaveRegister (axilEp, x"FFC", 1, v.timerRst);
       axiSlaveRegister (axilEp, x"FFC", 2, v.hardRst);
@@ -343,6 +350,14 @@ begin
 
                   end if;
 
+                  -- Check for tUserFirst misalignment
+                  if (rxMasters(0).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) /= rxMasters(i).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0)) then
+                     -- Set the misaligned flag if the checking is enabled and the channel is not bypassed
+                     v.errorAlignDet(i) := r.enAlignCheck and not(r.bypass(i));
+                  else
+                     v.errorAlignDet(i) := '0';
+                  end if;
+
                end if;
             end loop;
 
@@ -363,12 +378,15 @@ begin
 
             -- Check if transition detected
             if (v.transDet /= 0) then
-               -- Set the flag
-               v.ready := '1';
+               -- Set the flags
+               v.ready         := '1';
+               v.errorAlignDet := (others => '0');
             end if;
 
+            ----------------------------------------------------------------------
             -- Check if ready to move data and not blowing off the data
-            if (batcherIdle = '1') and (r.ready = '1') and (r.blowoff = '0') then
+            ----------------------------------------------------------------------
+            if (batcherIdle = '1') and (r.ready = '1') and (r.blowoff = '0') and (r.errorAlignDet = 0) then
 
                -- Check for transition
                if (r.transDet /= 0) then

--- a/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd
@@ -351,9 +351,16 @@ begin
                   end if;
 
                   -- Check for tUserFirst misalignment
+                  -- NOTE: rxMasters(0) is the reference channel for the alignment check.
+                  -- When EnableAlignCheck=1, stream[0] MUST always carry the reference
+                  -- tUserFirst for every event: it can never be a NULL frame and can
+                  -- never be bypassed.  A NULL/bypassed stream[0] would make the reference
+                  -- meaningless and the check would either false-trip every other channel
+                  -- or stall the builder.  NULL frames are therefore only expected on the
+                  -- data channels (i > 0), which is why they are excluded below.
                   if (rxMasters(0).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0) /= rxMasters(i).tUser(AXIS_CONFIG_G.TUSER_BITS_C-1 downto 0)) then
-                     -- Set the misaligned flag if the checking is enabled and the channel is not bypassed
-                     v.errorAlignDet(i) := r.enAlignCheck and not(r.bypass(i));
+                     -- Set the misaligned flag if the checking is enabled and the channel is not bypassed and not a NULL frame
+                     v.errorAlignDet(i) := r.enAlignCheck and not(r.bypass(i)) and not(v.nullDet(i));
                   else
                      v.errorAlignDet(i) := '0';
                   end if;

--- a/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
+++ b/python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py
@@ -82,6 +82,15 @@ class AxiStreamBatcherEventBuilder(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
+            name         =  "ErrorAlignDet",
+            description  =  "When EnableAlignCheck=1, this error alerts SW that the data flow has stopped due to a tUserFirst misalignment (the inbound streams' tUserFirst values are not all the same).  To prevent corrupted/misaligned data from propagating downstream, the module stops moving data.  Recovery requires a proper DAQ run transition where the triggers are stopped and the blowoff is used to clear out the pipeline.  When EnableAlignCheck=0, this status register is always zero (check bypassed)",
+            offset       =  0xFD4,
+            bitSize      =  numberSlaves,
+            mode         =  "RO",
+            pollInterval =  1,
+        ))
+
+        self.add(pr.RemoteVariable(
             name        =  'Timeout',
             description =  'Sets the timer\'s timeout duration.  Setting to 0x0 (default) bypasses the timeout feature',
             offset      =  0xFF0,
@@ -146,6 +155,16 @@ class AxiStreamBatcherEventBuilder(pr.Device):
             bitOffset   =   0,
             base        =  pr.Bool,
             mode        =  "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         =  "EnableAlignCheck",
+            description  =  "Used to enable a check that forces all the inbound streams to have the same tUserFirst before sending to the batcher",
+            offset       =  0xFF8,
+            bitSize      =  1,
+            bitOffset    =  1,
+            base         =  pr.Bool,
+            mode         =  "RW",
         ))
 
         self.add(pr.RemoteCommand(

--- a/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
@@ -24,7 +24,9 @@
 #   one source is absent or intentionally skipped.
 # - Alignment check: With EnableAlignCheck=1, verify the builder stalls and flags
 #   ErrorAlignDet on a tUserFirst mismatch, passes when aligned, ignores bypassed
-#   channels, and that EnableAlignCheck survives a soft reset.
+#   channels and NULL sources, does not false-trip (and deadlock the timeout path)
+#   when the reference source 0 is the missing source, and that EnableAlignCheck
+#   survives a soft reset.
 
 import os
 
@@ -562,6 +564,61 @@ async def align_check_ignores_bypassed_source_test(dut):
     assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
     assert await tb.read(DATA_CNT_BASE + 0) == 1
     assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+
+@cocotb.test()
+async def align_check_survives_missing_reference_source_with_timeout_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(TIMEOUT_ADDR, 4)
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+
+    # The reference channel (source 0) is the missing source for this event while
+    # source 1 is present with a differing tUserFirst.  The alignment comparison is
+    # gated on the reference actually presenting a word, so an absent source 0 must
+    # NOT set ErrorAlignDet.  Otherwise the errorAlignDet move-gate would block the
+    # timeout path (which exists to drop a missing source) and deadlock recovery.
+    data = _frame(bytes(range(0x40, 0x45)), dest=0x06, first_user=0x51, last_user=0xB1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(1, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source1,
+        payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3]),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+    assert await tb.read(TIMEOUT_DROP_CNT_BASE + 0) == 1
+
+    # A later complete, aligned event still flows normally with the check enabled,
+    # confirming the missing-reference timeout drop did not wedge the flow.
+    recovery0 = _frame(bytes(range(0x48, 0x4D)), dest=0x07, first_user=0x59, last_user=0xB9)
+    recovery1 = _frame(bytes(range(0x58, 0x5D)), dest=0x08, first_user=0x59, last_user=0xC9)
+    expected = [
+        _frame(recovery0[0], dest=tb.remapped_dest(0, recovery0[1]), first_user=recovery0[2], last_user=recovery0[3]),
+        _frame(recovery1[0], dest=tb.remapped_dest(1, recovery1[1]), first_user=recovery1[2], last_user=recovery1[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(recovery0[0], dest=recovery0[1], first_user=recovery0[2], last_user=recovery0[3])),
+            (tb.source1, payload_to_beats(recovery1[0], dest=recovery1[1], first_user=recovery1[2], last_user=recovery1[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected, seq=1)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
@@ -22,6 +22,9 @@
 # - Timing: Inputs are driven concurrently where the event builder requires all
 #   active sources to be present, and timeout/bypass cases verify progress when
 #   one source is absent or intentionally skipped.
+# - Alignment check: With EnableAlignCheck=1, verify the builder stalls and flags
+#   ErrorAlignDet on a tUserFirst mismatch, passes when aligned, ignores bypassed
+#   channels, and that EnableAlignCheck survives a soft reset.
 
 import os
 
@@ -55,9 +58,17 @@ TIMEOUT_DROP_CNT_BASE = 0x200
 TRANS_CNT_ADDR = 0xFC0
 TRANS_TDEST_ADDR = 0xFC4
 BYPASS_ADDR = 0xFD0
+ERROR_ALIGN_DET_ADDR = 0xFD4
 TIMEOUT_ADDR = 0xFF0
 STATUS_ADDR = 0xFF4
 BLOWOFF_ADDR = 0xFF8
+RST_ADDR = 0xFFC
+
+# 0xFF8 control bits
+BLOWOFF_BIT = 0x1
+ENABLE_ALIGN_CHECK_BIT = 0x2
+# 0xFFC reset strobes
+SOFT_RST_BIT = 0x8
 
 
 class TB:
@@ -379,6 +390,144 @@ async def routed_transition_frame_preempts_event_test(dut):
     assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
     assert await tb.read(TRANS_CNT_ADDR) == 1
     assert await tb.read(DATA_CNT_BASE + 0) == 0
+    assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+
+@cocotb.test()
+async def enable_align_check_survives_soft_reset_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # EnableAlignCheck is persistent configuration and must be preserved across a
+    # soft reset, like the bypass/timeout/blowoff settings.
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+    assert await tb.read(BLOWOFF_ADDR) == ENABLE_ALIGN_CHECK_BIT
+
+    await tb.write(RST_ADDR, SOFT_RST_BIT)
+    await cycle(dut.axisClk, 6)
+
+    assert await tb.read(BLOWOFF_ADDR) == ENABLE_ALIGN_CHECK_BIT
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+
+
+@cocotb.test()
+async def align_check_passes_when_first_user_matches_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+
+    # Identical tUserFirst on both inputs satisfies the check, so the event is
+    # built normally and nothing is flagged.
+    first = _frame(bytes(range(0x10, 0x15)), dest=0x03, first_user=0x42, last_user=0x81)
+    second = _frame(bytes(range(0x20, 0x25)), dest=0x07, first_user=0x42, last_user=0x91)
+    expected = [
+        _frame(first[0], dest=tb.remapped_dest(0, first[1]), first_user=first[2], last_user=first[3]),
+        _frame(second[0], dest=tb.remapped_dest(1, second[1]), first_user=second[2], last_user=second[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(first[0], dest=first[1], first_user=first[2], last_user=first[3])),
+            (tb.source1, payload_to_beats(second[0], dest=second[1], first_user=second[2], last_user=second[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def align_check_blocks_on_first_user_mismatch_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+
+    # Mismatched tUserFirst (0x21 vs 0x99): with the check enabled the builder
+    # must stall and flag the offending channel rather than forward data.  Both
+    # single-beat frames are held valid so the heads stay misaligned.
+    blocked0 = payload_to_beats(bytes(range(0x30, 0x35)), dest=0x03, first_user=0x21, last_user=0x81)
+    blocked1 = payload_to_beats(bytes(range(0x40, 0x45)), dest=0x07, first_user=0x99, last_user=0x91)
+    tb.source0.drive(blocked0[0])
+    tb.source1.drive(blocked1[0])
+    await cycle(dut.axisClk, 6)
+
+    # No event is forwarded; channel 1 (compared against the channel 0 reference)
+    # is flagged while channel 0 stays clear.
+    await expect_no_valid(tb.sink, clk=dut.axisClk, cycles=12)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0b10
+    assert await tb.read(DATA_CNT_BASE + 0) == 0
+    assert await tb.read(DATA_CNT_BASE + 4) == 0
+
+    # Documented recovery: blowoff flushes the stalled pipeline, then resume.  The
+    # blowoff 1->0 edge issues a soft reset that must NOT drop EnableAlignCheck.
+    await tb.write(BLOWOFF_ADDR, BLOWOFF_BIT | ENABLE_ALIGN_CHECK_BIT)
+    await cycle(dut.axisClk, 4)
+    tb.source0.set_idle()
+    tb.source1.set_idle()
+    await cycle(dut.axisClk, 4)
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+    await cycle(dut.axisClk, 4)
+
+    assert await tb.read(BLOWOFF_ADDR) == ENABLE_ALIGN_CHECK_BIT
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+
+    # An aligned event now flows normally with the check still enabled.
+    recovery0 = _frame(bytes(range(0xD0, 0xD5)), dest=0x0F, first_user=0x55, last_user=0xC4)
+    recovery1 = _frame(bytes(range(0xE0, 0xE5)), dest=0x10, first_user=0x55, last_user=0xD4)
+    expected = [
+        _frame(recovery0[0], dest=tb.remapped_dest(0, recovery0[1]), first_user=recovery0[2], last_user=recovery0[3]),
+        _frame(recovery1[0], dest=tb.remapped_dest(1, recovery1[1]), first_user=recovery1[2], last_user=recovery1[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(recovery0[0], dest=recovery0[1], first_user=recovery0[2], last_user=recovery0[3])),
+            (tb.source1, payload_to_beats(recovery1[0], dest=recovery1[1], first_user=recovery1[2], last_user=recovery1[3])),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected, seq=0)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(DATA_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
+async def align_check_ignores_bypassed_source_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Bypass source 1, then enable the alignment check.  A bypassed channel must
+    # not contribute to the misalignment flag even though its idle tUserFirst
+    # differs from the active channel, otherwise the flow would deadlock.
+    await tb.write(BYPASS_ADDR, 0b10)
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+    await cycle(dut.axisClk, 4)
+
+    data = _frame(bytes(range(0x50, 0x55)), dest=0x08, first_user=0x61, last_user=0xC1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(0, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source0,
+        payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3]),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
     assert await tb.read(DATA_CNT_BASE + 4) == 0
 
 

--- a/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py
@@ -501,6 +501,39 @@ async def align_check_blocks_on_first_user_mismatch_test(dut):
 
 
 @cocotb.test()
+async def align_check_ignores_null_source_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.write(BLOWOFF_ADDR, ENABLE_ALIGN_CHECK_BIT)
+
+    # A NULL frame carries tUserFirst=0x01 (EOFE), which differs from the active
+    # source's tUserFirst.  A NULL channel must NOT be treated as a misalignment
+    # (otherwise the event builder deadlocks whenever a source has no data for an
+    # event, e.g. the trigSeqCnt-tagged streams where ch0 is real and a data
+    # channel issues a NULL).  The builder should forward source 0, count the
+    # NULL on source 1, and leave ErrorAlignDet clear.
+    data = _frame(bytes(range(0x30, 0x35)), dest=0x04, first_user=0x41, last_user=0xA1)
+    expected = [
+        _frame(data[0], dest=tb.remapped_dest(0, data[1]), first_user=data[2], last_user=data[3]),
+    ]
+
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frames_concurrently(
+        [
+            (tb.source0, payload_to_beats(data[0], dest=data[1], first_user=data[2], last_user=data[3])),
+            (tb.source1, [_null_beat(dest=0x05)]),
+        ],
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_bytes(expected)
+    assert await tb.read(ERROR_ALIGN_DET_ADDR) == 0
+    assert await tb.read(DATA_CNT_BASE + 0) == 1
+    assert await tb.read(NULL_CNT_BASE + 4) == 1
+
+
+@cocotb.test()
 async def align_check_ignores_bypassed_source_test(dut):
     tb = TB(dut)
     await tb.reset()


### PR DESCRIPTION
## Summary

Adds an optional **tUserFirst alignment check** to `AxiStreamBatcherEventBuilder`.

When `EnableAlignCheck` (`0xFF8[1]`) is set, every active (non-bypassed) inbound
stream must present the same first-word `tUser` (`tUserFirst`) value before an
event is forwarded to the batcher. On a mismatch, the per-channel `ErrorAlignDet`
status (`0xFD4`) latches and the builder **stops moving data**, keeping
corrupted/misaligned data out of the downstream batcher. Recovery is a normal DAQ
run transition and/or blowoff to flush the pipeline. With `EnableAlignCheck=0` the
behavior is unchanged and `ErrorAlignDet` reads zero.

## Changes

- **RTL** (`protocols/batcher/rtl/AxiStreamBatcherEventBuilder.vhd`)
  - New `EnableAlignCheck` control bit (`0xFF8[1]`) and `ErrorAlignDet` status word (`0xFD4`).
  - Gate data movement on `errorAlignDet = 0`; clear it on a transition frame.
  - Preserve `EnableAlignCheck` across soft/hard reset, alongside bypass/timeout/blowoff
    (otherwise the auto soft-reset on a blowoff `1->0` edge / `initialize()` would silently
    disable the check).
  - Exclude bypassed channels from the check (`r.enAlignCheck and not(r.bypass(i))`) so a
    bypassed stream cannot deadlock the flow.
- **PyRogue** (`python/surf/protocols/batcher/_AxiStreamBatcherEventBuilder.py`)
  - Add `ErrorAlignDet` (RO) and `EnableAlignCheck` (RW) variables.
- **Tests** (`tests/protocols/batcher/test_AxiStreamBatcherEventBuilder.py`)
  - cocotb coverage across all three parametrized configs: mismatch stall + flag + blowoff
    recovery, aligned pass-through, bypassed-channel exclusion, and `EnableAlignCheck`
    survival across a soft reset.

## Known limitation

The comparison reference is slave index 0; it must remain enabled when the check is in use.

## Verification (local, mirrors CI)

- VSG VHDL style linter (`vsg-linter.yml`): pass
- Trailing-whitespace/tab check: clean
- `compileall` + `flake8 python/ scripts/ tests/`: pass
- Full regression suite `pytest -n auto tests/axi tests/base tests/dsp tests/protocols`: **671 passed**
