### PR TITLE
fix(axi-stream): drop numpy dependency from AxiStreamFrameBuffer test

### DIFF
--- a/tests/axi/axi_stream/test_AxiStreamFrameBuffer.py
+++ b/tests/axi/axi_stream/test_AxiStreamFrameBuffer.py
@@ -26,9 +26,10 @@
 #   first valid stream beat is presented (`tValid = 1`). Further,
 #   dataFrameRxDone timing is checked.
 
+import math
+
 import cocotb
 import pytest
-import numpy as np
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer, with_timeout
 from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiResp, AxiStreamBus, AxiStreamSink
@@ -84,8 +85,8 @@ class TB:
         tb = cls(
             dut,
             dataClkPeriod=baseClkPeriod,
-            axilClkPeriod=round(baseClkPeriod / np.pi, 5),
-            axisClkPeriod=round(baseClkPeriod * np.e, 5),
+            axilClkPeriod=round(baseClkPeriod / math.pi, 5),
+            axisClkPeriod=round(baseClkPeriod * math.e, 5),
         )
         return tb
 


### PR DESCRIPTION
## Problem

PR #1418 (`AxiStreamFrameBuffer`) was merged from a fork that never ran CI. After the merge, the `Regression Tests` job fails at **pytest collection time**:

```
tests/axi/axi_stream/test_AxiStreamFrameBuffer.py:31: in <module>
    import numpy as np
E   ModuleNotFoundError: No module named 'numpy'
786 passed, 1 error  →  exit code 1
```

`numpy` is not in `pip_requirements.txt`, so the clean CI runner cannot import the test module. Because it is a collection-time `ImportError`, pytest returns a non-zero exit even though all 786 real tests pass. It slipped through because local dev environments already have `numpy` installed.

Failing run: https://github.com/slaclab/surf/actions/runs/28809940992/job/85434982065#step:5:2025

## Fix

`numpy` was used in only one file across the whole `tests/` tree, and only for the `pi`/`e` constants that set the "silly" asynchronous clock ratios. Swap to the stdlib `math` module — `math.pi`/`math.e` are identical values — so the test no longer needs `numpy` and the suite stays `numpy`-free like the other 786 tests. No new dependency added.
