### PR TITLE
Add RAM backend selectors to dual-port RAM wrappers

### DIFF
--- a/axi/axi-lite/rtl/AxiDualPortRam.vhd
+++ b/axi/axi-lite/rtl/AxiDualPortRam.vhd
@@ -6,10 +6,10 @@
 --
 -- Supported RAM memory configurations:
 --
---    SYNTH_MODE_G     |    MEMORY_TYPE_G   | READ_LATENCY_G
--- "XPM" or "inferred" | "block" or "ultra" |      1 ~ 3
---       "XPM"         |  "distributed"     |      0 ~ 3
---       "inferred"    |  "distributed"     |      0 ~ 1
+--    SYNTH_MODE_G                 |    MEMORY_TYPE_G   | READ_LATENCY_G
+-- "xpm", "altera_mf", "inferred" | "block" or "ultra" |      1 ~ 3
+--       "xpm"                     |  "distributed"     |      0 ~ 3
+--       "inferred"                |  "distributed"     |      0 ~ 1
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the

--- a/axi/axi-lite/rtl/AxiDualPortRam.vhd
+++ b/axi/axi-lite/rtl/AxiDualPortRam.vhd
@@ -3,6 +3,13 @@
 -------------------------------------------------------------------------------
 -- Description: A wrapper of StdLib DualPortRam that places an AxiLite
 -- interface on the read/write port.
+--
+-- Supported RAM memory configurations:
+--
+--    SYNTH_MODE_G     |    MEMORY_TYPE_G   | READ_LATENCY_G
+-- "XPM" or "inferred" | "block" or "ultra" |      1 ~ 3
+--       "XPM"         |  "distributed"     |      0 ~ 3
+--       "inferred"    |  "distributed"     |      0 ~ 1
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -82,6 +89,8 @@ architecture rtl of AxiDualPortRam is
    constant RAM_WIDTH_C      : natural := ADDR_AXI_WORDS_C*32;
    constant STRB_WIDTH_C     : natural := minimum(4, ADDR_AXI_BYTES_C);
 
+   constant RAM_READ_LATENCY_C : natural := ite(SYNTH_MODE_G = "xpm", READ_LATENCY_G, ite(READ_LATENCY_G >= 2, 2, 1));
+
    type StateType is (
       IDLE_S,
       RD_S);
@@ -118,87 +127,50 @@ architecture rtl of AxiDualPortRam is
 
 begin
 
-   ------------------------------------------------------------
-   --       Supported RAM memory configurations
-   ------------------------------------------------------------
-   --    SYNTH_MODE_G     |    MEMORY_TYPE_G   | READ_LATENCY_G
-   ------------------------------------------------------------
-   -- "XPM" or "inferred" | "block" or "ultra" |      1 ~ 3
-   ------------------------------------------------------------
-   --       "XPM"         |  "distributed"     |      0 ~ 3
-   ------------------------------------------------------------
-   --       "inferred"    |  "distributed"     |      0 ~ 1
-   ------------------------------------------------------------
    assert
       (MEMORY_TYPE_G /= "distributed" and (READ_LATENCY_G >= 1 and READ_LATENCY_G      <= 3)) or
       (SYNTH_MODE_G = "xpm" and MEMORY_TYPE_G = "distributed" and (READ_LATENCY_G      <= 3)) or
       (SYNTH_MODE_G = "inferred" and MEMORY_TYPE_G = "distributed" and (READ_LATENCY_G <= 1))
       report "RAM memory configuration not supported" severity failure;
 
-   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-      U_RAM : entity surf.TrueDualPortRamXpm
+   GEN_VENDOR : if (SYNTH_MODE_G /= "inferred") generate
+      U_RAM : entity surf.TrueDualPortRam
          generic map (
             TPD_G               => TPD_G,
             RST_POLARITY_G      => RST_POLARITY_G,
+            SYNTH_MODE_G        => SYNTH_MODE_G,
             COMMON_CLK_G        => COMMON_CLK_G,
             MEMORY_TYPE_G       => MEMORY_TYPE_G,
             MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE_G,
             MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
-            WRITE_MODE_G        => ite(MEMORY_TYPE_G = "distributed", "read_first", "no_change"),
-            READ_LATENCY_G      => READ_LATENCY_G,
+            MODE_G              => ite(MEMORY_TYPE_G = "distributed", "read-first", "no-change"),
+            READ_LATENCY_G      => RAM_READ_LATENCY_C,
+            READ_LATENCY_A_G    => RAM_READ_LATENCY_C,
+            READ_LATENCY_B_G    => RAM_READ_LATENCY_C,
             DATA_WIDTH_G        => DATA_WIDTH_G,
             BYTE_WR_EN_G        => true,
             BYTE_WIDTH_G        => 8,
             ADDR_WIDTH_G        => ADDR_WIDTH_G)
          port map (
             -- Port A
-            clka  => axiClk,
-            ena   => '1',
-            wea   => r.axiWrStrobe(ADDR_AXI_BYTES_C-1 downto 0),
-            rsta  => NOT_RST_C,
-            addra => r.axiAddr,
-            dina  => axiWrDataFanout(DATA_WIDTH_G-1 downto 0),
-            douta => axiDout(DATA_WIDTH_G-1 downto 0),
+            clka    => axiClk,
+            ena     => '1',
+            wea     => '1',
+            weaByte => r.axiWrStrobe(ADDR_AXI_BYTES_C-1 downto 0),
+            rsta    => NOT_RST_C,
+            addra   => r.axiAddr,
+            dina    => axiWrDataFanout(DATA_WIDTH_G-1 downto 0),
+            douta   => axiDout(DATA_WIDTH_G-1 downto 0),
             -- Port B
-            clkb  => clk,
-            enb   => en,
-            web   => weByteMask,
-            rstb  => NOT_RST_C,
-            addrb => addr,
-            dinb  => din,
-            doutb => doutInt);
-   end generate;
-
-   GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
-      U_RAM : entity surf.TrueDualPortRamAlteraMf
-         generic map (
-            TPD_G          => TPD_G,
-            RST_POLARITY_G => RST_POLARITY_G,
-            COMMON_CLK_G   => COMMON_CLK_G,
-            MEMORY_TYPE_G  => MEMORY_TYPE_G,
-            READ_LATENCY_G => READ_LATENCY_G,
-            DATA_WIDTH_G   => DATA_WIDTH_G,
-            BYTE_WR_EN_G   => true,
-            BYTE_WIDTH_G   => 8,
-            ADDR_WIDTH_G   => ADDR_WIDTH_G)
-         port map (
-            -- Port A
-            clka  => axiClk,
-            ena   => '1',
-            wea   => r.axiWrStrobe(ADDR_AXI_BYTES_C-1 downto 0),
-            rsta  => NOT_RST_C,
-            addra => r.axiAddr,
-            dina  => axiWrDataFanout(DATA_WIDTH_G-1 downto 0),
-            douta => axiDout(DATA_WIDTH_G-1 downto 0),
-            -- Port B
-            clkb  => clk,
-            enb   => en,
-            web   => weByteMask,
-            rstb  => NOT_RST_C,
-            addrb => addr,
-            dinb  => din,
-            doutb => doutInt);
-   end generate;
+            clkb    => clk,
+            enb     => en,
+            web     => we,
+            webByte => weByteMask,
+            rstb    => NOT_RST_C,
+            addrb   => addr,
+            dinb    => din,
+            doutb   => doutInt);
+   end generate GEN_VENDOR;
 
    GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
 
@@ -270,16 +242,17 @@ begin
       AXI_RW_SYS_RW : if (AXI_WR_EN_G and SYS_WR_EN_G) generate
          U_TrueDualPortRam_1 : entity surf.TrueDualPortRam
             generic map (
-               TPD_G          => TPD_G,
-               RST_POLARITY_G => RST_POLARITY_G,
-               RST_ASYNC_G    => RST_ASYNC_G,
-               BYTE_WR_EN_G   => true,
-               DOA_REG_G      => ite(READ_LATENCY_G >= 2, true, false),
-               DOB_REG_G      => ite(READ_LATENCY_G >= 2, true, false),
-               DATA_WIDTH_G   => DATA_WIDTH_G,
-               BYTE_WIDTH_G   => 8,
-               ADDR_WIDTH_G   => ADDR_WIDTH_G,
-               INIT_G         => INIT_G)
+               TPD_G            => TPD_G,
+               RST_POLARITY_G   => RST_POLARITY_G,
+               RST_ASYNC_G      => RST_ASYNC_G,
+               BYTE_WR_EN_G     => true,
+               DATA_WIDTH_G     => DATA_WIDTH_G,
+               BYTE_WIDTH_G     => 8,
+               ADDR_WIDTH_G     => ADDR_WIDTH_G,
+               INIT_G           => INIT_G,
+               READ_LATENCY_G   => RAM_READ_LATENCY_C,
+               READ_LATENCY_A_G => RAM_READ_LATENCY_C,
+               READ_LATENCY_B_G => RAM_READ_LATENCY_C)
             port map (
                clka    => axiClk,                                    -- [in]
                ena     => '1',                                       -- [in]

--- a/axi/axi-lite/rtl/AxiDualPortRam.vhd
+++ b/axi/axi-lite/rtl/AxiDualPortRam.vhd
@@ -172,6 +172,10 @@ begin
             doutb   => doutInt);
    end generate GEN_VENDOR;
 
+   -- Keep the inferred read-only/simple-dual cases on DualPortRam for
+   -- compatibility. Those paths preserve the legacy inferred distributed RAM
+   -- behavior, including READ_LATENCY_G = 0 support, that the selector
+   -- wrappers intentionally do not imply.
    GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
 
       -- AXI read only, sys writable or read only (rom)

--- a/axi/axi-lite/rtl/AxiLiteSequencerRam.vhd
+++ b/axi/axi-lite/rtl/AxiLiteSequencerRam.vhd
@@ -140,6 +140,10 @@ architecture rtl of AxiLiteSequencerRam is
 
 begin
 
+   assert (SYNTH_MODE_G /= "inferred") or (READ_LATENCY_G >= 1)
+      report "AxiLiteSequencerRam: inferred mode requires READ_LATENCY_G >= 1"
+      severity failure;
+
    U_AxiLiteMaster : entity surf.AxiLiteMaster
       generic map (
          TPD_G          => TPD_G,

--- a/axi/axi-lite/rtl/AxiLiteSequencerRam.vhd
+++ b/axi/axi-lite/rtl/AxiLiteSequencerRam.vhd
@@ -86,6 +86,8 @@ architecture rtl of AxiLiteSequencerRam is
    constant AXI_RAM_ADDR_LOW_C  : integer := AXI_DEC_ADDR_RANGE_C'high+1;
    subtype AXI_RAM_ADDR_RANGE_C is integer range AXI_RAM_ADDR_HIGH_C downto AXI_RAM_ADDR_LOW_C;
 
+   constant RAM_READ_LATENCY_C : natural := ite(SYNTH_MODE_G = "inferred", ite(READ_LATENCY_G >= 2, 2, 1), READ_LATENCY_G);
+
    type StateType is (
       IDLE_S,
       S_AXI_RD_S,
@@ -153,83 +155,34 @@ begin
          axilReadMaster  => mAxilReadMaster,
          axilReadSlave   => mAxilReadSlave);
 
-   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-      U_RAM : entity surf.TrueDualPortRamXpm
-         generic map (
-            TPD_G               => TPD_G,
-            RST_POLARITY_G      => RST_POLARITY_G,
-            COMMON_CLK_G        => true,
-            MEMORY_TYPE_G       => MEMORY_TYPE_G,
-            MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE_G,
-            MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
-            READ_LATENCY_G      => READ_LATENCY_G,
-            DATA_WIDTH_G        => 64,
-            BYTE_WR_EN_G        => true,
-            BYTE_WIDTH_G        => 8,
-            ADDR_WIDTH_G        => ADDR_WIDTH_G)
-         port map (
-            -- Port A
-            clka  => axilClk,
-            wea   => r.wstrb,
-            addra => r.addr,
-            dina  => r.din,
-            douta => dout,
-            -- Port B
-            clkb  => axilClk,
-            addrb => r.seqAddr,
-            doutb => seqData);
-   end generate;
-
-   GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
-      U_RAM : entity surf.TrueDualPortRamAlteraMf
-         generic map (
-            TPD_G          => TPD_G,
-            RST_POLARITY_G => RST_POLARITY_G,
-            COMMON_CLK_G   => true,
-            MEMORY_TYPE_G  => MEMORY_TYPE_G,
-            READ_LATENCY_G => READ_LATENCY_G,
-            DATA_WIDTH_G   => 64,
-            BYTE_WR_EN_G   => true,
-            BYTE_WIDTH_G   => 8,
-            ADDR_WIDTH_G   => ADDR_WIDTH_G)
-         port map (
-            -- Port A
-            clka  => axilClk,
-            wea   => r.wstrb,
-            addra => r.addr,
-            dina  => r.din,
-            douta => dout,
-            -- Port B
-            clkb  => axilClk,
-            addrb => r.seqAddr,
-            doutb => seqData);
-   end generate;
-
-   GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
-      U_RAM : entity surf.TrueDualPortRam
-         generic map (
-            TPD_G          => TPD_G,
-            RST_POLARITY_G => RST_POLARITY_G,
-            RST_ASYNC_G    => RST_ASYNC_G,
-            BYTE_WR_EN_G   => true,
-            DOA_REG_G      => ite(READ_LATENCY_G >= 2, true, false),
-            DOB_REG_G      => ite(READ_LATENCY_G >= 2, true, false),
-            DATA_WIDTH_G   => 64,
-            BYTE_WIDTH_G   => 8,
-            ADDR_WIDTH_G   => ADDR_WIDTH_G)
-         port map (
-            -- Port A
-            clka    => axilClk,
-            wea     => '1',
-            weaByte => r.wstrb,
-            addra   => r.addr,
-            dina    => r.din,
-            douta   => dout,
-            -- Port B
-            clkb    => axilClk,
-            addrb   => r.seqAddr,
-            doutb   => seqData);
-   end generate;
+   U_RAM : entity surf.TrueDualPortRam
+      generic map (
+         TPD_G               => TPD_G,
+         RST_POLARITY_G      => RST_POLARITY_G,
+         RST_ASYNC_G         => RST_ASYNC_G,
+         SYNTH_MODE_G        => SYNTH_MODE_G,
+         COMMON_CLK_G        => true,
+         MEMORY_TYPE_G       => MEMORY_TYPE_G,
+         MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE_G,
+         MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
+         READ_LATENCY_G      => RAM_READ_LATENCY_C,
+         READ_LATENCY_A_G    => RAM_READ_LATENCY_C,
+         READ_LATENCY_B_G    => RAM_READ_LATENCY_C,
+         BYTE_WR_EN_G        => true,
+         DATA_WIDTH_G        => 64,
+         BYTE_WIDTH_G        => 8,
+         ADDR_WIDTH_G        => ADDR_WIDTH_G)
+      port map (
+         -- Port A
+         clka    => axilClk,
+         weaByte => r.wstrb,
+         addra   => r.addr,
+         dina    => r.din,
+         douta   => dout,
+         -- Port B
+         clkb    => axilClk,
+         addrb   => r.seqAddr,
+         doutb   => seqData);
 
    comb : process (ack, axilRst, dout, extSize, extStart, r, sAxilReadMaster,
                    sAxilWriteMaster, seqData) is

--- a/axi/axi4/rtl/AxiRam.vhd
+++ b/axi/axi4/rtl/AxiRam.vhd
@@ -113,82 +113,30 @@ begin
       ((SYNTH_MODE_G = "inferred") and (READ_LATENCY_G > 0))
       report "AxiRam: Inferred SimpleDualPortRam does not support zero latency reads" severity failure;
 
-   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-      U_RAM : entity surf.SimpleDualPortRamXpm
-         generic map (
-            TPD_G          => TPD_G,
-            COMMON_CLK_G   => true,
-            MEMORY_TYPE_G  => MEMORY_TYPE_G,
-            READ_LATENCY_G => READ_LATENCY_G,
-            DATA_WIDTH_G   => DATA_WIDTH_C,
-            BYTE_WR_EN_G   => true,
-            BYTE_WIDTH_G   => 8,
-            ADDR_WIDTH_G   => ADDR_WIDTH_C)
-         port map (
-            -- Port A
-            ena    => wrEn,
-            clka   => axiClk,
-            addra  => wrAddr,
-            dina   => wrData,
-            wea    => wstrb,
-            -- Read Interface
-            enb    => rdEn(0),
-            clkb   => axiClk,
-            addrb  => rdAddr,
-            doutb  => rdData,
-            regceb => rdEn(1));
-   end generate;
-
-   GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
-      U_RAM : entity surf.SimpleDualPortRamAlteraMf
-         generic map (
-            TPD_G          => TPD_G,
-            COMMON_CLK_G   => true,
-            MEMORY_TYPE_G  => MEMORY_TYPE_G,
-            READ_LATENCY_G => READ_LATENCY_G,
-            DATA_WIDTH_G   => DATA_WIDTH_C,
-            BYTE_WR_EN_G   => true,
-            BYTE_WIDTH_G   => 8,
-            ADDR_WIDTH_G   => ADDR_WIDTH_C)
-         port map (
-            -- Port A
-            ena    => wrEn,
-            clka   => axiClk,
-            addra  => wrAddr,
-            dina   => wrData,
-            wea    => wstrb,
-            -- Read Interface
-            enb    => rdEn(0),
-            clkb   => axiClk,
-            addrb  => rdAddr,
-            doutb  => rdData,
-            regceb => rdEn(1));
-   end generate;
-
-   GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
-      U_RAM : entity surf.SimpleDualPortRam
-         generic map (
-            TPD_G         => TPD_G,
-            MEMORY_TYPE_G => MEMORY_TYPE_G,
-            DOB_REG_G     => ite(READ_LATENCY_G = 2, true, false),
-            BYTE_WR_EN_G  => true,
-            DATA_WIDTH_G  => DATA_WIDTH_C,
-            BYTE_WIDTH_G  => 8,
-            ADDR_WIDTH_G  => ADDR_WIDTH_C)
-         port map (
-            -- Port A
-            ena     => wrEn,
-            clka    => axiClk,
-            addra   => wrAddr,
-            dina    => wrData,
-            weaByte => wstrb,
-            -- Read Interface
-            enb     => rdEn(0),
-            clkb    => axiClk,
-            addrb   => rdAddr,
-            doutb   => rdData,
-            regceb  => rdEn(1));
-   end generate;
+   U_RAM : entity surf.SimpleDualPortRam
+      generic map (
+         TPD_G          => TPD_G,
+         SYNTH_MODE_G   => SYNTH_MODE_G,
+         COMMON_CLK_G   => true,
+         MEMORY_TYPE_G  => MEMORY_TYPE_G,
+         READ_LATENCY_G => READ_LATENCY_G,
+         BYTE_WR_EN_G   => true,
+         DATA_WIDTH_G   => DATA_WIDTH_C,
+         BYTE_WIDTH_G   => 8,
+         ADDR_WIDTH_G   => ADDR_WIDTH_C)
+      port map (
+         -- Port A
+         ena     => wrEn,
+         clka    => axiClk,
+         addra   => wrAddr,
+         dina    => wrData,
+         weaByte => wstrb,
+         -- Read Interface
+         enb     => rdEn(0),
+         clkb    => axiClk,
+         addrb   => rdAddr,
+         doutb   => rdData,
+         regceb  => rdEn(1));
 
    comb : process (axiRst, r, rdData, sAxiReadMaster, sAxiWriteMaster) is
       variable v : RegType;

--- a/axi/axi4/rtl/AxiRingBuffer.vhd
+++ b/axi/axi4/rtl/AxiRingBuffer.vhd
@@ -626,46 +626,26 @@ begin
       end if;
    end process seq;
 
-   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-      U_BRAM : entity surf.SimpleDualPortRamXpm
-         generic map(
-            TPD_G          => TPD_G,
-            COMMON_CLK_G   => true,
-            MEMORY_TYPE_G  => MEMORY_TYPE_G,
-            READ_LATENCY_G => 2,
-            DATA_WIDTH_G   => 8*DATA_BYTES_G,
-            ADDR_WIDTH_G   => BURST_BITSIZE_C)
-         port map (
-            -- Port A
-            clka   => dataClk,
-            wea(0) => r.bramWe,
-            addra  => r.bramAddr,
-            dina   => r.bramWrDat,
-            -- Port B
-            clkb   => dataClk,
-            addrb  => r.bramAddr,
-            doutb  => bramData);
-   end generate;
-
-   GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
-      U_BRAM : entity surf.SimpleDualPortRam
-         generic map(
-            TPD_G         => TPD_G,
-            MEMORY_TYPE_G => MEMORY_TYPE_G,
-            DOB_REG_G     => true,
-            DATA_WIDTH_G  => 8*DATA_BYTES_G,
-            ADDR_WIDTH_G  => BURST_BITSIZE_C)
-         port map (
-            -- Port A
-            clka  => dataClk,
-            wea   => r.bramWe,
-            addra => r.bramAddr,
-            dina  => r.bramWrDat,
-            -- Port B
-            clkb  => dataClk,
-            addrb => r.bramAddr,
-            doutb => bramData);
-   end generate;
+   U_BRAM : entity surf.SimpleDualPortRam
+      generic map(
+         TPD_G          => TPD_G,
+         SYNTH_MODE_G   => SYNTH_MODE_G,
+         COMMON_CLK_G   => true,
+         MEMORY_TYPE_G  => MEMORY_TYPE_G,
+         DOB_REG_G      => true,
+         READ_LATENCY_G => 2,
+         DATA_WIDTH_G   => 8*DATA_BYTES_G,
+         ADDR_WIDTH_G   => BURST_BITSIZE_C)
+      port map (
+         -- Port A
+         clka  => dataClk,
+         wea   => r.bramWe,
+         addra => r.bramAddr,
+         dina  => r.bramWrDat,
+         -- Port B
+         clkb  => dataClk,
+         addrb => r.bramAddr,
+         doutb => bramData);
 
    GEN_SYNC_AXI : if (AXI_CLK_IS_DATA_CLK_G = true) generate
 

--- a/base/README.md
+++ b/base/README.md
@@ -7,7 +7,7 @@ This tree contains the foundational RTL used by the rest of SURF. Top-level `bas
 - `general/`: common packages and generic utilities such as `StdRtlPkg`, arbiters, muxes, reset pipelines, gearboxes, counters, and watchdog/reset helpers.
 - `sync/`: clock-domain crossing, synchronizers, reset synchronizers, trigger-rate, status, and frequency measurement helpers.
 - `fifo/`: synchronous, asynchronous, muxing, cascade, FWFT, and output-pipeline FIFO blocks.
-- `ram/`: inferred and Xilinx RAM implementations.
+- `ram/`: RAM selectors and inferred/Xilinx/Altera backend implementations. See `ram/README.md` for wrapper selection guidance.
 - `delay/`: fixed, RAM-backed, and FIFO-backed delay blocks.
 - `crc/`: CRC packages and implementations.
 

--- a/base/ram/README.md
+++ b/base/ram/README.md
@@ -1,0 +1,19 @@
+# RAM
+
+This directory contains SURF RAM selectors and implementation backends. Prefer the selectors in `rtl/` for new portable designs, and use the inferred, Xilinx, Altera, and dummy files directly only when a design needs that specific implementation behavior.
+
+## Preferred Wrappers
+
+| Use case | Preferred module | Notes |
+| --- | --- | --- |
+| One write port and one read port | `surf.SimpleDualPortRam` | Portable selector for inferred, XPM, and Altera backends. This is the usual choice for RAM-backed FIFOs, lookup tables, status tables, and simple AXI-accessible storage. |
+| Two writable ports | `surf.TrueDualPortRam` | Portable selector for true dual-port memories. Use this when both ports can write independently. |
+| Legacy inferred one-write/two-read behavior or inferred distributed zero-latency behavior | `surf.DualPortRam` | Compatibility helper under `inferred/`. It is inferred-only and is not the preferred general selector for new code. |
+| Explicit inferred implementation | `surf.SimpleDualPortRamInferred`, `surf.TrueDualPortRamInferred`, `surf.LutRam` | Backend modules for code that intentionally depends on inference style or LUTRAM behavior. |
+| Explicit vendor primitive wrapper | `surf.SimpleDualPortRamXpm`, `surf.TrueDualPortRamXpm`, `surf.*AlteraMf` | Backend modules for code that intentionally targets a vendor primitive wrapper. |
+
+## Latency Conventions
+
+`SimpleDualPortRam` and `TrueDualPortRam` expose read-latency generics for selector-based code. The inferred backends generally support only the legacy synchronous RAM latency plus optional output-register behavior, while XPM supports a wider latency range. Wrappers that need a latency beyond the inferred RAM backend may add a local output register and should document that behavior at the wrapper.
+
+`DOA_REG_G` and `DOB_REG_G` remain compatibility generics for older code that selected one extra output register. New selector-based code should prefer the explicit read-latency generics where they are available.

--- a/base/ram/dummy/TrueDualPortRamXpmDummy.vhd
+++ b/base/ram/dummy/TrueDualPortRamXpmDummy.vhd
@@ -30,6 +30,8 @@ entity TrueDualPortRamXpm is
       MEMORY_INIT_PARAM_G : string                     := "0";
       WRITE_MODE_G        : string                     := "no_change";
       READ_LATENCY_G      : natural range 0 to 100     := 1;
+      READ_LATENCY_A_G    : integer range -1 to 100    := -1;
+      READ_LATENCY_B_G    : integer range -1 to 100    := -1;
       DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
       BYTE_WR_EN_G        : boolean                    := false;
       BYTE_WIDTH_G        : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9

--- a/base/ram/inferred/DualPortRam.vhd
+++ b/base/ram/inferred/DualPortRam.vhd
@@ -62,7 +62,7 @@ architecture mapping of DualPortRam is
 begin
 
    GEN_BRAM : if (MEMORY_TYPE_G /= "distributed") generate
-      TrueDualPortRam_Inst : entity surf.TrueDualPortRam
+      TrueDualPortRam_Inst : entity surf.TrueDualPortRamInferred
          generic map (
             TPD_G          => TPD_G,
             RST_ASYNC_G    => RST_ASYNC_G,

--- a/base/ram/inferred/DualPortRam.vhd
+++ b/base/ram/inferred/DualPortRam.vhd
@@ -1,7 +1,17 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: This module infers either Block RAM or distributed RAM
+-- Description: Legacy inferred-only dual-port RAM helper
+--
+-- This module is not the preferred general RAM selector for new designs. Use
+-- surf.SimpleDualPortRam for a one-write/one-read memory, and use
+-- surf.TrueDualPortRam when both ports can write.
+--
+-- DualPortRam is kept for compatibility and for inferred-only cases that need
+-- its exact historical behavior. For MEMORY_TYPE_G /= "distributed", it wraps
+-- TrueDualPortRamInferred with port B read-only. For MEMORY_TYPE_G =
+-- "distributed", it wraps LutRam and can provide the legacy inferred
+-- distributed behavior.
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the

--- a/base/ram/inferred/SimpleDualPortRamInferred.vhd
+++ b/base/ram/inferred/SimpleDualPortRamInferred.vhd
@@ -20,7 +20,7 @@ use ieee.std_logic_unsigned.all;
 library surf;
 use surf.StdRtlPkg.all;
 
-entity SimpleDualPortRam is
+entity SimpleDualPortRamInferred is
    generic (
       TPD_G          : time                       := 1 ns;
       RST_POLARITY_G : sl                         := '1';  -- '1' for active high rst, '0' for active low
@@ -47,9 +47,9 @@ entity SimpleDualPortRam is
       rstb    : in  sl                                                    := not(RST_POLARITY_G);
       addrb   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
       doutb   : out slv(DATA_WIDTH_G-1 downto 0));
-end SimpleDualPortRam;
+end SimpleDualPortRamInferred;
 
-architecture rtl of SimpleDualPortRam is
+architecture rtl of SimpleDualPortRamInferred is
 
    -- Set byte width to word width if byte writes not enabled
    -- Otherwise block ram parity bits wont be utilized

--- a/base/ram/inferred/TrueDualPortRamInferred.vhd
+++ b/base/ram/inferred/TrueDualPortRamInferred.vhd
@@ -21,7 +21,7 @@ use ieee.std_logic_unsigned.all;
 library surf;
 use surf.StdRtlPkg.all;
 
-entity TrueDualPortRam is
+entity TrueDualPortRamInferred is
    -- MODE_G = {"no-change","read-first","write-first"}
    generic (
       TPD_G          : time                       := 1 ns;
@@ -56,9 +56,9 @@ entity TrueDualPortRam is
       dinb    : in  slv(DATA_WIDTH_G-1 downto 0)                          := (others => '0');
       doutb   : out slv(DATA_WIDTH_G-1 downto 0);
       regceb  : in  sl                                                    := '1');  -- Clock enable for extra output reg. Only used when DOA_REG_G = true
-end TrueDualPortRam;
+end TrueDualPortRamInferred;
 
-architecture rtl of TrueDualPortRam is
+architecture rtl of TrueDualPortRamInferred is
 
    -- Set byte width to word width if byte writes not enabled
    -- Otherwise block ram parity bits wont be utilized

--- a/base/ram/rtl/SimpleDualPortRam.vhd
+++ b/base/ram/rtl/SimpleDualPortRam.vhd
@@ -160,6 +160,10 @@ begin
       report "SimpleDualPortRam: SYNTH_MODE_G must be inferred, xpm, or altera_mf"
       severity failure;
 
+   assert (not RST_ASYNC_G) or (SYNTH_MODE_G = "inferred")
+      report "SimpleDualPortRam: RST_ASYNC_G is supported only for SYNTH_MODE_G = inferred"
+      severity failure;
+
    assert (SYNTH_MODE_G /= "inferred") or (READ_LATENCY_C = 1) or (READ_LATENCY_C = 2)
       report "SimpleDualPortRam: inferred mode supports READ_LATENCY_G = 1 or 2 because the legacy SimpleDualPortRam implementation is synchronous-read for all MEMORY_TYPE_G values"
       severity failure;

--- a/base/ram/rtl/SimpleDualPortRam.vhd
+++ b/base/ram/rtl/SimpleDualPortRam.vhd
@@ -1,0 +1,251 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Simple dual port RAM with backend selection
+--
+-- Supported RAM memory configurations:
+--
+-- SYNTH_MODE_G | MEMORY_TYPE_G                 | READ_LATENCY_G
+-- "inferred"   | "block", "distributed", etc.  |      1 ~ 2
+-- "xpm"        | delegated to SimpleDualPortRamXpm/vendor rules
+-- "altera_mf"  | delegated to SimpleDualPortRamAlteraMf/vendor rules
+--
+-- The inferred implementation remains the legacy synchronous-read
+-- SimpleDualPortRam, now named SimpleDualPortRamInferred. Its base read
+-- latency is one clkb cycle for every MEMORY_TYPE_G value, including
+-- "distributed". DOB_REG_G adds the historical B-side output register.
+-- In contrast, inferred distributed zero-latency LUTRAM is implemented by
+-- other RAM helpers such as LutRam/DualPortRam and is not implied here.
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+entity SimpleDualPortRam is
+   generic (
+      TPD_G               : time                       := 1 ns;
+      RST_POLARITY_G      : sl                         := '1';  -- '1' for active high rst, '0' for active low
+      RST_ASYNC_G         : boolean                    := false;
+      MEMORY_TYPE_G       : string                     := "block";
+      DOB_REG_G           : boolean                    := false;  -- Extra reg on doutb (folded into BRAM)
+      BYTE_WR_EN_G        : boolean                    := false;
+      DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
+      BYTE_WIDTH_G        : integer                    := 8;  -- If BRAM, should be multiple or 8 or 9
+      ADDR_WIDTH_G        : integer range 1 to (2**24) := 4;
+      INIT_G              : slv                        := "0";
+      SYNTH_MODE_G        : string                     := "inferred";
+      COMMON_CLK_G        : boolean                    := false;
+      MEMORY_INIT_FILE_G  : string                     := "none";
+      MEMORY_INIT_PARAM_G : string                     := "0";
+      READ_LATENCY_G      : natural range 0 to 100     := 1);
+   port (
+      -- Port A
+      clka    : in  sl                                                    := '0';
+      ena     : in  sl                                                    := '1';
+      wea     : in  sl                                                    := '0';
+      weaByte : in  slv(wordCount(DATA_WIDTH_G, BYTE_WIDTH_G)-1 downto 0) := (others => '0');
+      addra   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+      dina    : in  slv(DATA_WIDTH_G-1 downto 0)                          := (others => '0');
+      -- Port B
+      clkb    : in  sl                                                    := '0';
+      enb     : in  sl                                                    := '1';
+      regceb  : in  sl                                                    := '1';
+      rstb    : in  sl                                                    := not(RST_POLARITY_G);
+      addrb   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+      doutb   : out slv(DATA_WIDTH_G-1 downto 0));
+end SimpleDualPortRam;
+
+architecture rtl of SimpleDualPortRam is
+
+   component SimpleDualPortRamInferred is
+      generic (
+         TPD_G          : time                       := 1 ns;
+         RST_POLARITY_G : sl                         := '1';
+         RST_ASYNC_G    : boolean                    := false;
+         MEMORY_TYPE_G  : string                     := "block";
+         DOB_REG_G      : boolean                    := false;
+         BYTE_WR_EN_G   : boolean                    := false;
+         DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
+         BYTE_WIDTH_G   : integer                    := 8;
+         ADDR_WIDTH_G   : integer range 1 to (2**24) := 4;
+         INIT_G         : slv                        := "0");
+      port (
+         clka    : in  sl                                                    := '0';
+         ena     : in  sl                                                    := '1';
+         wea     : in  sl                                                    := '0';
+         weaByte : in  slv(wordCount(DATA_WIDTH_G, BYTE_WIDTH_G)-1 downto 0) := (others => '0');
+         addra   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+         dina    : in  slv(DATA_WIDTH_G-1 downto 0)                          := (others => '0');
+         clkb    : in  sl                                                    := '0';
+         enb     : in  sl                                                    := '1';
+         regceb  : in  sl                                                    := '1';
+         rstb    : in  sl                                                    := not(RST_POLARITY_G);
+         addrb   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+         doutb   : out slv(DATA_WIDTH_G-1 downto 0));
+   end component;
+
+   component SimpleDualPortRamXpm is
+      generic (
+         TPD_G               : time                       := 1 ns;
+         COMMON_CLK_G        : boolean                    := false;
+         RST_POLARITY_G      : sl                         := '1';
+         MEMORY_TYPE_G       : string                     := "block";
+         MEMORY_INIT_FILE_G  : string                     := "none";
+         MEMORY_INIT_PARAM_G : string                     := "0";
+         READ_LATENCY_G      : natural range 0 to 100     := 1;
+         DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
+         BYTE_WR_EN_G        : boolean                    := false;
+         BYTE_WIDTH_G        : integer range 8 to 9       := 8;
+         ADDR_WIDTH_G        : integer range 1 to (2**24) := 4);
+      port (
+         clka   : in  sl                                                                          := '0';
+         ena    : in  sl                                                                          := '1';
+         wea    : in  slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0) := (others => '0');
+         addra  : in  slv(ADDR_WIDTH_G-1 downto 0)                                                := (others => '0');
+         dina   : in  slv(DATA_WIDTH_G-1 downto 0)                                                := (others => '0');
+         clkb   : in  sl                                                                          := '0';
+         enb    : in  sl                                                                          := '1';
+         regceb : in  sl                                                                          := '1';
+         rstb   : in  sl                                                                          := not(RST_POLARITY_G);
+         addrb  : in  slv(ADDR_WIDTH_G-1 downto 0)                                                := (others => '0');
+         doutb  : out slv(DATA_WIDTH_G-1 downto 0));
+   end component;
+
+   component SimpleDualPortRamAlteraMf is
+      generic (
+         TPD_G          : time                       := 1 ns;
+         COMMON_CLK_G   : boolean                    := false;
+         RST_POLARITY_G : sl                         := '1';
+         MEMORY_TYPE_G  : string                     := "block";
+         READ_LATENCY_G : natural range 0 to 100     := 1;
+         DATA_WIDTH_G   : integer range 1 to (2**24) := 16;
+         BYTE_WR_EN_G   : boolean                    := false;
+         BYTE_WIDTH_G   : integer range 8 to 9       := 8;
+         ADDR_WIDTH_G   : integer range 1 to (2**24) := 4);
+      port (
+         clka   : in  sl                                                                          := '0';
+         ena    : in  sl                                                                          := '1';
+         wea    : in  slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0) := (others => '0');
+         addra  : in  slv(ADDR_WIDTH_G-1 downto 0)                                                := (others => '0');
+         dina   : in  slv(DATA_WIDTH_G-1 downto 0)                                                := (others => '0');
+         clkb   : in  sl                                                                          := '0';
+         enb    : in  sl                                                                          := '1';
+         regceb : in  sl                                                                          := '1';
+         rstb   : in  sl                                                                          := not(RST_POLARITY_G);
+         addrb  : in  slv(ADDR_WIDTH_G-1 downto 0)                                                := (others => '0');
+         doutb  : out slv(DATA_WIDTH_G-1 downto 0));
+   end component;
+
+   constant DOB_REG_C      : boolean := DOB_REG_G or (READ_LATENCY_G = 2);
+   constant READ_LATENCY_C : natural := ite(DOB_REG_C and READ_LATENCY_G = 1, 2, READ_LATENCY_G);
+
+   signal weaVector : slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0);
+
+begin
+
+   assert (SYNTH_MODE_G = "inferred") or (SYNTH_MODE_G = "xpm") or (SYNTH_MODE_G = "altera_mf")
+      report "SimpleDualPortRam: SYNTH_MODE_G must be inferred, xpm, or altera_mf"
+      severity failure;
+
+   assert (SYNTH_MODE_G /= "inferred") or (READ_LATENCY_C = 1) or (READ_LATENCY_C = 2)
+      report "SimpleDualPortRam: inferred mode supports READ_LATENCY_G = 1 or 2 because the legacy SimpleDualPortRam implementation is synchronous-read for all MEMORY_TYPE_G values"
+      severity failure;
+
+   weaVector <= weaByte when BYTE_WR_EN_G else (others => wea);
+
+   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
+      U_RAM : SimpleDualPortRamXpm
+         generic map (
+            TPD_G               => TPD_G,
+            RST_POLARITY_G      => RST_POLARITY_G,
+            COMMON_CLK_G        => COMMON_CLK_G,
+            MEMORY_TYPE_G       => MEMORY_TYPE_G,
+            MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE_G,
+            MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
+            READ_LATENCY_G      => READ_LATENCY_C,
+            DATA_WIDTH_G        => DATA_WIDTH_G,
+            BYTE_WR_EN_G        => BYTE_WR_EN_G,
+            BYTE_WIDTH_G        => BYTE_WIDTH_G,
+            ADDR_WIDTH_G        => ADDR_WIDTH_G)
+         port map (
+            clka   => clka,
+            ena    => ena,
+            wea    => weaVector,
+            addra  => addra,
+            dina   => dina,
+            clkb   => clkb,
+            enb    => enb,
+            regceb => regceb,
+            rstb   => rstb,
+            addrb  => addrb,
+            doutb  => doutb);
+   end generate;
+
+   GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
+      U_RAM : SimpleDualPortRamAlteraMf
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            COMMON_CLK_G   => COMMON_CLK_G,
+            MEMORY_TYPE_G  => MEMORY_TYPE_G,
+            READ_LATENCY_G => READ_LATENCY_C,
+            DATA_WIDTH_G   => DATA_WIDTH_G,
+            BYTE_WR_EN_G   => BYTE_WR_EN_G,
+            BYTE_WIDTH_G   => BYTE_WIDTH_G,
+            ADDR_WIDTH_G   => ADDR_WIDTH_G)
+         port map (
+            clka   => clka,
+            ena    => ena,
+            wea    => weaVector,
+            addra  => addra,
+            dina   => dina,
+            clkb   => clkb,
+            enb    => enb,
+            regceb => regceb,
+            rstb   => rstb,
+            addrb  => addrb,
+            doutb  => doutb);
+   end generate;
+
+   GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
+      U_RAM : SimpleDualPortRamInferred
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            MEMORY_TYPE_G  => MEMORY_TYPE_G,
+            DOB_REG_G      => DOB_REG_C,
+            BYTE_WR_EN_G   => BYTE_WR_EN_G,
+            DATA_WIDTH_G   => DATA_WIDTH_G,
+            BYTE_WIDTH_G   => BYTE_WIDTH_G,
+            ADDR_WIDTH_G   => ADDR_WIDTH_G,
+            INIT_G         => INIT_G)
+         port map (
+            clka    => clka,
+            ena     => ena,
+            wea     => wea,
+            weaByte => weaByte,
+            addra   => addra,
+            dina    => dina,
+            clkb    => clkb,
+            enb     => enb,
+            regceb  => regceb,
+            rstb    => rstb,
+            addrb   => addrb,
+            doutb   => doutb);
+   end generate;
+
+end rtl;

--- a/base/ram/rtl/TrueDualPortRam.vhd
+++ b/base/ram/rtl/TrueDualPortRam.vhd
@@ -1,0 +1,228 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: True dual port RAM with backend selection
+--
+-- Supported RAM memory configurations:
+--
+-- SYNTH_MODE_G | MEMORY_TYPE_G | READ_LATENCY_G
+-- "inferred"   | "block"       |      1 ~ 2
+-- "xpm"        | delegated to TrueDualPortRamXpm/vendor rules
+-- "altera_mf"  | delegated to TrueDualPortRamAlteraMf/vendor rules
+--
+-- The inferred implementation remains the legacy block RAM implementation,
+-- now named TrueDualPortRamInferred. Its base read latency is one clock cycle.
+-- DOA_REG_G and DOB_REG_G add the historical output registers. MODE_G keeps
+-- the legacy {"no-change", "read-first", "write-first"} spelling and is
+-- translated to XPM WRITE_MODE_G spelling when SYNTH_MODE_G = "xpm".
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+entity TrueDualPortRam is
+   -- MODE_G = {"no-change","read-first","write-first"}
+   generic (
+      TPD_G               : time                       := 1 ns;
+      RST_POLARITY_G      : sl                         := '1';  -- '1' for active high rst, '0' for active low
+      RST_ASYNC_G         : boolean                    := false;
+      DOA_REG_G           : boolean                    := false;  -- Extra output register on doutA.
+      DOB_REG_G           : boolean                    := false;  -- Extra output register on doutB.
+      MODE_G              : string                     := "read-first";
+      BYTE_WR_EN_G        : boolean                    := false;
+      DATA_WIDTH_G        : integer range 1 to (2**24) := 18;
+      BYTE_WIDTH_G        : integer                    := 8;  -- Should be multiple of 8 or 9.
+      ADDR_WIDTH_G        : integer range 1 to (2**24) := 9;
+      INIT_G              : slv                        := "0";
+      SYNTH_MODE_G        : string                     := "inferred";
+      COMMON_CLK_G        : boolean                    := false;
+      MEMORY_TYPE_G       : string                     := "block";
+      MEMORY_INIT_FILE_G  : string                     := "none";
+      MEMORY_INIT_PARAM_G : string                     := "0";
+      READ_LATENCY_G      : natural range 0 to 100     := 1);
+   port (
+      -- Port A
+      clka    : in  sl                                                    := '0';
+      ena     : in  sl                                                    := '1';
+      wea     : in  sl                                                    := '0';
+      weaByte : in  slv(wordCount(DATA_WIDTH_G, BYTE_WIDTH_G)-1 downto 0) := (others => '0');
+      rsta    : in  sl                                                    := not(RST_POLARITY_G);
+      addra   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+      dina    : in  slv(DATA_WIDTH_G-1 downto 0)                          := (others => '0');
+      douta   : out slv(DATA_WIDTH_G-1 downto 0);
+      regcea  : in  sl                                                    := '1';  -- Clock enable for extra output reg. Only used when DOA_REG_G = true
+      -- Port B
+      clkb    : in  sl                                                    := '0';
+      enb     : in  sl                                                    := '1';
+      web     : in  sl                                                    := '0';
+      webByte : in  slv(wordCount(DATA_WIDTH_G, BYTE_WIDTH_G)-1 downto 0) := (others => '0');
+      rstb    : in  sl                                                    := not(RST_POLARITY_G);
+      addrb   : in  slv(ADDR_WIDTH_G-1 downto 0)                          := (others => '0');
+      dinb    : in  slv(DATA_WIDTH_G-1 downto 0)                          := (others => '0');
+      doutb   : out slv(DATA_WIDTH_G-1 downto 0);
+      regceb  : in  sl                                                    := '1');  -- Clock enable for extra output reg. Only used when DOB_REG_G = true
+end TrueDualPortRam;
+
+architecture rtl of TrueDualPortRam is
+
+   function toXpmWriteMode(mode : string) return string is
+   begin
+      if (mode = "no-change") then
+         return "no_change";
+      elsif (mode = "read-first") then
+         return "read_first";
+      elsif (mode = "write-first") then
+         return "write_first";
+      else
+         return mode;
+      end if;
+   end function;
+
+   constant LEGACY_OUT_REG_C : boolean := DOA_REG_G or DOB_REG_G;
+   constant READ_LATENCY_C   : natural := ite(LEGACY_OUT_REG_C and READ_LATENCY_G = 1, 2, READ_LATENCY_G);
+   constant DOA_REG_C        : boolean := DOA_REG_G or (READ_LATENCY_G = 2);
+   constant DOB_REG_C        : boolean := DOB_REG_G or (READ_LATENCY_G = 2);
+   constant WRITE_MODE_C     : string  := toXpmWriteMode(MODE_G);
+
+   signal weaVector : slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0);
+   signal webVector : slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0);
+
+begin
+
+   assert (SYNTH_MODE_G = "inferred") or (SYNTH_MODE_G = "xpm") or (SYNTH_MODE_G = "altera_mf")
+      report "TrueDualPortRam: SYNTH_MODE_G must be inferred, xpm, or altera_mf"
+      severity failure;
+
+   assert (MODE_G = "no-change") or (MODE_G = "read-first") or (MODE_G = "write-first")
+      report "TrueDualPortRam: MODE_G must be no-change, read-first, or write-first"
+      severity failure;
+
+   assert (not LEGACY_OUT_REG_C) or (READ_LATENCY_G /= 0)
+      report "TrueDualPortRam: DOA_REG_G/DOB_REG_G are incompatible with READ_LATENCY_G = 0"
+      severity failure;
+
+   assert (SYNTH_MODE_G /= "inferred") or (MEMORY_TYPE_G = "block")
+      report "TrueDualPortRam: inferred mode supports MEMORY_TYPE_G = block"
+      severity failure;
+
+   assert (SYNTH_MODE_G /= "inferred") or (READ_LATENCY_C = 1) or (READ_LATENCY_C = 2)
+      report "TrueDualPortRam: inferred mode supports READ_LATENCY_G = 1 or 2 because the legacy TrueDualPortRam implementation is synchronous-read"
+      severity failure;
+
+   weaVector <= weaByte when BYTE_WR_EN_G else (others => wea);
+   webVector <= webByte when BYTE_WR_EN_G else (others => web);
+
+   GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
+      U_RAM : entity surf.TrueDualPortRamXpm
+         generic map (
+            TPD_G               => TPD_G,
+            RST_POLARITY_G      => RST_POLARITY_G,
+            COMMON_CLK_G        => COMMON_CLK_G,
+            MEMORY_TYPE_G       => MEMORY_TYPE_G,
+            MEMORY_INIT_FILE_G  => MEMORY_INIT_FILE_G,
+            MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
+            WRITE_MODE_G        => WRITE_MODE_C,
+            READ_LATENCY_G      => READ_LATENCY_C,
+            DATA_WIDTH_G        => DATA_WIDTH_G,
+            BYTE_WR_EN_G        => BYTE_WR_EN_G,
+            BYTE_WIDTH_G        => BYTE_WIDTH_G,
+            ADDR_WIDTH_G        => ADDR_WIDTH_G)
+         port map (
+            clka   => clka,
+            ena    => ena,
+            wea    => weaVector,
+            regcea => regcea,
+            rsta   => rsta,
+            addra  => addra,
+            dina   => dina,
+            douta  => douta,
+            clkb   => clkb,
+            enb    => enb,
+            web    => webVector,
+            regceb => regceb,
+            rstb   => rstb,
+            addrb  => addrb,
+            dinb   => dinb,
+            doutb  => doutb);
+   end generate;
+
+   GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
+      U_RAM : entity surf.TrueDualPortRamAlteraMf
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            COMMON_CLK_G   => COMMON_CLK_G,
+            MEMORY_TYPE_G  => MEMORY_TYPE_G,
+            READ_LATENCY_G => READ_LATENCY_C,
+            DATA_WIDTH_G   => DATA_WIDTH_G,
+            BYTE_WR_EN_G   => BYTE_WR_EN_G,
+            BYTE_WIDTH_G   => BYTE_WIDTH_G,
+            ADDR_WIDTH_G   => ADDR_WIDTH_G)
+         port map (
+            clka   => clka,
+            ena    => ena,
+            wea    => weaVector,
+            regcea => regcea,
+            rsta   => rsta,
+            addra  => addra,
+            dina   => dina,
+            douta  => douta,
+            clkb   => clkb,
+            enb    => enb,
+            web    => webVector,
+            regceb => regceb,
+            rstb   => rstb,
+            addrb  => addrb,
+            dinb   => dinb,
+            doutb  => doutb);
+   end generate;
+
+   GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
+      U_RAM : entity surf.TrueDualPortRamInferred
+         generic map (
+            TPD_G          => TPD_G,
+            RST_POLARITY_G => RST_POLARITY_G,
+            RST_ASYNC_G    => RST_ASYNC_G,
+            DOA_REG_G      => DOA_REG_C,
+            DOB_REG_G      => DOB_REG_C,
+            MODE_G         => MODE_G,
+            BYTE_WR_EN_G   => BYTE_WR_EN_G,
+            DATA_WIDTH_G   => DATA_WIDTH_G,
+            BYTE_WIDTH_G   => BYTE_WIDTH_G,
+            ADDR_WIDTH_G   => ADDR_WIDTH_G,
+            INIT_G         => INIT_G)
+         port map (
+            clka    => clka,
+            ena     => ena,
+            wea     => wea,
+            weaByte => weaByte,
+            rsta    => rsta,
+            addra   => addra,
+            dina    => dina,
+            douta   => douta,
+            regcea  => regcea,
+            clkb    => clkb,
+            enb     => enb,
+            web     => web,
+            webByte => webByte,
+            rstb    => rstb,
+            addrb   => addrb,
+            dinb    => dinb,
+            doutb   => doutb,
+            regceb  => regceb);
+   end generate;
+
+end rtl;

--- a/base/ram/rtl/TrueDualPortRam.vhd
+++ b/base/ram/rtl/TrueDualPortRam.vhd
@@ -119,6 +119,10 @@ begin
       report "TrueDualPortRam: MODE_G must be no-change, read-first, or write-first"
       severity failure;
 
+   assert (not RST_ASYNC_G) or (SYNTH_MODE_G = "inferred")
+      report "TrueDualPortRam: RST_ASYNC_G is supported only for SYNTH_MODE_G = inferred"
+      severity failure;
+
    assert (not DOA_REG_G) or (READ_LATENCY_A_G < 0)
       report "TrueDualPortRam: DOA_REG_G must not be combined with explicit READ_LATENCY_A_G"
       severity failure;

--- a/base/ram/rtl/TrueDualPortRam.vhd
+++ b/base/ram/rtl/TrueDualPortRam.vhd
@@ -5,16 +5,20 @@
 --
 -- Supported RAM memory configurations:
 --
--- SYNTH_MODE_G | MEMORY_TYPE_G | READ_LATENCY_G
+-- SYNTH_MODE_G | MEMORY_TYPE_G | Effective READ_LATENCY_A_G/B_G
 -- "inferred"   | "block"       |      1 ~ 2
 -- "xpm"        | delegated to TrueDualPortRamXpm/vendor rules
--- "altera_mf"  | delegated to TrueDualPortRamAlteraMf/vendor rules
+-- "altera_mf"  | delegated to TrueDualPortRamAlteraMf/vendor rules, shared A/B latency only
 --
 -- The inferred implementation remains the legacy block RAM implementation,
 -- now named TrueDualPortRamInferred. Its base read latency is one clock cycle.
 -- DOA_REG_G and DOB_REG_G add the historical output registers. MODE_G keeps
 -- the legacy {"no-change", "read-first", "write-first"} spelling and is
 -- translated to XPM WRITE_MODE_G spelling when SYNTH_MODE_G = "xpm".
+-- READ_LATENCY_A_G and READ_LATENCY_B_G default to -1, which selects the
+-- shared READ_LATENCY_G value for that port. DO*_REG_G remains the legacy way
+-- to select the 2-cycle registered-output path and must not be combined with
+-- explicit shared or per-port read latency settings.
 -------------------------------------------------------------------------------
 -- This file is part of 'SLAC Firmware Standard Library'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -52,7 +56,9 @@ entity TrueDualPortRam is
       MEMORY_TYPE_G       : string                     := "block";
       MEMORY_INIT_FILE_G  : string                     := "none";
       MEMORY_INIT_PARAM_G : string                     := "0";
-      READ_LATENCY_G      : natural range 0 to 100     := 1);
+      READ_LATENCY_G      : natural range 0 to 100     := 1;
+      READ_LATENCY_A_G    : integer range -1 to 100    := -1;
+      READ_LATENCY_B_G    : integer range -1 to 100    := -1);
    port (
       -- Port A
       clka    : in  sl                                                    := '0';
@@ -91,11 +97,14 @@ architecture rtl of TrueDualPortRam is
       end if;
    end function;
 
-   constant LEGACY_OUT_REG_C : boolean := DOA_REG_G or DOB_REG_G;
-   constant READ_LATENCY_C   : natural := ite(LEGACY_OUT_REG_C and READ_LATENCY_G = 1, 2, READ_LATENCY_G);
-   constant DOA_REG_C        : boolean := DOA_REG_G or (READ_LATENCY_G = 2);
-   constant DOB_REG_C        : boolean := DOB_REG_G or (READ_LATENCY_G = 2);
-   constant WRITE_MODE_C     : string  := toXpmWriteMode(MODE_G);
+   constant READ_LATENCY_A_BASE_C : natural := ite(READ_LATENCY_A_G < 0, READ_LATENCY_G, READ_LATENCY_A_G);
+   constant READ_LATENCY_B_BASE_C : natural := ite(READ_LATENCY_B_G < 0, READ_LATENCY_G, READ_LATENCY_B_G);
+   constant READ_LATENCY_A_C      : natural := ite(DOA_REG_G and (READ_LATENCY_A_BASE_C = 1), 2, READ_LATENCY_A_BASE_C);
+   constant READ_LATENCY_B_C      : natural := ite(DOB_REG_G and (READ_LATENCY_B_BASE_C = 1), 2, READ_LATENCY_B_BASE_C);
+   constant READ_LATENCY_C        : natural := ite(READ_LATENCY_A_C > READ_LATENCY_B_C, READ_LATENCY_A_C, READ_LATENCY_B_C);
+   constant DOA_REG_C             : boolean := (READ_LATENCY_A_C = 2);
+   constant DOB_REG_C             : boolean := (READ_LATENCY_B_C = 2);
+   constant WRITE_MODE_C          : string  := toXpmWriteMode(MODE_G);
 
    signal weaVector : slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0);
    signal webVector : slv(ite(BYTE_WR_EN_G, wordCount(DATA_WIDTH_G, BYTE_WIDTH_G), 1)-1 downto 0);
@@ -110,16 +119,46 @@ begin
       report "TrueDualPortRam: MODE_G must be no-change, read-first, or write-first"
       severity failure;
 
-   assert (not LEGACY_OUT_REG_C) or (READ_LATENCY_G /= 0)
-      report "TrueDualPortRam: DOA_REG_G/DOB_REG_G are incompatible with READ_LATENCY_G = 0"
+   assert (not DOA_REG_G) or (READ_LATENCY_A_G < 0)
+      report "TrueDualPortRam: DOA_REG_G must not be combined with explicit READ_LATENCY_A_G"
+      severity failure;
+
+   assert (not DOB_REG_G) or (READ_LATENCY_B_G < 0)
+      report "TrueDualPortRam: DOB_REG_G must not be combined with explicit READ_LATENCY_B_G"
+      severity failure;
+
+   assert (not DOA_REG_G) or (READ_LATENCY_G = 1)
+      report "TrueDualPortRam: DOA_REG_G must not be combined with READ_LATENCY_G /= 1"
+      severity failure;
+
+   assert (not DOB_REG_G) or (READ_LATENCY_G = 1)
+      report "TrueDualPortRam: DOB_REG_G must not be combined with READ_LATENCY_G /= 1"
+      severity failure;
+
+   assert (not DOA_REG_G) or (READ_LATENCY_A_BASE_C /= 0)
+      report "TrueDualPortRam: DOA_REG_G is incompatible with effective READ_LATENCY_A_G = 0"
+      severity failure;
+
+   assert (not DOB_REG_G) or (READ_LATENCY_B_BASE_C /= 0)
+      report "TrueDualPortRam: DOB_REG_G is incompatible with effective READ_LATENCY_B_G = 0"
+      severity failure;
+
+   assert (READ_LATENCY_A_C <= 100) and (READ_LATENCY_B_C <= 100)
+      report "TrueDualPortRam: effective read latency must be <= 100"
       severity failure;
 
    assert (SYNTH_MODE_G /= "inferred") or (MEMORY_TYPE_G = "block")
       report "TrueDualPortRam: inferred mode supports MEMORY_TYPE_G = block"
       severity failure;
 
-   assert (SYNTH_MODE_G /= "inferred") or (READ_LATENCY_C = 1) or (READ_LATENCY_C = 2)
-      report "TrueDualPortRam: inferred mode supports READ_LATENCY_G = 1 or 2 because the legacy TrueDualPortRam implementation is synchronous-read"
+   assert (SYNTH_MODE_G /= "inferred") or
+      (((READ_LATENCY_A_C = 1) or (READ_LATENCY_A_C = 2)) and
+       ((READ_LATENCY_B_C = 1) or (READ_LATENCY_B_C = 2)))
+      report "TrueDualPortRam: inferred mode supports effective READ_LATENCY_A_G/B_G = 1 or 2 because the legacy TrueDualPortRam implementation is synchronous-read"
+      severity failure;
+
+   assert (SYNTH_MODE_G /= "altera_mf") or (READ_LATENCY_A_C = READ_LATENCY_B_C)
+      report "TrueDualPortRam: altera_mf mode supports only shared A/B read latency"
       severity failure;
 
    weaVector <= weaByte when BYTE_WR_EN_G else (others => wea);
@@ -136,6 +175,8 @@ begin
             MEMORY_INIT_PARAM_G => MEMORY_INIT_PARAM_G,
             WRITE_MODE_G        => WRITE_MODE_C,
             READ_LATENCY_G      => READ_LATENCY_C,
+            READ_LATENCY_A_G    => READ_LATENCY_A_C,
+            READ_LATENCY_B_G    => READ_LATENCY_B_C,
             DATA_WIDTH_G        => DATA_WIDTH_G,
             BYTE_WR_EN_G        => BYTE_WR_EN_G,
             BYTE_WIDTH_G        => BYTE_WIDTH_G,

--- a/base/ram/ruckus.tcl
+++ b/base/ram/ruckus.tcl
@@ -17,3 +17,5 @@ if {  $::env(VIVADO_VERSION) >= 2019.1} {
 } else {
    loadSource -lib surf -dir "$::DIR_PATH/dummy"
 }
+
+loadSource -lib surf -dir "$::DIR_PATH/rtl"

--- a/base/ram/xilinx/TrueDualPortRamXpm.vhd
+++ b/base/ram/xilinx/TrueDualPortRamXpm.vhd
@@ -33,6 +33,8 @@ entity TrueDualPortRamXpm is
       MEMORY_INIT_PARAM_G : string                     := "0";
       WRITE_MODE_G        : string                     := "no_change";
       READ_LATENCY_G      : natural range 0 to 100     := 1;
+      READ_LATENCY_A_G    : integer range -1 to 100    := -1;
+      READ_LATENCY_B_G    : integer range -1 to 100    := -1;
       DATA_WIDTH_G        : integer range 1 to (2**24) := 16;
       BYTE_WR_EN_G        : boolean                    := false;
       BYTE_WIDTH_G        : integer range 8 to 9       := 8;  -- If BRAM, should be multiple or 8 or 9
@@ -60,6 +62,9 @@ end TrueDualPortRamXpm;
 
 architecture rtl of TrueDualPortRamXpm is
 
+   constant READ_LATENCY_A_C : natural := ite(READ_LATENCY_A_G < 0, READ_LATENCY_G, READ_LATENCY_A_G);
+   constant READ_LATENCY_B_C : natural := ite(READ_LATENCY_B_G < 0, READ_LATENCY_G, READ_LATENCY_B_G);
+
    signal resetA : sl;
    signal resetB : sl;
 
@@ -85,15 +90,15 @@ begin
          MESSAGE_CONTROL         => 0,  -- Default value = 0
          READ_DATA_WIDTH_A       => DATA_WIDTH_G,
          READ_DATA_WIDTH_B       => DATA_WIDTH_G,
-         READ_LATENCY_A          => READ_LATENCY_G,
-         READ_LATENCY_B          => READ_LATENCY_G,
+         READ_LATENCY_A          => READ_LATENCY_A_C,
+         READ_LATENCY_B          => READ_LATENCY_B_C,
          USE_EMBEDDED_CONSTRAINT => 0,  -- Default value = 0
          USE_MEM_INIT            => 1,  -- Default value = 1
          WAKEUP_TIME             => "disable_sleep",  -- "disable_sleep" to disable dynamic power saving option
          WRITE_DATA_WIDTH_A      => DATA_WIDTH_G,
          WRITE_DATA_WIDTH_B      => DATA_WIDTH_G,
-         WRITE_MODE_A            => ite(READ_LATENCY_G = 0, "read_first", WRITE_MODE_G),  -- Default value = no_change
-         WRITE_MODE_B            => ite(READ_LATENCY_G = 0, "read_first", WRITE_MODE_G))  -- Default value = no_change
+         WRITE_MODE_A            => ite(READ_LATENCY_A_C = 0, "read_first", WRITE_MODE_G),  -- Default value = no_change
+         WRITE_MODE_B            => ite(READ_LATENCY_B_C = 0, "read_first", WRITE_MODE_G))  -- Default value = no_change
       port map (
          -- Port A
          clka           => clka,

--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -669,66 +669,25 @@ begin
    -- Tx buffer RAM
    GEN_TX : if (BYP_TX_BUFFER_G = false) generate
 
-      GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-         U_RAM : entity surf.SimpleDualPortRamXpm
-            generic map (
-               TPD_G         => TPD_G,
-               COMMON_CLK_G  => true,
-               MEMORY_TYPE_G => MEMORY_TYPE_G,
-               DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka   => clk_i,
-               wea(0) => s_txWrBuffWe,
-               addra  => s_txWrBuffAddr,
-               dina   => s_txWrBuffData,
-               -- Port B - Read only
-               clkb   => clk_i,
-               rstb   => rst_i,
-               addrb  => s_txRdBuffAddr,
-               doutb  => s_txRdBuffData);
-      end generate;
-
-      GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
-         U_RAM : entity surf.SimpleDualPortRamAlteraMf
-            generic map (
-               TPD_G         => TPD_G,
-               COMMON_CLK_G  => true,
-               MEMORY_TYPE_G => MEMORY_TYPE_G,
-               DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka   => clk_i,
-               wea(0) => s_txWrBuffWe,
-               addra  => s_txWrBuffAddr,
-               dina   => s_txWrBuffData,
-               -- Port B - Read only
-               clkb   => clk_i,
-               rstb   => rst_i,
-               addrb  => s_txRdBuffAddr,
-               doutb  => s_txRdBuffData);
-      end generate;
-
-      GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
-         U_RAM : entity surf.SimpleDualPortRam
-            generic map (
-               TPD_G        => TPD_G,
-               DATA_WIDTH_G => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka  => clk_i,
-               wea   => s_txWrBuffWe,
-               addra => s_txWrBuffAddr,
-               dina  => s_txWrBuffData,
-               -- Port B - Read only
-               clkb  => clk_i,
-               rstb  => rst_i,
-               addrb => s_txRdBuffAddr,
-               doutb => s_txRdBuffData);
-      end generate;
+      U_RAM : entity surf.SimpleDualPortRam
+         generic map (
+            TPD_G         => TPD_G,
+            SYNTH_MODE_G  => SYNTH_MODE_G,
+            COMMON_CLK_G  => true,
+            MEMORY_TYPE_G => MEMORY_TYPE_G,
+            DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
+            ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
+         port map (
+            -- Port A - Write only
+            clka  => clk_i,
+            wea   => s_txWrBuffWe,
+            addra => s_txWrBuffAddr,
+            dina  => s_txWrBuffData,
+            -- Port B - Read only
+            clkb  => clk_i,
+            rstb  => rst_i,
+            addrb => s_txRdBuffAddr,
+            doutb => s_txRdBuffData);
 
    end generate;
 
@@ -795,66 +754,25 @@ begin
    -- Rx buffer RAM
    GEN_RX : if (BYP_RX_BUFFER_G = false) generate
 
-      GEN_XPM : if (SYNTH_MODE_G = "xpm") generate
-         U_RAM : entity surf.SimpleDualPortRamXpm
-            generic map (
-               TPD_G         => TPD_G,
-               COMMON_CLK_G  => true,
-               MEMORY_TYPE_G => MEMORY_TYPE_G,
-               DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka   => clk_i,
-               wea(0) => s_rxWrBuffWe,
-               addra  => s_rxWrBuffAddr,
-               dina   => s_rxWrBuffData,
-               -- Port B - Read only
-               clkb   => clk_i,
-               rstb   => rst_i,
-               addrb  => s_rxRdBuffAddr,
-               doutb  => s_rxRdBuffData);
-      end generate;
-
-      GEN_ALTERA : if (SYNTH_MODE_G = "altera_mf") generate
-         U_RAM : entity surf.SimpleDualPortRamAlteraMf
-            generic map (
-               TPD_G         => TPD_G,
-               COMMON_CLK_G  => true,
-               MEMORY_TYPE_G => MEMORY_TYPE_G,
-               DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka   => clk_i,
-               wea(0) => s_rxWrBuffWe,
-               addra  => s_rxWrBuffAddr,
-               dina   => s_rxWrBuffData,
-               -- Port B - Read only
-               clkb   => clk_i,
-               rstb   => rst_i,
-               addrb  => s_rxRdBuffAddr,
-               doutb  => s_rxRdBuffData);
-      end generate;
-
-      GEN_INFERRED : if (SYNTH_MODE_G = "inferred") generate
-         U_RAM : entity surf.SimpleDualPortRam
-            generic map (
-               TPD_G        => TPD_G,
-               DATA_WIDTH_G => RSSI_WORD_WIDTH_C*8,
-               ADDR_WIDTH_G => BUFFER_ADDR_WIDTH_C)
-            port map (
-               -- Port A - Write only
-               clka  => clk_i,
-               wea   => s_rxWrBuffWe,
-               addra => s_rxWrBuffAddr,
-               dina  => s_rxWrBuffData,
-               -- Port B - Read only
-               clkb  => clk_i,
-               rstb  => rst_i,
-               addrb => s_rxRdBuffAddr,
-               doutb => s_rxRdBuffData);
-      end generate;
+      U_RAM : entity surf.SimpleDualPortRam
+         generic map (
+            TPD_G         => TPD_G,
+            SYNTH_MODE_G  => SYNTH_MODE_G,
+            COMMON_CLK_G  => true,
+            MEMORY_TYPE_G => MEMORY_TYPE_G,
+            DATA_WIDTH_G  => RSSI_WORD_WIDTH_C*8,
+            ADDR_WIDTH_G  => BUFFER_ADDR_WIDTH_C)
+         port map (
+            -- Port A - Write only
+            clka  => clk_i,
+            wea   => s_rxWrBuffWe,
+            addra => s_rxWrBuffAddr,
+            dina  => s_rxWrBuffData,
+            -- Port B - Read only
+            clkb  => clk_i,
+            rstb  => rst_i,
+            addrb => s_rxRdBuffAddr,
+            doutb => s_rxRdBuffData);
 
    end generate;
 

--- a/tests/axi/axi_lite/test_AxiDualPortRam.py
+++ b/tests/axi/axi_lite/test_AxiDualPortRam.py
@@ -9,9 +9,10 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Keep a three-case wrapper-focused sweep covering AXI-writeable RAM,
-#   dual-port RAM with byte-enabled system writes, and AXI read-only behavior
-#   with error responses exposed through the existing IP-integrator wrapper.
+# - Sweep: Keep a wrapper-focused sweep covering AXI-writeable RAM, dual-port
+#   RAM with byte-enabled system writes, latency-3 output-register behavior,
+#   and AXI read-only behavior with error responses exposed through the
+#   existing IP-integrator wrapper.
 # - Stimulus: Drive AXI-Lite reads and writes through the flat wrapper port,
 #   read the same locations back through the system-side port, and in writable
 #   system-port cases issue full-word and partial-byte writes from the system
@@ -179,6 +180,19 @@ PARAMETER_SWEEP = [
         SYNTH_MODE="inferred",
         MEMORY_TYPE="block",
         READ_LATENCY="2",
+        AXI_WR_EN="true",
+        SYS_WR_EN="true",
+        SYS_BYTE_WR_EN="true",
+        COMMON_CLK="false",
+        ADDR_WIDTH="6",
+        DATA_WIDTH="32",
+    ),
+    parameter_case(
+        "dual_port_byte_write_latency3_async",
+        EN_ERROR_RESP="true",
+        SYNTH_MODE="inferred",
+        MEMORY_TYPE="block",
+        READ_LATENCY="3",
         AXI_WR_EN="true",
         SYS_WR_EN="true",
         SYS_BYTE_WR_EN="true",

--- a/tests/base/ram/test_SimpleDualPortRam.py
+++ b/tests/base/ram/test_SimpleDualPortRam.py
@@ -9,9 +9,9 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Sweep block vs distributed implementations, optional `DOB` output
-#   registration, byte-write enable, and asynchronous plus active-low reset
-#   behavior.
+# - Sweep: Sweep legacy inferred block vs distributed attributes, optional
+#   `DOB` output registration, explicit inferred synthesis selection/read
+#   latency, byte-write enable, and asynchronous plus active-low reset behavior.
 # - Stimulus: Write through port A and read through port B, apply partial byte
 #   masks to an existing word, optionally hold port-B enable low in direct and
 #   registered-output modes, and then reset after a registered output has
@@ -19,8 +19,12 @@
 # - Checks: The bench checks basic dual-port readback, byte-write merging, hold
 #   behavior of the optional B output register, and reset clearing of that
 #   registered output.
-# - Timing: Latency is checked across separate A and B clocks, with one
-#   additional cycle expected when the B-side output register is enabled.
+# - Timing: The inferred SimpleDualPortRam implementation is synchronous-read
+#   for every MEMORY_TYPE_G value. Latency is checked across separate A and B
+#   clocks, with one additional cycle expected when the B-side output register
+#   is enabled directly or through READ_LATENCY_G = 2.
+
+import os
 
 import cocotb
 import pytest
@@ -41,7 +45,8 @@ class TB(DualClockRamTB):
         # This DUT has two independent clocks, so the cocotb testbench needs to
         # drive both domains explicitly.
         self.byte_write_enabled = env_flag("BYTE_WR_EN_G", default=False)
-        self.dob_reg_enabled = env_flag("DOB_REG_G", default=False)
+        self.read_latency = int(os.environ.get("READ_LATENCY_G", "1"))
+        self.dob_reg_enabled = env_flag("DOB_REG_G", default=False) or self.read_latency == 2
 
         # Initialize every DUT input to a known idle state before time starts.
         dut.ena.value = 1
@@ -224,6 +229,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "block_baseline",
         MEMORY_TYPE_G="block",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="false",
         BYTE_WR_EN_G="false",
         DATA_WIDTH_G="16",
@@ -237,6 +244,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "distributed_dob_reg",
         MEMORY_TYPE_G="distributed",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="true",
         BYTE_WR_EN_G="false",
         DATA_WIDTH_G="16",
@@ -251,6 +260,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "byte_write_enable",
         MEMORY_TYPE_G="block",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="false",
         BYTE_WR_EN_G="true",
         DATA_WIDTH_G="16",
@@ -264,6 +275,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "async_reset",
         MEMORY_TYPE_G="distributed",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="false",
         BYTE_WR_EN_G="false",
         DATA_WIDTH_G="16",
@@ -277,6 +290,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "active_low_reset",
         MEMORY_TYPE_G="block",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="false",
         BYTE_WR_EN_G="false",
         DATA_WIDTH_G="16",
@@ -290,6 +305,8 @@ PARAMETER_SWEEP = [
     parameter_case(
         "read_enable_hold",
         MEMORY_TYPE_G="block",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="1",
         DOB_REG_G="false",
         BYTE_WR_EN_G="false",
         DATA_WIDTH_G="16",
@@ -298,6 +315,22 @@ PARAMETER_SWEEP = [
         RST_ASYNC_G="false",
         RST_POLARITY_G="'1'",
         CHECK_READ_ENABLE_HOLD="1",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "block_read_latency_registered",
+        MEMORY_TYPE_G="block",
+        SYNTH_MODE_G="inferred",
+        READ_LATENCY_G="2",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CHECK_REGISTERED_ENB_HOLD="1",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="5",
     ),

--- a/tests/base/ram/test_TrueDualPortRam.py
+++ b/tests/base/ram/test_TrueDualPortRam.py
@@ -21,7 +21,8 @@
 # - Timing: Because both ports are active, the bench checks results relative to
 #   the specific `clka` or `clkb` edge that triggered the interaction and
 #   expects registered outputs to lag by one extra cycle. READ_LATENCY_G = 2
-#   enables both output registers in the inferred selector path.
+#   enables both output registers in the inferred selector path, and
+#   READ_LATENCY_A_G/B_G can select the registered path per port.
 
 import os
 
@@ -43,8 +44,10 @@ class TB(DualClockRamTB):
         super().__init__(dut)
         self.mode = os.environ["MODE_G"]
         self.read_latency = int(os.environ.get("READ_LATENCY_G", "1"))
-        self.doa_reg_enabled = env_flag("DOA_REG_G", default=False) or self.read_latency == 2
-        self.dob_reg_enabled = env_flag("DOB_REG_G", default=False) or self.read_latency == 2
+        self.read_latency_a = self._effective_read_latency("A", env_flag("DOA_REG_G", default=False))
+        self.read_latency_b = self._effective_read_latency("B", env_flag("DOB_REG_G", default=False))
+        self.doa_reg_enabled = self.read_latency_a == 2
+        self.dob_reg_enabled = self.read_latency_b == 2
         self.byte_write_enabled = env_flag("BYTE_WR_EN_G", default=False)
 
         # Put every input into a defined idle state before the simulator starts.
@@ -63,6 +66,13 @@ class TB(DualClockRamTB):
         dut.addrb.value = 0
         dut.dinb.value = 0
         dut.regceb.value = 1
+
+    def _effective_read_latency(self, port: str, legacy_reg_enabled: bool) -> int:
+        port_latency = int(os.environ.get(f"READ_LATENCY_{port}_G", "-1"))
+        latency = self.read_latency if port_latency < 0 else port_latency
+        if legacy_reg_enabled and latency == 1:
+            latency = 2
+        return latency
 
     async def write_a(self, addr: int, value: int, *, byte_mask: int | None = None) -> None:
         self.dut.addra.value = addr
@@ -370,6 +380,25 @@ PARAMETER_SWEEP = [
         SYNTH_MODE_G="inferred",
         MEMORY_TYPE_G="block",
         READ_LATENCY_G="2",
+        MODE_G="read-first",
+        DOA_REG_G="false",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "read_latency_a_registered",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
+        READ_LATENCY_A_G="2",
+        READ_LATENCY_B_G="1",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="false",

--- a/tests/base/ram/test_TrueDualPortRam.py
+++ b/tests/base/ram/test_TrueDualPortRam.py
@@ -21,8 +21,8 @@
 # - Timing: Because both ports are active, the bench checks results relative to
 #   the specific `clka` or `clkb` edge that triggered the interaction and
 #   expects registered outputs to lag by one extra cycle. READ_LATENCY_G = 2
-#   enables both output registers in the inferred selector path, and
-#   READ_LATENCY_A_G/B_G can select the registered path per port.
+#   enables both output registers in the inferred selector path, and explicit
+#   READ_LATENCY_A_G/B_G cases select and check the registered path per port.
 
 import os
 
@@ -249,6 +249,29 @@ async def registered_output_hold_test(dut):
 
 
 @cocotb.test()
+async def registered_output_hold_a_test(dut):
+    tb = TB(dut)
+    await tb.warmup()
+    if not tb.doa_reg_enabled:
+        return
+
+    await tb.write_b(0, 0x1111)
+    await tb.write_b(1, 0x2222)
+    assert await tb.read_a(0) == 0x1111
+
+    # With `regcea=0`, the A-side registered output should keep the previously
+    # captured word even though the address and internal RAM output are moving.
+    tb.dut.addra.value = 1
+    tb.dut.regcea.value = 0
+    await tb.cycle_a(2)
+    assert int(dut.douta.value) == 0x1111
+
+    tb.dut.regcea.value = 1
+    await tb.cycle_a(1)
+    assert int(dut.douta.value) == 0x2222
+
+
+@cocotb.test()
 async def reset_behavior_test(dut):
     tb = TB(dut)
     await tb.warmup()
@@ -399,6 +422,25 @@ PARAMETER_SWEEP = [
         READ_LATENCY_G="1",
         READ_LATENCY_A_G="2",
         READ_LATENCY_B_G="1",
+        MODE_G="read-first",
+        DOA_REG_G="false",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "read_latency_b_registered",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
+        READ_LATENCY_A_G="1",
+        READ_LATENCY_B_G="2",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="false",

--- a/tests/base/ram/test_TrueDualPortRam.py
+++ b/tests/base/ram/test_TrueDualPortRam.py
@@ -9,9 +9,9 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Sweep `read-first`, `write-first`, and `no-change` modes, add a
-#   byte-write plus `DOB`-registered case, and include an asynchronous
-#   active-low reset case.
+# - Sweep: Sweep legacy inferred `read-first`, `write-first`, and `no-change`
+#   modes, add a byte-write plus `DOB`-registered case, check explicit
+#   selector read latency, and include an asynchronous active-low reset case.
 # - Stimulus: Alternate reads and writes on both ports, create same-address
 #   interactions to expose mode semantics, optionally collide both write ports,
 #   apply partial byte writes, and then reset after a registered capture.
@@ -20,7 +20,8 @@
 #   behavior, and reset recovery.
 # - Timing: Because both ports are active, the bench checks results relative to
 #   the specific `clka` or `clkb` edge that triggered the interaction and
-#   expects registered outputs to lag by one extra cycle.
+#   expects registered outputs to lag by one extra cycle. READ_LATENCY_G = 2
+#   enables both output registers in the inferred selector path.
 
 import os
 
@@ -41,8 +42,9 @@ class TB(DualClockRamTB):
     def __init__(self, dut):
         super().__init__(dut)
         self.mode = os.environ["MODE_G"]
-        self.doa_reg_enabled = env_flag("DOA_REG_G", default=False)
-        self.dob_reg_enabled = env_flag("DOB_REG_G", default=False)
+        self.read_latency = int(os.environ.get("READ_LATENCY_G", "1"))
+        self.doa_reg_enabled = env_flag("DOA_REG_G", default=False) or self.read_latency == 2
+        self.dob_reg_enabled = env_flag("DOB_REG_G", default=False) or self.read_latency == 2
         self.byte_write_enabled = env_flag("BYTE_WR_EN_G", default=False)
 
         # Put every input into a defined idle state before the simulator starts.
@@ -262,6 +264,9 @@ async def reset_behavior_test(dut):
 PARAMETER_SWEEP = [
     parameter_case(
         "read_first_baseline",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="false",
@@ -276,6 +281,9 @@ PARAMETER_SWEEP = [
     ),
     parameter_case(
         "write_first_baseline",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="write-first",
         DOA_REG_G="false",
         DOB_REG_G="false",
@@ -290,6 +298,9 @@ PARAMETER_SWEEP = [
     ),
     parameter_case(
         "no_change_baseline",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="no-change",
         DOA_REG_G="false",
         DOB_REG_G="false",
@@ -304,6 +315,9 @@ PARAMETER_SWEEP = [
     ),
     parameter_case(
         "byte_write_and_dob_reg",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="true",
@@ -318,6 +332,9 @@ PARAMETER_SWEEP = [
     ),
     parameter_case(
         "async_active_low_reset",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="false",
@@ -332,6 +349,9 @@ PARAMETER_SWEEP = [
     ),
     parameter_case(
         "same_clock_dual_write_collision",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="1",
         MODE_G="read-first",
         DOA_REG_G="false",
         DOB_REG_G="false",
@@ -342,6 +362,23 @@ PARAMETER_SWEEP = [
         RST_ASYNC_G="false",
         RST_POLARITY_G="'1'",
         CHECK_DUAL_WRITE_COLLISION="1",
+        CLKA_PERIOD_NS="5",
+        CLKB_PERIOD_NS="5",
+    ),
+    parameter_case(
+        "read_latency_registered",
+        SYNTH_MODE_G="inferred",
+        MEMORY_TYPE_G="block",
+        READ_LATENCY_G="2",
+        MODE_G="read-first",
+        DOA_REG_G="false",
+        DOB_REG_G="false",
+        BYTE_WR_EN_G="false",
+        DATA_WIDTH_G="16",
+        BYTE_WIDTH_G="8",
+        ADDR_WIDTH_G="4",
+        RST_ASYNC_G="false",
+        RST_POLARITY_G="'1'",
         CLKA_PERIOD_NS="5",
         CLKB_PERIOD_NS="5",
     ),

--- a/tests/common/regression_utils.py
+++ b/tests/common/regression_utils.py
@@ -200,9 +200,9 @@ def cocotb_module_name_from_test_file(test_file: str | Path) -> str:
 
 
 def _sim_build_suffix(parameters: dict[str, object]) -> str:
-    suffix = ",".join(f"{key}={value}" for key, value in parameters.items())
+    suffix = ",".join(f"{key}={value}" for key, value in sorted(parameters.items()))
     if len(suffix) > 120 or "/" in suffix or "\\" in suffix:
-        suffix = f"params-{hashlib.sha1(suffix.encode()).hexdigest()}"
+        suffix = f"params-{hashlib.sha256(suffix.encode()).hexdigest()}"
     return suffix
 
 

--- a/tests/common/regression_utils.py
+++ b/tests/common/regression_utils.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import hashlib
 import os
 from pathlib import Path
 import shlex
@@ -207,6 +208,8 @@ def _sim_build_path(test_file: Path, parameters: dict[str, object] | None) -> st
     # Parameter-specific build directories keep parallel pytest runs from
     # trampling each other's compile/elaboration artifacts.
     suffix = ",".join(f"{key}={value}" for key, value in parameters.items())
+    if len(suffix) > 120:
+        suffix = f"params-{hashlib.sha1(suffix.encode()).hexdigest()}"
     return str(build_dir.with_name(f"{test_file.stem}.{suffix}"))
 
 
@@ -224,8 +227,10 @@ def run_surf_vhdl_test(
     sim_build_parameters = parameters
     if extra_env is not None:
         simulator_env = {key: str(value) for key, value in extra_env.items()}
-        if sim_build_parameters is None:
-            sim_build_parameters = simulator_env
+        sim_build_parameters = {
+            **({key: str(value) for key, value in parameters.items()} if parameters is not None else {}),
+            **simulator_env,
+        }
     elif parameters is not None:
         simulator_env = {key: str(value) for key, value in parameters.items()}
 

--- a/tests/common/regression_utils.py
+++ b/tests/common/regression_utils.py
@@ -199,6 +199,13 @@ def cocotb_module_name_from_test_file(test_file: str | Path) -> str:
     return _module_name_from_test_file(Path(test_file))
 
 
+def _sim_build_suffix(parameters: dict[str, object]) -> str:
+    suffix = ",".join(f"{key}={value}" for key, value in parameters.items())
+    if len(suffix) > 120 or "/" in suffix or "\\" in suffix:
+        suffix = f"params-{hashlib.sha1(suffix.encode()).hexdigest()}"
+    return suffix
+
+
 def _sim_build_path(test_file: Path, parameters: dict[str, object] | None) -> str:
     rel_parent = test_file.resolve().relative_to(TESTS_ROOT).parent
     build_dir = TESTS_ROOT / "sim_build" / rel_parent / test_file.stem
@@ -207,9 +214,7 @@ def _sim_build_path(test_file: Path, parameters: dict[str, object] | None) -> st
 
     # Parameter-specific build directories keep parallel pytest runs from
     # trampling each other's compile/elaboration artifacts.
-    suffix = ",".join(f"{key}={value}" for key, value in parameters.items())
-    if len(suffix) > 120:
-        suffix = f"params-{hashlib.sha1(suffix.encode()).hexdigest()}"
+    suffix = _sim_build_suffix(parameters)
     return str(build_dir.with_name(f"{test_file.stem}.{suffix}"))
 
 


### PR DESCRIPTION
### Description
Add `SYNTH_MODE_G` backend selection to `SimpleDualPortRam` and `TrueDualPortRam` so users can choose inferred, XPM, or Altera implementations through the portable SURF RAM wrappers instead of instantiating backend-specific modules directly.

This makes `SimpleDualPortRam` and `TrueDualPortRam` the preferred public entry points for new dual-port RAM code. Existing inferred behavior and legacy output-register generics are preserved for compatibility.

### Details
- Adds `SYNTH_MODE_G` selector support to `SimpleDualPortRam` and `TrueDualPortRam`.
- Routes selector instances to inferred, XPM, or Altera backend implementations as requested.
- Migrates AXI4 `AxiRam` and `AxiRingBuffer` from backend-specific RAM generate branches to `SimpleDualPortRam` selector instances.
- Migrates AXI-Lite `AxiLiteSequencerRam` and `AxiDualPortRam` to use selector-based true dual-port RAM paths where appropriate.
- Updates `RssiCore` RAM instantiation to use the selector path.
- Adds explicit `READ_LATENCY_A_G` and `READ_LATENCY_B_G` support for true dual-port selector/XPM paths.
- Keeps `DOA_REG_G` and `DOB_REG_G` as the legacy way to request one extra inferred output register, with assertions to reject ambiguous combinations with explicit read-latency settings.
- Preserves `AxiDualPortRam` inferred special cases that rely on legacy `DualPortRam` behavior.
- Adds focused cocotb coverage for selector latency behavior and `AxiDualPortRam` latency-3 behavior.
- Adds `base/ram/README.md` guidance describing which RAM wrapper users should prefer for new designs.

Validation run:
- `./.venv/bin/python -m pytest -q tests/base/ram/test_TrueDualPortRam.py tests/base/ram/test_SimpleDualPortRam.py tests/axi/axi_lite/test_AxiLiteSequencerRam.py tests/axi/axi_lite/test_AxiDualPortRam.py` (`21 passed`)
- `make MODULES=/Users/bareese import`
- Focused VSG checks on edited VHDL files

### JIRA

### Related
