### PR TITLE
Change-aware GHDL/cocotb CI: run only affected cocotb tests on feature-branch pushes

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -14,7 +14,20 @@
 # secrets.CONDA_UPLOAD_TOKEN_TAG
 
 name: CI
-on: [push]
+# Triggers: every push runs the workflow (selective regression on feature
+# branches, full on main/tags); PRs into main additionally run it in full.
+# A feature branch with an open PR into main therefore runs the regression
+# job twice per push -- once selective (push ref) and once full (PR merge
+# ref). The two use distinct concurrency groups (github.ref differs) so
+# neither cancels the other. This is intentional: the push run gives fast
+# per-commit feedback and the PR run is the full pre-merge release gate; the
+# selective set is always a strict subset of the full suite, so the overlap
+# is redundant-but-safe, and in this repo feature branches target
+# pre-release (not main), so the double run is confined to release PRs.
+on:
+  push:
+  pull_request:
+    branches: [ main ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -84,6 +97,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -104,12 +119,96 @@ jobs:
           fi
           python -m pip install -r ruckus/scripts/pip_requirements.txt
 
+      - name: Determine run mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+             || [[ "${{ github.ref }}" == "refs/heads/main" ]] \
+             || [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "value=full" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=selective" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The resolver needs `ghdl --gen-depends`, which apt mcode lacks and apt
+      # ghdl-llvm is broken on ubuntu-24.04. Install GHDL's official LLVM
+      # build (bundles libLLVM) for the resolver ONLY, and only on selective
+      # runs -- full runs (tag/main/PR->main) skip the resolver entirely and
+      # build/simulate on the apt mcode ghdl, so the llvm install is pure
+      # overhead there. The cocotb sims always run on mcode (fast -- llvm
+      # codegen is far slower).
+      - name: Setup GHDL (official LLVM build, for the resolver)
+        if: steps.mode.outputs.value == 'selective'
+        uses: ghdl/setup-ghdl@v1
+        with:
+          version: v6.0.0
+          backend: llvm
+
       - name: Parallel Regression Tests
         run: |
-          make MODULES=$PWD import
-          python -m pytest --cov -v -n auto --dist=worksteal tests/axi tests/base tests/dsp tests/protocols
+          # Full runs (tag/main/PR->main) never touch the resolver: build and
+          # simulate on the apt mcode ghdl and collect coverage for Codecov.
+          if [[ "${{ steps.mode.outputs.value }}" == "full" ]]; then
+            make MODULES=$PWD import
+            python -m pytest --cov -v -n auto --dist=worksteal tests/common tests/axi tests/base tests/dsp tests/protocols
+            exit 0
+          fi
+
+          # Selective runs: setup-ghdl prepended the official llvm ghdl (has
+          # --gen-depends). The apt mcode ghdl (/usr/bin/ghdl) runs the fast
+          # cocotb sims; build MCODE_PATH by dropping the llvm bin dir so bare
+          # `ghdl` is mcode. `grep -v` exits 1 when it filters out every entry
+          # (e.g. PATH were only the llvm dir); `|| true` keeps that from
+          # tripping the step's `pipefail`.
+          LLVM_GHDL="$(command -v ghdl)"
+          LLVM_DIR="$(dirname "$LLVM_GHDL")"
+          MCODE_PATH="$(printf '%s' "$PATH" | tr ':' '\n' | { grep -vxF "$LLVM_DIR" || true; } | paste -sd:)"
+
+          # Build the surf library with the llvm ghdl so the resolver's
+          # gen-depends (also llvm) reads a version-consistent .cf. build/ is
+          # consumed only by the resolver and the source-list step; the sims
+          # recompile from source on mcode.
+          GHDL_CMD="$LLVM_GHDL" make MODULES=$PWD import
+
+          # Resolve affected tests with the llvm ghdl (--gen-depends). The
+          # resolver prints a rationale (resolved/unresolved counts) to stderr;
+          # set SURF_DEP_MAP_DEBUG=1 here to also log why each toplevel is
+          # unresolved when diagnosing selection.
+          if resolver_output="$(GHDL_CMD="$LLVM_GHDL" python -m tests.common)"; then
+            resolver_rc=0
+          else
+            resolver_rc=$?
+          fi
+
+          echo "${resolver_output}"
+
+          # Run the cocotb sims on the fast apt mcode ghdl, not llvm. Coverage
+          # is dropped on selective runs -- the Codecov step is full-only, so
+          # collecting it here is wasted work and artifact churn.
+          export PATH="$MCODE_PATH"
+
+          if [[ "${resolver_rc}" -ne 0 ]] || grep -qx "FORCE_FULL" <<< "${resolver_output}"; then
+            echo "Resolver forced a full run (rc=${resolver_rc})"
+            python -m pytest -v -n auto --dist=worksteal tests/common tests/axi tests/base tests/dsp tests/protocols
+          else
+            # Always run the resolver's own unit tests (tests/common) on
+            # selective runs. They are fast (pure-Python, GHDL monkeypatched)
+            # and are the only coverage a feature-branch push that touches just
+            # the resolver would get: a resolver-only change resolves to zero
+            # affected cocotb tests, so without this the run would execute
+            # nothing and leave the resolver change untested until a full run.
+            targets=(tests/common)
+            if [[ -n "${resolver_output}" ]]; then
+              mapfile -t selected < <(printf '%s\n' "${resolver_output}" | tr '.' '/' | sed 's/$/.py/')
+              targets+=("${selected[@]}")
+            else
+              echo "No affected cocotb tests for this change set -- running resolver unit tests only."
+            fi
+            python -m pytest -v -n auto --dist=worksteal "${targets[@]}"
+          fi
 
       - name: Code Coverage
+        if: steps.mode.outputs.value == 'full'
         run: |
           codecov
           coverage report -m

--- a/tests/common/__main__.py
+++ b/tests/common/__main__.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+from tests.common import dep_map
+from tests.common.regression_utils import BASE_GHDL_COMPILE_ARGS, REPO_ROOT
+
+
+def _parse_changed_files_override(raw: str) -> dict[str, str]:
+    # Unit tests / Phase 2 pass an explicit changed-file list rather than
+    # having the CLI compute the diff itself (D-13). Entries default to
+    # status 'M'; an optional ':A'/':D' suffix expresses Added/Deleted so
+    # callers can exercise the D-14 deletion-forces-full path without a
+    # real git history (e.g. `--changed-files-override foo.vhd:D`).
+    changed: dict[str, str] = {}
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        path, _, status = entry.partition(":")
+        changed[path] = status if status in ("A", "M", "D") else "M"
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print the pytest targets affected by the current changed-file set, "
+        "or a FORCE_FULL sentinel when that cannot be determined."
+    )
+    parser.add_argument(
+        "--workdir",
+        default=str(REPO_ROOT / "build"),
+        help="GHDL working directory produced by `make MODULES=$PWD import` (default: build/).",
+    )
+    parser.add_argument(
+        "--scan-dir",
+        action="append",
+        dest="scan_dirs",
+        help="Restrict test discovery to one or more tests/<dir> subtrees. "
+        "Defaults to the CI test universe (axi, base, dsp, protocols).",
+    )
+    parser.add_argument(
+        "--changed-files-override",
+        help="Comma-separated list of repo-relative changed files, used instead of "
+        "computing the diff against origin/main (for unit tests / Phase 2).",
+    )
+    args = parser.parse_args()
+
+    scan_dirs = tuple(args.scan_dirs) if args.scan_dirs else dep_map.DEFAULT_SCAN_DIRS
+
+    if args.changed_files_override is not None:
+        changed = _parse_changed_files_override(args.changed_files_override)
+    else:
+        try:
+            merge_base = dep_map.merge_base_with_origin_main()
+            changed = dep_map.changed_files(merge_base)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            print(dep_map.FORCE_FULL)
+            print("rationale: could not compute merge-base with origin/main", file=sys.stderr)
+            return 1
+
+    try:
+        resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs)
+    except FileNotFoundError as exc:
+        # A bad --scan-dir (mistyped, or a future DEFAULT_SCAN_DIRS typo)
+        # makes discover_toplevels() raise loudly rather than silently
+        # discover zero tests. Fail open the same way as the merge-base and
+        # .cf paths below: emit the FORCE_FULL sentinel on stdout so the
+        # single-stdout-line contract holds (indeterminate -> full run).
+        print(dep_map.FORCE_FULL)
+        print(f"rationale: could not discover test toplevels ({exc})", file=sys.stderr)
+        return 1
+
+    # Every GHDL call below runs with cwd=workdir (import_test_local_sources'
+    # `ghdl -i` and build_dependency_map's `ghdl --gen-depends`). A missing
+    # workdir makes subprocess.run raise FileNotFoundError before the
+    # parse_cf_units guard downstream can catch it, escaping unhandled. Fail
+    # open the same way as the merge-base, scan-dir, and .cf paths: emit the
+    # FORCE_FULL sentinel on stdout so the single-stdout-line contract holds
+    # (indeterminate -> full run).
+    if not Path(args.workdir).is_dir():
+        print(dep_map.FORCE_FULL)
+        print(f"rationale: GHDL working directory does not exist ({args.workdir})", file=sys.stderr)
+        return 1
+
+    # Import the wrapper / ip_integrator sources `make import` omits so their
+    # toplevels are analyzable by `ghdl --gen-depends`. Without this, the
+    # majority of cocotb tests -- which wrap their DUT because cocotb cannot
+    # drive VHDL records -- fail resolution and fall back to always-run,
+    # degrading selective mode into a near-full run.
+    dep_map.import_test_local_sources(REPO_ROOT, args.workdir, BASE_GHDL_COMPILE_ARGS, scan_dirs)
+    built_map, unresolved_modules = dep_map.build_dependency_map(resolved, args.workdir, BASE_GHDL_COMPILE_ARGS)
+    # A module whose GHDL analysis failed (ip_integrator wrapper only
+    # compiled via extra_vhdl_sources, or a genuine analysis error) gets
+    # the same fail-safe treatment as a non-literal toplevel (D-08): it is
+    # unconditionally selected rather than silently dropped (D-10).
+    always_run = always_run | unresolved_modules
+
+    try:
+        cf_units = dep_map.parse_cf_units(Path(args.workdir) / "surf-obj08.cf")
+    except FileNotFoundError:
+        print(dep_map.FORCE_FULL)
+        print("rationale: could not find the GHDL .cf library index needed for wrapper attribution", file=sys.stderr)
+        return 1
+    # wrappers/ files are never loaded into `.cf` by any ruckus.tcl (they
+    # are compiled per-test via extra_vhdl_sources instead), so wrapper
+    # unit names come from a direct scan of the wrapper files themselves;
+    # `.cf` is unioned in only opportunistically.
+    wrapper_units = dep_map.parse_wrapper_entity_units(REPO_ROOT, scan_dirs)
+    for path, units in wrapper_units.items():
+        cf_units.setdefault(path, set()).update(units)
+    wrapper_index = dep_map.build_wrapper_index(cf_units, resolved)
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, wrapper_index)
+    python_selected, _ = dep_map.map_python_changes(changed, resolved, always_run)
+    selected |= python_selected
+
+    if force_full:
+        print(dep_map.FORCE_FULL)
+        print(
+            "rationale: full run because a changed RTL file could not be resolved to a "
+            "safe test subset (deleted/renamed-away/unwired design unit, unattributable "
+            "wrapper edit, or a high-fanout hub file above FAN_OUT_THRESHOLD)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # An entry in `selected` that names neither a resolved nor an always-run
+    # module is impossible by construction (select_tests only ever adds
+    # dep_map keys, wrapper_index owners, always_run, or map_python_changes
+    # output, all of which are subsets of resolved | always_run) -- its
+    # presence would mean a resolver logic bug, not a genuine indeterminacy,
+    # so it is dropped here rather than escalated to FORCE_FULL.
+    selected &= set(resolved) | always_run
+
+    for module_name in sorted(selected):
+        print(module_name)
+
+    print(
+        f"rationale: {len(selected)} test(s) selected from {len(changed)} changed file(s); "
+        f"{len(built_map)} toplevel(s) resolved, {len(unresolved_modules)} unresolved",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/common/dep_map.py
+++ b/tests/common/dep_map.py
@@ -1,0 +1,764 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from pathlib import Path, PurePosixPath
+import shlex
+import subprocess
+import sys
+
+from tests.common.regression_utils import (
+    REPO_ROOT,
+    cocotb_module_name_from_test_file,
+)
+
+
+# Scanned cocotb-test universe (surf_ci.yml simulates `tests/axi tests/base
+# tests/dsp tests/protocols`); tests/ethernet is deliberately excluded.
+# tests/common (the resolver's own unit tests) is also run by CI but is not a
+# scan dir -- it holds no cocotb toplevels for this map to resolve.
+DEFAULT_SCAN_DIRS = ("axi", "base", "dsp", "protocols")
+
+# Sentinel line printed on stdout (and used as the CLI's fail-open signal)
+# whenever the changed-files -> affected-tests resolution is indeterminate.
+FORCE_FULL = "FORCE_FULL"
+
+# GHDL binary used for `--gen-depends`. Overridable via the GHDL_CMD env var --
+# the repo-wide convention (Makefile exports `GHDL_CMD`, regression_utils.py
+# reads it), so `make import` and the resolver never disagree on which `ghdl`
+# to use. The apt `ghdl-mcode` backend on the CI runner does not implement
+# `--gen-depends`, so CI points GHDL_CMD at an LLVM-backend GHDL for dependency
+# resolution while the cocotb simulations still run on the default `ghdl`.
+# shlex.split (matching regression_utils.py) tolerates a command with args.
+# Defaults to `ghdl`.
+GHDL_CMD = shlex.split(os.environ.get("GHDL_CMD", "ghdl"))
+
+# Minimum fraction of the discovered universe (len(set(dep_map) | always_run))
+# a source must appear in to be treated as a shared base-package hub. 0.09 is
+# the tightest value that still catches all three widely-shared packages a
+# selective run must never miss: StdRtlPkg.vhd (41.25%), AxiStreamPkg.vhd
+# (11.67%), and AxiLitePkg.vhd (9.17%), measured against a clean
+# `make MODULES=$PWD import` build of this tree on 2026-07-01. This is a
+# tree-size-dependent value, not a permanent constant -- re-derive it if the
+# scanned test universe grows substantially, since a larger denominator could
+# push a currently-caught hub back below threshold.
+FAN_OUT_THRESHOLD = 0.09
+
+
+def discover_toplevels(
+    repo_root: Path,
+    scan_dirs: tuple[str, ...] = DEFAULT_SCAN_DIRS,
+) -> tuple[dict[str, set[str]], set[str]]:
+    """Walk `tests/<scan_dir>/**/test_*.py` and statically resolve each
+    test's `toplevel` design unit(s) from its `toplevel=` call site(s)
+    (`run_surf_vhdl_test(...)` and its thin per-family wrappers, e.g.
+    `run_pgp_wrapper_test`/`run_line_code_*_test` — any call passing a
+    `toplevel=` keyword is in scope, per D-07/D-08).
+
+    Returns `(resolved, always_run)`:
+    - `resolved`: {cocotb_module_name: {toplevel_unit, ...}} for tests whose
+      `toplevel=` kwarg(s) are literal string constants, or a one-level
+      dict-literal backtrack (`parameters["TOPLEVEL"]`) that resolves to one
+      or more literal string values (D-08). A module can resolve to more
+      than one toplevel when its `toplevel=` call site is itself
+      parametrized over several literal design units (e.g. one wrapper test
+      module sweeping several `surf.*wrapper` entities) — every one of them
+      is included so the module's dependency set is the union of all of
+      them, never a silent partial match.
+    - `always_run`: cocotb module names whose `toplevel` could not be
+      statically resolved to a literal string (fail-safe per D-08) —
+      f-strings, cross-module passthrough params, or ambiguous backtracks.
+    """
+    resolved: dict[str, set[str]] = {}
+    always_run: set[str] = set()
+
+    tests_root = repo_root / "tests"
+    test_files: list[Path] = []
+    for scan_dir in scan_dirs:
+        scan_path = tests_root / scan_dir
+        if not scan_path.is_dir():
+            # Path.rglob on a nonexistent directory returns an empty
+            # iterator rather than raising, which would otherwise silently
+            # discover zero tests for a mistyped --scan-dir (or a future
+            # DEFAULT_SCAN_DIRS typo) with no always_run/FORCE_FULL trigger
+            # to catch it. Raise loudly instead (D-10 indeterminacy).
+            raise FileNotFoundError(f"--scan-dir {scan_dir!r} does not exist under {tests_root}")
+        test_files.extend(sorted(scan_path.rglob("test_*.py")))
+
+    for test_file in test_files:
+        module_name = cocotb_module_name_from_test_file(test_file)
+        toplevels = _literal_toplevels_from_file(test_file)
+        if toplevels:
+            resolved[module_name] = toplevels
+        else:
+            # Zero calls found, or an unresolvable kwarg (f-string,
+            # cross-module passthrough, ambiguous dict backtrack) —
+            # conservatively always-run rather than guess (D-08).
+            always_run.add(module_name)
+
+    return dict(sorted(resolved.items())), always_run
+
+
+def _literal_toplevels_from_file(test_file: Path) -> set[str]:
+    tree = ast.parse(test_file.read_text(encoding="utf-8"), filename=str(test_file))
+    toplevels: set[str] = set()
+    unresolved = False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _has_toplevel_kwarg(node):
+            continue
+
+        literals = _literal_toplevel_from_call(node, tree)
+        if literals is None:
+            unresolved = True
+            continue
+        toplevels.update(literals)
+
+    if unresolved:
+        return set()
+
+    return toplevels
+
+
+def _has_toplevel_kwarg(call: ast.Call) -> bool:
+    return any(keyword.arg == "toplevel" for keyword in call.keywords)
+
+
+def _literal_toplevel_from_call(call: ast.Call, module_tree: ast.Module) -> set[str] | None:
+    for keyword in call.keywords:
+        if keyword.arg != "toplevel":
+            continue
+        return _resolve_literal_value(keyword.value, module_tree)
+    return None  # no toplevel= kwarg on this call
+
+
+def _resolve_literal_value(value: ast.expr, module_tree: ast.Module) -> set[str] | None:
+    """Resolve a `toplevel=` kwarg's AST value to a set of literal strings,
+    or None if it cannot be statically resolved (D-08 always-run fallback).
+
+    Handles the direct literal case and one level of dict-literal backtrack:
+    `parameters["TOPLEVEL"]`, where `parameters` is ultimately sourced (via a
+    `@pytest.mark.parametrize("parameters", SOME_SWEEP)` decorator and/or a
+    plain pass-through helper argument, both common in this repo) from a
+    module-level list of `pytest.param({"TOPLEVEL": "...", ...}, ...)`
+    entries. Rather than trace the exact name-binding chain (decorator ->
+    parameter -> helper argument), collect every dict literal anywhere in
+    the module carrying a literal `"TOPLEVEL"` key — this file's dicts are
+    the only possible source of a `"TOPLEVEL"` value, so it is equivalent
+    in practice and avoids a fragile multi-hop resolver. Anything deeper
+    (f-strings, cross-module passthrough, arbitrary expressions) is
+    intentionally left unresolved."""
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return {value.value}
+
+    if (
+        isinstance(value, ast.Subscript)
+        and isinstance(value.value, ast.Name)
+        and isinstance(value.slice, ast.Constant)
+        and value.slice.value == "TOPLEVEL"
+    ):
+        return _module_toplevel_dict_literals(module_tree)
+
+    return None  # non-literal kwarg (f-string, variable, ...)
+
+
+def _module_toplevel_dict_literals(module_tree: ast.Module) -> set[str] | None:
+    """Collect the literal string values under the `"TOPLEVEL"` key of
+    every dict literal in the module (bare `{...}` or `pytest.param({...})`
+    entries). Returns None if any such dict's `"TOPLEVEL"` value is not a
+    literal string (ambiguous — always-run), or if none are found.
+
+    NOTE: this backtrack is module-scoped, not call-site-scoped — it
+    unions every `"TOPLEVEL"`-keyed dict literal found anywhere in the
+    module, regardless of which `parameters=`/`toplevel=` call site
+    actually consumes it. Safe by over-inclusion today (verified: every
+    file with more than one such dict feeds the same call site), but a
+    future file with two unrelated `toplevel=` call sites each fed by
+    their own distinct `TOPLEVEL`-keyed list would have both dicts unioned
+    into one over-broad set for that module — still safe (over-selection,
+    not under-selection), just less precise than the docstring above might
+    otherwise imply."""
+    dict_literals: list[ast.Dict] = []
+    for node in ast.walk(module_tree):
+        if isinstance(node, ast.Dict) and _has_toplevel_key(node):
+            dict_literals.append(node)
+
+    if not dict_literals:
+        return None  # no statically-visible "TOPLEVEL" dict literal in this module
+
+    toplevels: set[str] = set()
+    for dict_node in dict_literals:
+        literal = _toplevel_key_literal(dict_node)
+        if literal is None:
+            return None  # a candidate dict has a non-literal "TOPLEVEL" value — ambiguous
+        toplevels.add(literal)
+
+    return toplevels
+
+
+def _has_toplevel_key(dict_node: ast.Dict) -> bool:
+    return any(isinstance(key, ast.Constant) and key.value == "TOPLEVEL" for key in dict_node.keys)
+
+
+def _toplevel_key_literal(dict_node: ast.Dict) -> str | None:
+    for key, val in zip(dict_node.keys, dict_node.values):
+        if isinstance(key, ast.Constant) and key.value == "TOPLEVEL":
+            if isinstance(val, ast.Constant) and isinstance(val.value, str):
+                return val.value
+            return None  # "TOPLEVEL" value isn't a literal string — ambiguous
+    return None  # this dict has no "TOPLEVEL" key at all
+
+
+def gen_depends_sources(toplevel: str, workdir: str, ghdl_flags: list[str]) -> set[str] | None:
+    """Return the repo-relative RTL source paths `toplevel` transitively
+    depends on, per GHDL's own elaboration-order analysis.
+
+    Some discovered toplevels (e.g. `**/ip_integrator/*.vhd` wrappers) are
+    only compiled as a test's `extra_vhdl_sources`, not by
+    `make MODULES=$PWD import` — GHDL cannot resolve those from `build/`
+    alone, and `ghdl --gen-depends` fails for them. That failure is
+    indistinguishable here from any other genuine GHDL analysis error, so
+    it is NOT folded into an empty (but valid) dependency set: `None` is
+    returned instead, and callers must treat an unresolved toplevel as
+    force-full-eligible on its own (D-10), never as "no dependencies"."""
+    try:
+        result = subprocess.run(
+            [*GHDL_CMD, "--gen-depends", *ghdl_flags, f"-P{workdir}", "--work=surf", toplevel.split(".")[-1]],
+            capture_output=True,
+            text=True,
+            cwd=workdir,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # A resolution failure is silent by default (the toplevel simply
+        # becomes always-run). Set SURF_DEP_MAP_DEBUG to surface why each
+        # toplevel could not be resolved -- the first line of GHDL's stderr
+        # is usually enough to tell a genuine unresolvable wrapper apart from
+        # an environment problem (missing library, wrong workdir, etc.).
+        if os.environ.get("SURF_DEP_MAP_DEBUG"):
+            stderr_lines = (exc.stderr or "").strip().splitlines()
+            detail = stderr_lines[0] if stderr_lines else f"ghdl exit {exc.returncode}"
+            print(f"gen-depends unresolved: {toplevel} -- {detail}", file=sys.stderr)
+        return None  # genuine analysis failure -- distinguish from "no deps"
+
+    sources: set[str] = set()
+    in_targets_section = False
+    for line in result.stdout.splitlines():
+        if line.startswith("# Targets to analyze files"):
+            in_targets_section = True
+            continue
+        if line.startswith("# Files dependences"):
+            break
+        if not in_targets_section or ":" not in line:
+            continue
+
+        _, _, path = line.partition(":")
+        path = path.strip()
+        if not path.endswith((".vhd", ".vhdl")):
+            continue
+
+        try:
+            repo_relative = Path(path).resolve().relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            # Outside the repo (GHDL stdlib under /usr/local/lib/ghdl/...) —
+            # never appears in `git diff` output, so it naturally falls out
+            # of the changed-files intersection.
+            continue
+        sources.add(repo_relative)
+
+    return sources
+
+
+def is_wrapper_path(repo_relative_path: str) -> bool:
+    """True when `repo_relative_path` has a `wrappers` path segment at any
+    depth (e.g. "base/sync/wrappers/SyncTrigRateVectorFlatWrapper.vhd" or
+    "protocols/pgp/pgp2b/wrappers/Foo.vhd"). Segment-exact, so
+    "base/sync/wrappersXYZ/Foo.vhd" is correctly rejected."""
+    return "wrappers" in PurePosixPath(repo_relative_path).parts
+
+
+_CF_FILE_LINE = re.compile(r'^file\s+\S+\s+"([^"]+)"')
+_CF_UNIT_LINE = re.compile(r'^\s\s(entity|architecture|package)\s+(?:body\s+)?(\S+)')
+
+
+def parse_cf_units(cf_path: Path) -> dict[str, set[str]]:
+    """{repo_relative_source_path: {design_unit_name, ...}} reversed from a
+    GHDL `.cf` library index (`file "<path>" ...:` blocks followed by
+    2-space-indented `entity`/`architecture ... of ...`/`package`/
+    `package body` lines).
+
+    `architecture <arch> of <entity>` lines contribute the entity name
+    parsed from the `" of "` substring rather than being skipped: nothing
+    in VHDL disallows an architecture being declared in a different file
+    from its entity, so relying solely on the `entity`/`package`
+    declaration line would miss that case. Every unit name is lowercased,
+    matching GHDL's case-insensitive unit names and the lowercase
+    `toplevel=` strings `discover_toplevels()` already produces.
+
+    Paths outside REPO_ROOT (e.g. GHDL's own stdlib) are skipped via the
+    same try/except relative_to idiom `gen_depends_sources` uses. A
+    missing or malformed `.cf` file raises naturally (FileNotFoundError),
+    consistent with `discover_toplevels()` raising loudly on a bad scan
+    dir rather than silently returning empty."""
+    file_to_units: dict[str, set[str]] = {}
+    current_file: str | None = None
+
+    for line in cf_path.read_text(encoding="utf-8").splitlines():
+        file_match = _CF_FILE_LINE.match(line)
+        if file_match:
+            try:
+                current_file = Path(file_match.group(1)).resolve().relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                current_file = None  # outside the repo -- never in a changed-file set
+            continue
+
+        if current_file is None:
+            continue
+
+        unit_match = _CF_UNIT_LINE.match(line)
+        if not unit_match:
+            continue
+
+        kind, name = unit_match.groups()
+        if kind == "architecture":
+            _, _, name = line.partition(" of ")
+            name = name.split()[0]
+        file_to_units.setdefault(current_file, set()).add(name.lower())
+
+    return dict(sorted(file_to_units.items()))
+
+
+_WRAPPER_ENTITY_LINE = re.compile(r'^\s*entity\s+(\S+)\s+is\b', re.IGNORECASE)
+
+
+def parse_wrapper_entity_units(
+    repo_root: Path,
+    scan_dirs: tuple[str, ...] = DEFAULT_SCAN_DIRS,
+) -> dict[str, set[str]]:
+    """{repo_relative_wrapper_path: {declared_entity_name}} from a direct
+    regex scan of every `<scan_dir>/**/wrappers/*.vhd` file's own
+    `entity <Name> is` declaration line.
+
+    No `ruckus.tcl` in this repo ever loads a `wrappers/` directory into
+    `make import` (verified: zero `wrappers/` entries in a clean
+    `build/surf-obj08.cf`), so a `.cf` from `make import` alone would not
+    carry these files -- every wrapper is compiled per-test via
+    `extra_vhdl_sources` instead. This direct scan is therefore the primary
+    source `build_wrapper_index` needs for wrapper unit names. The resolver
+    does inject wrapper sources into the `.cf` itself (the CLI runs
+    `import_test_local_sources` -> `ghdl -i` on these same files before
+    reading the `.cf`), so `parse_cf_units` can in fact surface wrappers;
+    they are unioned in on top of this scan, which is harmless -- both
+    describe the same file -> unit mapping.
+
+    The scan is scoped to `scan_dirs` (mirroring
+    `discover_test_local_sources`): a wrapper outside the scanned universe
+    (e.g. under `ethernet/**/wrappers/`) can never join to a discovered
+    module owner in `build_wrapper_index` -- `discover_toplevels()` is
+    itself scoped to `scan_dirs` -- so scanning it is pure IO overhead."""
+    wrapper_units: dict[str, set[str]] = {}
+    for scan_dir in scan_dirs:
+        for wrapper_file in sorted((repo_root / scan_dir).rglob("wrappers/*.vhd")):
+            repo_relative = wrapper_file.resolve().relative_to(repo_root).as_posix()
+            with wrapper_file.open(encoding="utf-8") as handle:
+                for line in handle:
+                    match = _WRAPPER_ENTITY_LINE.match(line)
+                    if match:
+                        wrapper_units.setdefault(repo_relative, set()).add(match.group(1).lower())
+                        # A wrapper file declares exactly one entity (the DUT it
+                        # wraps for cocotb), so stop at the first declaration.
+                        # Iterating the handle reads lazily, so the break also
+                        # avoids reading the rest of the file (unlike
+                        # read_text(), which loads it all up front).
+                        break
+    return dict(sorted(wrapper_units.items()))
+
+
+def build_wrapper_index(
+    cf_units: dict[str, set[str]],
+    toplevels: dict[str, set[str]],
+) -> dict[str, set[str]]:
+    """{wrapper_path: {owning_module_name, ...}} for every source path in
+    `cf_units` that has a "wrappers" path segment, joined against
+    `toplevels` (`discover_toplevels()`'s {module: {toplevel_unit}} shape)
+    by lowercased bare unit name (the "surf." library prefix is stripped
+    from each toplevel string before comparing).
+
+    `cf_units` need not come from `.cf` alone -- callers should union
+    `parse_cf_units`'s output with `parse_wrapper_entity_units`'s output
+    before calling this. A `.cf` produced by `make import` alone carries no
+    wrapper files, so the direct wrapper scan is the reliable source; note
+    the resolver can still add wrapper/ip_integrator sources to the `.cf` by
+    running `ghdl -i` in the same workdir (see `parse_wrapper_entity_units`),
+    so `.cf` is not guaranteed wrapper-free. This join itself is
+    source-agnostic: it only cares that wrapper paths map to the unit
+    name(s) they declare.
+
+    A wrapper file whose unit no test's `toplevel=` names produces no
+    entry here -- that is not an error, it is the expected shape for a
+    wrapper this join cannot attribute to any owner; `select_tests`
+    handles an unattributed wrapper edit as a FORCE_FULL trigger. This
+    join never depends on `ghdl --gen-depends` succeeding for the
+    wrapper's own toplevel, which is exactly the gap that otherwise leaves
+    a wrapper edit unresolvable when its owning test's toplevel can't be
+    GHDL-analyzed on its own (e.g. an ip_integrator-only toplevel)."""
+    unit_to_modules: dict[str, set[str]] = {}
+    for module_name, module_toplevels in toplevels.items():
+        for toplevel in module_toplevels:
+            bare = toplevel.split(".")[-1]
+            unit_to_modules.setdefault(bare, set()).add(module_name)
+
+    wrapper_index: dict[str, set[str]] = {}
+    for source_path, units in cf_units.items():
+        if not is_wrapper_path(source_path):
+            continue
+        owners: set[str] = set()
+        for unit in units:
+            owners |= unit_to_modules.get(unit, set())
+        if owners:
+            wrapper_index[source_path] = owners
+
+    return dict(sorted(wrapper_index.items()))
+
+
+def is_base_package_hub(source: str, dep_map: dict[str, set[str]], universe_size: int) -> bool:
+    """True when `source` appears in at least `FAN_OUT_THRESHOLD` of the
+    discovered universe's dependency sets -- i.e. it is widely-shared enough
+    that a selective run must not be trusted to have found every affected
+    test, so the caller should force a full run instead.
+
+    `dependent_count` counts every `dep_map` value-set containing `source`,
+    not a lookup of `source` as a key -- `dep_map` is keyed by test module
+    name, not by source path. Returns False when `universe_size == 0` (no
+    discovered universe to compute a fraction against) rather than raising a
+    ZeroDivisionError."""
+    dependent_count = sum(1 for sources in dep_map.values() if source in sources)
+    return universe_size > 0 and (dependent_count / universe_size) >= FAN_OUT_THRESHOLD
+
+
+# Wrapper (cocotb DUT-flattening) and Vivado IP-integrator shim sources live
+# under **/wrappers/ and **/ip_integrator/ and are compiled per-test via
+# `extra_vhdl_sources` -- no ruckus.tcl loads them into
+# `make MODULES=$PWD import`, so they are absent from the surf work library the
+# resolver queries. A test whose `toplevel=` names one of these entities
+# therefore fails `ghdl --gen-depends` ("cannot find entity") and falls back to
+# always-run (D-08/D-10). Because most surf cocotb tests wrap their DUT (cocotb
+# cannot drive VHDL records), that fallback collapses selective mode into a
+# near-full run. Importing these sources into the resolver's surf library makes
+# their toplevels analyzable, so each such test gets a precise transitive
+# dependency set instead.
+_TEST_LOCAL_SOURCE_GLOBS = ("wrappers/*.vhd", "ip_integrator/*.vhd")
+
+
+def discover_test_local_sources(
+    repo_root: Path,
+    scan_dirs: tuple[str, ...] = DEFAULT_SCAN_DIRS,
+) -> list[Path]:
+    """Absolute, de-duplicated, sorted paths of every wrapper / ip_integrator
+    VHDL source under the active scan-dir subtrees (excluding the build/ output
+    dir). These are exactly the design units `make import` omits but tests
+    compile via `extra_vhdl_sources`.
+
+    The search is scoped to `scan_dirs` -- the top-level RTL source dirs share
+    their names with the cocotb scan dirs (`axi`, `base`, `dsp`, `protocols`),
+    so restricting to them keeps a selective run from importing wrapper sources
+    for subsystems outside the scanned universe (e.g. the ~40 sources under
+    `ethernet/**/wrappers/`, which `DEFAULT_SCAN_DIRS` excludes) -- pure
+    resolver overhead, since no scanned test resolves to those toplevels. A
+    scan dir with no source subtree of that name simply contributes nothing."""
+    build_root = (repo_root / "build").resolve()
+    sources: set[Path] = set()
+    for scan_dir in scan_dirs:
+        scan_root = repo_root / scan_dir
+        for pattern in _TEST_LOCAL_SOURCE_GLOBS:
+            for path in scan_root.rglob(pattern):
+                resolved_path = path.resolve()
+                if build_root in resolved_path.parents:
+                    continue  # skip copies under the GHDL output tree (build/SRC_VHDL)
+                if resolved_path.is_file():
+                    sources.add(resolved_path)
+    return sorted(sources)
+
+
+def import_test_local_sources(
+    repo_root: Path,
+    workdir: str,
+    ghdl_flags: list[str],
+    scan_dirs: tuple[str, ...] = DEFAULT_SCAN_DIRS,
+) -> int:
+    """`ghdl -i` the wrapper / ip_integrator sources into the surf work library
+    at `workdir`, so `gen_depends_sources` can analyze wrapper/ip_integrator
+    toplevels instead of failing them open (which makes selective mode near-full
+    -- see `discover_test_local_sources`).
+
+    Absolute source paths are passed deliberately: `ghdl -i` records the path as
+    given, and only an absolute path yields the `file / "<abs>"` .cf form that
+    `parse_cf_units` and the changed-file intersection resolve relative to
+    REPO_ROOT. A workdir-relative import would instead write `.././...` entries
+    that resolve against the wrong base and silently drop out.
+
+    Returns the number of sources imported. A non-zero `ghdl -i` exit is
+    non-fatal (logged under SURF_DEP_MAP_DEBUG): any toplevel that still cannot
+    be found simply stays always-run, preserving the never-false-skip
+    fail-safe."""
+    sources = discover_test_local_sources(repo_root, scan_dirs)
+    if not sources:
+        return 0
+    result = subprocess.run(
+        [*GHDL_CMD, "-i", f"--workdir={workdir}", *ghdl_flags, "--work=surf", *(str(path) for path in sources)],
+        capture_output=True,
+        text=True,
+        cwd=workdir,
+        check=False,
+    )
+    if result.returncode != 0 and os.environ.get("SURF_DEP_MAP_DEBUG"):
+        stderr_lines = (result.stderr or "").strip().splitlines()
+        detail = stderr_lines[0] if stderr_lines else f"ghdl exit {result.returncode}"
+        print(f"import-test-local-sources warning: {detail}", file=sys.stderr)
+    return len(sources)
+
+
+def build_dependency_map(
+    toplevels: dict[str, set[str]],
+    workdir: str,
+    ghdl_flags: list[str],
+) -> tuple[dict[str, set[str]], set[str]]:
+    """(dep_map, unresolved_modules).
+
+    `dep_map`: {cocotb_module_name: {repo_relative_source, ...}} for every
+    module in `toplevels` whose GHDL analysis fully succeeded, sorted for
+    reproducibility (DEP-02). A module resolved to multiple toplevels
+    (parametrized `toplevel=` call site, D-08) gets the union of every
+    toplevel's transitive dependency set — a changed file that only one of
+    the parametrized toplevels depends on must still select the module
+    (never-false-skip).
+
+    `unresolved_modules`: module names for which `gen_depends_sources`
+    could not analyze at least one of their toplevels (e.g. an
+    `ip_integrator` wrapper only compiled via `extra_vhdl_sources`, or a
+    genuine GHDL analysis failure). These modules are deliberately excluded
+    from `dep_map` rather than given an empty-but-valid dependency set —
+    an empty set would be indistinguishable from "no dependencies" and
+    would let the module silently drop out of `select_tests` (D-10)."""
+    dep_map: dict[str, set[str]] = {}
+    unresolved_modules: set[str] = set()
+    for module_name, module_toplevels in toplevels.items():
+        sources: set[str] = set()
+        unresolved = False
+        for toplevel in module_toplevels:
+            result = gen_depends_sources(toplevel, workdir, ghdl_flags)
+            if result is None:
+                unresolved = True
+                continue
+            sources |= result
+        if unresolved:
+            unresolved_modules.add(module_name)
+            continue
+        dep_map[module_name] = sources
+    return dict(sorted(dep_map.items())), unresolved_modules
+
+
+def merge_base_with_origin_main() -> str:
+    """`git merge-base origin/main HEAD`. Raises subprocess.CalledProcessError
+    if it cannot be computed (e.g. `origin/main` missing) — callers must
+    treat that as a fail-open trigger (D-10), not a crash."""
+    result = subprocess.run(
+        ["git", "merge-base", "origin/main", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def changed_files(merge_base: str) -> dict[str, str]:
+    """{repo_relative_path: status} where status in {A, M, D}. Renames
+    resolve to the new path with status 'M' (content-preserving, D-14);
+    true deletions get status 'D' (a force-full trigger upstream, D-10)."""
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-M", merge_base, "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    changes: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        parts = line.split("\t")
+        status, paths = parts[0], parts[1:]
+        if status.startswith("R"):
+            _, new_path = paths
+            changes[new_path] = "M"
+        elif status.startswith("D"):
+            changes[paths[0]] = "D"
+        else:
+            # Normalize any other status code (e.g. 'T' typechange) to 'M' so
+            # the documented {A, M, D} contract holds. Downstream select_tests
+            # only special-cases 'D'; every other status is treated like a
+            # modification anyway, so this is contract-tightening, not a
+            # behavior change.
+            code = status[0]
+            changes[paths[0]] = code if code in ("A", "M") else "M"
+    return changes
+
+
+_VHDL_SUFFIXES = (".vhd", ".vhdl")
+
+
+def select_tests(
+    dep_map: dict[str, set[str]],
+    always_run: set[str],
+    changed: dict[str, str],
+    wrapper_index: dict[str, set[str]],
+) -> tuple[set[str], bool]:
+    """(selected_module_names, force_full).
+
+    force_full becomes True (D-10 broad fail-open) when either:
+    - a changed `.vhd`/`.vhdl` file is a true deletion (status 'D', not a
+      rename — renames already resolve to the new path as 'M' upstream in
+      `changed_files`); a deleted unit's former dependents can't be
+      resolved from the post-change graph (D-14), or
+    - a changed `wrappers/*.vhd` file has no entry in `wrapper_index` —
+      the join could not attribute it to any owning test, so its effect
+      is indeterminate, or
+    - a changed `.vhd`/`.vhdl` file (any other status) intersects NO test's
+      dependency set at all — an Added/renamed-away/unwired unit that the
+      current graph can't attribute to any known test, which is exactly
+      the kind of indeterminacy that requires failing open, or
+    - a changed production `.vhd`/`.vhdl` file's fan-out fraction across the
+      discovered universe is `>= FAN_OUT_THRESHOLD` — it is widely-shared
+      enough (e.g. StdRtlPkg.vhd, AxiLitePkg.vhd, AxiStreamPkg.vhd) that a
+      selective run can't be trusted to have found every affected test.
+
+    A changed `wrappers/*.vhd` file with a `wrapper_index` entry selects
+    exactly its attributed owner module(s) and is never subjected to the
+    generic dependency-set check above. `wrapper_index` is built from the
+    `resolved` toplevels (CLI: `build_wrapper_index(cf_units, resolved)`),
+    which still carry the literal `toplevel=` names of modules whose
+    `ghdl --gen-depends` later failed (`unresolved_modules`, folded into
+    `always_run`). So a wrapper edit for such an *unresolved* owner is
+    attributed precisely by the wrapper scan and does not trip a full run,
+    even though that owner's toplevel can't be GHDL-analyzed on its own. A
+    wrapper whose only owner is a *non-literal-toplevel* always_run test
+    (absent from `resolved`, so unattributable) has no `wrapper_index` entry
+    and does fall to the unattributable-wrapper FORCE_FULL branch above — the
+    precise handling here covers resolved and gen-depends-unresolved owners,
+    not non-literal always_run owners.
+
+    Python test/helper changes are resolved by `map_python_changes` (D-11)
+    and unioned into the selection; they participate in this function only
+    via the `changed` file/status map's RTL entries."""
+    changed_paths = set(changed.keys())
+    all_known_sources: set[str] = set()
+    for sources in dep_map.values():
+        all_known_sources |= sources
+    universe_size = len(set(dep_map) | always_run)
+
+    force_full = False
+    selected: set[str] = set()
+
+    for module_name, sources in dep_map.items():
+        if sources & changed_paths:
+            selected.add(module_name)
+
+    for path, status in changed.items():
+        if not path.endswith(_VHDL_SUFFIXES):
+            continue
+        if status == "D":
+            # True deletion: former dependents are unresolvable from the
+            # post-change graph (D-14) — fail open rather than guess.
+            force_full = True
+            continue
+        if is_wrapper_path(path):
+            owners = wrapper_index.get(path)
+            if owners:
+                selected |= owners
+            else:
+                # Unattributable wrapper edit — indeterminate, fail open.
+                force_full = True
+            continue  # never fall through to the generic check below
+        if path not in all_known_sources:
+            # Added/renamed-away/unwired unit that no known test's
+            # dependency set attributes to anything — indeterminate (D-10).
+            force_full = True
+        if is_base_package_hub(path, dep_map, universe_size):
+            # Widely-shared base package: a selective run can't be trusted
+            # to have found every affected test, so force a full run.
+            force_full = True
+
+    selected |= always_run
+    return selected, force_full
+
+
+def map_python_changes(
+    changed: dict[str, str],
+    resolved_map: dict[str, set[str]],
+    always_run: set[str],
+) -> tuple[set[str], bool]:
+    """D-11 Python test/helper change mapping. Returns
+    (selected_module_names, force_full) contributed by changed `tests/**`
+    Python files only (RTL `.vhd`/`.vhdl` changes are handled by
+    `select_tests`, not here):
+
+    - a changed `tests/<sub>/.../test_X.py` selects the cocotb module for
+      that exact file. `resolved_map`/`always_run` are discovered from the
+      current checkout, so a test file added on this branch is already in
+      the universe and selects itself; a test file is ignored here only
+      when it falls outside the discovered universe (e.g. under a
+      non-scanned subtree such as `tests/ethernet/...`), since it has no
+      dependency-map entry to select;
+    - a changed non-`test_*.py` `.py` helper anywhere under
+      `tests/<sub>/...` (at any depth, e.g. `tests/axi/utils.py` or
+      `tests/base/sync/sync_test_utils.py`) selects every discovered test
+      module under that same top-level `tests/<sub>` subtree — a safe
+      directory-prefix over-approximation keyed on `<sub>` alone (D-11),
+      not import-graph resolution;
+    - a change confined to `tests/common/` (including
+      `regression_utils.py`) selects nothing and never forces full — the
+      PROJECT.md accepted-risk carve-out.
+
+    This function never sets force_full=True on its own; Python-side
+    changes are an over-approximation by design and cannot be
+    "unresolvable" the way an RTL file can."""
+    all_modules = set(resolved_map.keys()) | always_run
+    selected: set[str] = set()
+
+    for path in changed.keys():
+        if not path.startswith("tests/"):
+            continue
+        if path.startswith("tests/common/"):
+            continue  # accepted-risk carve-out: never selects, never forces full
+
+        parts = path.split("/")
+        if len(parts) < 2:
+            continue
+        subsystem = parts[1]
+        filename = parts[-1]
+
+        if filename.startswith("test_") and filename.endswith(".py"):
+            module_name = path[: -len(".py")].replace("/", ".")
+            if module_name in all_modules:
+                selected.add(module_name)
+        elif filename.endswith(".py"):
+            # Subsystem helper (e.g. tests/axi/utils.py, tests/base/sync/
+            # sync_test_utils.py) — over-approximate to every discovered
+            # module under this subsystem's subtree (D-11).
+            prefix = f"tests.{subsystem}."
+            selected |= {module for module in all_modules if module.startswith(prefix)}
+
+    return selected, False

--- a/tests/common/test_dep_map.py
+++ b/tests/common/test_dep_map.py
@@ -1,0 +1,873 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+from __future__ import annotations
+
+import ast
+import random
+import subprocess
+
+import pytest
+
+from tests.common import dep_map
+from tests.common.regression_utils import REPO_ROOT, TESTS_ROOT
+
+
+def test_select_tests_happy_path():
+    # Hand-built dep_map + changed-file set standing in for a real
+    # `ghdl --gen-depends` result and a real `git diff` — this is the
+    # failing-first end-to-end assertion for the whole resolver path.
+    # The dep_map is padded with unrelated modules so the changed source's
+    # fan-out fraction stays below FAN_OUT_THRESHOLD -- this test asserts
+    # selection precision, not the fan-out force-full route (covered
+    # separately below).
+    built_map = {
+        "tests.axi.axi_lite.test_AxiLiteAsync": {"axi/axi-lite/rtl/AxiLiteAsync.vhd", "base/general/rtl/StdRtlPkg.vhd"},
+        "tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"},
+        **{f"tests.padding.test_{i}": {f"padding/rtl/Padding{i}.vhd"} for i in range(20)},
+    }
+    always_run = {"tests.dsp.generic.test_FirFilterTap"}
+    changed = {"axi/axi-lite/rtl/AxiLiteAsync.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert selected == {
+        "tests.axi.axi_lite.test_AxiLiteAsync",
+        "tests.dsp.generic.test_FirFilterTap",
+    }
+    assert force_full is False
+
+
+def test_select_tests_no_matching_dependency():
+    # A changed .vhd that matches no test's dependency set is exactly the
+    # D-10 fail-open trigger (superseding Plan 01's placeholder
+    # "force_full is always False" note) — see
+    # test_select_tests_force_full_on_unresolved_changed_rtl_file below for
+    # the dedicated D-10 assertion.
+    built_map = {"tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"}}
+    always_run: set[str] = set()
+    changed = {"axi/axi-lite/rtl/AxiLiteAsync.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert selected == set()
+    assert force_full is True
+
+
+def test_discover_toplevels_literal():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("axi",))
+
+    assert resolved["tests.axi.axi_lite.test_AxiLiteAsync"] == {"surf.axiliteasyncipintegrator"}
+    assert "tests.axi.axi_lite.test_AxiLiteAsync" not in always_run
+
+
+def test_discover_toplevels_always_run_for_dynamic_toplevel():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("dsp",))
+
+    # test_FirFilterTap.py builds its toplevel from an f-string
+    # (`f"surf.{wrapper_name.lower()}"`) — not a literal, so it must be
+    # conservatively always-run per D-08, never silently resolved/skipped.
+    assert "tests.dsp.generic.test_FirFilterTap" in always_run
+    assert "tests.dsp.generic.test_FirFilterTap" not in resolved
+
+
+def test_discover_toplevels_raises_on_nonexistent_scan_dir():
+    # A mistyped --scan-dir (or a future DEFAULT_SCAN_DIRS typo) must raise
+    # rather than silently discover zero tests for that subtree -- Path.rglob
+    # on a nonexistent directory returns an empty iterator, not an error, so
+    # this must be checked explicitly.
+    with pytest.raises(FileNotFoundError):
+        dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("no_such_subtree",))
+
+
+def _run_git(args: list[str], cwd) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_changed_files_classification(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    _run_git(["init", "-q"], cwd=repo)
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo)
+    _run_git(["config", "user.name", "Test"], cwd=repo)
+
+    keep_file = repo / "keep.vhd"
+    keep_file.write_text("-- unchanged\n", encoding="utf-8")
+    old_name = repo / "old_name.vhd"
+    old_name.write_text("-- will be renamed\n", encoding="utf-8")
+    delete_me = repo / "delete_me.vhd"
+    delete_me.write_text("-- will be deleted\n", encoding="utf-8")
+
+    _run_git(["add", "."], cwd=repo)
+    _run_git(["commit", "-q", "-m", "base"], cwd=repo)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # Modify one file, rename another, delete a third, add a fourth.
+    keep_file.write_text("-- modified\n", encoding="utf-8")
+    new_name = repo / "new_name.vhd"
+    old_name.rename(new_name)
+    delete_me.unlink()
+    added_file = repo / "added.vhd"
+    added_file.write_text("-- new\n", encoding="utf-8")
+
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-q", "-m", "changes"], cwd=repo)
+
+    original_run = subprocess.run
+
+    def run_in_repo(args, **kwargs):
+        kwargs.setdefault("cwd", repo)
+        return original_run(args, **kwargs)
+
+    import tests.common.dep_map as dep_map_module
+
+    old_subprocess_run = dep_map_module.subprocess.run
+    dep_map_module.subprocess.run = run_in_repo
+    try:
+        changes = dep_map_module.changed_files(base_sha)
+    finally:
+        dep_map_module.subprocess.run = old_subprocess_run
+
+    assert changes["keep.vhd"] == "M"
+    assert changes["new_name.vhd"] == "M"
+    assert changes["added.vhd"] == "A"
+    assert changes["delete_me.vhd"] == "D"
+    assert "old_name.vhd" not in changes
+
+
+def test_changed_files_normalizes_unknown_status_to_modified():
+    # git can emit statuses beyond {A, M, D, R} (e.g. 'T' typechange). The
+    # documented contract is {A, M, D}, so any such status must normalize to
+    # 'M' — downstream select_tests only special-cases 'D', treating every
+    # other status as a modification anyway.
+    import tests.common.dep_map as dep_map_module
+
+    class _FakeCompleted:
+        stdout = "T\ttypechanged.vhd\nX\tweird.vhd\nM\tmodified.vhd\n"
+
+    def fake_run(args, **kwargs):
+        return _FakeCompleted()
+
+    old_run = dep_map_module.subprocess.run
+    dep_map_module.subprocess.run = fake_run
+    try:
+        changes = dep_map_module.changed_files("deadbeef")
+    finally:
+        dep_map_module.subprocess.run = old_run
+
+    assert changes["typechanged.vhd"] == "M"
+    assert changes["weird.vhd"] == "M"
+    assert changes["modified.vhd"] == "M"
+    assert set(changes.values()) <= {"A", "M", "D"}
+
+
+# --- D-10: broad fail-open --------------------------------------------------
+
+
+def test_select_tests_force_full_on_unresolved_changed_rtl_file():
+    # A changed .vhd that intersects NO test's dependency set (a new,
+    # renamed-away, or unwired unit the current graph can't attribute) must
+    # fail open to a full run, not silently select nothing (D-10).
+    built_map = {"tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"}}
+    always_run: set[str] = set()
+    changed = {"axi/axi-lite/rtl/NewNeverSeenEntity.vhd": "A"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is True
+
+
+def test_select_tests_no_force_full_when_all_changed_rtl_resolves():
+    # The mirror-image happy path: every changed .vhd is a known dependency
+    # of some test, so force_full must stay False (no false full-run either).
+    # The dep_map is padded with unrelated modules so the changed source's
+    # fan-out fraction stays below FAN_OUT_THRESHOLD -- this test asserts
+    # selection precision, not the fan-out force-full route (covered separately
+    # below).
+    built_map = {
+        "tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"},
+        **{f"tests.padding.test_{i}": {f"padding/rtl/Padding{i}.vhd"} for i in range(20)},
+    }
+    always_run: set[str] = set()
+    changed = {"base/fifo/rtl/FifoAsync.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is False
+    assert selected == {"tests.base.fifo.test_FifoAsync"}
+
+
+def test_select_tests_force_full_on_deletion():
+    # D-14: a true deletion (status 'D', not a rename) forces a full run —
+    # the former dependents can't be resolved from the post-change graph.
+    built_map = {"tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"}}
+    always_run: set[str] = set()
+    changed = {"base/fifo/rtl/FifoAsync.vhd": "D"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is True
+
+
+def test_select_tests_rename_stays_precise():
+    # D-14: a rename resolves via the new path (changed_files() already
+    # emits status 'M' at the new path for renames) and stays precise — it
+    # must NOT force a full run merely because the path is "new" to us.
+    # The dep_map is padded with unrelated modules so the changed source's
+    # fan-out fraction stays below FAN_OUT_THRESHOLD -- this test asserts
+    # rename precision, not the fan-out force-full route (covered separately
+    # below).
+    built_map = {
+        "tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsyncRenamed.vhd"},
+        **{f"tests.padding.test_{i}": {f"padding/rtl/Padding{i}.vhd"} for i in range(20)},
+    }
+    always_run: set[str] = set()
+    changed = {"base/fifo/rtl/FifoAsyncRenamed.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is False
+    assert selected == {"tests.base.fifo.test_FifoAsync"}
+
+
+def test_select_tests_wrapper_change_selects_owner_only():
+    # A changed wrappers/ path with a wrapper_index entry selects exactly
+    # its attributed owner(s) and does not force a full run.
+    built_map: dict[str, set[str]] = {}
+    always_run: set[str] = set()
+    changed = {"base/sync/wrappers/W.vhd": "M"}
+    wrapper_index = {"base/sync/wrappers/W.vhd": {"tests.base.sync.test_X"}}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, wrapper_index)
+
+    assert selected == {"tests.base.sync.test_X"}
+    assert force_full is False
+
+
+def test_select_tests_wrapper_change_unattributable_forces_full():
+    # A changed wrappers/ path absent from wrapper_index is indeterminate —
+    # fail open, and must not fall through to the generic
+    # not-in-all_known_sources check.
+    built_map: dict[str, set[str]] = {}
+    always_run: set[str] = set()
+    changed = {"base/sync/wrappers/W.vhd": "M"}
+    wrapper_index: dict[str, set[str]] = {}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, wrapper_index)
+
+    assert force_full is True
+
+
+def test_merge_base_failure_is_a_fail_open_trigger(monkeypatch):
+    # merge_base_with_origin_main() raises subprocess.CalledProcessError on
+    # failure (e.g. origin/main absent) rather than returning a sentinel —
+    # callers (the CLI) must catch this and fail open, never crash (D-10).
+    def raise_called_process_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=128, cmd=args[0] if args else [])
+
+    monkeypatch.setattr(dep_map.subprocess, "run", raise_called_process_error)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        dep_map.merge_base_with_origin_main()
+
+
+# --- gen_depends_sources / build_dependency_map -----------------------------
+
+
+def test_gen_depends_sources_returns_none_on_ghdl_failure(monkeypatch):
+    # A `ghdl --gen-depends` failure (CalledProcessError) must be signaled
+    # distinctly from "no dependencies" -- None, not set() -- so callers can
+    # tell "unresolved" apart from "genuinely empty" (D-10).
+    def raise_called_process_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0] if args else [])
+
+    monkeypatch.setattr(dep_map.subprocess, "run", raise_called_process_error)
+
+    result = dep_map.gen_depends_sources("surf.somewrapper", "/nonexistent/workdir", [])
+
+    assert result is None
+
+
+def test_build_dependency_map_reports_unresolved_toplevel(monkeypatch):
+    # A toplevel whose gen_depends_sources() call fails must make its module
+    # unresolved (excluded from dep_map, listed in unresolved_modules) rather
+    # than silently getting an empty-but-valid dependency set.
+    def fake_gen_depends_sources(toplevel, workdir, ghdl_flags):
+        if toplevel == "surf.brokenwrapper":
+            return None
+        return {"base/general/rtl/StdRtlPkg.vhd"}
+
+    monkeypatch.setattr(dep_map, "gen_depends_sources", fake_gen_depends_sources)
+
+    toplevels = {
+        "tests.axi.test_A": {"surf.brokenwrapper"},
+        "tests.base.test_B": {"surf.healthywrapper"},
+    }
+
+    built_map, unresolved_modules = dep_map.build_dependency_map(toplevels, "/workdir", [])
+
+    assert unresolved_modules == {"tests.axi.test_A"}
+    assert "tests.axi.test_A" not in built_map
+    assert built_map == {"tests.base.test_B": {"base/general/rtl/StdRtlPkg.vhd"}}
+
+
+def test_unresolved_toplevel_is_not_silently_dropped_from_selection(monkeypatch):
+    # CR-01 repro: toplevel A's GHDL analysis fails (unresolved) while
+    # healthy toplevel B shares a changed file (StdRtlPkg.vhd) with it. Prior
+    # to the fix, gen_depends_sources() folded A's failure into set(), so
+    # dep_map["tests.axi.test_A"] == set() -- A could never be selected via
+    # the changed-file intersection, and it was not in `always_run` either
+    # (it's a "resolved" toplevel, not a non-literal one) -- so it silently
+    # dropped out of `selected` entirely. Worse, `force_full` also stayed
+    # False, because StdRtlPkg.vhd was still a "known source" via B's healthy
+    # entry -- a hard false-skip on the one path D-10 must not allow.
+    #
+    # This test asserts the fix: A's failure is threaded through as an
+    # `unresolved_modules` entry and unioned into `always_run` (the same
+    # fail-safe treatment D-08 already gives non-literal toplevels), so A's
+    # test is unconditionally selected -- never silently dropped.
+    def fake_gen_depends_sources(toplevel, workdir, ghdl_flags):
+        if toplevel == "surf.brokenwrapper":
+            return None  # GHDL analysis failed for toplevel A
+        return {"base/general/rtl/StdRtlPkg.vhd"}  # healthy toplevel B
+
+    monkeypatch.setattr(dep_map, "gen_depends_sources", fake_gen_depends_sources)
+
+    toplevels = {
+        "tests.axi.test_A": {"surf.brokenwrapper"},
+        "tests.base.test_B": {"surf.healthywrapper"},
+    }
+    always_run: set[str] = set()
+    changed = {"base/general/rtl/StdRtlPkg.vhd": "M"}
+
+    built_map, unresolved_modules = dep_map.build_dependency_map(toplevels, "/workdir", [])
+    always_run = always_run | unresolved_modules
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert "tests.axi.test_A" in selected  # must NOT be silently dropped
+    assert "tests.base.test_B" in selected  # healthy toplevel still selected normally
+
+
+# --- D-11: Python test/helper change mapping --------------------------------
+
+
+def test_map_python_changes_test_file_selects_itself():
+    resolved_map = {"tests.axi.axi_lite.test_AxiLiteAsync": {"axi/axi-lite/rtl/AxiLiteAsync.vhd"}}
+    always_run: set[str] = set()
+    changed = {"tests/axi/axi_lite/test_AxiLiteAsync.py": "M"}
+
+    selected, force_full = dep_map.map_python_changes(changed, resolved_map, always_run)
+
+    assert selected == {"tests.axi.axi_lite.test_AxiLiteAsync"}
+    assert force_full is False
+
+
+def test_map_python_changes_subsystem_helper_selects_whole_subtree():
+    resolved_map = {
+        "tests.axi.axi_lite.test_AxiLiteAsync": {"axi/axi-lite/rtl/AxiLiteAsync.vhd"},
+        "tests.axi.axi4.test_AxiRam": {"axi/axi4/rtl/AxiRam.vhd"},
+        "tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd"},
+    }
+    always_run: set[str] = set()
+    changed = {"tests/axi/utils.py": "M"}
+
+    selected, force_full = dep_map.map_python_changes(changed, resolved_map, always_run)
+
+    assert selected == {"tests.axi.axi_lite.test_AxiLiteAsync", "tests.axi.axi4.test_AxiRam"}
+    assert force_full is False
+
+
+def test_map_python_changes_common_carve_out_selects_nothing():
+    # PROJECT.md accepted-risk carve-out: a change confined to tests/common/
+    # (including regression_utils.py) must neither force full nor select
+    # anything by itself.
+    resolved_map = {"tests.axi.axi_lite.test_AxiLiteAsync": {"axi/axi-lite/rtl/AxiLiteAsync.vhd"}}
+    always_run = {"tests.dsp.generic.test_FirFilterTap"}
+    changed = {"tests/common/regression_utils.py": "M", "tests/common/dep_map.py": "M"}
+
+    selected, force_full = dep_map.map_python_changes(changed, resolved_map, always_run)
+
+    assert selected == set()
+    assert force_full is False
+
+
+# --- D-08: dict-literal AST backtrack ---------------------------------------
+
+
+def test_discover_toplevels_dict_literal_backtrack_resolves_pgp2b_wrappers():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("protocols",))
+
+    module_name = "tests.protocols.pgp.pgp2b.test_Pgp2bCoreWrappers"
+    assert module_name not in always_run
+    assert resolved[module_name] == {
+        "surf.pgp2btxwrapper",
+        "surf.pgp2brxwrapper",
+        "surf.pgp2btxcellwrapper",
+        "surf.pgp2brxcellwrapper",
+        "surf.pgp2btxphywrapper",
+        "surf.pgp2brxphywrapper",
+        "surf.pgp2btxschedwrapper",
+    }
+
+
+def test_discover_toplevels_dict_literal_backtrack_resolves_srpv3axilite():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("protocols",))
+
+    module_name = "tests.protocols.srp.test_SrpV3AxiLite"
+    assert module_name not in always_run
+    assert resolved[module_name] == {"surf.srpv3axilitewrapper", "surf.srpv3axilitefullwrapper"}
+
+
+def test_discover_toplevels_fstring_toplevel_stays_always_run():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("dsp",))
+
+    # Genuinely dynamic f-string toplevels (test_FirFilterTap.py,
+    # test_FirFilterMultiChannel.py) are not resolvable by any static
+    # backtrack and must remain always-run (D-08).
+    assert "tests.dsp.generic.test_FirFilterTap" in always_run
+    assert "tests.dsp.generic.test_FirFilterMultiChannel" in always_run
+    assert "tests.dsp.generic.test_FirFilterTap" not in resolved
+    assert "tests.dsp.generic.test_FirFilterMultiChannel" not in resolved
+
+
+# --- Pitfall 4: every toplevel= call site is resolved-or-always-run, never a
+# silent third state -----------------------------------------------------
+
+
+def _toplevel_call_sites(test_file):
+    tree = ast.parse(test_file.read_text(encoding="utf-8"), filename=str(test_file))
+    sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and dep_map._has_toplevel_kwarg(node):
+            sites.append(node)
+    return sites
+
+
+def test_every_toplevel_call_site_is_resolved_or_always_run():
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT)
+
+    unaccounted = []
+    for scan_dir in dep_map.DEFAULT_SCAN_DIRS:
+        for test_file in sorted((TESTS_ROOT / scan_dir).rglob("test_*.py")):
+            module_name = dep_map.cocotb_module_name_from_test_file(test_file)
+            has_call_site = bool(_toplevel_call_sites(test_file))
+            if not has_call_site:
+                continue  # no toplevel= call site in this file at all
+            if module_name not in resolved and module_name not in always_run:
+                unaccounted.append(module_name)
+
+    assert unaccounted == [], (
+        f"toplevel= call site(s) not classified as resolved-or-always-run: {unaccounted}"
+    )
+
+
+# --- parse_cf_units / is_wrapper_path / build_wrapper_index ----------------
+
+
+def test_parse_cf_units_extracts_entity_and_package_units(tmp_path):
+    cf_file = tmp_path / "surf-obj08.cf"
+    cf_file.write_text(
+        "v 4\n"
+        f'file / "{REPO_ROOT}/base/general/rtl/StdRtlPkg.vhd" "sha1" "ts":\n'
+        "  package stdrtlpkg at 17( 979) + 0 on 4;\n"
+        "  package body stdrtlpkg at 105( 4525) + 0 on 4;\n",
+        encoding="utf-8",
+    )
+
+    result = dep_map.parse_cf_units(cf_file)
+
+    assert result == {"base/general/rtl/StdRtlPkg.vhd": {"stdrtlpkg"}}
+
+
+def test_parse_cf_units_architecture_line_names_entity(tmp_path):
+    cf_file = tmp_path / "surf-obj08.cf"
+    cf_file.write_text(
+        "v 4\n"
+        f'file / "{REPO_ROOT}/axi/bridge/rtl/AxiLiteToDrp.vhd" "sha1" "ts":\n'
+        "  entity axilitetodrp at 15( 869) + 0 on 4;\n"
+        "  architecture rtl of axilitetodrp at 57( 2455) + 0 on 4;\n",
+        encoding="utf-8",
+    )
+
+    result = dep_map.parse_cf_units(cf_file)
+
+    # "architecture rtl of axilitetodrp" contributes "axilitetodrp" (the
+    # entity name after "of"), not "rtl" (the architecture's own name).
+    assert result == {"axi/bridge/rtl/AxiLiteToDrp.vhd": {"axilitetodrp"}}
+
+
+def test_is_wrapper_path_matches_segment_rejects_near_miss():
+    assert dep_map.is_wrapper_path("base/sync/wrappers/SyncTrigRateVectorFlatWrapper.vhd") is True
+    assert dep_map.is_wrapper_path("protocols/pgp/pgp2b/wrappers/Foo.vhd") is True
+    assert dep_map.is_wrapper_path("base/sync/rtl/Synchronizer.vhd") is False
+    assert dep_map.is_wrapper_path("base/sync/wrappersXYZ/Foo.vhd") is False
+
+
+def test_build_wrapper_index_joins_by_unit_name():
+    cf_units = {"base/sync/wrappers/W.vhd": {"synctrigratevectorflatwrapper"}}
+    toplevels = {"tests.base.sync.test_X": {"surf.synctrigratevectorflatwrapper"}}
+
+    result = dep_map.build_wrapper_index(cf_units, toplevels)
+
+    assert result == {"base/sync/wrappers/W.vhd": {"tests.base.sync.test_X"}}
+
+
+def test_build_wrapper_index_unattributable_wrapper_absent():
+    cf_units = {"base/sync/wrappers/W.vhd": {"somewrapper"}}
+    toplevels = {"tests.base.sync.test_X": {"surf.unrelatedwrapper"}}
+
+    result = dep_map.build_wrapper_index(cf_units, toplevels)
+
+    assert result == {}
+
+
+def test_parse_wrapper_entity_units_finds_real_sync_trig_wrapper():
+    # Direct-scan fallback (Pitfall 1): .cf never contains wrapper files, so
+    # this is the actual source of a wrapper file's declared entity name.
+    wrapper_units = dep_map.parse_wrapper_entity_units(REPO_ROOT)
+
+    assert wrapper_units["base/sync/wrappers/SyncTrigRateVectorFlatWrapper.vhd"] == {
+        "synctrigratevectorflatwrapper"
+    }
+
+
+def test_parse_wrapper_entity_units_scoped_to_scan_dirs(tmp_path):
+    # The scan is scoped to `scan_dirs` (mirroring discover_test_local_sources):
+    # a wrapper under a scanned subtree is parsed, one under an unscanned subtree
+    # (ethernet) is not -- so a selective run never does wrapper-attribution IO
+    # for subsystems outside the scanned universe.
+    (tmp_path / "protocols/srp/wrappers").mkdir(parents=True)
+    (tmp_path / "ethernet/RoCEv2/wrappers").mkdir(parents=True)
+    (tmp_path / "protocols/srp/wrappers/SrpV3AxiWrapper.vhd").write_text(
+        "entity SrpV3AxiWrapper is\n", encoding="utf-8"
+    )
+    (tmp_path / "ethernet/RoCEv2/wrappers/RoceConfiguratorWrapper.vhd").write_text(
+        "entity RoceConfiguratorWrapper is\n", encoding="utf-8"
+    )
+
+    result = dep_map.parse_wrapper_entity_units(tmp_path, scan_dirs=("protocols",))
+
+    assert result == {"protocols/srp/wrappers/SrpV3AxiWrapper.vhd": {"srpv3axiwrapper"}}
+
+
+def test_wrapper_change_selects_owner_live_repo():
+    # The full live-repo join: parse_wrapper_entity_units gives the
+    # wrapper's own declared entity name (never available from .cf), joined
+    # against the real discover_toplevels() map, then routed through
+    # select_tests -- proving the real SyncTrigRateVectorFlatWrapper.vhd ->
+    # test_SyncTrigRateVector pairing end to end without requiring a built
+    # .cf in the unit-test environment.
+    resolved, _ = dep_map.discover_toplevels(REPO_ROOT, scan_dirs=("base",))
+    wrapper_units = dep_map.parse_wrapper_entity_units(REPO_ROOT)
+    wrapper_index = dep_map.build_wrapper_index(wrapper_units, resolved)
+
+    changed = {"base/sync/wrappers/SyncTrigRateVectorFlatWrapper.vhd": "M"}
+    selected, force_full = dep_map.select_tests({}, set(), changed, wrapper_index)
+
+    assert selected == {"tests.base.sync.test_SyncTrigRateVector"}
+    assert force_full is False
+
+
+def test_wrapper_never_in_production_dependency_set():
+    # Invariant: no dependency set in a built dep_map should ever
+    # contain a path with a "wrappers" path segment -- GHDL closures are
+    # kept intact, never stripped, but a wrapper genuinely showing up
+    # as another test's *production* dependency would be a silent fan-out
+    # bug this invariant catches. Synthetic fixture, no GHDL build needed.
+    built_map = {
+        "tests.base.fifo.test_FifoAsync": {"base/fifo/rtl/FifoAsync.vhd", "base/general/rtl/StdRtlPkg.vhd"},
+        "tests.base.sync.test_SyncTrigRateVector": {"base/sync/rtl/Synchronizer.vhd"},
+    }
+
+    for sources in built_map.values():
+        for source in sources:
+            assert not dep_map.is_wrapper_path(source)
+
+
+# --- FAN_OUT_THRESHOLD / is_base_package_hub / fan-out force-full ----------
+
+
+def test_is_base_package_hub_threshold_boundary():
+    # 12-module universe: a source in 1 of 12 (~8.33%) stays just below the
+    # 9% threshold; a source in 2 of 12 (~16.67%) sits comfortably above it.
+    # Build the dep_map fixtures directly so the boundary is explicit rather
+    # than relied on for a single reused fixture.
+    below_map = {f"tests.mod{i}": {"shared.vhd"} if i == 0 else {"other.vhd"} for i in range(12)}
+    at_or_above_map = {f"tests.mod{i}": {"shared.vhd"} if i < 2 else {"other.vhd"} for i in range(12)}
+
+    assert dep_map.is_base_package_hub("shared.vhd", below_map, universe_size=12) is False
+    assert dep_map.is_base_package_hub("shared.vhd", at_or_above_map, universe_size=12) is True
+
+
+def test_is_base_package_hub_zero_universe_size_is_false():
+    # universe_size == 0 must return False, not raise ZeroDivisionError.
+    assert dep_map.is_base_package_hub("shared.vhd", {}, universe_size=0) is False
+
+
+def test_select_tests_force_full_on_base_package_fanout():
+    # A source present in 2 of ~12 discovered modules exceeds the 9%
+    # fan-out threshold and must force a full run even though its own
+    # directly-intersecting test is also selected.
+    built_map = {
+        "tests.base.general.test_StdRtlPkg": {"base/general/rtl/StdRtlPkg.vhd"},
+        "tests.base.general.test_Other": {"base/general/rtl/StdRtlPkg.vhd", "base/other/rtl/Other.vhd"},
+    }
+    always_run = {f"tests.always_run.test_{i}" for i in range(10)}
+    changed = {"base/general/rtl/StdRtlPkg.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is True
+    assert {"tests.base.general.test_StdRtlPkg", "tests.base.general.test_Other"} <= selected
+
+
+def test_select_tests_no_force_full_below_fanout_threshold():
+    # A source present in only 1 of a large universe stays below the 9%
+    # fan-out threshold: force_full stays False and the directly-
+    # intersecting test is still selected precisely.
+    built_map = {
+        "tests.base.crc.test_CrcPkg": {"base/crc/rtl/CrcPkg.vhd"},
+    }
+    always_run = {f"tests.always_run.test_{i}" for i in range(20)}
+    changed = {"base/crc/rtl/CrcPkg.vhd": "M"}
+
+    selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+    assert force_full is False
+    assert "tests.base.crc.test_CrcPkg" in selected
+
+
+def test_select_tests_selection_stays_within_universe_live_repo():
+    # Live-universe fan-out assertion: using the real discovered universe
+    # (no GHDL invocation -- discover_toplevels() is pure static AST
+    # parsing), a synthetic dep_map places each of StdRtlPkg.vhd,
+    # AxiLitePkg.vhd, and AxiStreamPkg.vhd into >=9% of the real universe's
+    # modules. Each, changed alone, must force a full run.
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT)
+    universe = sorted(set(resolved) | always_run)
+    # >= 9% of the universe -- pick enough modules to comfortably clear the
+    # threshold regardless of exact universe size.
+    hub_share = max(1, (len(universe) * 9 + 99) // 100)  # ceil(9% of universe)
+    hub_modules = universe[:hub_share]
+
+    for package in (
+        "base/general/rtl/StdRtlPkg.vhd",
+        "axi/axi-lite/rtl/AxiLitePkg.vhd",
+        "axi/axi-stream/rtl/AxiStreamPkg.vhd",
+    ):
+        built_map = {module_name: {package} for module_name in hub_modules}
+        changed = {package: "M"}
+
+        selected, force_full = dep_map.select_tests(built_map, always_run, changed, {})
+
+        assert force_full is True, f"{package} did not force full against the real universe"
+
+
+# --- Never-false-skip subset invariant --------------------------------------
+
+
+def test_never_false_skip_subset_invariant():
+    # For N seeded, randomized changed-file-set shapes: selected must always
+    # be a subset of the full discovered test universe, and always_run must
+    # always be a subset of selected — the phase's north star, asserted
+    # directly. Each seed mixes production RTL paths (drawn from the
+    # synthetic dep_map), a synthetic wrappers/ path (routed through a
+    # synthetic wrapper_index), and an out-of-universe path, so the
+    # invariant is exercised across every select_tests routing branch, not
+    # just the plain production-RTL case. stdlib random only -- no
+    # hypothesis (not a project dependency).
+    resolved, always_run = dep_map.discover_toplevels(REPO_ROOT)
+    discovered_universe = set(resolved.keys()) | always_run
+
+    built_map = {
+        module_name: {f"fake/source/for/{module_name}.vhd"} for module_name in resolved
+    }
+    all_sources = sorted({source for sources in built_map.values() for source in sources})
+
+    wrapper_path = "some/path/wrappers/Rand.vhd"
+    wrapper_owner = next(iter(resolved), None)
+    wrapper_index = {wrapper_path: {wrapper_owner}} if wrapper_owner is not None else {}
+    out_of_universe_path = "totally/unknown/Path.vhd"
+
+    for seed in range(30):
+        rng = random.Random(seed)
+        changed: dict[str, str] = {}
+
+        sample_size = rng.randint(0, min(3, len(all_sources)))
+        for source in rng.sample(all_sources, sample_size):
+            changed[source] = rng.choice(["A", "M"])
+
+        if rng.random() < 0.5:
+            changed[wrapper_path] = "M"
+        if rng.random() < 0.5:
+            changed[out_of_universe_path] = "M"
+
+        selected, force_full = dep_map.select_tests(built_map, always_run, changed, wrapper_index)
+
+        assert selected <= discovered_universe, f"seed {seed}: selected escaped the discovered universe"
+        assert always_run <= selected, f"seed {seed}: always_run was not a subset of selected"
+
+
+# --- discover_test_local_sources / import_test_local_sources ----------------
+
+
+def test_discover_test_local_sources_collects_wrappers_and_ip_integrator(tmp_path):
+    # Wrapper and ip_integrator .vhd sources are collected as absolute paths;
+    # normal rtl/, non-.vhd files, and copies under build/ are excluded.
+    (tmp_path / "protocols/srp/wrappers").mkdir(parents=True)
+    (tmp_path / "axi/axi-lite/ip_integrator").mkdir(parents=True)
+    (tmp_path / "base/general/rtl").mkdir(parents=True)
+    (tmp_path / "build/x/wrappers").mkdir(parents=True)
+
+    wrapper = tmp_path / "protocols/srp/wrappers/SrpV3AxiWrapper.vhd"
+    wrapper.write_text("-- wrapper\n", encoding="utf-8")
+    ip_integrator = tmp_path / "axi/axi-lite/ip_integrator/AxiDualPortRamIpIntegrator.vhd"
+    ip_integrator.write_text("-- ipi\n", encoding="utf-8")
+    # Excluded: ordinary rtl, a non-.vhd file, and a wrappers/ copy under build/.
+    (tmp_path / "base/general/rtl/StdRtlPkg.vhd").write_text("-- rtl\n", encoding="utf-8")
+    (tmp_path / "protocols/srp/wrappers/notes.txt").write_text("x\n", encoding="utf-8")
+    (tmp_path / "build/x/wrappers/Copied.vhd").write_text("-- copy\n", encoding="utf-8")
+
+    result = dep_map.discover_test_local_sources(tmp_path)
+
+    assert result == sorted([wrapper.resolve(), ip_integrator.resolve()])
+
+
+def test_discover_test_local_sources_scoped_to_scan_dirs(tmp_path):
+    # The scan is scoped to `scan_dirs`: a wrapper under a scanned subtree is
+    # collected, one under an unscanned subtree (ethernet) is not -- so a
+    # selective run never imports wrapper sources for subsystems outside the
+    # scanned universe.
+    (tmp_path / "protocols/srp/wrappers").mkdir(parents=True)
+    (tmp_path / "ethernet/RoCEv2/wrappers").mkdir(parents=True)
+    in_scope = tmp_path / "protocols/srp/wrappers/SrpV3AxiWrapper.vhd"
+    in_scope.write_text("-- wrapper\n", encoding="utf-8")
+    out_of_scope = tmp_path / "ethernet/RoCEv2/wrappers/RoceConfiguratorWrapper.vhd"
+    out_of_scope.write_text("-- wrapper\n", encoding="utf-8")
+
+    result = dep_map.discover_test_local_sources(tmp_path, scan_dirs=("protocols",))
+
+    assert result == [in_scope.resolve()]
+
+
+def test_discover_test_local_sources_finds_real_wrapper_and_ip_integrator():
+    # Live-repo smoke check (pure filesystem scan, no GHDL): the real
+    # wrapper/ip_integrator sources under the scanned universe are discovered,
+    # all absolute and none under the build/ output tree.
+    sources = dep_map.discover_test_local_sources(REPO_ROOT)
+    names = {path.name for path in sources}
+
+    assert "SrpV3AxiWrapper.vhd" in names
+    assert "AxiDualPortRamIpIntegrator.vhd" in names
+
+    build_root = (REPO_ROOT / "build").resolve()
+    for path in sources:
+        assert path.is_absolute()
+        assert build_root not in path.parents
+
+
+def test_import_test_local_sources_invokes_ghdl_i_with_absolute_paths(monkeypatch, tmp_path):
+    # `ghdl -i` is invoked with --workdir, the resolver flags, --work=surf, and
+    # the absolute source paths last -- absolute paths are what yield the
+    # REPO_ROOT-resolvable `file / "<abs>"` .cf form (workdir-relative would
+    # write `.././...` entries that resolve against the wrong base).
+    src_a = tmp_path / "a/wrappers/A.vhd"
+    src_b = tmp_path / "b/ip_integrator/B.vhd"
+    monkeypatch.setattr(dep_map, "discover_test_local_sources", lambda *args, **kwargs: [src_a, src_b])
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stderr="")
+
+    monkeypatch.setattr(dep_map.subprocess, "run", fake_run)
+
+    count = dep_map.import_test_local_sources(tmp_path, "/wd", ["--std=08", "-fsynopsys"])
+
+    assert count == 2
+    assert captured["cmd"][: len(dep_map.GHDL_CMD) + 1] == [*dep_map.GHDL_CMD, "-i"]
+    assert "--workdir=/wd" in captured["cmd"]
+    assert "--work=surf" in captured["cmd"]
+    assert "--std=08" in captured["cmd"] and "-fsynopsys" in captured["cmd"]
+    assert captured["cmd"][-2:] == [str(src_a), str(src_b)]
+    assert captured["cwd"] == "/wd"
+
+
+def test_import_test_local_sources_no_sources_is_noop(monkeypatch, tmp_path):
+    # With no wrapper/ip_integrator sources, ghdl is never invoked and the
+    # count is zero.
+    monkeypatch.setattr(dep_map, "discover_test_local_sources", lambda *args, **kwargs: [])
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("ghdl must not run when there are no sources")
+
+    monkeypatch.setattr(dep_map.subprocess, "run", fail_run)
+
+    assert dep_map.import_test_local_sources(tmp_path, "/wd", []) == 0
+
+
+def test_import_test_local_sources_ghdl_failure_is_nonfatal(monkeypatch, tmp_path):
+    # A non-zero `ghdl -i` exit must not raise (check=False): any toplevel that
+    # still cannot be found simply stays always-run (fail-safe preserved).
+    monkeypatch.setattr(
+        dep_map, "discover_test_local_sources", lambda *args, **kwargs: [tmp_path / "w/wrappers/W.vhd"]
+    )
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stderr="ghdl: boom")
+
+    monkeypatch.setattr(dep_map.subprocess, "run", fake_run)
+
+    assert dep_map.import_test_local_sources(tmp_path, "/wd", []) == 1
+
+
+# --- CLI fail-open (tests/common/__main__.py) -------------------------------
+
+
+def test_cli_bad_scan_dir_fails_open_to_force_full(monkeypatch, capsys):
+    # discover_toplevels() raises FileNotFoundError on a bad --scan-dir; the
+    # CLI must fail open by printing the FORCE_FULL sentinel on stdout (single
+    # line, per the indeterminate-resolution contract) and returning non-zero,
+    # rather than letting the exception escape unhandled.
+    from tests.common import __main__ as cli
+
+    monkeypatch.setattr(cli.sys, "argv", ["dep_map", "--scan-dir", "no_such_subtree", "--changed-files-override", ""])
+
+    rc = cli.main()
+
+    out = capsys.readouterr().out.splitlines()
+    assert rc == 1
+    assert out == [dep_map.FORCE_FULL]
+
+
+def test_cli_bad_workdir_fails_open_to_force_full(monkeypatch, capsys):
+    # A missing --workdir would make the first GHDL subprocess (ghdl -i, run
+    # with cwd=workdir) raise FileNotFoundError before the parse_cf_units guard
+    # can catch it. The CLI must instead fail open by printing FORCE_FULL on a
+    # single stdout line and returning non-zero, so the indeterminate-resolution
+    # contract holds without a stray subprocess touching a real ghdl.
+    from tests.common import __main__ as cli
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["dep_map", "--workdir", "/no/such/workdir/xyz", "--changed-files-override", ""],
+    )
+
+    rc = cli.main()
+
+    out = capsys.readouterr().out.splitlines()
+    assert rc == 1
+    assert out == [dep_map.FORCE_FULL]


### PR DESCRIPTION
### Description
Make the GHDL/cocotb regression job change-aware: on ordinary feature-branch pushes it runs only the cocotb tests whose RTL dependencies actually changed, while the release path (tags, `main`, and PRs into `main`) still runs the complete suite. Previously every push re-ran the entire suite.

The dependency graph is derived from the actual build (`build/*.cf` + `ghdl --gen-depends`) at CI time — never a hand-maintained list — so it cannot drift from the RTL. Every indeterminate case fails safe toward running more tests, so selective mode can never skip a test the full suite would have run. Because cocotb cannot drive VHDL records, most tests wrap their DUT in a `**/wrappers/` or `**/ip_integrator/` entity that `make import` never compiles; those sources are imported into the resolver's library first so their toplevels resolve to real dependency sets instead of falling back to always-run. Subsystems whose core RTL is family-gated out of the generic GHDL build (pgp2b, pgp2fc, coaxpress) remain always-run by fail-safe.

### CI trigger behavior

When the full suite runs vs. only the affected tests:

| Trigger Type #| Trigger                                                            | Test Suite Run                        | Why                                                                                             |
|:--------------------:|---------------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------------------------|
| 1                     | Push to a feature branch (ref is not `main` and not a tag)          | **Selective** — only affected cocotb tests | Fast feedback on work in progress                                                                 |
| 2                     | Push to `main`                                                       | **Full**                               | Integration branch                                                                                |
| 3                     | Tag push (`refs/tags/*`)                                             | **Full**                               | Release path                                                                                      |
| 4                     | Pull request targeting `main`                                        | **Full**                               | Pre-merge gate before release                                                                     |
| 5                     | Pull request targeting a non-`main` branch (e.g. `pre-release`)      | **No run**                             | The `pull_request` trigger is scoped to `main`; the branch's own push already ran the selective job |

