### PR TITLE
HTSP: parameterize HtspRxFifo/HtspTxFifo application AXI-Stream width

### DIFF
--- a/protocols/htsp/core/rtl/HtspRxFifo.vhd
+++ b/protocols/htsp/core/rtl/HtspRxFifo.vhd
@@ -32,7 +32,7 @@ entity HtspRxFifo is
       FIFO_PAUSE_THRESH_G   : positive := 256;
       TX_MAX_PAYLOAD_SIZE_G : positive := 8192;
       ROGUE_SIM_EN_G        : boolean  := false;
-      GEN_SYNC_FIFO_G       : boolean  := false;
+      GEN_SYNC_FIFO_G       : boolean  := false;  -- Set true only when appClks(i) equals htspClk
       MEMORY_TYPE_G         : string   := "uram";
       NUM_VC_G              : positive;
       APP_AXI_CONFIG_G      : AxiStreamConfigType);
@@ -167,6 +167,7 @@ begin
                mAxisSlave  => appRxSlaves(i));
       end generate;
 
+      -- When clocks are common, use gearbox directly instead of an async resize FIFO
       GEN_SYNC_FIFO : if GEN_SYNC_FIFO_G generate
          U_Gearbox : entity surf.AxiStreamGearbox
             generic map (

--- a/protocols/htsp/core/rtl/HtspRxFifo.vhd
+++ b/protocols/htsp/core/rtl/HtspRxFifo.vhd
@@ -30,22 +30,25 @@ entity HtspRxFifo is
       CASCADE_SIZE_G        : positive := 1;
       FIFO_ADDR_WIDTH_G     : positive := 12;
       FIFO_PAUSE_THRESH_G   : positive := 256;
-      INT_WIDTH_SELECT_G    : string   := "WIDE";
-      INT_DATA_WIDTH_G      : positive := 64;
       TX_MAX_PAYLOAD_SIZE_G : positive := 8192;
-      NUM_VC_G              : positive);
+      ROGUE_SIM_EN_G        : boolean  := false;
+      GEN_SYNC_FIFO_G       : boolean  := false;
+      MEMORY_TYPE_G         : string   := "uram";
+      NUM_VC_G              : positive;
+      APP_AXI_CONFIG_G      : AxiStreamConfigType);
    port (
-      -- Application Interface (appClk domain)
-      appClks       : in  slv(NUM_VC_G-1 downto 0);
-      appRsts       : in  slv(NUM_VC_G-1 downto 0);
-      appRxMasters  : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
-      appRxSlaves   : in  AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
       -- HTSP Interface (htspClk domain)
       htspClk       : in  sl;
       htspRst       : in  sl;
       rxlinkReady   : in  sl;
       htspRxMasters : in  AxiStreamMasterArray(NUM_VC_G-1 downto 0);
-      htspRxCtrl    : out AxiStreamCtrlArray(NUM_VC_G-1 downto 0));
+      htspRxSlaves  : out AxiStreamSlaveArray(NUM_VC_G-1 downto 0);
+      htspRxCtrl    : out AxiStreamCtrlArray(NUM_VC_G-1 downto 0);
+      -- Application Interface (appClk domain)
+      appClks       : in  slv(NUM_VC_G-1 downto 0);
+      appRsts       : in  slv(NUM_VC_G-1 downto 0);
+      appRxMasters  : out AxiStreamMasterArray(NUM_VC_G-1 downto 0);
+      appRxSlaves   : in  AxiStreamSlaveArray(NUM_VC_G-1 downto 0));
 end HtspRxFifo;
 
 architecture mapping of HtspRxFifo is
@@ -97,24 +100,27 @@ begin
    GEN_VEC :
    for i in NUM_VC_G-1 downto 0 generate
 
+      -------------------------------------------------------------------------------------
+      -- Note: The reason why we don't combine the U_FIFO with GEN_ASYNC_FIFO.ASYNC_FIFO is
+      -- because "READY_EN_G must be true if slave width is great than master"
+      -- and common for APP_AXI_CONFIG_G to be less than HTSP_AXIS_CONFIG_C
+      -------------------------------------------------------------------------------------
       U_FIFO : entity surf.AxiStreamFifoV2
          generic map (
             -- General Configurations
             TPD_G               => TPD_G,
             INT_PIPE_STAGES_G   => 1,
             PIPE_STAGES_G       => 1,
-            SLAVE_READY_EN_G    => false,
+            SLAVE_READY_EN_G    => ROGUE_SIM_EN_G,
             VALID_THOLD_G       => (TX_MAX_PAYLOAD_SIZE_G/64),  -- Hold until enough to burst into the interleaving MUX
             VALID_BURST_MODE_G  => true,
             -- FIFO configurations
             SYNTH_MODE_G        => "xpm",
-            MEMORY_TYPE_G       => "uram",
+            MEMORY_TYPE_G       => MEMORY_TYPE_G,
             GEN_SYNC_FIFO_G     => true,
             FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
             FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_G,
             CASCADE_SIZE_G      => CASCADE_SIZE_G,
-            INT_WIDTH_SELECT_G  => INT_WIDTH_SELECT_G,
-            INT_DATA_WIDTH_G    => INT_DATA_WIDTH_G,
             -- AXI Stream Port Configurations
             SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
             MASTER_AXI_CONFIG_G => HTSP_AXIS_CONFIG_C)
@@ -124,38 +130,60 @@ begin
             sAxisRst    => htspReset,
             sAxisMaster => htspMasters(i),
             sAxisCtrl   => htspRxCtrl(i),
+            sAxisSlave  => htspRxSlaves(i),
             -- Master Port
             mAxisClk    => htspClk,
             mAxisRst    => htspReset,
             mAxisMaster => rxMasters(i),
             mAxisSlave  => rxSlaves(i));
 
-      ASYNC_FIFO : entity surf.AxiStreamFifoV2
-         generic map (
-            -- General Configurations
-            TPD_G               => TPD_G,
-            INT_PIPE_STAGES_G   => 1,
-            PIPE_STAGES_G       => 1,
-            SLAVE_READY_EN_G    => true,
-            VALID_THOLD_G       => 1,
-            -- FIFO configurations
-            MEMORY_TYPE_G       => "block",
-            GEN_SYNC_FIFO_G     => false,
-            FIFO_ADDR_WIDTH_G   => 9,
-            -- AXI Stream Port Configurations
-            SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
-            MASTER_AXI_CONFIG_G => HTSP_AXIS_CONFIG_C)
-         port map (
-            -- Slave Port
-            sAxisClk    => htspClk,
-            sAxisRst    => htspReset,
-            sAxisMaster => rxMasters(i),
-            sAxisSlave  => rxSlaves(i),
-            -- Master Port
-            mAxisClk    => appClks(i),
-            mAxisRst    => appRsts(i),
-            mAxisMaster => appRxMasters(i),
-            mAxisSlave  => appRxSlaves(i));
+      GEN_ASYNC_FIFO : if not GEN_SYNC_FIFO_G generate
+         ASYNC_FIFO : entity surf.AxiStreamFifoV2
+            generic map (
+               -- General Configurations
+               TPD_G               => TPD_G,
+               INT_PIPE_STAGES_G   => 1,
+               PIPE_STAGES_G       => 1,
+               SLAVE_READY_EN_G    => true,
+               VALID_THOLD_G       => 1,
+               -- FIFO configurations
+               MEMORY_TYPE_G       => "distributed",
+               GEN_SYNC_FIFO_G     => false,
+               FIFO_ADDR_WIDTH_G   => 4,
+               INT_WIDTH_SELECT_G  => "NARROW",
+               -- AXI Stream Port Configurations
+               SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
+               MASTER_AXI_CONFIG_G => APP_AXI_CONFIG_G)
+            port map (
+               -- Slave Port
+               sAxisClk    => htspClk,
+               sAxisRst    => htspReset,
+               sAxisMaster => rxMasters(i),
+               sAxisSlave  => rxSlaves(i),
+               -- Master Port
+               mAxisClk    => appClks(i),
+               mAxisRst    => appResets(i),
+               mAxisMaster => appRxMasters(i),
+               mAxisSlave  => appRxSlaves(i));
+      end generate;
+
+      GEN_SYNC_FIFO : if GEN_SYNC_FIFO_G generate
+         U_Gearbox : entity surf.AxiStreamGearbox
+            generic map (
+               TPD_G               => TPD_G,
+               SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
+               MASTER_AXI_CONFIG_G => APP_AXI_CONFIG_G)
+            port map (
+               -- Clock and reset
+               axisClk     => htspClk,
+               axisRst     => htspReset,
+               -- Inbound Stream
+               sAxisMaster => rxMasters(i),
+               sAxisSlave  => rxSlaves(i),
+               -- Outbound Stream
+               mAxisMaster => appRxMasters(i),
+               mAxisSlave  => appRxSlaves(i));
+      end generate;
 
    end generate GEN_VEC;
 

--- a/protocols/htsp/core/rtl/HtspTxFifo.vhd
+++ b/protocols/htsp/core/rtl/HtspTxFifo.vhd
@@ -28,7 +28,8 @@ entity HtspTxFifo is
    generic (
       TPD_G                 : time     := 1 ns;
       TX_MAX_PAYLOAD_SIZE_G : positive := 8192;
-      NUM_VC_G              : positive);
+      NUM_VC_G              : positive;
+      APP_AXI_CONFIG_G      : AxiStreamConfigType);
    port (
       -- APP Interface (appClks domain)
       appClks       : in  slv(NUM_VC_G-1 downto 0);
@@ -97,7 +98,7 @@ begin
       U_Flush : entity surf.AxiStreamFlush
          generic map (
             TPD_G         => TPD_G,
-            AXIS_CONFIG_G => HTSP_AXIS_CONFIG_C,
+            AXIS_CONFIG_G => APP_AXI_CONFIG_G,
             SSI_EN_G      => true)
          port map (
             axisClk     => appClks(vc),
@@ -123,7 +124,7 @@ begin
             FIFO_ADDR_WIDTH_G   => 9,
             FIFO_PAUSE_THRESH_G => 256,
             -- AXI Stream Port Configurations
-            SLAVE_AXI_CONFIG_G  => HTSP_AXIS_CONFIG_C,
+            SLAVE_AXI_CONFIG_G  => APP_AXI_CONFIG_G,
             MASTER_AXI_CONFIG_G => HTSP_AXIS_CONFIG_C)
          port map (
             -- Slave Port


### PR DESCRIPTION
### Description
Parameterize the application-side interface of `HtspRxFifo` and `HtspTxFifo` with a new `APP_AXI_CONFIG_G` so an application stream of arbitrary width can attach to the 512-bit HTSP data path, instead of the fixed HTSP config.

### Details
- Adds `APP_AXI_CONFIG_G` to both `HtspRxFifo` and `HtspTxFifo`.
- `HtspRxFifo`: adds `ROGUE_SIM_EN_G`, `GEN_SYNC_FIFO_G`, `MEMORY_TYPE_G`; removes `INT_WIDTH_SELECT_G`/`INT_DATA_WIDTH_G`; exposes `htspRxSlaves` and reorders ports (HTSP interface first).
- `HtspRxFifo`: splits into a 512-bit URAM staging FIFO followed by either an async resize FIFO (default) or an `AxiStreamGearbox` when `GEN_SYNC_FIFO_G` is set.
- `HtspRxFifo`: drives the async FIFO master reset from the pipelined `appResets`.
- `HtspTxFifo`: applies `APP_AXI_CONFIG_G` to the `AxiStreamFlush` and resize FIFO slave-side config.

Validation run:
- Focused VSG checks on edited VHDL files (`vsg -c vsg-linter.yml`, clean)

### JIRA

### Related