### PR TITLE
Add Vivado xsim DPI-C co-simulation backend for RogueTcpStream, RogueTcpMemory, and RogueSideBand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ruckus
 ruckus/
 build/
 sim_build*
+xsc.pb
 .coverage*
 
 # Local editor/agent state

--- a/axi/README.md
+++ b/axi/README.md
@@ -9,6 +9,6 @@ This tree contains reusable AXI-family RTL and wrappers. Top-level `axi/ruckus.t
 - `axi4/`: full AXI4 support blocks and adapters.
 - `bridge/`: bridges between AXI-family buses and SURF protocol records.
 - `dma/`: DMA register, descriptor, FIFO, and stream integration cores.
-- `simlink/`: simulator-link support and C/C++/VHDL pieces used by simulation flows.
+- `simlink/`: simulator-link support and C/C++/VHDL pieces used by simulation flows (GHDL, VCS, and Vivado xsim backends). See [simlink/README.md](simlink/README.md) for the Rogue TCP/SideBand co-simulation usage guide.
 
 Use existing package record types before adding flattened ports. Put durable adapter entities in `ip_integrator/` or `wrappers/`, and keep executable cocotb tests under `tests/axi/`.

--- a/axi/simlink/README.md
+++ b/axi/simlink/README.md
@@ -30,15 +30,20 @@ connect the peer and keep it draining before HDL produces outbound messages.
 Simulator-thread receive is nonblocking, but send retains the existing
 synchronous ZeroMQ behavior across all three backends.
 
-## Checked-In xsim Example
+## Checked-In xsim Examples
 
-The repository's runnable example is the focused multi-instance regression:
+The repository includes two focused multi-instance regressions:
 
 - `tests/axi/simlink/RogueXsimMultiTb.vhd` instantiates four Stream, two
   Memory, and two SideBand models concurrently.
 - `tests/axi/simlink/test_RogueXsimMulti.py` builds the DPI library, checks the
   generated DPI-C prototypes, compiles the mixed-language design, runs xsim,
   and verifies duplicate-port rejection.
+- `tests/axi/simlink/RogueXsimTrafficTb.vhd` drives the same eight-instance
+  topology with isolated Stream, Memory, and SideBand traffic.
+- `tests/axi/simlink/test_RogueXsimTraffic.py` starts one deterministic
+  `rogue_tcp_peer.py` process per instance and verifies the xsim and peer-side
+  results.
 
 The standalone DPI library and ABI check can be built with:
 
@@ -49,12 +54,19 @@ make -C axi/simlink/xsim all abi-check
 Run it from the repository root in a Vivado-enabled shell:
 
 ```bash
-./.venv/bin/python -m pytest -q -n 0 tests/axi/simlink/test_RogueXsimMulti.py
+./.venv/bin/python -m pytest -q -n 0 \
+  tests/axi/simlink/test_RogueXsimMulti.py \
+  tests/axi/simlink/test_RogueXsimTraffic.py
 ```
 
 The test skips with an explicit reason when Vivado simulator tools are not on
 `PATH`. The protocol codecs and deterministic ZeroMQ peer used by the broader
-simlink regressions are in `tests/axi/simlink/rogue_tcp_peer.py`.
+simlink regressions are in `tests/axi/simlink/rogue_tcp_peer.py`. The active
+traffic regression uses test-only ready files to tell the parent process that
+each peer has configured its sockets and issued its ZeroMQ connect calls. It
+then retains a short fixed settle delay because the underlying ZeroMQ
+connection handshake is asynchronous. This coordination does not add a socket,
+message, or handshake to the production Rogue TCP wire protocol.
 
 ## Troubleshooting
 

--- a/axi/simlink/README.md
+++ b/axi/simlink/README.md
@@ -1,0 +1,39 @@
+# Simlink
+
+This directory holds three interchangeable Rogue co-simulation backends -- GHDL/VHPIDIRECT (`ghdl/`), Synopsys VCS/VHPI (`vcs/`), and Vivado xsim/DPI (`xsim/`) -- selected automatically by `ruckus.tcl` based on the active simulator. All three backends share the same `shared/` C cores and speak the same ZeroMQ wire protocol to a Rogue-side Python peer, so a testbench built against one backend behaves the same on any of the others.
+
+## Prerequisites
+
+- `libzmq >= 4.1.0` -- check with `pkg-config --modversion libzmq`.
+- A Rogue-environment shell for the peer scripts (they `import pyrogue` / `import rogue`).
+
+## Running the Vivado xsim Co-Simulation
+
+1. Run `make gui` from the target directory. Ruckus auto-detects whichever of `RogueTcpStream.vhd`, `RogueTcpMemory.vhd`, or `RogueSideBand.vhd` is present in the sim sources, builds the combined `RogueTcpDpi.so` via `xsc`, and binds it with a single `-sv_lib RogueTcpDpi` -- no manual build step is required.
+2. Watch the Tcl/GUI console for the `xsc` build completing and, after `launch_simulation` / `run`, the module's `Listening on ports N & N+1` message -- that print is the ready-for-peer signal.
+3. In a separate terminal, start the matching Rogue-side driver script against that module's port.
+4. Watch the waveform -- data movement between the DPI adapter and the peer confirms the round trip.
+
+| Module | Demo TB | Ports | Peer script |
+|--------|---------|-------|-------------|
+| RogueTcpStream | `RogueTcpStreamXsimDemoTb` | 9000 (push on 9001) | `prbsLoopbackDemo.py` |
+| RogueTcpMemory | `RogueTcpMemoryXsimDemoTb` | 9100 (push on 9101) | `axiVersionMemoryDemo.py` |
+| RogueSideBand | `RogueSideBandXsimDemoTb` | 9200 (push on 9201) | `sideBandDemo.py` |
+
+## Selecting a Module
+
+Vivado elaborates one top per simulation fileset, so switching which module's demo runs is a single manual step: in the target's `ruckus.tcl`, comment/uncomment the desired `set_property top {...XsimDemoTb}` line, then run `make gui` again. This is the only manual step when switching between modules -- the DPI build and `-sv_lib` binding stay identical regardless of which module is selected.
+
+## Troubleshooting
+
+**"libzmq package was not found"**
+If the Tcl console prints:
+```
+libzmq package was not found
+Please make sure that you have libzmq installed
+or have sourced the necessary rogue setup scripts
+```
+install libzmq (or source the Rogue setup scripts that put it on `PKG_CONFIG_PATH`) and re-run `make gui`.
+
+**Idle waveform, no data movement**
+If the console printed `Listening on ports N & N+1` but the waveform never shows activity, the peer has not connected. Confirm the driver script is running, targeting the same host (loopback `127.0.0.1`) and port pair as the module under test, and that push/pull directions are not swapped.

--- a/axi/simlink/README.md
+++ b/axi/simlink/README.md
@@ -5,24 +5,56 @@ This directory holds three interchangeable Rogue co-simulation backends -- GHDL/
 ## Prerequisites
 
 - `libzmq >= 4.1.0` -- check with `pkg-config --modversion libzmq`.
-- A Rogue-environment shell for the peer scripts (they `import pyrogue` / `import rogue`).
+- Vivado simulator tools (`xsc`, `xvlog`, `xvhdl`, `xelab`, and `xsim`) for
+  the xsim backend.
+- A compatible Rogue or ZeroMQ peer for the selected Stream, Memory, or
+  SideBand wire protocol.
 
 ## Running the Vivado xsim Co-Simulation
 
-1. Run `make gui` from the target directory. Ruckus auto-detects whichever of `RogueTcpStream.vhd`, `RogueTcpMemory.vhd`, or `RogueSideBand.vhd` is present in the sim sources, builds the combined `RogueTcpDpi.so` via `xsc`, and binds it with a single `-sv_lib RogueTcpDpi` -- no manual build step is required.
-2. Watch the Tcl/GUI console for the `xsc` build completing and, after `launch_simulation` / `run`, the module's `Listening on ports N & N+1` message -- that print is the ready-for-peer signal.
-3. In a separate terminal, start the matching Rogue-side driver script against that module's port.
-4. Watch the waveform -- data movement between the DPI adapter and the peer confirms the round trip.
+An external target must provide a simulation top containing one or more
+`RogueTcpStream`, `RogueTcpMemory`, `RogueSideBand`, or corresponding SURF
+wrapper instances. It must drive clock/reset, assign a distinct two-port pair
+to every live instance, and provide a peer that implements the matching wire
+protocol. The first instance uses `portNum` and `portNum+1`; a subsequent
+instance must therefore start at least two ports higher.
 
-| Module | Demo TB | Ports | Peer script |
-|--------|---------|-------|-------------|
-| RogueTcpStream | `RogueTcpStreamXsimDemoTb` | 9000 (push on 9001) | `prbsLoopbackDemo.py` |
-| RogueTcpMemory | `RogueTcpMemoryXsimDemoTb` | 9100 (push on 9101) | `axiVersionMemoryDemo.py` |
-| RogueSideBand | `RogueSideBandXsimDemoTb` | 9200 (push on 9201) | `sideBandDemo.py` |
+From a target using the standard ruckus simulation flow, run `make gui` or the
+target's xsim make target. `axi/simlink/ruckus.tcl` selects `xsim/`, the build
+creates the combined `RogueTcpDpi.so`, and elaboration binds it once with
+`-sv_lib RogueTcpDpi`. After reset is released, each instance prints its
+`Listening on ports N & N+1` message.
 
-## Selecting a Module
+The transport preserves the long-standing VCS/GHDL operating contract:
+connect the peer and keep it draining before HDL produces outbound messages.
+Simulator-thread receive is nonblocking, but send retains the existing
+synchronous ZeroMQ behavior across all three backends.
 
-Vivado elaborates one top per simulation fileset, so switching which module's demo runs is a single manual step: in the target's `ruckus.tcl`, comment/uncomment the desired `set_property top {...XsimDemoTb}` line, then run `make gui` again. This is the only manual step when switching between modules -- the DPI build and `-sv_lib` binding stay identical regardless of which module is selected.
+## Checked-In xsim Example
+
+The repository's runnable example is the focused multi-instance regression:
+
+- `tests/axi/simlink/RogueXsimMultiTb.vhd` instantiates four Stream, two
+  Memory, and two SideBand models concurrently.
+- `tests/axi/simlink/test_RogueXsimMulti.py` builds the DPI library, checks the
+  generated DPI-C prototypes, compiles the mixed-language design, runs xsim,
+  and verifies duplicate-port rejection.
+
+The standalone DPI library and ABI check can be built with:
+
+```bash
+make -C axi/simlink/xsim all abi-check
+```
+
+Run it from the repository root in a Vivado-enabled shell:
+
+```bash
+./.venv/bin/python -m pytest -q -n 0 tests/axi/simlink/test_RogueXsimMulti.py
+```
+
+The test skips with an explicit reason when Vivado simulator tools are not on
+`PATH`. The protocol codecs and deterministic ZeroMQ peer used by the broader
+simlink regressions are in `tests/axi/simlink/rogue_tcp_peer.py`.
 
 ## Troubleshooting
 

--- a/axi/simlink/ruckus.tcl
+++ b/axi/simlink/ruckus.tcl
@@ -4,11 +4,36 @@ source $::env(RUCKUS_PROC_TCL)
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
 
-# Check if not GHDL
-if {![info exists ::env(GHDLFLAGS)]} {
-   # Include VHPI
-   loadSource -lib surf -sim_only -dir "$::DIR_PATH/vcs"
+# Select the simulator backend. Prefer the backend explicitly requested by the
+# ruckus make target (make xsim/gui -> xsim, make vcs -> vcs). Fall back to
+# environment sniffing for older ruckus. Note: sniffing VCS_VERSION alone is
+# unreliable because users commonly source both Vivado and VCS in one setup
+# script, so VCS_VERSION is set even during a Vivado xsim run.
+if {[info exists ::env(RUCKUS_SIM_BACKEND)]} {
+   set simBackend $::env(RUCKUS_SIM_BACKEND)
+} elseif {[info exists ::env(GHDLFLAGS)]} {
+   set simBackend "ghdl"
+} elseif {[info exists ::env(VCS_VERSION)]} {
+   set simBackend "vcs"
 } else {
-   # Exclude VHPI
-   loadSource -lib surf -sim_only -dir "$::DIR_PATH/ghdl"
+   set simBackend "xsim"
 }
+
+# When re-generating an existing Vivado project, purge sibling-backend sources
+# so switching backends doesn't leave duplicate RogueTcp* entities in sim_1.
+# Only remove when present, to avoid needless add/remove churn in the project.
+# Guard on VIVADO_VERSION because get_files/remove_files are Vivado-only; GHDL
+# re-analyzes from scratch and has no persistent project to clean.
+if {$::env(VIVADO_VERSION) > 0.0} {
+   foreach other {ghdl vcs xsim} {
+      if {${other} ne ${simBackend}} {
+         set staleFiles [get_files -quiet [file normalize "$::DIR_PATH/${other}/*"]]
+         if {[llength ${staleFiles}] > 0} {
+            remove_files -quiet ${staleFiles}
+         }
+      }
+   }
+}
+
+# Load the selected backend
+loadSource -lib surf -sim_only -dir "$::DIR_PATH/${simBackend}"

--- a/axi/simlink/tb/RogueTcpStreamWrap.vhd
+++ b/axi/simlink/tb/RogueTcpStreamWrap.vhd
@@ -133,7 +133,7 @@ begin
    end generate;
 
    -- Channels
-   U_ChanGen : for i in 0 to CHAN_COUNT_C-1 generate
+   GEN_CHAN : for i in 0 to CHAN_COUNT_C-1 generate
       ------------------
       -- Inbound Resizer
       ------------------

--- a/axi/simlink/xsim/Makefile
+++ b/axi/simlink/xsim/Makefile
@@ -10,17 +10,16 @@
 # xsc-based build (Vivado xsim DPI-C), re-targeted from ghdl/Makefile's
 # gcc -shared -fPIC + pkg-config libzmq pattern to the xsc two-step compile/
 # link flow. Builds the combined RogueTcpDpi.so from every module's DPI-C
-# adapter (RogueTcpStream.c, RogueTcpMemory.c, RogueSideBand.c); a single
-# "-sv_lib RogueTcpDpi" binds all of them. Each adapter keeps its own
-# file-scope static data and name-prefixed
-# functions, so linking them into one .so has no symbol collisions. The
-# file is named RogueTcpDpi.so (no "lib" prefix): xelab's "-sv_lib
+# adapter plus the shared per-instance ownership manager; a single
+# "-sv_lib RogueTcpDpi" binds all of them. The file is named RogueTcpDpi.so
+# (no "lib" prefix): xelab's "-sv_lib
 # RogueTcpDpi" resolves the DPI library as <name>.so, not lib<name>.so
 # (per UG900). xsc stages its compiled object under its own implicit
 # ./xsim.dir/work/xsc/ directory (no BUILD_DIR indirection like GHDL/VCS use).
 ##############################################################################
 
 CC     := xsc
+ELAB   := xelab
 # -I../shared resolves the shared RogueTcp*Core.h headers that every backend
 # includes; xsc's underlying gcc searches the including file's own dir
 # first, so the xsim/ RogueTcp*.h still take precedence. svdpi.h is
@@ -37,16 +36,32 @@ MULTIARCH_DIR := $(dir $(shell gcc -print-file-name=crti.o))
 LFLAGS := $(shell pkg-config --libs libzmq) -B$(MULTIARCH_DIR) -L$(MULTIARCH_DIR)
 
 LIB := RogueTcpDpi.so
+SOURCES := RogueDpiInstance.c RogueTcpStream.c RogueTcpMemory.c RogueSideBand.c
+HEADERS := RogueDpiInstance.h RogueTcpStream.h RogueTcpMemory.h RogueSideBand.h \
+           ../shared/RogueTcpStreamCore.h ../shared/RogueTcpMemoryCore.h \
+           ../shared/RogueSideBandCore.h
+SV_SOURCES := RogueTcpStreamDpi.sv RogueTcpMemoryDpi.sv RogueSideBandDpi.sv
+ABI_HEADER := xsim.dir/RogueTcpDpi.generated.h
 
 all: $(LIB)
 
-$(LIB): RogueTcpStream.c RogueTcpMemory.c RogueSideBand.c
+$(LIB): $(SOURCES) $(HEADERS)
+	$(CC) -c RogueDpiInstance.c -gcc_compile_options "$(CFLAGS)"
 	$(CC) -c RogueTcpStream.c -gcc_compile_options "$(CFLAGS)"
 	$(CC) -c RogueTcpMemory.c -gcc_compile_options "$(CFLAGS)"
 	$(CC) -c RogueSideBand.c -gcc_compile_options "$(CFLAGS)"
 	$(CC) --shared -o $(LIB) -gcc_link_options "$(LFLAGS)"
 
-clean:
-	rm -rf xsim.dir xsc.pb xsc.log $(LIB)
+$(ABI_HEADER): $(SV_SOURCES)
+	mkdir -p $(dir $@)
+	$(ELAB) -dpiheader $@ -svlog $(SV_SOURCES)
 
-.PHONY: all clean
+abi-check: $(ABI_HEADER) $(SOURCES) $(HEADERS)
+	$(CC) -c RogueTcpStream.c -gcc_compile_options "$(CFLAGS) -include $(abspath $(ABI_HEADER))"
+	$(CC) -c RogueTcpMemory.c -gcc_compile_options "$(CFLAGS) -include $(abspath $(ABI_HEADER))"
+	$(CC) -c RogueSideBand.c -gcc_compile_options "$(CFLAGS) -include $(abspath $(ABI_HEADER))"
+
+clean:
+	rm -rf xsim.dir xsc.pb xsc.log xelab.pb xelab.log xelab.jou $(LIB)
+
+.PHONY: all abi-check clean

--- a/axi/simlink/xsim/Makefile
+++ b/axi/simlink/xsim/Makefile
@@ -1,0 +1,52 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+# xsc-based build (Vivado xsim DPI-C), re-targeted from ghdl/Makefile's
+# gcc -shared -fPIC + pkg-config libzmq pattern to the xsc two-step compile/
+# link flow. Builds the combined RogueTcpDpi.so from every module's DPI-C
+# adapter (RogueTcpStream.c, RogueTcpMemory.c, RogueSideBand.c); a single
+# "-sv_lib RogueTcpDpi" binds all of them. Each adapter keeps its own
+# file-scope static data and name-prefixed
+# functions, so linking them into one .so has no symbol collisions. The
+# file is named RogueTcpDpi.so (no "lib" prefix): xelab's "-sv_lib
+# RogueTcpDpi" resolves the DPI library as <name>.so, not lib<name>.so
+# (per UG900). xsc stages its compiled object under its own implicit
+# ./xsim.dir/work/xsc/ directory (no BUILD_DIR indirection like GHDL/VCS use).
+##############################################################################
+
+CC     := xsc
+# -I../shared resolves the shared RogueTcp*Core.h headers that every backend
+# includes; xsc's underlying gcc searches the including file's own dir
+# first, so the xsim/ RogueTcp*.h still take precedence. svdpi.h is
+# auto-found by xsc (adds $XILINX_VIVADO/data/xsim/include automatically).
+CFLAGS := -I../shared $(shell pkg-config --cflags libzmq)
+# Vivado <= 2024.1 bundles a gcc-9.3.0 whose link driver invokes its own
+# binutils via -B and does not search the host multiarch lib dir, so the
+# RogueTcpDpi.so link fails with "cannot find crti.o / -lzmq / -lm". Point both
+# the startfile search (-B, for crt*.o) and the library search (-L) at the
+# active gcc's lib dir, derived portably from `gcc -print-file-name=crti.o`
+# (resolves to /usr/lib/x86_64-linux-gnu on Debian/Ubuntu, /usr/lib64 on RHEL).
+# Harmless on Vivado >= 2024.2, whose xsc already resolves these.
+MULTIARCH_DIR := $(dir $(shell gcc -print-file-name=crti.o))
+LFLAGS := $(shell pkg-config --libs libzmq) -B$(MULTIARCH_DIR) -L$(MULTIARCH_DIR)
+
+LIB := RogueTcpDpi.so
+
+all: $(LIB)
+
+$(LIB): RogueTcpStream.c RogueTcpMemory.c RogueSideBand.c
+	$(CC) -c RogueTcpStream.c -gcc_compile_options "$(CFLAGS)"
+	$(CC) -c RogueTcpMemory.c -gcc_compile_options "$(CFLAGS)"
+	$(CC) -c RogueSideBand.c -gcc_compile_options "$(CFLAGS)"
+	$(CC) --shared -o $(LIB) -gcc_link_options "$(LFLAGS)"
+
+clean:
+	rm -rf xsim.dir xsc.pb xsc.log $(LIB)
+
+.PHONY: all clean

--- a/axi/simlink/xsim/Makefile
+++ b/axi/simlink/xsim/Makefile
@@ -54,7 +54,7 @@ $(LIB): $(SOURCES) $(HEADERS)
 
 $(ABI_HEADER): $(SV_SOURCES)
 	mkdir -p $(dir $@)
-	$(ELAB) -dpiheader $@ -svlog $(SV_SOURCES)
+	$(ELAB) -dpiheader $@ $(foreach src,$(SV_SOURCES),-svlog $(src))
 
 abi-check: $(ABI_HEADER) $(SOURCES) $(HEADERS)
 	$(CC) -c RogueTcpStream.c -gcc_compile_options "$(CFLAGS) -include $(abspath $(ABI_HEADER))"

--- a/axi/simlink/xsim/RogueDpiInstance.c
+++ b/axi/simlink/xsim/RogueDpiInstance.c
@@ -1,0 +1,195 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "RogueDpiInstance.h"
+
+#define ROGUE_DPI_MAGIC_C 0x52445049U
+
+typedef struct RogueDpiInstance {
+    uint32_t magic;
+    RogueDpiModel model;
+    uint16_t requestedPort;
+    void *data;
+    RogueDpiCleanup cleanup;
+    struct RogueDpiInstance *next;
+    struct RogueDpiInstance *previous;
+} RogueDpiInstance;
+
+static RogueDpiInstance *rogueDpiInstances = NULL;
+static int rogueDpiCleanupRegistered = 0;
+
+static const char *rogueDpiModelName(RogueDpiModel model) {
+    switch (model) {
+        case ROGUE_DPI_STREAM_C:
+            return "RogueTcpStream";
+        case ROGUE_DPI_MEMORY_C:
+            return "RogueTcpMemory";
+        case ROGUE_DPI_SIDEBAND_C:
+            return "RogueSideBand";
+        default:
+            return "UnknownRogueDpiModel";
+    }
+}
+
+static RogueDpiInstance *rogueDpiValidate(const void *context,
+                                           RogueDpiModel expectedModel) {
+    RogueDpiInstance *instance = (RogueDpiInstance *)context;
+
+    if (instance == NULL) {
+        fprintf(stderr, "%s: null DPI instance context\n",
+                rogueDpiModelName(expectedModel));
+        return NULL;
+    }
+
+    if (instance->magic != ROGUE_DPI_MAGIC_C) {
+        fprintf(stderr, "%s: invalid DPI instance context\n",
+                rogueDpiModelName(expectedModel));
+        return NULL;
+    }
+
+    if (instance->model != expectedModel) {
+        fprintf(stderr, "%s: DPI context belongs to %s\n",
+                rogueDpiModelName(expectedModel),
+                rogueDpiModelName(instance->model));
+        return NULL;
+    }
+
+    return instance;
+}
+
+static void rogueDpiRemove(RogueDpiInstance *instance) {
+    if (instance->previous == NULL) {
+        rogueDpiInstances = instance->next;
+    } else {
+        instance->previous->next = instance->next;
+    }
+
+    if (instance->next != NULL) instance->next->previous = instance->previous;
+    instance->next = NULL;
+    instance->previous = NULL;
+}
+
+static void rogueDpiRelease(RogueDpiInstance *instance) {
+    rogueDpiRemove(instance);
+    instance->magic = 0;
+    if (instance->cleanup != NULL) instance->cleanup(instance->data);
+    free(instance->data);
+    free(instance);
+}
+
+static void rogueDpiDestroyAll(void) {
+    while (rogueDpiInstances != NULL) rogueDpiRelease(rogueDpiInstances);
+}
+
+void *rogueDpiCreate(RogueDpiModel model,
+                     size_t dataSize,
+                     RogueDpiCleanup cleanup) {
+    RogueDpiInstance *instance;
+
+    instance = calloc(1, sizeof(*instance));
+    if (instance == NULL) {
+        fprintf(stderr, "%s: failed to allocate DPI instance metadata\n",
+                rogueDpiModelName(model));
+        return NULL;
+    }
+
+    instance->data = calloc(1, dataSize);
+    if (instance->data == NULL) {
+        fprintf(stderr, "%s: failed to allocate DPI instance state\n",
+                rogueDpiModelName(model));
+        free(instance);
+        return NULL;
+    }
+
+    if (!rogueDpiCleanupRegistered) {
+        if (atexit(rogueDpiDestroyAll) != 0) {
+            fprintf(stderr, "%s: failed to register DPI instance cleanup\n",
+                    rogueDpiModelName(model));
+            free(instance->data);
+            free(instance);
+            return NULL;
+        }
+        rogueDpiCleanupRegistered = 1;
+    }
+
+    instance->magic = ROGUE_DPI_MAGIC_C;
+    instance->model = model;
+    instance->cleanup = cleanup;
+    instance->next = rogueDpiInstances;
+    if (rogueDpiInstances != NULL) rogueDpiInstances->previous = instance;
+    rogueDpiInstances = instance;
+
+    return instance;
+}
+
+void *rogueDpiGetData(const void *context, RogueDpiModel expectedModel) {
+    RogueDpiInstance *instance = rogueDpiValidate(context, expectedModel);
+
+    return (instance == NULL) ? NULL : instance->data;
+}
+
+int rogueDpiReservePort(const void *context,
+                        RogueDpiModel expectedModel,
+                        uint16_t requestedPort) {
+    RogueDpiInstance *instance;
+    RogueDpiInstance *other;
+    uint32_t requestedEnd;
+    uint32_t otherEnd;
+
+    instance = rogueDpiValidate(context, expectedModel);
+    if (instance == NULL) return 0;
+
+    if (requestedPort == 0 || requestedPort == UINT16_MAX) {
+        fprintf(stderr, "%s: invalid DPI base port %u\n",
+                rogueDpiModelName(expectedModel), requestedPort);
+        return 0;
+    }
+
+    if (instance->requestedPort != 0) {
+        if (instance->requestedPort != requestedPort) {
+            fprintf(stderr, "%s: DPI base port changed from %u to %u\n",
+                    rogueDpiModelName(expectedModel),
+                    instance->requestedPort, requestedPort);
+            return 0;
+        }
+        return 1;
+    }
+
+    requestedEnd = (uint32_t)requestedPort + 1U;
+    for (other = rogueDpiInstances; other != NULL; other = other->next) {
+        if (other == instance || other->requestedPort == 0) continue;
+        otherEnd = (uint32_t)other->requestedPort + 1U;
+        if ((uint32_t)requestedPort <= otherEnd &&
+            (uint32_t)other->requestedPort <= requestedEnd) {
+            fprintf(stderr,
+                    "%s: DPI port pair %u/%u overlaps live %s port pair %u/%u\n",
+                    rogueDpiModelName(expectedModel),
+                    requestedPort, requestedPort + 1U,
+                    rogueDpiModelName(other->model),
+                    other->requestedPort, other->requestedPort + 1U);
+            return 0;
+        }
+    }
+
+    instance->requestedPort = requestedPort;
+    return 1;
+}
+
+int rogueDpiDestroy(const void *context, RogueDpiModel expectedModel) {
+    RogueDpiInstance *instance = rogueDpiValidate(context, expectedModel);
+
+    if (instance == NULL) return 0;
+    rogueDpiRelease(instance);
+    return 1;
+}

--- a/axi/simlink/xsim/RogueDpiInstance.h
+++ b/axi/simlink/xsim/RogueDpiInstance.h
@@ -1,0 +1,37 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef ROGUE_DPI_INSTANCE_H
+#define ROGUE_DPI_INSTANCE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+    ROGUE_DPI_STREAM_C,
+    ROGUE_DPI_MEMORY_C,
+    ROGUE_DPI_SIDEBAND_C,
+} RogueDpiModel;
+
+typedef void (*RogueDpiCleanup)(void *data);
+
+void *rogueDpiCreate(RogueDpiModel model,
+                     size_t dataSize,
+                     RogueDpiCleanup cleanup);
+
+void *rogueDpiGetData(const void *context, RogueDpiModel expectedModel);
+
+int rogueDpiReservePort(const void *context,
+                        RogueDpiModel expectedModel,
+                        uint16_t requestedPort);
+
+int rogueDpiDestroy(const void *context, RogueDpiModel expectedModel);
+
+#endif

--- a/axi/simlink/xsim/RogueSideBand.c
+++ b/axi/simlink/xsim/RogueSideBand.c
@@ -1,0 +1,72 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// Vivado xsim DPI-C backend for the Rogue side-band model. The ZMQ transport
+// (RogueSideBandRestart/Send/Recv) and the opcode/remData FSM
+// (RogueSideBandStep) live in axi/simlink/shared/RogueSideBandCore.h,
+// included by every backend. This file provides only the DPI-specific
+// plumbing: a per-edge update function (rogueSideBandUpdate) that copies the
+// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
+// step, and writes the outputs back through the DPI output pointers. Unlike
+// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
+// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <zmq.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "svdpi.h"
+#include "RogueSideBand.h"
+#include "RogueSideBandCore.h"
+
+// Single instance for this simulation; file-scope statics are zero-
+// initialized by C, replacing the src Init's malloc+memset.
+static RogueSideBandData sideBandData;
+
+// Per-edge update function, called from the RogueSideBandDpi SV leaf every
+// rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
+// into the input snapshot (the getInt seam), runs one shared FSM step, then
+// writes the outputs back through the DPI output pointers.
+void rogueSideBandUpdate(unsigned char reset, const svBitVecVal *portNum,
+                          const svBitVecVal *txOpCode, unsigned char txOpCodeEn, const svBitVecVal *txRemData,
+                          svBitVecVal *rxOpCode, unsigned char *rxOpCodeEn, svBitVecVal *rxRemData) {
+    RogueSideBandData *data = &sideBandData;
+    unsigned int reqPort = portNum[0] & 0xFFFF;
+
+    // DPI-C imports carry no per-instance context, so this backend hosts a
+    // single global sideBandData and supports only one RogueSideBand per
+    // simulation. A second instance would otherwise silently share this
+    // state and bind only the first port. Fail fast once a different,
+    // already-latched port is observed rather than corrupt state.
+    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
+        vhpi_printf("RogueSideBand: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
+        vhpi_assert("RogueSideBand: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
+        return;
+    }
+
+    data->inSnap[s_reset]      = reset ? 1 : 0;
+    data->inSnap[s_port]       = reqPort;
+    data->inSnap[s_txOpCode]   = txOpCode[0];
+    data->inSnap[s_txOpCodeEn] = txOpCodeEn ? 1 : 0;
+    data->inSnap[s_txRemData]  = txRemData[0];
+
+    // RogueSideBandStep (shared FSM) calls RogueSideBandRecv, which uses
+    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
+    // whole Vivado xsim process, not just a background thread.
+    RogueSideBandStep(data);
+
+    rxOpCode[0]  = data->outState[s_rxOpCode];
+    *rxOpCodeEn  = data->outState[s_rxOpCodeEn] ? 1 : 0;
+    rxRemData[0] = data->outState[s_rxRemData];
+}

--- a/axi/simlink/xsim/RogueSideBand.c
+++ b/axi/simlink/xsim/RogueSideBand.c
@@ -12,11 +12,12 @@
 // (RogueSideBandRestart/Send/Recv) and the opcode/remData FSM
 // (RogueSideBandStep) live in axi/simlink/shared/RogueSideBandCore.h,
 // included by every backend. This file provides only the DPI-specific
-// plumbing: a per-edge update function (rogueSideBandUpdate) that copies the
-// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
-// step, and writes the outputs back through the DPI output pointers. Unlike
-// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
-// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+// plumbing: one C-owned state object per SystemVerilog DPI leaf, plus a
+// per-edge update function (rogueSideBandUpdate) that copies the DPI
+// svBit/svBitVecVal parameters into the input snapshot, runs one FSM step, and
+// writes the outputs back through the DPI output pointers. Unlike the GHDL
+// VHPIDIRECT backend, every port here is <=32 bits, so each vector argument is
+// a single svBitVecVal word -- no encode/decode loop is needed.
 //////////////////////////////////////////////////////////////////////////////
 
 #include <zmq.h>
@@ -27,33 +28,40 @@
 #include <errno.h>
 
 #include "svdpi.h"
+#include "RogueDpiInstance.h"
 #include "RogueSideBand.h"
 #include "RogueSideBandCore.h"
 
-// Single instance for this simulation; file-scope statics are zero-
-// initialized by C, replacing the src Init's malloc+memset.
-static RogueSideBandData sideBandData;
+static void rogueSideBandCleanup(void *opaque) {
+    RogueSideBandData *data = opaque;
+
+    if (data->zmqPush != NULL) zmq_close(data->zmqPush);
+    if (data->zmqPull != NULL) zmq_close(data->zmqPull);
+    if (data->zmqCtx  != NULL) zmq_ctx_term(data->zmqCtx);
+}
+
+void *rogueSideBandCreate(void) {
+    return rogueDpiCreate(ROGUE_DPI_SIDEBAND_C,
+                          sizeof(RogueSideBandData),
+                          rogueSideBandCleanup);
+}
+
+void rogueSideBandDestroy(void *context) {
+    (void)rogueDpiDestroy(context, ROGUE_DPI_SIDEBAND_C);
+}
 
 // Per-edge update function, called from the RogueSideBandDpi SV leaf every
 // rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
 // into the input snapshot (the getInt seam), runs one shared FSM step, then
 // writes the outputs back through the DPI output pointers.
-void rogueSideBandUpdate(unsigned char reset, const svBitVecVal *portNum,
-                          const svBitVecVal *txOpCode, unsigned char txOpCodeEn, const svBitVecVal *txRemData,
-                          svBitVecVal *rxOpCode, unsigned char *rxOpCodeEn, svBitVecVal *rxRemData) {
-    RogueSideBandData *data = &sideBandData;
+int rogueSideBandUpdate(void *context, svBit reset, const svBitVecVal *portNum,
+                         const svBitVecVal *txOpCode, svBit txOpCodeEn, const svBitVecVal *txRemData,
+                         svBitVecVal *rxOpCode, svBit *rxOpCodeEn, svBitVecVal *rxRemData) {
+    RogueSideBandData *data = rogueDpiGetData(context, ROGUE_DPI_SIDEBAND_C);
     unsigned int reqPort = portNum[0] & 0xFFFF;
 
-    // DPI-C imports carry no per-instance context, so this backend hosts a
-    // single global sideBandData and supports only one RogueSideBand per
-    // simulation. A second instance would otherwise silently share this
-    // state and bind only the first port. Fail fast once a different,
-    // already-latched port is observed rather than corrupt state.
-    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
-        vhpi_printf("RogueSideBand: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
-        vhpi_assert("RogueSideBand: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
-        return;
-    }
+    if (data == NULL) return 0;
+    if (!reset && !rogueDpiReservePort(context, ROGUE_DPI_SIDEBAND_C, reqPort)) return 0;
 
     data->inSnap[s_reset]      = reset ? 1 : 0;
     data->inSnap[s_port]       = reqPort;
@@ -61,12 +69,13 @@ void rogueSideBandUpdate(unsigned char reset, const svBitVecVal *portNum,
     data->inSnap[s_txOpCodeEn] = txOpCodeEn ? 1 : 0;
     data->inSnap[s_txRemData]  = txRemData[0];
 
-    // RogueSideBandStep (shared FSM) calls RogueSideBandRecv, which uses
-    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
-    // whole Vivado xsim process, not just a background thread.
+    // The shared step retains the established backend transport contract:
+    // receive polls with ZMQ_DONTWAIT, while events are sent synchronously
+    // after the peer is connected and draining.
     RogueSideBandStep(data);
 
     rxOpCode[0]  = data->outState[s_rxOpCode];
     *rxOpCodeEn  = data->outState[s_rxOpCodeEn] ? 1 : 0;
     rxRemData[0] = data->outState[s_rxRemData];
+    return 1;
 }

--- a/axi/simlink/xsim/RogueSideBand.h
+++ b/axi/simlink/xsim/RogueSideBand.h
@@ -1,0 +1,81 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef __ROGUE_SIDE_BAND_H__
+#define __ROGUE_SIDE_BAND_H__
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Signals
+#define s_clock        0
+#define s_reset        1
+#define s_port         2
+
+#define s_txOpCode     3
+#define s_txOpCodeEn   4
+#define s_txRemData    5
+
+#define s_rxOpCode     6
+#define s_rxOpCodeEn   7
+#define s_rxRemData    8
+
+#define PORT_COUNT     9
+
+// Vivado xsim's DPI-C boundary has no VHPI (no vhpi_register_cb / value-change
+// callbacks), so the VHPI print/assert calls in the transplanted FSM body are
+// shimmed straight to printf/abort. The severity argument is accepted but
+// never referenced, so no VHPI severity token (e.g. vhpiFatal) needs defining.
+// This shim is backend-agnostic and is shared verbatim with the GHDL backend.
+#define vhpi_printf(...) printf(__VA_ARGS__)
+#define vhpi_assert(msg, sev) \
+    do { \
+        fprintf(stderr, "%s\n", (msg)); \
+        abort(); \
+    } while (0)
+
+// Macros for get/set ints, redefined for the per-edge update-procedure model:
+// getInt reads the input snapshot populated at update-procedure entry;
+// setInt writes the output state read back through the DPI output pointers.
+#define getInt(idx)      (data->inSnap[idx])
+#define setInt(idx, val) (data->outState[idx] = (val))
+
+// Structure to track state
+typedef struct {
+    uint16_t  port;
+
+    uint8_t   rxRemData;
+    uint8_t   rxOpCode;
+    uint8_t   rxOpCodeEn;
+
+    uint8_t   txRemData;
+    uint8_t   txRemDataChanged;
+    uint8_t   txOpCode;
+    uint8_t   txOpCodeEn;
+
+    unsigned int inSnap[PORT_COUNT];
+    unsigned int outState[PORT_COUNT];
+
+    void *    zmqCtx;
+    void *    zmqPull;
+    void *    zmqPush;
+} RogueSideBandData;
+
+// Start/restart zeromq server
+void RogueSideBandRestart(RogueSideBandData *data);
+
+// Send a message
+void RogueSideBandSend(RogueSideBandData *data);
+
+// Receive data if it is available
+int RogueSideBandRecv(RogueSideBandData *data);
+
+#endif

--- a/axi/simlink/xsim/RogueSideBand.h
+++ b/axi/simlink/xsim/RogueSideBand.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "svdpi.h"
+
 // Signals
 #define s_clock        0
 #define s_reset        1
@@ -68,6 +70,14 @@ typedef struct {
     void *    zmqPull;
     void *    zmqPush;
 } RogueSideBandData;
+
+// Vivado xsim DPI-C instance lifecycle and per-edge update
+void *rogueSideBandCreate(void);
+void rogueSideBandDestroy(void *context);
+int rogueSideBandUpdate(void *context, svBit reset, const svBitVecVal *portNum,
+                        const svBitVecVal *txOpCode, svBit txOpCodeEn,
+                        const svBitVecVal *txRemData, svBitVecVal *rxOpCode,
+                        svBit *rxOpCodeEn, svBitVecVal *rxRemData);
 
 // Start/restart zeromq server
 void RogueSideBandRestart(RogueSideBandData *data);

--- a/axi/simlink/xsim/RogueSideBand.vhd
+++ b/axi/simlink/xsim/RogueSideBand.vhd
@@ -1,0 +1,70 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Rogue Side Band Simulation Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity RogueSideBand is
+   port (
+      clock   : in std_logic;
+      reset   : in std_logic;
+      portNum : in std_logic_vector(15 downto 0);
+
+      txOpCode   : in  std_logic_vector(7 downto 0);
+      txOpCodeEn : in  std_logic;
+      txRemData  : in  std_logic_vector(7 downto 0);
+      rxOpCode   : out std_logic_vector(7 downto 0);
+      rxOpCodeEn : out std_logic;
+      rxRemData  : out std_logic_vector(7 downto 0));
+end RogueSideBand;
+
+-- Define architecture
+architecture RogueSideBand of RogueSideBand is
+
+------------------------------------------------------------------------
+-- Vivado xsim has no VHPI, so this fork forwards to the DPI-C model via a
+-- native mixed-language component instantiation of the SV leaf
+-- RogueSideBandDpi (below), instead of GHDL's attribute foreign
+-- VHPIDIRECT binding. VHPI original: axi/simlink/vcs/RogueSideBand.vhd
+------------------------------------------------------------------------
+
+   component RogueSideBandDpi
+      port (
+         clock   : in std_logic;
+         reset   : in std_logic;
+         portNum : in std_logic_vector(15 downto 0);
+
+         txOpCode   : in  std_logic_vector(7 downto 0);
+         txOpCodeEn : in  std_logic;
+         txRemData  : in  std_logic_vector(7 downto 0);
+         rxOpCode   : out std_logic_vector(7 downto 0);
+         rxOpCodeEn : out std_logic;
+         rxRemData  : out std_logic_vector(7 downto 0));
+   end component;
+
+begin
+
+   U_Dpi : component RogueSideBandDpi
+      port map (
+         clock      => clock,
+         reset      => reset,
+         portNum    => portNum,
+         txOpCode   => txOpCode,
+         txOpCodeEn => txOpCodeEn,
+         txRemData  => txRemData,
+         rxOpCode   => rxOpCode,
+         rxOpCodeEn => rxOpCodeEn,
+         rxRemData  => rxRemData);
+
+end RogueSideBand;

--- a/axi/simlink/xsim/RogueSideBandDpi.sv
+++ b/axi/simlink/xsim/RogueSideBandDpi.sv
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// SV DPI leaf for the Rogue side-band model under Vivado xsim. Ports stay
+// logic-typed for clean VHDL interop; only the DPI import's formal arguments
+// are 2-state bit/bit-vector (SV auto-narrows 4-state logic to 2-state bit at
+// the call site). Drives the DPI-C adapter (RogueSideBand.c) once per rising
+// clock edge, mirroring the GHDL backend's per-edge update process.
+//////////////////////////////////////////////////////////////////////////////
+
+module RogueSideBandDpi (
+   input  logic        clock,
+   input  logic        reset,
+   input  logic [15:0] portNum,
+
+   input  logic [7:0]  txOpCode,
+   input  logic        txOpCodeEn,
+   input  logic [7:0]  txRemData,
+   output logic [7:0]  rxOpCode,
+   output logic        rxOpCodeEn,
+   output logic [7:0]  rxRemData
+);
+
+   import "DPI-C" function void rogueSideBandUpdate
+     (input  bit        reset,
+      input  bit [15:0] portNum,
+      input  bit [7:0]  txOpCode,
+      input  bit        txOpCodeEn,
+      input  bit [7:0]  txRemData,
+      output bit [7:0]  rxOpCode,
+      output bit        rxOpCodeEn,
+      output bit [7:0]  rxRemData);
+
+   always_ff @(posedge clock) begin
+      rogueSideBandUpdate(reset, portNum, txOpCode, txOpCodeEn, txRemData,
+                           rxOpCode, rxOpCodeEn, rxRemData);
+   end
+
+endmodule

--- a/axi/simlink/xsim/RogueSideBandDpi.sv
+++ b/axi/simlink/xsim/RogueSideBandDpi.sv
@@ -11,8 +11,9 @@
 // SV DPI leaf for the Rogue side-band model under Vivado xsim. Ports stay
 // logic-typed for clean VHDL interop; only the DPI import's formal arguments
 // are 2-state bit/bit-vector (SV auto-narrows 4-state logic to 2-state bit at
-// the call site). Drives the DPI-C adapter (RogueSideBand.c) once per rising
-// clock edge, mirroring the GHDL backend's per-edge update process.
+// the call site). Each elaborated leaf retains its own DPI chandle and drives
+// the corresponding C-owned model once per rising clock edge, mirroring the
+// GHDL backend's per-instance update process.
 //////////////////////////////////////////////////////////////////////////////
 
 module RogueSideBandDpi (
@@ -28,8 +29,11 @@ module RogueSideBandDpi (
    output logic [7:0]  rxRemData
 );
 
-   import "DPI-C" function void rogueSideBandUpdate
-     (input  bit        reset,
+   import "DPI-C" function chandle rogueSideBandCreate();
+   import "DPI-C" function void rogueSideBandDestroy(input chandle handle);
+   import "DPI-C" function int rogueSideBandUpdate
+     (input  chandle    handle,
+      input  bit        reset,
       input  bit [15:0] portNum,
       input  bit [7:0]  txOpCode,
       input  bit        txOpCodeEn,
@@ -38,9 +42,22 @@ module RogueSideBandDpi (
       output bit        rxOpCodeEn,
       output bit [7:0]  rxRemData);
 
-   always_ff @(posedge clock) begin
-      rogueSideBandUpdate(reset, portNum, txOpCode, txOpCodeEn, txRemData,
-                           rxOpCode, rxOpCodeEn, rxRemData);
+   chandle handle = null;
+
+   always @(posedge clock) begin
+      if (handle == null) begin
+         handle = rogueSideBandCreate();
+         if (handle == null) $fatal(1, "%m: rogueSideBandCreate failed");
+      end
+
+      if (!rogueSideBandUpdate(handle, reset, portNum, txOpCode, txOpCodeEn, txRemData,
+                               rxOpCode, rxOpCodeEn, rxRemData)) begin
+         $fatal(1, "%m: rogueSideBandUpdate failed");
+      end
+   end
+
+   final begin
+      if (handle != null) rogueSideBandDestroy(handle);
    end
 
 endmodule

--- a/axi/simlink/xsim/RogueTcpMemory.c
+++ b/axi/simlink/xsim/RogueTcpMemory.c
@@ -12,11 +12,12 @@
 // transport (RogueTcpMemoryRestart/Send/Recv) and the transaction FSM
 // (RogueTcpMemoryStep) live in axi/simlink/shared/RogueTcpMemoryCore.h,
 // included by every backend. This file provides only the DPI-specific
-// plumbing: a per-edge update function (rogueTcpMemoryUpdate) that copies the
-// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
-// step, and writes the outputs back through the DPI output pointers. Unlike
-// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
-// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+// plumbing: one C-owned state object per SystemVerilog DPI leaf, plus a
+// per-edge update function (rogueTcpMemoryUpdate) that copies the DPI
+// svBit/svBitVecVal parameters into the input snapshot, runs one FSM step, and
+// writes the outputs back through the DPI output pointers. Unlike the GHDL
+// VHPIDIRECT backend, every port here is <=32 bits, so each vector argument is
+// a single svBitVecVal word -- no encode/decode loop is needed.
 //////////////////////////////////////////////////////////////////////////////
 
 #include <zmq.h>
@@ -27,36 +28,43 @@
 #include <errno.h>
 
 #include "svdpi.h"
+#include "RogueDpiInstance.h"
 #include "RogueTcpMemory.h"
 #include "RogueTcpMemoryCore.h"
 
-// Single instance for this simulation; file-scope statics are zero-
-// initialized by C, replacing the src Init's malloc+memset.
-static RogueTcpMemoryData memoryData;
+static void rogueTcpMemoryCleanup(void *opaque) {
+    RogueTcpMemoryData *data = opaque;
+
+    if (data->zmqPush != NULL) zmq_close(data->zmqPush);
+    if (data->zmqPull != NULL) zmq_close(data->zmqPull);
+    if (data->zmqCtx  != NULL) zmq_ctx_term(data->zmqCtx);
+}
+
+void *rogueTcpMemoryCreate(void) {
+    return rogueDpiCreate(ROGUE_DPI_MEMORY_C,
+                          sizeof(RogueTcpMemoryData),
+                          rogueTcpMemoryCleanup);
+}
+
+void rogueTcpMemoryDestroy(void *context) {
+    (void)rogueDpiDestroy(context, ROGUE_DPI_MEMORY_C);
+}
 
 // Per-edge update function, called from the RogueTcpMemoryDpi SV leaf every
 // rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
 // into the input snapshot (the getInt seam), runs one shared FSM step, then
 // writes the outputs back through the DPI output pointers.
-void rogueTcpMemoryUpdate(unsigned char reset, const svBitVecVal *portNum,
-                           svBitVecVal *araddr, svBitVecVal *arprot, unsigned char *arvalid, unsigned char *rready,
-                           unsigned char arready, const svBitVecVal *rdata, const svBitVecVal *rresp, unsigned char rvalid,
-                           svBitVecVal *awaddr, svBitVecVal *awprot, unsigned char *awvalid,
-                           svBitVecVal *wdata, svBitVecVal *wstrb, unsigned char *wvalid, unsigned char *bready,
-                           unsigned char awready, unsigned char wready, const svBitVecVal *bresp, unsigned char bvalid) {
-    RogueTcpMemoryData *data = &memoryData;
+int rogueTcpMemoryUpdate(void *context, svBit reset, const svBitVecVal *portNum,
+                          svBitVecVal *araddr, svBitVecVal *arprot, svBit *arvalid, svBit *rready,
+                          svBit arready, const svBitVecVal *rdata, const svBitVecVal *rresp, svBit rvalid,
+                          svBitVecVal *awaddr, svBitVecVal *awprot, svBit *awvalid,
+                          svBitVecVal *wdata, svBitVecVal *wstrb, svBit *wvalid, svBit *bready,
+                          svBit awready, svBit wready, const svBitVecVal *bresp, svBit bvalid) {
+    RogueTcpMemoryData *data = rogueDpiGetData(context, ROGUE_DPI_MEMORY_C);
     unsigned int reqPort = portNum[0] & 0xFFFF;
 
-    // DPI-C imports carry no per-instance context, so this backend hosts a
-    // single global memoryData and supports only one RogueTcpMemory per
-    // simulation. A second instance would otherwise silently share this
-    // state and bind only the first port. Fail fast once a different,
-    // already-latched port is observed rather than corrupt state.
-    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
-        vhpi_printf("RogueTcpMemory: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
-        vhpi_assert("RogueTcpMemory: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
-        return;
-    }
+    if (data == NULL) return 0;
+    if (!reset && !rogueDpiReservePort(context, ROGUE_DPI_MEMORY_C, reqPort)) return 0;
 
     data->inSnap[s_reset]   = reset ? 1 : 0;
     data->inSnap[s_port]    = reqPort;
@@ -69,9 +77,9 @@ void rogueTcpMemoryUpdate(unsigned char reset, const svBitVecVal *portNum,
     data->inSnap[s_bresp]   = bresp[0];
     data->inSnap[s_bvalid]  = bvalid ? 1 : 0;
 
-    // RogueTcpMemoryStep (shared FSM) calls RogueTcpMemoryRecv, which uses
-    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
-    // whole Vivado xsim process, not just a background thread.
+    // The shared step retains the established backend transport contract:
+    // receive polls with ZMQ_DONTWAIT, while responses are sent synchronously
+    // after the peer is connected and draining.
     RogueTcpMemoryStep(data);
 
     araddr[0]  = data->outState[s_araddr];
@@ -85,4 +93,5 @@ void rogueTcpMemoryUpdate(unsigned char reset, const svBitVecVal *portNum,
     wstrb[0]   = data->outState[s_wstrb];
     *wvalid    = data->outState[s_wvalid]  ? 1 : 0;
     *bready    = data->outState[s_bready]  ? 1 : 0;
+    return 1;
 }

--- a/axi/simlink/xsim/RogueTcpMemory.c
+++ b/axi/simlink/xsim/RogueTcpMemory.c
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// Vivado xsim DPI-C backend for the Rogue-TCP AXI-Lite memory model. The ZMQ
+// transport (RogueTcpMemoryRestart/Send/Recv) and the transaction FSM
+// (RogueTcpMemoryStep) live in axi/simlink/shared/RogueTcpMemoryCore.h,
+// included by every backend. This file provides only the DPI-specific
+// plumbing: a per-edge update function (rogueTcpMemoryUpdate) that copies the
+// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
+// step, and writes the outputs back through the DPI output pointers. Unlike
+// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
+// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <zmq.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "svdpi.h"
+#include "RogueTcpMemory.h"
+#include "RogueTcpMemoryCore.h"
+
+// Single instance for this simulation; file-scope statics are zero-
+// initialized by C, replacing the src Init's malloc+memset.
+static RogueTcpMemoryData memoryData;
+
+// Per-edge update function, called from the RogueTcpMemoryDpi SV leaf every
+// rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
+// into the input snapshot (the getInt seam), runs one shared FSM step, then
+// writes the outputs back through the DPI output pointers.
+void rogueTcpMemoryUpdate(unsigned char reset, const svBitVecVal *portNum,
+                           svBitVecVal *araddr, svBitVecVal *arprot, unsigned char *arvalid, unsigned char *rready,
+                           unsigned char arready, const svBitVecVal *rdata, const svBitVecVal *rresp, unsigned char rvalid,
+                           svBitVecVal *awaddr, svBitVecVal *awprot, unsigned char *awvalid,
+                           svBitVecVal *wdata, svBitVecVal *wstrb, unsigned char *wvalid, unsigned char *bready,
+                           unsigned char awready, unsigned char wready, const svBitVecVal *bresp, unsigned char bvalid) {
+    RogueTcpMemoryData *data = &memoryData;
+    unsigned int reqPort = portNum[0] & 0xFFFF;
+
+    // DPI-C imports carry no per-instance context, so this backend hosts a
+    // single global memoryData and supports only one RogueTcpMemory per
+    // simulation. A second instance would otherwise silently share this
+    // state and bind only the first port. Fail fast once a different,
+    // already-latched port is observed rather than corrupt state.
+    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
+        vhpi_printf("RogueTcpMemory: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
+        vhpi_assert("RogueTcpMemory: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
+        return;
+    }
+
+    data->inSnap[s_reset]   = reset ? 1 : 0;
+    data->inSnap[s_port]    = reqPort;
+    data->inSnap[s_arready] = arready ? 1 : 0;
+    data->inSnap[s_rdata]   = rdata[0];
+    data->inSnap[s_rresp]   = rresp[0];
+    data->inSnap[s_rvalid]  = rvalid ? 1 : 0;
+    data->inSnap[s_awready] = awready ? 1 : 0;
+    data->inSnap[s_wready]  = wready ? 1 : 0;
+    data->inSnap[s_bresp]   = bresp[0];
+    data->inSnap[s_bvalid]  = bvalid ? 1 : 0;
+
+    // RogueTcpMemoryStep (shared FSM) calls RogueTcpMemoryRecv, which uses
+    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
+    // whole Vivado xsim process, not just a background thread.
+    RogueTcpMemoryStep(data);
+
+    araddr[0]  = data->outState[s_araddr];
+    arprot[0]  = data->outState[s_arprot];
+    *arvalid   = data->outState[s_arvalid] ? 1 : 0;
+    *rready    = data->outState[s_rready]  ? 1 : 0;
+    awaddr[0]  = data->outState[s_awaddr];
+    awprot[0]  = data->outState[s_awprot];
+    *awvalid   = data->outState[s_awvalid] ? 1 : 0;
+    wdata[0]   = data->outState[s_wdata];
+    wstrb[0]   = data->outState[s_wstrb];
+    *wvalid    = data->outState[s_wvalid]  ? 1 : 0;
+    *bready    = data->outState[s_bready]  ? 1 : 0;
+}

--- a/axi/simlink/xsim/RogueTcpMemory.h
+++ b/axi/simlink/xsim/RogueTcpMemory.h
@@ -1,0 +1,109 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef __ROGUE_TCP_MEMORY_H__
+#define __ROGUE_TCP_MEMORY_H__
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Signals
+#define s_clock        0
+#define s_reset        1
+#define s_port         2
+
+#define s_araddr       3
+#define s_arprot       4
+#define s_arvalid      5
+#define s_rready       6
+
+#define s_arready      7
+#define s_rdata        8
+#define s_rresp        9
+#define s_rvalid       10
+
+#define s_awaddr       11
+#define s_awprot       12
+#define s_awvalid      13
+#define s_wdata        14
+#define s_wstrb        15
+#define s_wvalid       16
+#define s_bready       17
+
+#define s_awready      18
+#define s_wready       19
+#define s_bresp        20
+#define s_bvalid       21
+
+#define PORT_COUNT     22
+
+#define T_READ   0x1
+#define T_WRITE  0x2
+#define T_POST   0x3
+#define T_VERIFY 0x4
+
+#define ST_IDLE  0x0
+#define ST_START 0x1
+#define ST_WRESP 0x4
+#define ST_RADDR 0x5
+#define ST_RDATA 0x6
+#define ST_PAUSE 0x7
+
+#define MAX_DATA 2000000
+
+// Vivado xsim's DPI-C boundary has no VHPI (no vhpi_register_cb / value-change
+// callbacks), so the VHPI print/assert calls in the transplanted FSM body are
+// shimmed straight to printf/abort. The severity argument is accepted but
+// never referenced, so no VHPI severity token (e.g. vhpiFatal) needs defining.
+// This shim is backend-agnostic and is shared verbatim with the GHDL backend.
+#define vhpi_printf(...) printf(__VA_ARGS__)
+#define vhpi_assert(msg, sev) \
+    do { \
+        fprintf(stderr, "%s\n", (msg)); \
+        abort(); \
+    } while (0)
+
+// Macros for get/set ints, redefined for the per-edge update-procedure model:
+// getInt reads the input snapshot populated at update-procedure entry;
+// setInt writes the output state read back through the DPI output pointers.
+#define getInt(idx)      (data->inSnap[idx])
+#define setInt(idx, val) (data->outState[idx] = (val))
+
+// Structure to track state
+typedef struct {
+    uint16_t   port;
+    uint8_t    state;
+    uint32_t   id;
+    uint64_t   addr;
+    uint8_t    data[MAX_DATA];
+    uint32_t   size;
+    uint32_t   curr;
+    uint32_t   type;
+    uint32_t   result;
+
+    unsigned int inSnap[PORT_COUNT];
+    unsigned int outState[PORT_COUNT];
+
+    void *     zmqCtx;
+    void *     zmqPull;
+    void *     zmqPush;
+} RogueTcpMemoryData;
+
+// Start/restart zeromq server
+void RogueTcpMemoryRestart(RogueTcpMemoryData *data);
+
+// Send a message
+void RogueTcpMemorySend(RogueTcpMemoryData *data);
+
+// Receive data if it is available
+int RogueTcpMemoryRecv(RogueTcpMemoryData *data);
+
+#endif

--- a/axi/simlink/xsim/RogueTcpMemory.h
+++ b/axi/simlink/xsim/RogueTcpMemory.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "svdpi.h"
+
 // Signals
 #define s_clock        0
 #define s_reset        1
@@ -96,6 +98,16 @@ typedef struct {
     void *     zmqPull;
     void *     zmqPush;
 } RogueTcpMemoryData;
+
+// Vivado xsim DPI-C instance lifecycle and per-edge update
+void *rogueTcpMemoryCreate(void);
+void rogueTcpMemoryDestroy(void *context);
+int rogueTcpMemoryUpdate(void *context, svBit reset, const svBitVecVal *portNum,
+                         svBitVecVal *araddr, svBitVecVal *arprot, svBit *arvalid, svBit *rready,
+                         svBit arready, const svBitVecVal *rdata, const svBitVecVal *rresp, svBit rvalid,
+                         svBitVecVal *awaddr, svBitVecVal *awprot, svBit *awvalid,
+                         svBitVecVal *wdata, svBitVecVal *wstrb, svBit *wvalid, svBit *bready,
+                         svBit awready, svBit wready, const svBitVecVal *bresp, svBit bvalid);
 
 // Start/restart zeromq server
 void RogueTcpMemoryRestart(RogueTcpMemoryData *data);

--- a/axi/simlink/xsim/RogueTcpMemory.vhd
+++ b/axi/simlink/xsim/RogueTcpMemory.vhd
@@ -1,0 +1,119 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Rogue TCP Memory Simulation Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity RogueTcpMemory is
+   port (
+      clock   : in std_logic;
+      reset   : in std_logic;
+      portNum : in std_logic_vector(15 downto 0);
+
+      -- axiReadMaster
+      araddr  : out std_logic_vector(31 downto 0);
+      arprot  : out std_logic_vector(2 downto 0);
+      arvalid : out std_logic;
+      rready  : out std_logic;
+
+      -- axiReadSlave
+      arready : in std_logic;
+      rdata   : in std_logic_vector(31 downto 0);
+      rresp   : in std_logic_vector(1 downto 0);
+      rvalid  : in std_logic;
+
+      -- axiWriteMaster
+      awaddr  : out std_logic_vector(31 downto 0);
+      awprot  : out std_logic_vector(2 downto 0);
+      awvalid : out std_logic;
+      wdata   : out std_logic_vector(31 downto 0);
+      wstrb   : out std_logic_vector(3 downto 0);
+      wvalid  : out std_logic;
+      bready  : out std_logic;
+
+      -- axiWriteSlave
+      awready : in std_logic;
+      wready  : in std_logic;
+      bresp   : in std_logic_vector(1 downto 0);
+      bvalid  : in std_logic);
+end RogueTcpMemory;
+
+-- Define architecture
+architecture RogueTcpMemory of RogueTcpMemory is
+
+------------------------------------------------------------------------
+-- Vivado xsim has no VHPI, so this fork forwards to the DPI-C model via a
+-- native mixed-language component instantiation of the SV leaf
+-- RogueTcpMemoryDpi (below), instead of GHDL's attribute foreign
+-- VHPIDIRECT binding. VHPI original: axi/simlink/vcs/RogueTcpMemory.vhd
+------------------------------------------------------------------------
+
+   component RogueTcpMemoryDpi
+      port (
+         clock   : in std_logic;
+         reset   : in std_logic;
+         portNum : in std_logic_vector(15 downto 0);
+
+         araddr  : out std_logic_vector(31 downto 0);
+         arprot  : out std_logic_vector(2 downto 0);
+         arvalid : out std_logic;
+         rready  : out std_logic;
+
+         arready : in std_logic;
+         rdata   : in std_logic_vector(31 downto 0);
+         rresp   : in std_logic_vector(1 downto 0);
+         rvalid  : in std_logic;
+
+         awaddr  : out std_logic_vector(31 downto 0);
+         awprot  : out std_logic_vector(2 downto 0);
+         awvalid : out std_logic;
+         wdata   : out std_logic_vector(31 downto 0);
+         wstrb   : out std_logic_vector(3 downto 0);
+         wvalid  : out std_logic;
+         bready  : out std_logic;
+
+         awready : in std_logic;
+         wready  : in std_logic;
+         bresp   : in std_logic_vector(1 downto 0);
+         bvalid  : in std_logic);
+   end component;
+
+begin
+
+   U_Dpi : component RogueTcpMemoryDpi
+      port map (
+         clock   => clock,
+         reset   => reset,
+         portNum => portNum,
+         araddr  => araddr,
+         arprot  => arprot,
+         arvalid => arvalid,
+         rready  => rready,
+         arready => arready,
+         rdata   => rdata,
+         rresp   => rresp,
+         rvalid  => rvalid,
+         awaddr  => awaddr,
+         awprot  => awprot,
+         awvalid => awvalid,
+         wdata   => wdata,
+         wstrb   => wstrb,
+         wvalid  => wvalid,
+         bready  => bready,
+         awready => awready,
+         wready  => wready,
+         bresp   => bresp,
+         bvalid  => bvalid);
+
+end RogueTcpMemory;

--- a/axi/simlink/xsim/RogueTcpMemoryDpi.sv
+++ b/axi/simlink/xsim/RogueTcpMemoryDpi.sv
@@ -11,9 +11,9 @@
 // SV DPI leaf for the Rogue-TCP AXI-Lite memory model under Vivado xsim. Ports
 // stay logic-typed for clean VHDL interop; only the DPI import's formal
 // arguments are 2-state bit/bit-vector (SV auto-narrows 4-state logic to
-// 2-state bit at the call site). Drives the DPI-C adapter (RogueTcpMemory.c)
-// once per rising clock edge, mirroring the GHDL backend's per-edge update
-// process.
+// 2-state bit at the call site). Each elaborated leaf retains its own DPI
+// chandle and drives the corresponding C-owned model once per rising clock
+// edge, mirroring the GHDL backend's per-instance update process.
 //////////////////////////////////////////////////////////////////////////////
 
 module RogueTcpMemoryDpi (
@@ -43,8 +43,11 @@ module RogueTcpMemoryDpi (
    input  logic        bvalid
 );
 
-   import "DPI-C" function void rogueTcpMemoryUpdate
-     (input  bit        reset,
+   import "DPI-C" function chandle rogueTcpMemoryCreate();
+   import "DPI-C" function void rogueTcpMemoryDestroy(input chandle handle);
+   import "DPI-C" function int rogueTcpMemoryUpdate
+     (input  chandle    handle,
+      input  bit        reset,
       input  bit [15:0] portNum,
       output bit [31:0] araddr,
       output bit [2:0]  arprot,
@@ -66,10 +69,23 @@ module RogueTcpMemoryDpi (
       input  bit [1:0]  bresp,
       input  bit        bvalid);
 
-   always_ff @(posedge clock) begin
-      rogueTcpMemoryUpdate(reset, portNum,
-                            araddr, arprot, arvalid, rready, arready, rdata, rresp, rvalid,
-                            awaddr, awprot, awvalid, wdata, wstrb, wvalid, bready, awready, wready, bresp, bvalid);
+   chandle handle = null;
+
+   always @(posedge clock) begin
+      if (handle == null) begin
+         handle = rogueTcpMemoryCreate();
+         if (handle == null) $fatal(1, "%m: rogueTcpMemoryCreate failed");
+      end
+
+      if (!rogueTcpMemoryUpdate(handle, reset, portNum,
+                                araddr, arprot, arvalid, rready, arready, rdata, rresp, rvalid,
+                                awaddr, awprot, awvalid, wdata, wstrb, wvalid, bready, awready, wready, bresp, bvalid)) begin
+         $fatal(1, "%m: rogueTcpMemoryUpdate failed");
+      end
+   end
+
+   final begin
+      if (handle != null) rogueTcpMemoryDestroy(handle);
    end
 
 endmodule

--- a/axi/simlink/xsim/RogueTcpMemoryDpi.sv
+++ b/axi/simlink/xsim/RogueTcpMemoryDpi.sv
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// SV DPI leaf for the Rogue-TCP AXI-Lite memory model under Vivado xsim. Ports
+// stay logic-typed for clean VHDL interop; only the DPI import's formal
+// arguments are 2-state bit/bit-vector (SV auto-narrows 4-state logic to
+// 2-state bit at the call site). Drives the DPI-C adapter (RogueTcpMemory.c)
+// once per rising clock edge, mirroring the GHDL backend's per-edge update
+// process.
+//////////////////////////////////////////////////////////////////////////////
+
+module RogueTcpMemoryDpi (
+   input  logic        clock,
+   input  logic        reset,
+   input  logic [15:0] portNum,
+
+   output logic [31:0] araddr,
+   output logic [2:0]  arprot,
+   output logic        arvalid,
+   output logic        rready,
+   input  logic        arready,
+   input  logic [31:0] rdata,
+   input  logic [1:0]  rresp,
+   input  logic        rvalid,
+
+   output logic [31:0] awaddr,
+   output logic [2:0]  awprot,
+   output logic        awvalid,
+   output logic [31:0] wdata,
+   output logic [3:0]  wstrb,
+   output logic        wvalid,
+   output logic        bready,
+   input  logic        awready,
+   input  logic        wready,
+   input  logic [1:0]  bresp,
+   input  logic        bvalid
+);
+
+   import "DPI-C" function void rogueTcpMemoryUpdate
+     (input  bit        reset,
+      input  bit [15:0] portNum,
+      output bit [31:0] araddr,
+      output bit [2:0]  arprot,
+      output bit        arvalid,
+      output bit        rready,
+      input  bit        arready,
+      input  bit [31:0] rdata,
+      input  bit [1:0]  rresp,
+      input  bit        rvalid,
+      output bit [31:0] awaddr,
+      output bit [2:0]  awprot,
+      output bit        awvalid,
+      output bit [31:0] wdata,
+      output bit [3:0]  wstrb,
+      output bit        wvalid,
+      output bit        bready,
+      input  bit        awready,
+      input  bit        wready,
+      input  bit [1:0]  bresp,
+      input  bit        bvalid);
+
+   always_ff @(posedge clock) begin
+      rogueTcpMemoryUpdate(reset, portNum,
+                            araddr, arprot, arvalid, rready, arready, rdata, rresp, rvalid,
+                            awaddr, awprot, awvalid, wdata, wstrb, wvalid, bready, awready, wready, bresp, bvalid);
+   end
+
+endmodule

--- a/axi/simlink/xsim/RogueTcpStream.c
+++ b/axi/simlink/xsim/RogueTcpStream.c
@@ -12,11 +12,12 @@
 // transport (RogueTcpStreamRestart/Send/Recv) and the data-movement FSM
 // (RogueTcpStreamStep) live in axi/simlink/shared/RogueTcpStreamCore.h,
 // included by every backend. This file provides only the DPI-specific
-// plumbing: a per-edge update function (rogueTcpStreamUpdate) that copies the
-// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
-// step, and writes the outputs back through the DPI output pointers. Unlike
-// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
-// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+// plumbing: one C-owned state object per SystemVerilog DPI leaf, plus a
+// per-edge update function (rogueTcpStreamUpdate) that copies the DPI
+// svBit/svBitVecVal parameters into the input snapshot, runs one FSM step, and
+// writes the outputs back through the DPI output pointers. Unlike the GHDL
+// VHPIDIRECT backend, every port here is <=32 bits, so each vector argument is
+// a single svBitVecVal word -- no encode/decode loop is needed.
 //////////////////////////////////////////////////////////////////////////////
 
 #include <zmq.h>
@@ -27,41 +28,46 @@
 #include <errno.h>
 
 #include "svdpi.h"
+#include "RogueDpiInstance.h"
 #include "RogueTcpStream.h"
 #include "RogueTcpStreamCore.h"
 
-// Single instance for this simulation; file-scope statics are zero-
-// initialized by C, replacing the src Init's malloc+memset.
-static RogueTcpStreamData streamData;
+static void rogueTcpStreamCleanup(void *opaque) {
+    RogueTcpStreamData *data = opaque;
+
+    if (data->zmqPush != NULL) zmq_close(data->zmqPush);
+    if (data->zmqPull != NULL) zmq_close(data->zmqPull);
+    if (data->zmqCtx  != NULL) zmq_ctx_term(data->zmqCtx);
+}
+
+void *rogueTcpStreamCreate(void) {
+    return rogueDpiCreate(ROGUE_DPI_STREAM_C,
+                          sizeof(RogueTcpStreamData),
+                          rogueTcpStreamCleanup);
+}
+
+void rogueTcpStreamDestroy(void *context) {
+    (void)rogueDpiDestroy(context, ROGUE_DPI_STREAM_C);
+}
 
 // Per-edge update function, called from the RogueTcpStreamDpi SV leaf every
 // rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
 // into the input snapshot (the getInt seam), runs one shared FSM step, then
 // writes the outputs back through the DPI output pointers.
-void rogueTcpStreamUpdate(unsigned char reset, const svBitVecVal *portNum, unsigned char ssi,
-                           unsigned char obReady, unsigned char *obValid,
-                           svBitVecVal *obDataLow, svBitVecVal *obDataHigh,
-                           svBitVecVal *obUserLow, svBitVecVal *obUserHigh,
-                           svBitVecVal *obKeep, unsigned char *obLast,
-                           unsigned char ibValid, unsigned char *ibReady,
-                           const svBitVecVal *ibDataLow, const svBitVecVal *ibDataHigh,
-                           const svBitVecVal *ibUserLow, const svBitVecVal *ibUserHigh,
-                           const svBitVecVal *ibKeep, unsigned char ibLast) {
-    RogueTcpStreamData *data = &streamData;
+int rogueTcpStreamUpdate(void *context, svBit reset, const svBitVecVal *portNum, svBit ssi,
+                          svBit obReady, svBit *obValid,
+                          svBitVecVal *obDataLow, svBitVecVal *obDataHigh,
+                          svBitVecVal *obUserLow, svBitVecVal *obUserHigh,
+                          svBitVecVal *obKeep, svBit *obLast,
+                          svBit ibValid, svBit *ibReady,
+                          const svBitVecVal *ibDataLow, const svBitVecVal *ibDataHigh,
+                          const svBitVecVal *ibUserLow, const svBitVecVal *ibUserHigh,
+                          const svBitVecVal *ibKeep, svBit ibLast) {
+    RogueTcpStreamData *data = rogueDpiGetData(context, ROGUE_DPI_STREAM_C);
     unsigned int reqPort = portNum[0] & 0xFFFF;
 
-    // DPI-C imports carry no per-instance context, so this backend hosts a
-    // single global streamData and supports only one RogueTcpStream per
-    // simulation. A second instance (e.g. RogueTcpStreamWrap with
-    // CHAN_COUNT_G>1, one distinct port per channel) would otherwise
-    // silently share this state and bind only the first port. Fail fast once
-    // a different, already-latched port is observed rather than corrupt
-    // state.
-    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
-        vhpi_printf("RogueTcpStream: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
-        vhpi_assert("RogueTcpStream: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
-        return;
-    }
+    if (data == NULL) return 0;
+    if (!reset && !rogueDpiReservePort(context, ROGUE_DPI_STREAM_C, reqPort)) return 0;
 
     data->inSnap[s_reset]      = reset ? 1 : 0;
     data->inSnap[s_port]       = reqPort;
@@ -75,9 +81,9 @@ void rogueTcpStreamUpdate(unsigned char reset, const svBitVecVal *portNum, unsig
     data->inSnap[s_ibKeep]     = ibKeep[0];
     data->inSnap[s_ibLast]     = ibLast ? 1 : 0;
 
-    // RogueTcpStreamStep (shared FSM) calls RogueTcpStreamRecv, which uses
-    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
-    // whole Vivado xsim process, not just a background thread.
+    // The shared step retains the established backend transport contract:
+    // receive polls with ZMQ_DONTWAIT, while outbound frames are sent
+    // synchronously after the peer is connected and draining.
     RogueTcpStreamStep(data);
 
     *obValid      = data->outState[s_obValid] ? 1 : 0;
@@ -88,4 +94,5 @@ void rogueTcpStreamUpdate(unsigned char reset, const svBitVecVal *portNum, unsig
     obKeep[0]     = data->outState[s_obKeep];
     *obLast       = data->outState[s_obLast] ? 1 : 0;
     *ibReady      = data->outState[s_ibReady] ? 1 : 0;
+    return 1;
 }

--- a/axi/simlink/xsim/RogueTcpStream.c
+++ b/axi/simlink/xsim/RogueTcpStream.c
@@ -1,0 +1,91 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// Vivado xsim DPI-C backend for the Rogue-TCP AXI-Stream model. The ZMQ
+// transport (RogueTcpStreamRestart/Send/Recv) and the data-movement FSM
+// (RogueTcpStreamStep) live in axi/simlink/shared/RogueTcpStreamCore.h,
+// included by every backend. This file provides only the DPI-specific
+// plumbing: a per-edge update function (rogueTcpStreamUpdate) that copies the
+// DPI svBit/svBitVecVal parameters into the input snapshot, runs one FSM
+// step, and writes the outputs back through the DPI output pointers. Unlike
+// the GHDL VHPIDIRECT backend, every port here is <=32 bits, so each vector
+// argument is a single svBitVecVal word -- no encode/decode loop is needed.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <zmq.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "svdpi.h"
+#include "RogueTcpStream.h"
+#include "RogueTcpStreamCore.h"
+
+// Single instance for this simulation; file-scope statics are zero-
+// initialized by C, replacing the src Init's malloc+memset.
+static RogueTcpStreamData streamData;
+
+// Per-edge update function, called from the RogueTcpStreamDpi SV leaf every
+// rising_edge(clock) via import "DPI-C". Copies each DPI parameter straight
+// into the input snapshot (the getInt seam), runs one shared FSM step, then
+// writes the outputs back through the DPI output pointers.
+void rogueTcpStreamUpdate(unsigned char reset, const svBitVecVal *portNum, unsigned char ssi,
+                           unsigned char obReady, unsigned char *obValid,
+                           svBitVecVal *obDataLow, svBitVecVal *obDataHigh,
+                           svBitVecVal *obUserLow, svBitVecVal *obUserHigh,
+                           svBitVecVal *obKeep, unsigned char *obLast,
+                           unsigned char ibValid, unsigned char *ibReady,
+                           const svBitVecVal *ibDataLow, const svBitVecVal *ibDataHigh,
+                           const svBitVecVal *ibUserLow, const svBitVecVal *ibUserHigh,
+                           const svBitVecVal *ibKeep, unsigned char ibLast) {
+    RogueTcpStreamData *data = &streamData;
+    unsigned int reqPort = portNum[0] & 0xFFFF;
+
+    // DPI-C imports carry no per-instance context, so this backend hosts a
+    // single global streamData and supports only one RogueTcpStream per
+    // simulation. A second instance (e.g. RogueTcpStreamWrap with
+    // CHAN_COUNT_G>1, one distinct port per channel) would otherwise
+    // silently share this state and bind only the first port. Fail fast once
+    // a different, already-latched port is observed rather than corrupt
+    // state.
+    if ( data->port != 0 && reqPort != 0 && reqPort != data->port ) {
+        vhpi_printf("RogueTcpStream: Vivado xsim DPI-C backend supports only one instance per simulation; observed ports %u and %u\n", data->port, reqPort);
+        vhpi_assert("RogueTcpStream: multiple instances unsupported under Vivado xsim DPI-C", vhpiFatal);
+        return;
+    }
+
+    data->inSnap[s_reset]      = reset ? 1 : 0;
+    data->inSnap[s_port]       = reqPort;
+    data->inSnap[s_ssi]        = ssi ? 1 : 0;
+    data->inSnap[s_obReady]    = obReady ? 1 : 0;
+    data->inSnap[s_ibValid]    = ibValid ? 1 : 0;
+    data->inSnap[s_ibDataLow]  = ibDataLow[0];
+    data->inSnap[s_ibDataHigh] = ibDataHigh[0];
+    data->inSnap[s_ibUserLow]  = ibUserLow[0];
+    data->inSnap[s_ibUserHigh] = ibUserHigh[0];
+    data->inSnap[s_ibKeep]     = ibKeep[0];
+    data->inSnap[s_ibLast]     = ibLast ? 1 : 0;
+
+    // RogueTcpStreamStep (shared FSM) calls RogueTcpStreamRecv, which uses
+    // ZMQ_DONTWAIT -- never make this a blocking call, or it freezes the
+    // whole Vivado xsim process, not just a background thread.
+    RogueTcpStreamStep(data);
+
+    *obValid      = data->outState[s_obValid] ? 1 : 0;
+    obDataLow[0]  = data->outState[s_obDataLow];
+    obDataHigh[0] = data->outState[s_obDataHigh];
+    obUserLow[0]  = data->outState[s_obUserLow];
+    obUserHigh[0] = data->outState[s_obUserHigh];
+    obKeep[0]     = data->outState[s_obKeep];
+    *obLast       = data->outState[s_obLast] ? 1 : 0;
+    *ibReady      = data->outState[s_ibReady] ? 1 : 0;
+}

--- a/axi/simlink/xsim/RogueTcpStream.h
+++ b/axi/simlink/xsim/RogueTcpStream.h
@@ -1,0 +1,98 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef __ROGUE_TCP_STREAM_H__
+#define __ROGUE_TCP_STREAM_H__
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Signals
+#define s_clock        0
+#define s_reset        1
+#define s_port         2
+#define s_ssi          3
+
+#define s_obValid      4
+#define s_obReady      5
+#define s_obDataLow    6
+#define s_obDataHigh   7
+#define s_obUserLow    8
+#define s_obUserHigh   9
+#define s_obKeep       10
+#define s_obLast       11
+
+#define s_ibValid      12
+#define s_ibReady      13
+#define s_ibDataLow    14
+#define s_ibDataHigh   15
+#define s_ibUserLow    16
+#define s_ibUserHigh   17
+#define s_ibKeep       18
+#define s_ibLast       19
+
+#define PORT_COUNT     20
+
+#define MAX_FRAME 20000000
+
+// Vivado xsim's DPI-C boundary has no VHPI (no vhpi_register_cb / value-change
+// callbacks), so the VHPI print/assert calls in the transplanted FSM body are
+// shimmed straight to printf/abort. The severity argument is accepted but
+// never referenced, so no VHPI severity token (e.g. vhpiFatal) needs defining.
+// This shim is backend-agnostic and is shared verbatim with the GHDL backend.
+#define vhpi_printf(...) printf(__VA_ARGS__)
+#define vhpi_assert(msg, sev) \
+    do { \
+        fprintf(stderr, "%s\n", (msg)); \
+        abort(); \
+    } while (0)
+
+// Macros for get/set ints, redefined for the per-edge update-procedure model:
+// getInt reads the input snapshot populated at update-procedure entry;
+// setInt writes the output state read back through the DPI output pointers.
+#define getInt(idx)      (data->inSnap[idx])
+#define setInt(idx, val) (data->outState[idx] = (val))
+
+// Structure to track state
+typedef struct {
+    uint8_t   obFuser;
+    uint8_t   obLuser;
+    uint32_t  obSize;
+    uint32_t  obCount;
+    uint8_t   obData[MAX_FRAME];
+    uint32_t  obValid;
+
+    uint8_t   ibFuser;
+    uint8_t   ibLuser;
+    uint32_t  ibSize;
+    uint8_t   ibData[MAX_FRAME];
+
+    uint16_t  port;
+    uint8_t   ssi;
+
+    unsigned int inSnap[PORT_COUNT];
+    unsigned int outState[PORT_COUNT];
+
+    void *    zmqCtx;
+    void *    zmqPush;
+    void *    zmqPull;
+} RogueTcpStreamData;
+
+// Start/restart zeromq server
+void RogueTcpStreamRestart(RogueTcpStreamData *data);
+
+// Send a message
+void RogueTcpStreamSend(RogueTcpStreamData *data);
+
+// Receive data if it is available
+int RogueTcpStreamRecv(RogueTcpStreamData *data);
+
+#endif

--- a/axi/simlink/xsim/RogueTcpStream.h
+++ b/axi/simlink/xsim/RogueTcpStream.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "svdpi.h"
+
 // Signals
 #define s_clock        0
 #define s_reset        1
@@ -85,6 +87,19 @@ typedef struct {
     void *    zmqPush;
     void *    zmqPull;
 } RogueTcpStreamData;
+
+// Vivado xsim DPI-C instance lifecycle and per-edge update
+void *rogueTcpStreamCreate(void);
+void rogueTcpStreamDestroy(void *context);
+int rogueTcpStreamUpdate(void *context, svBit reset, const svBitVecVal *portNum, svBit ssi,
+                         svBit obReady, svBit *obValid,
+                         svBitVecVal *obDataLow, svBitVecVal *obDataHigh,
+                         svBitVecVal *obUserLow, svBitVecVal *obUserHigh,
+                         svBitVecVal *obKeep, svBit *obLast,
+                         svBit ibValid, svBit *ibReady,
+                         const svBitVecVal *ibDataLow, const svBitVecVal *ibDataHigh,
+                         const svBitVecVal *ibUserLow, const svBitVecVal *ibUserHigh,
+                         const svBitVecVal *ibKeep, svBit ibLast);
 
 // Start/restart zeromq server
 void RogueTcpStreamRestart(RogueTcpStreamData *data);

--- a/axi/simlink/xsim/RogueTcpStream.vhd
+++ b/axi/simlink/xsim/RogueTcpStream.vhd
@@ -1,0 +1,107 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Rogue Stream Module
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+entity RogueTcpStream is
+   port (
+      clock   : in std_logic;
+      reset   : in std_logic;
+      portNum : in std_logic_vector(15 downto 0);
+      ssi     : in std_logic;
+
+      obValid    : out std_logic;
+      obReady    : in  std_logic;
+      obDataLow  : out std_logic_vector(31 downto 0);
+      obDataHigh : out std_logic_vector(31 downto 0);
+      obUserLow  : out std_logic_vector(31 downto 0);
+      obUserHigh : out std_logic_vector(31 downto 0);
+      obKeep     : out std_logic_vector(7 downto 0);
+      obLast     : out std_logic;
+
+      ibValid    : in  std_logic;
+      ibReady    : out std_logic;
+      ibDataLow  : in  std_logic_vector(31 downto 0);
+      ibDataHigh : in  std_logic_vector(31 downto 0);
+      ibUserLow  : in  std_logic_vector(31 downto 0);
+      ibUserHigh : in  std_logic_vector(31 downto 0);
+      ibKeep     : in  std_logic_vector(7 downto 0);
+      ibLast     : in  std_logic);
+end RogueTcpStream;
+
+-- Define architecture
+architecture RogueTcpStream of RogueTcpStream is
+
+------------------------------------------------------------------------
+-- Vivado xsim has no VHPI, so this fork forwards to the DPI-C model via a
+-- native mixed-language component instantiation of the SV leaf
+-- RogueTcpStreamDpi (below), instead of GHDL's attribute foreign
+-- VHPIDIRECT binding. VHPI original: axi/simlink/vcs/RogueTcpStream.vhd
+------------------------------------------------------------------------
+
+   component RogueTcpStreamDpi
+      port (
+         clock   : in std_logic;
+         reset   : in std_logic;
+         portNum : in std_logic_vector(15 downto 0);
+         ssi     : in std_logic;
+
+         obValid    : out std_logic;
+         obReady    : in  std_logic;
+         obDataLow  : out std_logic_vector(31 downto 0);
+         obDataHigh : out std_logic_vector(31 downto 0);
+         obUserLow  : out std_logic_vector(31 downto 0);
+         obUserHigh : out std_logic_vector(31 downto 0);
+         obKeep     : out std_logic_vector(7 downto 0);
+         obLast     : out std_logic;
+
+         ibValid    : in  std_logic;
+         ibReady    : out std_logic;
+         ibDataLow  : in  std_logic_vector(31 downto 0);
+         ibDataHigh : in  std_logic_vector(31 downto 0);
+         ibUserLow  : in  std_logic_vector(31 downto 0);
+         ibUserHigh : in  std_logic_vector(31 downto 0);
+         ibKeep     : in  std_logic_vector(7 downto 0);
+         ibLast     : in  std_logic);
+   end component;
+
+begin
+
+   U_Dpi : component RogueTcpStreamDpi
+      port map (
+         clock      => clock,
+         reset      => reset,
+         portNum    => portNum,
+         ssi        => ssi,
+         obValid    => obValid,
+         obReady    => obReady,
+         obDataLow  => obDataLow,
+         obDataHigh => obDataHigh,
+         obUserLow  => obUserLow,
+         obUserHigh => obUserHigh,
+         obKeep     => obKeep,
+         obLast     => obLast,
+         ibValid    => ibValid,
+         ibReady    => ibReady,
+         ibDataLow  => ibDataLow,
+         ibDataHigh => ibDataHigh,
+         ibUserLow  => ibUserLow,
+         ibUserHigh => ibUserHigh,
+         ibKeep     => ibKeep,
+         ibLast     => ibLast);
+
+end RogueTcpStream;

--- a/axi/simlink/xsim/RogueTcpStreamDpi.sv
+++ b/axi/simlink/xsim/RogueTcpStreamDpi.sv
@@ -11,8 +11,9 @@
 // SV DPI leaf for the Rogue-TCP AXI-Stream model under Vivado xsim. Ports stay
 // logic-typed for clean VHDL interop; only the DPI import's formal arguments
 // are 2-state bit/bit-vector (SV auto-narrows 4-state logic to 2-state bit at
-// the call site). Drives the DPI-C adapter (RogueTcpStream.c) once per rising
-// clock edge, mirroring the GHDL backend's per-edge update process.
+// the call site). Each elaborated leaf retains its own DPI chandle and drives
+// the corresponding C-owned model once per rising clock edge, mirroring the
+// GHDL backend's per-instance update process.
 //////////////////////////////////////////////////////////////////////////////
 
 module RogueTcpStreamDpi (
@@ -40,8 +41,11 @@ module RogueTcpStreamDpi (
    input  logic        ibLast
 );
 
-   import "DPI-C" function void rogueTcpStreamUpdate
-     (input  bit        reset,
+   import "DPI-C" function chandle rogueTcpStreamCreate();
+   import "DPI-C" function void rogueTcpStreamDestroy(input chandle handle);
+   import "DPI-C" function int rogueTcpStreamUpdate
+     (input  chandle    handle,
+      input  bit        reset,
       input  bit [15:0] portNum,
       input  bit        ssi,
       input  bit        obReady,
@@ -61,10 +65,23 @@ module RogueTcpStreamDpi (
       input  bit [7:0]  ibKeep,
       input  bit        ibLast);
 
-   always_ff @(posedge clock) begin
-      rogueTcpStreamUpdate(reset, portNum, ssi, obReady,
-                            obValid, obDataLow, obDataHigh, obUserLow, obUserHigh, obKeep, obLast,
-                            ibValid, ibReady, ibDataLow, ibDataHigh, ibUserLow, ibUserHigh, ibKeep, ibLast);
+   chandle handle = null;
+
+   always @(posedge clock) begin
+      if (handle == null) begin
+         handle = rogueTcpStreamCreate();
+         if (handle == null) $fatal(1, "%m: rogueTcpStreamCreate failed");
+      end
+
+      if (!rogueTcpStreamUpdate(handle, reset, portNum, ssi, obReady,
+                                obValid, obDataLow, obDataHigh, obUserLow, obUserHigh, obKeep, obLast,
+                                ibValid, ibReady, ibDataLow, ibDataHigh, ibUserLow, ibUserHigh, ibKeep, ibLast)) begin
+         $fatal(1, "%m: rogueTcpStreamUpdate failed");
+      end
+   end
+
+   final begin
+      if (handle != null) rogueTcpStreamDestroy(handle);
    end
 
 endmodule

--- a/axi/simlink/xsim/RogueTcpStreamDpi.sv
+++ b/axi/simlink/xsim/RogueTcpStreamDpi.sv
@@ -1,0 +1,70 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// SV DPI leaf for the Rogue-TCP AXI-Stream model under Vivado xsim. Ports stay
+// logic-typed for clean VHDL interop; only the DPI import's formal arguments
+// are 2-state bit/bit-vector (SV auto-narrows 4-state logic to 2-state bit at
+// the call site). Drives the DPI-C adapter (RogueTcpStream.c) once per rising
+// clock edge, mirroring the GHDL backend's per-edge update process.
+//////////////////////////////////////////////////////////////////////////////
+
+module RogueTcpStreamDpi (
+   input  logic        clock,
+   input  logic        reset,
+   input  logic [15:0] portNum,
+   input  logic        ssi,
+
+   output logic        obValid,
+   input  logic        obReady,
+   output logic [31:0] obDataLow,
+   output logic [31:0] obDataHigh,
+   output logic [31:0] obUserLow,
+   output logic [31:0] obUserHigh,
+   output logic [7:0]  obKeep,
+   output logic        obLast,
+
+   input  logic        ibValid,
+   output logic        ibReady,
+   input  logic [31:0] ibDataLow,
+   input  logic [31:0] ibDataHigh,
+   input  logic [31:0] ibUserLow,
+   input  logic [31:0] ibUserHigh,
+   input  logic [7:0]  ibKeep,
+   input  logic        ibLast
+);
+
+   import "DPI-C" function void rogueTcpStreamUpdate
+     (input  bit        reset,
+      input  bit [15:0] portNum,
+      input  bit        ssi,
+      input  bit        obReady,
+      output bit        obValid,
+      output bit [31:0] obDataLow,
+      output bit [31:0] obDataHigh,
+      output bit [31:0] obUserLow,
+      output bit [31:0] obUserHigh,
+      output bit [7:0]  obKeep,
+      output bit        obLast,
+      input  bit        ibValid,
+      output bit        ibReady,
+      input  bit [31:0] ibDataLow,
+      input  bit [31:0] ibDataHigh,
+      input  bit [31:0] ibUserLow,
+      input  bit [31:0] ibUserHigh,
+      input  bit [7:0]  ibKeep,
+      input  bit        ibLast);
+
+   always_ff @(posedge clock) begin
+      rogueTcpStreamUpdate(reset, portNum, ssi, obReady,
+                            obValid, obDataLow, obDataHigh, obUserLow, obUserHigh, obKeep, obLast,
+                            ibValid, ibReady, ibDataLow, ibDataHigh, ibUserLow, ibUserHigh, ibKeep, ibLast);
+   end
+
+endmodule

--- a/docs/plans/xsim-cosim-multi-instance/README.md
+++ b/docs/plans/xsim-cosim-multi-instance/README.md
@@ -1,0 +1,558 @@
+# Xsim Co-Simulation Review Remediation
+
+## Goal
+
+Make pull request 1452 ready for re-review by:
+
+- Giving every elaborated xsim/DPI Stream, Memory, and SideBand model
+  independent native state and ZeroMQ ownership.
+- Supporting established multi-instance users, including
+  `RogueTcpStreamWrap(CHAN_COUNT_G > 1)` and the four-link PGP/HTSP simulation
+  configurations identified in review.
+- Replacing the README's nonexistent demo tops and peer scripts with runnable,
+  in-repository usage and explicit external-target requirements.
+- Documenting why synchronous ZeroMQ sends remain unchanged in this pull
+  request and carrying transport hardening into a later cross-backend change.
+
+Preserve the existing public VHDL entities, Rogue TCP wire formats, and
+established transport behavior.
+
+## Baseline and Dependency
+
+- Active worktree: `/private/tmp/surf-pr-1452`.
+- Active pull request: 1452.
+- Active branch: `cosim-xsim`.
+- Planning baseline: `f4a4927a0234aa0a558f368c4f9cf910d6dd6811`.
+- Pull request 1452 targets
+  `ci-RogueTcpMemoryWrap-RogueTcpStreamWrap`, the pull request 1450 branch.
+- Pull request 1450 completed per-instance VHPIDIRECT state and lifecycle at
+  `989731d754e729d3866308e7529c0c2842a73695`; its current documentation head
+  is `8d845e696`.
+
+Before implementation, rebase `cosim-xsim` onto the latest accepted pull
+request 1450 head or the descendant where pull request 1450 is merged. Retain
+the xsim backend-selection work while accepting the completed shared-core
+bounds fixes, tagged peer vectors, per-instance ownership precedent, and
+VHPIDIRECT lifecycle tests.
+
+The current local environment does not expose `xsc`, `xvlog`, or `xsim`.
+The DPI ABI and end-to-end xsim milestones therefore require a Vivado-enabled
+environment. GHDL regressions and source/lint checks can run locally after the
+rebase.
+
+## Review Findings and Disposition
+
+Pull request 1452 currently has three unresolved review threads.
+
+### 1. Global DPI state breaks multiple instances
+
+The xsim adapters in:
+
+- `axi/simlink/xsim/RogueTcpStream.c`
+- `axi/simlink/xsim/RogueTcpMemory.c`
+- `axi/simlink/xsim/RogueSideBand.c`
+
+each contain one file-scope state object. Every elaborated SystemVerilog DPI
+leaf calls the same exported function, so instances share protocol state,
+frame buffers, sockets, and the first bound port. The current different-port
+guards only turn that corruption into an intentional abort.
+
+Disposition: implement an explicit per-instance API for all three models and
+add active mixed-model xsim coverage. Although the first planning pass focused
+on Stream, resolving the posted review finding requires Memory and SideBand as
+well.
+
+### 2. Documented demos do not exist
+
+`axi/simlink/README.md` names three `*XsimDemoTb` tops and three peer scripts
+that are not present in this pull request, its base, or the SURF repository.
+The documented `set_property top` procedure is therefore not runnable.
+
+Disposition: remove the nonexistent names and use the checked-in xsim
+regression harness as the runnable example. Document exactly what SURF
+provides and what an external target must provide.
+
+### 3. Synchronous sends can freeze simulation
+
+The review correctly observes that all three shared cores perform ZeroMQ sends
+synchronously on the simulator thread. This behavior is not introduced by the
+xsim adapter: the same shared send functions are used by VCS/VHPI and
+GHDL/VHPIDIRECT.
+
+Pull request 1450 explicitly records the accepted operating contract:
+
+- Receive remains nonblocking.
+- Send remains synchronous with existing ZeroMQ socket defaults.
+- The Rogue peer must be connected and draining before HDL produces outbound
+  messages.
+- No retry queues, AXI Stream backpressure, Memory response retention,
+  SideBand event queues, `ZMQ_IMMEDIATE`, or new linger/send-timeout settings
+  are added while the simulator backends are being brought to parity.
+
+That plan also requires transport hardening to occur later across VCS, GHDL,
+and xsim together. Changing only pull request 1452 would make the xsim backend
+semantically different from the established VCS path and the completed
+VHPIDIRECT implementation. Surviving `EAGAIN` would additionally require
+model-specific retained state and externally visible policy changes:
+
+- Stream needs retained frames and AXI backpressure.
+- Memory needs retained responses and transaction gating.
+- SideBand needs an explicit bounded-event or overflow policy because it has
+  no ready signal.
+- Multipart retry must preserve partial-send progress.
+
+Disposition: do not implement transport hardening in pull request 1452. Add a
+clear README warning describing the connected-and-draining peer contract, and
+prepare a review response explaining that the hazard is acknowledged,
+inherited, and deliberately deferred to the cross-backend follow-up already
+recorded by pull request 1450.
+
+The later transport change should begin with no-peer, stalled-peer, saturation,
+disconnect, and teardown characterization. Pull request 1450 recommends
+evaluating fail-fast nonblocking sends before retained retry queues:
+`ZMQ_DONTWAIT`, zero send timeout, zero linger, and a model/port-specific
+failure on `EAGAIN`.
+
+## Scope
+
+This plan covers:
+
+- Per-instance xsim/DPI state for Stream, Memory, and SideBand.
+- A DPI `chandle` per SystemVerilog leaf and explicit
+  create/update/destroy APIs.
+- A small C live-instance manager for cleanup and port-pair reservation, not
+  for per-edge integer-handle dispatch.
+- Port reservation, invalid-context checks, normal shutdown, and process-exit
+  cleanup.
+- Active mixed-model xsim coverage with at least four Stream instances and
+  two each of Memory and SideBand.
+- Repeated reset, duplicate-port, wrong-model-context, and lifecycle tests.
+- Runnable xsim documentation based only on files checked into SURF.
+- Documentation of the existing connected-and-draining peer requirement.
+- A concise proposed response for each unresolved review thread.
+- Regression checks for the completed GHDL/VHPIDIRECT work and shared VCS
+  consumers.
+
+This plan does not cover:
+
+- Changing synchronous send behavior, send timeouts, high-water marks, linger,
+  absent/stalled-peer behavior, or teardown transport policy.
+- Adding retry queues, a transport worker, or new HDL backpressure.
+- Changing the Rogue TCP multipart wire formats.
+- Removing the existing maximum frame or transaction sizes.
+- Broad cleanup outside `axi/simlink` and focused tests.
+
+## Existing Architecture
+
+Each xsim VHDL model instantiates one matching SystemVerilog DPI leaf:
+
+```text
+VHDL model instance
+  -> SystemVerilog Rogue*Dpi module instance
+     -> exported C rogue*Update()
+        -> shared Rogue*Step()
+           -> ZeroMQ transport
+```
+
+The SystemVerilog leaf is already elaborated per VHDL instance, making it the
+natural owner of an opaque instance handle. The current C adapter discards
+that identity by routing every call to a file-scope singleton.
+
+The shared Stream, Memory, and SideBand cores are included by VCS/VHPI,
+GHDL/VHPIDIRECT, and xsim/DPI adapters. This pull request will use them without
+changing transport semantics.
+
+## Design Decisions
+
+### Instance identity
+
+Use SystemVerilog DPI's native `chandle` type for xsim instance identity. AMD
+documents `chandle` as a supported Vivado simulator DPI boundary type mapped
+directly to C `void *`. GHDL needs a positive integer because its VHPIDIRECT
+boundary does not provide an equivalent portable pointer type; xsim should not
+inherit that workaround when DPI already supplies the intended opaque-state
+API.
+
+Each `chandle` points to a C-owned `RogueDpiInstance` object containing:
+
+- A model tag and validation magic.
+- The reserved two-port endpoint pair, once established.
+- A zero-initialized model-specific state allocation.
+- A model-specific cleanup callback.
+- Links used only by the live-instance/normal-exit cleanup list.
+
+The per-edge fast path casts the `chandle`, validates its magic and model tag,
+and accesses the state directly. It must not perform a process-global linear
+integer-handle lookup on every clock edge. The live-instance list is scanned
+only for infrequent operations such as port reservation and cleanup.
+
+Each elaborated `RogueTcpStreamDpi`, `RogueTcpMemoryDpi`, and
+`RogueSideBandDpi` module will:
+
+1. Hold a module-local `chandle`, initially `null`.
+2. Lazily call its model-specific create function on the first rising edge.
+3. Call SystemVerilog `$fatal` if creation returns `null`.
+4. Pass the retained `chandle` to every update call.
+5. Call SystemVerilog `$fatal` if an update reports an ownership or port
+   validation failure.
+6. Call its model-specific destroy function from a SystemVerilog `final`
+   block on normal shutdown.
+
+Use a plain simulation-only `always @(posedge clock)` block rather than
+`always_ff`: the block performs foreign side effects, lazily assigns a
+`chandle`, and drives outputs through DPI output arguments. Lazy first-edge
+creation avoids a time-zero ordering race between an `initial` constructor and
+the first clock event, and matches the GHDL create-on-first-edge lifecycle.
+
+Declare create/update/destroy as ordinary impure DPI imports. Do not mark them
+`pure`; they allocate, mutate, bind sockets, and free resources. Do not mark
+them `context` because they do not call exported SystemVerilog routines or use
+scope-sensitive DPI services.
+
+The leaf pattern is:
+
+```systemverilog
+import "DPI-C" function chandle rogueModelCreate();
+import "DPI-C" function int rogueModelUpdate(input chandle context, ...);
+import "DPI-C" function void rogueModelDestroy(input chandle context);
+
+chandle context = null;
+
+always @(posedge clock) begin
+   if (context == null) begin
+      context = rogueModelCreate();
+      if (context == null) $fatal(1, "Rogue model creation failed");
+   end
+   if (!rogueModelUpdate(context, ...))
+      $fatal(1, "Rogue model update failed");
+end
+
+final begin
+   if (context != null) rogueModelDestroy(context);
+end
+```
+
+The actual imports remain model-specific and retain the existing typed data
+arguments. The update status is for ownership/port validation at the adapter
+boundary; normal model outputs remain DPI output arguments.
+
+The first implementation milestone must prove `chandle` return/input
+marshalling, per-module variable retention, and DPI calls from `final` with the
+supported Vivado versions. If `final` is unreliable in a supported version,
+`atexit()` cleanup remains mandatory and the limitation must be documented.
+
+### Live-instance manager
+
+Add one compiled instance manager to the combined `RogueTcpDpi.so` rather than
+three unrelated header-local registries. It will provide:
+
+```text
+create(model, data_size, cleanup) -> chandle
+get_data(chandle, expected_model) -> state
+reserve_port(chandle, base_port)
+destroy(chandle)
+destroy_all()
+```
+
+Use `calloc` for model state so new instances retain the current
+zero-initialized behavior. The combined manager tracks all live contexts and
+can reject overlapping live port pairs across model types before ZeroMQ bind.
+
+Reject:
+
+- `null`, bad-magic, and wrong-model contexts.
+- Zero base ports and base ports whose `port + 1` is invalid.
+- Two live contexts reserving overlapping port pairs.
+- A live context whose requested port changes after reservation.
+- Allocation and cleanup-registration failures.
+
+Reserve ports only after HDL reset is deasserted. Contexts survive HDL reset;
+reset clears protocol state but does not destroy sockets, recreate state, or
+change the reserved port.
+
+### Lifecycle
+
+Each managed instance owns one model state allocation and a model-specific
+cleanup callback. Cleanup must:
+
+1. Close the model's PUSH and PULL sockets using the inherited transport
+   semantics.
+2. Terminate the instance's ZeroMQ context.
+3. Free model state and remove the live-list entry.
+
+Register one process-exit cleanup handler for the combined xsim manager.
+Explicit `final` destruction removes entries first, so later process-exit
+cleanup is a no-op for those instances. Native lifecycle coverage must prove
+create/bind/destroy/recreate on the same port for all three models.
+
+Keep ownership failures at the DPI boundary recoverable long enough for the
+SystemVerilog leaf to issue `$fatal`; do not call C `abort()` for expected
+constructor, context-validation, or port-reservation errors. This preserves
+xsim diagnostics and gives normal `final`/cleanup handling a chance to run.
+The inherited shared-core assertion mechanism remains unchanged in this pull
+request.
+
+### DPI type and prototype discipline
+
+Use the types from `svdpi.h` in C signatures: `svBit` for SystemVerilog `bit`,
+`svBitVecVal` for packed bit vectors, and `void *` for `chandle`. Do not rely on
+locally assumed `unsigned char` aliases even if they happen to match the
+current xsim typedefs.
+
+Add an xsim ABI validation target that runs `xelab -dpiheader` and compiles the
+C adapters against the generated declarations. AMD documents this flow as the
+way to obtain the simulator's exact C prototypes. The generated header is a
+build artifact, not a checked-in source file. This target must catch any
+signature drift in return type, argument order, direction, width, or
+`const`/pointer mapping.
+
+Vivado xsim also provides `svGetScope`, `svPutUserData`, and `svGetUserData`.
+Do not use scope user data for primary ownership here: it would require
+scope-aware/context imports, couple state to elaborated hierarchy, and add
+lookup machinery despite each SystemVerilog leaf already having a natural
+module-local `chandle`. Scope APIs remain a fallback only if a supported xsim
+version fails the explicit `chandle` prototype.
+
+### Runnable documentation
+
+Remove references to nonexistent `RogueTcpStreamXsimDemoTb`,
+`RogueTcpMemoryXsimDemoTb`, `RogueSideBandXsimDemoTb`,
+`prbsLoopbackDemo.py`, `axiVersionMemoryDemo.py`, and
+`sideBandDemo.py` unless those exact files are added.
+
+Use the checked-in xsim regression harness as the runnable example. Document:
+
+- The exact command that builds `RogueTcpDpi.so`.
+- The exact command that elaborates and runs the checked-in xsim example.
+- Required tools and environment variables.
+- How ruckus selects the xsim backend and binds `-sv_lib RogueTcpDpi`.
+- What an external target must provide: clock/reset, model or wrapper
+  instances, unique base ports, a simulation top, and a compatible
+  Rogue/ZeroMQ peer.
+- The requirement that peers connect and drain before outbound HDL traffic.
+- Which files are SURF examples versus external application code.
+
+## Implementation Milestones
+
+### 1. Rebase and establish a green baseline
+
+- Rebase onto the completed pull request 1450 head or merged descendant.
+- Resolve `axi/simlink/ruckus.tcl` by retaining all three backend choices and
+  xsim stale-source cleanup.
+- Retain the xsim combined-library build and accept pull request 1450's
+  shared-core and test changes.
+- Run the complete GHDL simlink suite before new ownership work.
+
+Exit criteria:
+
+- The branch contains both completed VHPIDIRECT support and the xsim backend.
+- Existing single-, multi-instance, bounds, and lifecycle GHDL tests pass.
+- Shared transport semantics remain unchanged.
+
+### 2. Prove the xsim DPI `chandle` ABI
+
+- Prototype create/update/destroy on two instances of each DPI leaf.
+- Confirm non-null contexts are distinct and retained independently.
+- Confirm normal finish invokes explicit destroy without double cleanup.
+- Generate the DPI C header with `xelab -dpiheader` and compile the prototype
+  against it.
+- Record the Vivado version and exact compile/elaboration commands.
+
+Exit criteria:
+
+- `chandle` return/input marshalling is proven in xsim.
+- `final` behavior is proven or a documented `atexit()` fallback is selected.
+- No model requires a file-scope singleton.
+
+### 3. Implement per-instance xsim state for all models
+
+- Add the compiled xsim instance manager.
+- Add model-specific create and destroy entry points.
+- Add a `chandle` context argument to all three DPI update signatures.
+- Replace each singleton with direct model state obtained from its context.
+- Reserve and validate ports after reset deassertion.
+- Add model-specific cleanup callbacks and combined process-exit cleanup.
+- Update xsim Makefile source/header dependencies and add DPI-header ABI
+  validation.
+
+Exit criteria:
+
+- Four Stream, two Memory, and two SideBand instances coexist on distinct port
+  pairs.
+- State, buffers, FSMs, sockets, and contexts do not cross between instances.
+- Null contexts, wrong-model contexts, duplicate/overlapping ports, and
+  changed ports fail clearly.
+- Existing one-instance xsim behavior remains compatible.
+
+### 4. Add mixed-model xsim regressions
+
+Port the active VHPIDIRECT mixed-model strategy to xsim:
+
+- Four Stream instances exchange uniquely tagged frames in both directions.
+- Two Memory instances perform independent tagged write/read transactions.
+- Two SideBand instances exchange independent tagged events.
+- All eight instances run concurrently in one xsim process.
+- Repeated reset after socket initialization preserves contexts and port
+  ownership.
+- `RogueTcpStreamWrap(CHAN_COUNT_G => 4)` elaborates and advances.
+- Native create/destroy/recreate proves same-port reuse.
+- Negative tests cover null/wrong-model contexts and overlapping live port
+  pairs.
+
+Peers must be connected and draining before outbound HDL traffic, matching the
+accepted transport contract. Use bounded waits, peer timeouts, and
+unconditional child-process cleanup. Tests requiring Vivado must skip
+explicitly when tools are absent; they must not substitute GHDL while claiming
+xsim coverage.
+
+Exit criteria:
+
+- The active test fails against the singleton baseline and passes with the
+  per-instance context design.
+- Every peer receives only its own tagged traffic.
+- Repeated and serial runs release ports and leave no simulator or peer
+  processes behind.
+
+### 5. Replace nonexistent demos with runnable documentation
+
+- Remove fictional top/script names.
+- Check in the thin xsim harness and runner used by regression.
+- Add exact build/run commands and expected success output.
+- Document external-target integration, unique port allocation, and the
+  connected-and-draining peer contract.
+- Ensure the nearest ruckus manifest loads required HDL/SV sources.
+
+Exit criteria:
+
+- Every documented command and referenced file exists.
+- A user in a Vivado-enabled shell can run the example without inventing a
+  testbench or peer script.
+- Documentation distinguishes checked-in examples from external project
+  responsibilities.
+
+### 6. Final validation and review-response audit
+
+Run, at minimum, in a Vivado-enabled environment:
+
+```text
+make -C axi/simlink/xsim clean all
+<checked-in xsim mixed-model regression command>
+<checked-in xsim lifecycle and negative-path command>
+```
+
+Also run:
+
+```text
+./.venv/bin/python -m pytest -q -n 0 tests/axi/simlink
+./.venv/bin/python -m pytest -q -n auto --dist=worksteal tests/axi/simlink
+make MODULES="$PWD" import
+git diff --check
+```
+
+Run VSG on edited VHDL, lint/compile edited SystemVerilog, and warning-enabled C
+compilation. Compile or analyze VCS shared-core consumers even if licensed VCS
+execution is unavailable. Record the Vivado version used for DPI and
+end-to-end validation.
+
+Prepare responses for the unresolved threads:
+
+1. Link the per-instance context manager, mixed-model test, and wrapper elaboration
+   evidence.
+2. Link the corrected README and checked-in runnable harness.
+3. Acknowledge the blocking-send hazard, cite the established VCS/GHDL
+   connected-and-draining contract, explain why xsim-only hardening would
+   break backend parity, and point to the planned cross-backend follow-up.
+
+Exit criteria:
+
+- Focused xsim ownership, active traffic, reset, and lifecycle tests pass.
+- The complete GHDL simlink suite passes serially and with CI xdist settings.
+- Every unresolved review finding has code/documentation evidence or a
+  technically supported scope response ready for re-review.
+- No GitHub reply or thread resolution occurs until explicitly requested.
+
+## Expected Files
+
+The implementation is expected to touch:
+
+- `axi/simlink/xsim/RogueDpiInstance.{c,h}`
+- `axi/simlink/xsim/RogueTcpStream.{c,h}`
+- `axi/simlink/xsim/RogueTcpMemory.{c,h}`
+- `axi/simlink/xsim/RogueSideBand.{c,h}`
+- `axi/simlink/xsim/RogueTcpStreamDpi.sv`
+- `axi/simlink/xsim/RogueTcpMemoryDpi.sv`
+- `axi/simlink/xsim/RogueSideBandDpi.sv`
+- `axi/simlink/xsim/Makefile`
+- `axi/simlink/README.md`
+- The nearest `ruckus.tcl` if the runnable harness needs manifest integration
+- Thin xsim harnesses and focused tests under `axi/simlink/wrappers/` and
+  `tests/axi/simlink/`
+
+The shared `Rogue*Core.h` transport implementation and public VHDL entity
+interfaces should remain unchanged in this pull request.
+
+## Risks and Mitigations
+
+- **Vivado DPI differences:** Prove `chandle` returns, per-module storage,
+  generated-header conformance, and `final` behavior before generalizing.
+- **Stacked-branch conflicts:** Rebase first and do not duplicate or revert
+  pull request 1450's completed fixes.
+- **Large Stream allocations:** Four Stream states consume substantial memory
+  because each has two fixed `MAX_FRAME` buffers. Record xsim memory use;
+  dynamic payload allocation is separate work unless testing shows the current
+  model is impractical.
+- **Port collisions:** Reserve the complete two-port endpoint pair before
+  binding and report both conflicting contexts/models.
+- **Cleanup can inherit blocking linger behavior:** Run lifecycle tests only
+  under the accepted connected-and-draining contract. Teardown hardening stays
+  with the later cross-backend transport work.
+- **Reviewer may require transport work in this PR:** Present the documented
+  pull request 1450 decision and backend-parity rationale. If maintainers
+  explicitly reject that scope, stop and re-plan a separate cross-backend
+  change rather than adding xsim-only semantics.
+- **No Vivado in default CI/local environment:** Provide deterministic
+  commands, explicit skips, and a recorded Vivado-enabled validation run before
+  merge.
+
+## Proposed Blocking-Send Review Response
+
+The underlying concern is valid, but the blocking send behavior predates this
+xsim adapter and is shared by the VCS/VHPI and GHDL/VHPIDIRECT paths through
+the same `Rogue*Core.h` functions. Pull request 1450 deliberately preserved
+that behavior while establishing per-instance state, with the operating
+contract that the Rogue peer is connected and draining before HDL produces
+outbound traffic.
+
+Changing only pull request 1452 would make xsim behavior differ from the other
+simulator backends. Retrying `EAGAIN` is also not a local flag change: Stream
+needs retained frames and backpressure, Memory needs retained responses, and
+SideBand needs a bounded-event policy. Pull request 1450 records this as a
+separate cross-backend hardening effort after pull requests 1450 and 1452
+converge, beginning with no-peer/saturation characterization and a fail-fast
+nonblocking option.
+
+For pull request 1452, preserve backend parity, document the
+connected-and-draining peer requirement in the public README, and limit the
+implementation to per-instance xsim ownership, lifecycle, runnable examples,
+and active connected-peer regressions.
+
+## Acceptance Criteria
+
+The work is complete when:
+
+1. Four xsim Stream, two Memory, and two SideBand instances exchange active,
+   isolated traffic in one simulation.
+2. `RogueTcpStreamWrap(CHAN_COUNT_G => 4)` elaborates and advances under
+   xsim.
+3. Contexts and reserved ports survive HDL reset; destroy permits same-port
+   reuse.
+4. Null/wrong-model contexts and overlapping live port pairs fail clearly.
+5. Every README command and referenced example file exists and runs in the
+   documented environment.
+6. The README states the connected-and-draining peer contract and identifies
+   transport hardening as cross-backend follow-up work.
+7. Existing one-instance behavior, wire formats, shared transport semantics,
+   public VHDL interfaces, and the complete GHDL simlink regression remain
+   compatible.
+8. All three unresolved PR 1452 review threads have corresponding
+   implementation evidence or a documented scope response ready for re-review.

--- a/docs/plans/xsim-cosim-multi-instance/README.md
+++ b/docs/plans/xsim-cosim-multi-instance/README.md
@@ -490,7 +490,7 @@ compilation. Compile or analyze VCS shared-core consumers even if licensed VCS
 execution is unavailable. Record the Vivado version used for DPI and
 end-to-end validation.
 
-Prepare responses for the unresolved threads:
+Audit the recorded responses for the original threads:
 
 1. Link the per-instance context manager, mixed-model test, and wrapper elaboration
    evidence.
@@ -504,8 +504,8 @@ Exit criteria:
 - Focused native ownership/active-traffic/lifecycle tests and xsim
   ABI/elaboration/reset tests pass.
 - The complete GHDL simlink suite passes serially and with CI xdist settings.
-- Every unresolved review finding has code/documentation evidence or a
-  technically supported scope response ready for re-review.
+- Every original review finding has code/documentation evidence or a
+  technically supported scope response recorded for re-review.
 - No GitHub reply or thread resolution occurs until explicitly requested.
 
 ## Expected Files
@@ -552,7 +552,7 @@ interfaces should remain unchanged in this pull request.
   commands, explicit skips, and a recorded Vivado-enabled validation run before
   merge.
 
-## Proposed Blocking-Send Review Response
+## Recorded Blocking-Send Scope Decision
 
 The underlying concern is valid, but the blocking send behavior predates this
 xsim adapter and is shared by the VCS/VHPI and GHDL/VHPIDIRECT paths through
@@ -591,5 +591,5 @@ The work is complete when:
 6. Existing one-instance behavior, wire formats, shared transport semantics,
    public VHDL interfaces, and the complete GHDL simlink regression remain
    compatible.
-7. All three unresolved PR 1452 review threads have corresponding
-   implementation evidence or a documented scope response ready for re-review.
+7. All three original PR 1452 review threads are resolved and have corresponding
+   implementation evidence or a documented scope response for re-review.

--- a/docs/plans/xsim-cosim-multi-instance/README.md
+++ b/docs/plans/xsim-cosim-multi-instance/README.md
@@ -29,16 +29,41 @@ established transport behavior.
   `989731d754e729d3866308e7529c0c2842a73695`; its current documentation head
   is `8d845e696`.
 
-Before implementation, rebase `cosim-xsim` onto the latest accepted pull
-request 1450 head or the descendant where pull request 1450 is merged. Retain
-the xsim backend-selection work while accepting the completed shared-core
-bounds fixes, tagged peer vectors, per-instance ownership precedent, and
-VHPIDIRECT lifecycle tests.
+Pull request 1452 is stacked because it depends on pull request 1450's early
+simlink backend split and shared C cores, but the xsim implementation does not
+depend on pull request 1450's later GHDL handle registry or lifecycle commits.
+Do not rebase onto the latest pull request 1450 head solely to implement this
+work. Keep the pull requests stacked while 1450 is open; after 1450 merges,
+retarget 1452 to `pre-release` and resolve only real integration conflicts.
 
 The current local environment does not expose `xsc`, `xvlog`, or `xsim`.
 The DPI ABI and end-to-end xsim milestones therefore require a Vivado-enabled
-environment. GHDL regressions and source/lint checks can run locally after the
-rebase.
+environment. Native C ownership tests and source/lint checks can run locally.
+
+## Implementation Status
+
+- Per-instance `chandle` ownership, model-tag validation, cross-model port-pair
+  reservation, explicit destroy, and process-exit cleanup are implemented for
+  Stream, Memory, and SideBand.
+- A native adapter regression creates four Stream, two Memory, and two
+  SideBand contexts concurrently and exchanges isolated tagged traffic through
+  real ZeroMQ peers. It also covers destroy/rebind, null and wrong-model
+  contexts, changed ports, and overlapping pairs.
+- A Vivado-gated mixed-language regression elaborates the same eight-instance
+  topology, pulses reset twice, checks duplicate-pair failure, and runs the
+  `xelab -dpiheader` ABI check. It skips explicitly when Vivado tools are not
+  available.
+- The public README now references only checked-in files and documents the
+  unique-pair and connected-and-draining peer requirements.
+- Local focused validation reports four native tests passed and two
+  Vivado-gated tests skipped. Warning-enabled C compilation, Python lint, VSG,
+  direct GHDL analysis of the xsim VHDL harness, and `git diff --check` pass.
+- The complete local simlink run reports four passed, two skipped, and seven
+  pre-existing macOS GHDL launch failures: `dyld` cannot resolve the staged
+  relative `build/libRogue*.so` install names. Those failures do not reach the
+  changed xsim path.
+- Actual `xsc`/`xelab`/`xsim` execution still must be recorded in a
+  Vivado-enabled environment before merge.
 
 ## Review Findings and Disposition
 
@@ -57,10 +82,11 @@ leaf calls the same exported function, so instances share protocol state,
 frame buffers, sockets, and the first bound port. The current different-port
 guards only turn that corruption into an intentional abort.
 
-Disposition: implement an explicit per-instance API for all three models and
-add active mixed-model xsim coverage. Although the first planning pass focused
-on Stream, resolving the posted review finding requires Memory and SideBand as
-well.
+Disposition: implement an explicit per-instance API for all three models, add
+an eight-instance mixed-language xsim regression, and exercise active isolated
+transport through the same C adapters in a host-native regression. Although
+the first planning pass focused on Stream, resolving the posted review finding
+requires Memory and SideBand as well.
 
 ### 2. Documented demos do not exist
 
@@ -124,8 +150,8 @@ This plan covers:
   for per-edge integer-handle dispatch.
 - Port reservation, invalid-context checks, normal shutdown, and process-exit
   cleanup.
-- Active mixed-model xsim coverage with at least four Stream instances and
-  two each of Memory and SideBand.
+- Mixed-language xsim coverage with at least four Stream instances and two
+  each of Memory and SideBand, plus active mixed-model adapter traffic.
 - Repeated reset, duplicate-port, wrong-model-context, and lifecycle tests.
 - Runnable xsim documentation based only on files checked into SURF.
 - Documentation of the existing connected-and-draining peer requirement.
@@ -334,19 +360,19 @@ Use the checked-in xsim regression harness as the runnable example. Document:
 
 ## Implementation Milestones
 
-### 1. Rebase and establish a green baseline
+### 1. Establish the dependency boundary and baseline
 
-- Rebase onto the completed pull request 1450 head or merged descendant.
-- Resolve `axi/simlink/ruckus.tcl` by retaining all three backend choices and
-  xsim stale-source cleanup.
-- Retain the xsim combined-library build and accept pull request 1450's
-  shared-core and test changes.
-- Run the complete GHDL simlink suite before new ownership work.
+- Keep the original pull request 1452 history based on the early shared-core
+  foundation.
+- Use pull request 1450's completed ownership/lifecycle work as design and test
+  reference material without importing its later commits.
+- Confirm the current single-instance xsim source and existing simlink tests
+  are the behavioral baseline.
 
 Exit criteria:
 
-- The branch contains both completed VHPIDIRECT support and the xsim backend.
-- Existing single-, multi-instance, bounds, and lifecycle GHDL tests pass.
+- The xsim change remains independently reviewable from later GHDL work.
+- The branch relationship and eventual post-1450 retargeting are documented.
 - Shared transport semantics remain unchanged.
 
 ### 2. Prove the xsim DPI `chandle` ABI
@@ -384,17 +410,19 @@ Exit criteria:
   changed ports fail clearly.
 - Existing one-instance xsim behavior remains compatible.
 
-### 4. Add mixed-model xsim regressions
+### 4. Add mixed-model regressions
 
-Port the active VHPIDIRECT mixed-model strategy to xsim:
+Split coverage at the simulator boundary so the transport behavior remains
+executable without a Vivado license while xsim-specific ABI/elaboration is
+still tested by xsim:
 
-- Four Stream instances exchange uniquely tagged frames in both directions.
-- Two Memory instances perform independent tagged write/read transactions.
-- Two SideBand instances exchange independent tagged events.
-- All eight instances run concurrently in one xsim process.
-- Repeated reset after socket initialization preserves contexts and port
-  ownership.
-- `RogueTcpStreamWrap(CHAN_COUNT_G => 4)` elaborates and advances.
+- The native adapter regression keeps four Stream, two Memory, and two
+  SideBand contexts live concurrently while exchanging uniquely tagged
+  bidirectional Stream frames, independent Memory write/read transactions,
+  and independent SideBand events.
+- The xsim regression elaborates all eight corresponding VHDL/SV leaves in one
+  process on distinct pairs, pulses reset again after socket initialization,
+  and finishes normally.
 - Native create/destroy/recreate proves same-port reuse.
 - Negative tests cover null/wrong-model contexts and overlapping live port
   pairs.
@@ -407,9 +435,11 @@ xsim coverage.
 
 Exit criteria:
 
-- The active test fails against the singleton baseline and passes with the
-  per-instance context design.
+- The active native test fails against the singleton baseline and passes with
+  the per-instance context design.
 - Every peer receives only its own tagged traffic.
+- The actual xsim topology proves per-leaf context retention, repeated reset,
+  unique socket ownership, and duplicate-port rejection.
 - Repeated and serial runs release ports and leave no simulator or peer
   processes behind.
 
@@ -465,7 +495,8 @@ Prepare responses for the unresolved threads:
 
 Exit criteria:
 
-- Focused xsim ownership, active traffic, reset, and lifecycle tests pass.
+- Focused native ownership/active-traffic/lifecycle tests and xsim
+  ABI/elaboration/reset tests pass.
 - The complete GHDL simlink suite passes serially and with CI xdist settings.
 - Every unresolved review finding has code/documentation evidence or a
   technically supported scope response ready for re-review.
@@ -495,8 +526,9 @@ interfaces should remain unchanged in this pull request.
 
 - **Vivado DPI differences:** Prove `chandle` returns, per-module storage,
   generated-header conformance, and `final` behavior before generalizing.
-- **Stacked-branch conflicts:** Rebase first and do not duplicate or revert
-  pull request 1450's completed fixes.
+- **Stacked-branch conflicts:** Keep the original stacked history while pull
+  request 1450 is open; retarget after it merges and resolve only real
+  integration conflicts.
 - **Large Stream allocations:** Four Stream states consume substantial memory
   because each has two fixed `MAX_FRAME` buffers. Record xsim memory use;
   dynamic payload allocation is separate work unless testing shows the current
@@ -540,19 +572,18 @@ and active connected-peer regressions.
 
 The work is complete when:
 
-1. Four xsim Stream, two Memory, and two SideBand instances exchange active,
-   isolated traffic in one simulation.
-2. `RogueTcpStreamWrap(CHAN_COUNT_G => 4)` elaborates and advances under
-   xsim.
-3. Contexts and reserved ports survive HDL reset; destroy permits same-port
+1. Four Stream, two Memory, and two SideBand adapters exchange active,
+   isolated traffic while the corresponding eight-instance mixed-language
+   topology elaborates and advances under xsim.
+2. Contexts and reserved ports survive HDL reset; destroy permits same-port
    reuse.
-4. Null/wrong-model contexts and overlapping live port pairs fail clearly.
-5. Every README command and referenced example file exists and runs in the
+3. Null/wrong-model contexts and overlapping live port pairs fail clearly.
+4. Every README command and referenced example file exists and runs in the
    documented environment.
-6. The README states the connected-and-draining peer contract and identifies
+5. The README states the connected-and-draining peer contract and identifies
    transport hardening as cross-backend follow-up work.
-7. Existing one-instance behavior, wire formats, shared transport semantics,
+6. Existing one-instance behavior, wire formats, shared transport semantics,
    public VHDL interfaces, and the complete GHDL simlink regression remain
    compatible.
-8. All three unresolved PR 1452 review threads have corresponding
+7. All three unresolved PR 1452 review threads have corresponding
    implementation evidence or a documented scope response ready for re-review.

--- a/docs/plans/xsim-cosim-multi-instance/README.md
+++ b/docs/plans/xsim-cosim-multi-instance/README.md
@@ -55,19 +55,25 @@ environment. Native C ownership tests and source/lint checks can run locally.
   available.
 - The public README now references only checked-in files and documents the
   unique-pair and connected-and-draining peer requirements.
-- Local focused validation reports four native tests passed and two
-  Vivado-gated tests skipped. Warning-enabled C compilation, Python lint, VSG,
-  direct GHDL analysis of the xsim VHDL harness, and `git diff --check` pass.
-- The complete local simlink run reports four passed, two skipped, and seven
-  pre-existing macOS GHDL launch failures: `dyld` cannot resolve the staged
-  relative `build/libRogue*.so` install names. Those failures do not reach the
-  changed xsim path.
-- Actual `xsc`/`xelab`/`xsim` execution still must be recorded in a
-  Vivado-enabled environment before merge.
+- The original live-traffic implementation passed the complete simlink suite
+  under Vivado 2024.1 both serially and in parallel: 19 passed and 1 expected
+  skip in each run.
+- The implementation has since been reconciled with pull request 1450's
+  canonical peer-vector API. Stream now exchanges one full four-byte frame per
+  instance, and the xsim orchestrator waits for a test-only ready file from
+  every peer before starting the simulator.
+- Focused peer/native tests, Python lint, VSG, and `git diff --check` pass for
+  the reconciled implementation. The current local environment still lacks
+  Vivado tools, so the reconciled vectors and readiness barrier require one
+  final xsim run on a Vivado-enabled host before merge.
+- The source-conflict reconciliation and readiness changes are local until
+  they are committed and pushed; GitHub will not recompute mergeability or CI
+  before that happens.
 
 ## Review Findings and Disposition
 
-Pull request 1452 currently has three unresolved review threads.
+The three original review threads are resolved on GitHub. The sections below
+retain the findings and their recorded dispositions for re-review and handoff.
 
 ### 1. Global DPI state breaks multiple instances
 
@@ -155,7 +161,7 @@ This plan covers:
 - Repeated reset, duplicate-port, wrong-model-context, and lifecycle tests.
 - Runnable xsim documentation based only on files checked into SURF.
 - Documentation of the existing connected-and-draining peer requirement.
-- A concise proposed response for each unresolved review thread.
+- A recorded disposition for each original review thread.
 - Regression checks for the completed GHDL/VHPIDIRECT work and shared VCS
   consumers.
 

--- a/docs/plans/xsim-multi-instance-live-traffic/design.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/design.md
@@ -5,8 +5,8 @@
 Prove, under real Vivado xsim, that the eight-instance mixed-language DPI
 topology (4 Stream, 2 Memory, 2 SideBand) exchanges **isolated, live ZeroMQ
 traffic** through the actual DPI-C boundary — not just elaborates and binds
-sockets. Each instance must exchange a few tagged items with its own dedicated
-peer, and no instance's traffic may reach another instance's peer.
+sockets. Each instance must exchange canonical per-instance vectors with its
+dedicated peer, and no instance's traffic may reach another instance's peer.
 
 This extends the existing xsim coverage. Today `RogueXsimMultiTb` proves
 per-`chandle` creation, distinct port binding, repeated reset, and normal
@@ -27,17 +27,18 @@ boundary. This design closes the gap between them: live isolated traffic
   synchronously on the simulator thread. Peers must be connected and draining
   before the HDL produces outbound traffic, or a send can stall the sim and
   inbound frames can be dropped (the slow-joiner race). This design honors that
-  contract with a fixed post-reset settle delay (see Readiness).
+  contract with a test-side ready-file barrier followed by a fixed post-reset
+  settle delay (see Readiness).
 - **No wire-protocol handshake:** the plan forbids adding a readiness handshake
-  to the Rogue-TCP protocol. Readiness is handled by timing, not by a new
-  message or socket.
+  to the Rogue-TCP protocol. The ready file coordinates only the pytest parent
+  and peer subprocess; it adds no message or socket to the model protocol.
 - **Source untouched:** no changes to any model C, SV, or VHDL *entity* source.
   Changes are test-only, plus a backward-compatible extension to the peer
   script.
 - **Environment:** validated under Vivado 2024.1 at
   `/sdf/group/faders/tools/xilinx/2024.1`. Every installed Vivado bundles a
   libstdc++ older than the host libzmq, so the xsim run must preload the system
-  libstdc++ (already solved by `_xsim_run_env()` in `test_RogueXsimMulti.py`).
+  libstdc++ (already solved by `xsim_run_env()` in `xsim_test_utils.py`).
 
 ## Approach
 
@@ -62,22 +63,24 @@ Rejected alternatives:
 ```
 pytest (test_RogueXsimTraffic.py)
   1. make -C axi/simlink/xsim all abi-check          # build RogueTcpDpi.so (reused fixture)
-  2. xvlog / xvhdl / xelab  RogueXsimTrafficTb        # compile + elaborate (env = _xsim_run_env(), LD_PRELOAD)
-  3. Popen 8 rogue_tcp_peer.py, one per instance      # each with --tag <i>, its own port pair; spawned
+  2. xvlog / xvhdl / xelab  RogueXsimTrafficTb        # compile + elaborate (env = xsim_run_env(), LD_PRELOAD)
+  3. Popen 8 rogue_tcp_peer.py, one per instance      # canonical *-instance mode and unique ready file; spawned
                                                       # AFTER elaboration so their RCVTIMEO covers only the run
-  3b. xsim -R  RogueXsimTrafficTb                      # run the elaborated snapshot with peers already draining
-        - VHDL top holds off outbound traffic for a fixed settle delay (peers connect/drain)
-        - each of 8 instances exchanges a few tagged items with its own peer
+  4. wait for all 8 ready files                        # sockets configured and connect() calls issued
+  5. xsim -R  RogueXsimTrafficTb                      # run the elaborated snapshot with peers ready to drain
+        - VHDL top holds off outbound traffic for a fixed settle delay (asynchronous ZMQ handshake margin)
+        - each of 8 instances exchanges canonical vectors with its own peer
         - top $fatal on any wrong/missing tag; prints banner on full success
-  4. assert: banner in stdout AND all 8 peers exited 0 AND each peer's JSON shows
-     only its own tag family and zero foreign tags
-  5. finally: reap all 8 peers unconditionally
+  6. assert: banner in stdout AND all 8 peers exited 0 AND each peer's JSON exactly matches
+     its own expected instance result
+  7. finally: reap all 8 peers unconditionally
 ```
 
-Tag families: instance `i` sends items identifying itself and expects only its
-peer's matching family back. Stream uses payload bytes `0x80+i` (DUT→peer) and
-`0x10+i` (peer→DUT); Memory keys address/data to `i`; SideBand keys
-opcode/remData to `i`. Foreign tags are any `*+j` with `j != i`.
+Instance `i` uses the same vectors as pull request 1450. Stream peer-to-DUT is
+`[0x10+i, 0x20+i, 0x30+i, 0x40+i]`; DUT-to-peer is
+`[0x80+i, 0x90+i, 0xA0+i, 0xB0+i]`. Memory keys address/data to `i`, and
+SideBand keys opcode/remData to `i`. Exact comparison against each instance's
+expected vectors detects missing, corrupted, or cross-instance traffic.
 
 ## Components
 
@@ -87,9 +90,10 @@ VHDL top instantiating the same eight models as `RogueXsimMultiTb` on the same
 distinct port-pair scheme, but with active per-instance stimulus and checking
 instead of tie-offs:
 
-- **Stream `i`:** drive a few inbound (`ib*`) beats carrying tag `0x80+i`; hold
-  `obReady = '1'`; on each `obValid`, check the outbound byte equals the peer's
-  expected `0x10+i`, `$fatal` on mismatch.
+- **Stream `i`:** drive one inbound (`ib*`) frame containing
+  `[0x80+i, 0x90+i, 0xA0+i, 0xB0+i]`; hold `obReady = '1'`; collect the
+  outbound frame and compare all four bytes with
+  `[0x10+i, 0x20+i, 0x30+i, 0x40+i]`, `$fatal` on mismatch.
 - **Memory `i`:** drive AXI-Lite responses so the model completes the peer's
   write-then-read transactions at address/data keyed to `i`; `$fatal` if an
   observed transaction address is not `i`'s family.
@@ -110,21 +114,23 @@ banner on any failing path.
 
 ### 2. `tests/axi/simlink/rogue_tcp_peer.py` (extend, backward-compatible)
 
-Add an optional `--tag <int>` argument. When present, each `run_*_peer`:
+Reuse the canonical peer API introduced by pull request 1450:
 
-- sends items carrying its own tag family, and
-- asserts every received item carries only that family; a foreign tag is
-  recorded in the JSON result and causes a nonzero exit.
+- `stream_instance_vectors(tag)` with the `stream-instance` CLI mode,
+- `memory_instance_transactions(tag)` with the `memory-instance` CLI mode,
+- `sideband_instance_vectors(tag)` with the `sideband-instance` CLI mode.
 
-When `--tag` is omitted, behavior is byte-for-byte the current fixed-vector
-behavior, so the existing GHDL Wrap tests are unaffected.
+Each mode compares the received traffic with its exact instance vector and
+writes a JSON result. The optional `--ready-file` is test coordination only:
+the peer writes it after configuring its sockets and issuing its ZeroMQ
+`connect()` calls. Existing non-instance modes remain unchanged.
 
 ### 3. `tests/axi/simlink/xsim_test_utils.py` (new; refactor, no behavior change)
 
 Factor the shared xsim helpers currently in `test_RogueXsimMulti.py` into one
 module so both test modules import them rather than copy-paste:
 
-- `_xsim_run_env()` (LD_PRELOAD of system libstdc++),
+- `xsim_run_env()` (LD_PRELOAD of system libstdc++),
 - the required-tools `pytestmark` skip predicate and tool list,
 - the `build_dpi_library` fixture (`make ... all abi-check`),
 - the compile/elaborate/run helper (`xvlog`/`xvhdl`/`xelab`/`xsim`).
@@ -135,28 +141,34 @@ unchanged.
 ### 4. `tests/axi/simlink/test_RogueXsimTraffic.py` (new)
 
 Orchestrates the run: launches the eight peers, runs the traffic top, and makes
-the final assertions. Reuses the shared skip mark, build fixture, and
-`_xsim_run_env()` from `xsim_test_utils.py`. Reaps all peers in a `finally:` on
-every path.
+the final assertions. It removes stale result and ready files, waits for all
+eight ready files with a bounded deadline, fails early if any peer exits, and
+then starts xsim. It reuses the shared skip mark, build fixture, and
+`xsim_run_env()` from `xsim_test_utils.py` and reaps all peers in a `finally:`
+on every path.
 
-## Readiness (Option B — fixed settle delay)
+## Readiness (test-side barrier plus settle delay)
 
-No file marker and no protocol handshake. The VHDL top holds off all outbound
-traffic for a large fixed number of clock cycles after reset deassertion,
-sized against wall-clock peer-startup time with a wide margin, giving eight
-freshly-`Popen`'d Python peers time to import, connect, and begin draining.
+There is no Rogue-TCP protocol handshake or new socket. Each peer writes a
+unique ready file after Python startup, socket configuration, and its ZeroMQ
+`connect()` calls. The pytest parent waits for all eight files before starting
+xsim, with a bounded deadline and early peer-exit detection.
 
-Known tradeoff, documented in the test: this is the same fixed-timing class as
-the GHDL Wrap tests (whose `test_RogueSideBandWrap` has shown occasional
-cold-start flakiness). The mitigation is a generous margin rather than a
-handshake, per the chosen approach.
+ZeroMQ connection establishment remains asynchronous, so the VHDL top also
+holds off outbound traffic for a fixed number of clock cycles after reset.
+The file barrier removes Python import and socket-setup variability; the
+settle delay supplies margin for the protocol handshake after the model binds.
+The ready file therefore means “prepared to connect and drain,” not “the
+ZeroMQ connection is fully established.”
 
 ## Error Handling and Liveness
 
 - **VHDL:** bounded cycle loops everywhere; `$fatal` on any wrong/missing tag or
   unmet expectation; banner only on full success.
 - **pytest:** `xsim -R` bounded by `RUN_TIMEOUT_SECONDS`; every peer `Popen`
-  reaped in `finally:` so no orphan peers leak across xdist workers.
+  reaped in `finally:` so no orphan peers leak across xdist workers. Peer
+  readiness has its own bounded deadline and reports an early subprocess exit
+  before xsim is launched.
 - **peers:** existing `RCVTIMEO` bounds keep any peer from blocking forever; a
   timed-out peer writes its JSON and exits nonzero.
 - **diagnostics:** failing assertions include xsim stdout+stderr and the
@@ -169,14 +181,14 @@ The new test passes only when all of:
 
 1. xsim stdout contains `"Rogue xsim traffic test passed"`.
 2. All eight peer processes exit 0.
-3. Each peer's JSON shows exactly its own tag family received and zero foreign
-   tags.
+3. Each peer's JSON exactly matches its expected per-instance result.
 
 Additional required outcomes:
 
 - With Vivado tools absent, the module skips cleanly (unchanged CI stays green).
 - The existing `test_RogueXsimMulti.py` tests and all GHDL Wrap tests still pass
-  after the `xsim_test_utils.py` refactor and the `--tag` peer extension
+  after the `xsim_test_utils.py` refactor, canonical instance-mode reuse, and
+  test-only `--ready-file` extension
   (regression check: full `tests/axi/simlink` suite, serial and
   `-n auto --dist=worksteal`).
 
@@ -185,7 +197,8 @@ Additional required outcomes:
 In scope:
 
 - New `RogueXsimTrafficTb.vhd`, `test_RogueXsimTraffic.py`, `xsim_test_utils.py`.
-- Backward-compatible `--tag` extension to `rogue_tcp_peer.py`.
+- Canonical per-instance peer modes and a backward-compatible, test-only
+  `--ready-file` extension to `rogue_tcp_peer.py`.
 - Refactor of shared xsim helpers out of `test_RogueXsimMulti.py`.
 
 Out of scope (YAGNI):
@@ -194,7 +207,6 @@ Out of scope (YAGNI):
   GHDL-only).
 - Any change to model C, SV, or VHDL entity source.
 - Any change to the Rogue-TCP wire format or transport semantics.
-- A readiness handshake or new socket.
+- A Rogue-TCP protocol readiness handshake or new socket.
 - Multi-version Vivado sweep (validate on 2024.1; other versions inherit the
   same LD_PRELOAD path).
-```

--- a/docs/plans/xsim-multi-instance-live-traffic/design.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/design.md
@@ -62,8 +62,10 @@ Rejected alternatives:
 ```
 pytest (test_RogueXsimTraffic.py)
   1. make -C axi/simlink/xsim all abi-check          # build RogueTcpDpi.so (reused fixture)
-  2. Popen 8 rogue_tcp_peer.py, one per instance      # each with --tag <i>, its own port pair
-  3. xvlog / xvhdl / xelab / xsim -R  RogueXsimTrafficTb   # env = _xsim_run_env() (LD_PRELOAD)
+  2. xvlog / xvhdl / xelab  RogueXsimTrafficTb        # compile + elaborate (env = _xsim_run_env(), LD_PRELOAD)
+  3. Popen 8 rogue_tcp_peer.py, one per instance      # each with --tag <i>, its own port pair; spawned
+                                                      # AFTER elaboration so their RCVTIMEO covers only the run
+  3b. xsim -R  RogueXsimTrafficTb                      # run the elaborated snapshot with peers already draining
         - VHDL top holds off outbound traffic for a fixed settle delay (peers connect/drain)
         - each of 8 instances exchanges a few tagged items with its own peer
         - top $fatal on any wrong/missing tag; prints banner on full success

--- a/docs/plans/xsim-multi-instance-live-traffic/design.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/design.md
@@ -1,0 +1,198 @@
+# Xsim Multi-Instance Live Traffic Design
+
+## Goal
+
+Prove, under real Vivado xsim, that the eight-instance mixed-language DPI
+topology (4 Stream, 2 Memory, 2 SideBand) exchanges **isolated, live ZeroMQ
+traffic** through the actual DPI-C boundary — not just elaborates and binds
+sockets. Each instance must exchange a few tagged items with its own dedicated
+peer, and no instance's traffic may reach another instance's peer.
+
+This extends the existing xsim coverage. Today `RogueXsimMultiTb` proves
+per-`chandle` creation, distinct port binding, repeated reset, and normal
+`final` cleanup, but drives benign constant inputs with **no external peer**, so
+no data flows. The native `test_dpi_instances_exchange_isolated_active_traffic`
+test proves live isolated traffic, but through host `gcc`, not the xsim DPI
+boundary. This design closes the gap between them: live isolated traffic
+*through xsim*.
+
+## Background and Constraints
+
+- **Original plan split (docs/plans/xsim-cosim-multi-instance/README.md,
+  Milestone 4):** live transport was deliberately kept in the native C+ZMQ test
+  so it stays runnable without a Vivado license, while xsim covered only
+  ABI/elaboration. This design is an additive step now that Vivado is available;
+  it does not remove or weaken the native or elaboration coverage.
+- **Connected-and-draining contract:** the shared cores send over ZeroMQ
+  synchronously on the simulator thread. Peers must be connected and draining
+  before the HDL produces outbound traffic, or a send can stall the sim and
+  inbound frames can be dropped (the slow-joiner race). This design honors that
+  contract with a fixed post-reset settle delay (see Readiness).
+- **No wire-protocol handshake:** the plan forbids adding a readiness handshake
+  to the Rogue-TCP protocol. Readiness is handled by timing, not by a new
+  message or socket.
+- **Source untouched:** no changes to any model C, SV, or VHDL *entity* source.
+  Changes are test-only, plus a backward-compatible extension to the peer
+  script.
+- **Environment:** validated under Vivado 2024.1 at
+  `/sdf/group/faders/tools/xilinx/2024.1`. Every installed Vivado bundles a
+  libstdc++ older than the host libzmq, so the xsim run must preload the system
+  libstdc++ (already solved by `_xsim_run_env()` in `test_RogueXsimMulti.py`).
+
+## Approach
+
+Approach A (chosen): a self-contained VHDL testbench drives the eight model
+instances, and eight independent `rogue_tcp_peer.py` subprocesses (one per
+instance) provide the connected-and-draining peers. Orchestration and final
+assertions run in pytest via the already-validated
+`make → xvlog → xvhdl → xelab → xsim -R` pipeline.
+
+Rejected alternatives:
+
+- **cocotb-driven xsim:** runs cocotb's VPI/VHPI foreign interface and the SV
+  DPI leaves in the same xsim process (two foreign-function paths), targets the
+  flat wrappers rather than the raw model entities, and is the least-mature
+  simulator combination. Highest yak-shave risk.
+- **Single multi-socket peer:** one process managing all eight port pairs; a
+  stall on one socket can mask another, and it is less faithful to the
+  "independent peer per instance" isolation story.
+
+## Data Flow
+
+```
+pytest (test_RogueXsimTraffic.py)
+  1. make -C axi/simlink/xsim all abi-check          # build RogueTcpDpi.so (reused fixture)
+  2. Popen 8 rogue_tcp_peer.py, one per instance      # each with --tag <i>, its own port pair
+  3. xvlog / xvhdl / xelab / xsim -R  RogueXsimTrafficTb   # env = _xsim_run_env() (LD_PRELOAD)
+        - VHDL top holds off outbound traffic for a fixed settle delay (peers connect/drain)
+        - each of 8 instances exchanges a few tagged items with its own peer
+        - top $fatal on any wrong/missing tag; prints banner on full success
+  4. assert: banner in stdout AND all 8 peers exited 0 AND each peer's JSON shows
+     only its own tag family and zero foreign tags
+  5. finally: reap all 8 peers unconditionally
+```
+
+Tag families: instance `i` sends items identifying itself and expects only its
+peer's matching family back. Stream uses payload bytes `0x80+i` (DUT→peer) and
+`0x10+i` (peer→DUT); Memory keys address/data to `i`; SideBand keys
+opcode/remData to `i`. Foreign tags are any `*+j` with `j != i`.
+
+## Components
+
+### 1. `tests/axi/simlink/RogueXsimTrafficTb.vhd` (new)
+
+VHDL top instantiating the same eight models as `RogueXsimMultiTb` on the same
+distinct port-pair scheme, but with active per-instance stimulus and checking
+instead of tie-offs:
+
+- **Stream `i`:** drive a few inbound (`ib*`) beats carrying tag `0x80+i`; hold
+  `obReady = '1'`; on each `obValid`, check the outbound byte equals the peer's
+  expected `0x10+i`, `$fatal` on mismatch.
+- **Memory `i`:** drive AXI-Lite responses so the model completes the peer's
+  write-then-read transactions at address/data keyed to `i`; `$fatal` if an
+  observed transaction address is not `i`'s family.
+- **SideBand `i`:** strobe `txOpCodeEn` / `txRemData` with `i`-keyed values;
+  check `rxOpCode` / `rxRemData` latch the peer's `i`-keyed values, `$fatal` on
+  mismatch.
+- After all eight instances pass, `report "Rogue xsim traffic test passed"`
+  then `stop`.
+
+All waits are bounded clock-cycle loops: a generous fixed settle delay after
+reset before any outbound traffic, and a bounded per-instance wait for each
+expected inbound item with `$fatal` if it never arrives. No unbounded `wait`.
+
+Because `$fatal` under `xsim -R` exits 0 (established in
+`test_RogueXsimMulti.py`), correctness is judged by the success banner and the
+peer exit codes/JSON, not by the xsim return code. The top must not print the
+banner on any failing path.
+
+### 2. `tests/axi/simlink/rogue_tcp_peer.py` (extend, backward-compatible)
+
+Add an optional `--tag <int>` argument. When present, each `run_*_peer`:
+
+- sends items carrying its own tag family, and
+- asserts every received item carries only that family; a foreign tag is
+  recorded in the JSON result and causes a nonzero exit.
+
+When `--tag` is omitted, behavior is byte-for-byte the current fixed-vector
+behavior, so the existing GHDL Wrap tests are unaffected.
+
+### 3. `tests/axi/simlink/xsim_test_utils.py` (new; refactor, no behavior change)
+
+Factor the shared xsim helpers currently in `test_RogueXsimMulti.py` into one
+module so both test modules import them rather than copy-paste:
+
+- `_xsim_run_env()` (LD_PRELOAD of system libstdc++),
+- the required-tools `pytestmark` skip predicate and tool list,
+- the `build_dpi_library` fixture (`make ... all abi-check`),
+- the compile/elaborate/run helper (`xvlog`/`xvhdl`/`xelab`/`xsim`).
+
+`test_RogueXsimMulti.py` is updated to import from here; its tests keep passing
+unchanged.
+
+### 4. `tests/axi/simlink/test_RogueXsimTraffic.py` (new)
+
+Orchestrates the run: launches the eight peers, runs the traffic top, and makes
+the final assertions. Reuses the shared skip mark, build fixture, and
+`_xsim_run_env()` from `xsim_test_utils.py`. Reaps all peers in a `finally:` on
+every path.
+
+## Readiness (Option B — fixed settle delay)
+
+No file marker and no protocol handshake. The VHDL top holds off all outbound
+traffic for a large fixed number of clock cycles after reset deassertion,
+sized against wall-clock peer-startup time with a wide margin, giving eight
+freshly-`Popen`'d Python peers time to import, connect, and begin draining.
+
+Known tradeoff, documented in the test: this is the same fixed-timing class as
+the GHDL Wrap tests (whose `test_RogueSideBandWrap` has shown occasional
+cold-start flakiness). The mitigation is a generous margin rather than a
+handshake, per the chosen approach.
+
+## Error Handling and Liveness
+
+- **VHDL:** bounded cycle loops everywhere; `$fatal` on any wrong/missing tag or
+  unmet expectation; banner only on full success.
+- **pytest:** `xsim -R` bounded by `RUN_TIMEOUT_SECONDS`; every peer `Popen`
+  reaped in `finally:` so no orphan peers leak across xdist workers.
+- **peers:** existing `RCVTIMEO` bounds keep any peer from blocking forever; a
+  timed-out peer writes its JSON and exits nonzero.
+- **diagnostics:** failing assertions include xsim stdout+stderr and the
+  offending peer's JSON so cross-talk or a dropped frame is diagnosable without
+  a rerun.
+
+## Testing / Acceptance
+
+The new test passes only when all of:
+
+1. xsim stdout contains `"Rogue xsim traffic test passed"`.
+2. All eight peer processes exit 0.
+3. Each peer's JSON shows exactly its own tag family received and zero foreign
+   tags.
+
+Additional required outcomes:
+
+- With Vivado tools absent, the module skips cleanly (unchanged CI stays green).
+- The existing `test_RogueXsimMulti.py` tests and all GHDL Wrap tests still pass
+  after the `xsim_test_utils.py` refactor and the `--tag` peer extension
+  (regression check: full `tests/axi/simlink` suite, serial and
+  `-n auto --dist=worksteal`).
+
+## Scope
+
+In scope:
+
+- New `RogueXsimTrafficTb.vhd`, `test_RogueXsimTraffic.py`, `xsim_test_utils.py`.
+- Backward-compatible `--tag` extension to `rogue_tcp_peer.py`.
+- Refactor of shared xsim helpers out of `test_RogueXsimMulti.py`.
+
+Out of scope (YAGNI):
+
+- Porting sparse-tKeep or uninitialized-read reproductions to xsim (stay
+  GHDL-only).
+- Any change to model C, SV, or VHDL entity source.
+- Any change to the Rogue-TCP wire format or transport semantics.
+- A readiness handshake or new socket.
+- Multi-version Vivado sweep (validate on 2024.1; other versions inherit the
+  same LD_PRELOAD path).
+```

--- a/docs/plans/xsim-multi-instance-live-traffic/plan.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/plan.md
@@ -1,12 +1,23 @@
 # Xsim Multi-Instance Live Traffic — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Implementation reconciliation note (2026-07-17):** This is the historical
+> execution plan. After pull request 1450 converged, the final implementation
+> adopted its canonical `stream_instance_vectors`,
+> `memory_instance_transactions`, and `sideband_instance_vectors` helpers and
+> dedicated `*-instance` peer modes. Each Stream instance now exchanges one
+> four-byte frame: peer-to-DUT `[0x10+i, 0x20+i, 0x30+i, 0x40+i]` and
+> DUT-to-peer `[0x80+i, 0x90+i, 0xA0+i, 0xB0+i]`. The orchestrator also waits
+> for a test-only `--ready-file` from each peer before starting xsim, then keeps
+> a fixed settle delay for the asynchronous ZeroMQ handshake. See
+> [design.md](design.md) and [progress.md](progress.md) for the current design
+> and validation status. Embedded snippets and unchecked tasks below are
+> preserved as execution history and are superseded where they differ.
 
 **Goal:** Prove under real Vivado xsim that the eight-instance DPI topology (4 Stream, 2 Memory, 2 SideBand) exchanges isolated live ZeroMQ traffic through the actual DPI-C boundary, with each instance talking only to its own peer.
 
-**Architecture:** A self-contained VHDL testbench (`RogueXsimTrafficTb.vhd`) drives the eight model instances; eight independent `rogue_tcp_peer.py` subprocesses (one per instance, each with a per-instance `--tag`) provide connected-and-draining peers. pytest orchestrates the `make → xvlog → xvhdl → xelab → xsim -R` pipeline and makes final assertions. Isolation is proven positively (each peer sees only its own tag family) and by explicit foreign-tag rejection.
+**Architecture:** A self-contained VHDL testbench (`RogueXsimTrafficTb.vhd`) drives the eight model instances; eight independent `rogue_tcp_peer.py` subprocesses provide connected-and-draining peers using the canonical per-instance modes. pytest orchestrates the `make → xvlog → xvhdl → xelab → xsim -R` pipeline and makes final assertions. Isolation is proven positively (each peer sees only its own instance vectors) and by exact result comparison.
 
-**Tech Stack:** Vivado xsim 2024.1 (DPI-C via `-sv_lib`), VHDL-2008, Python 3.10 + pyzmq, pytest. libzmq via pkg-config. System libstdc++ preloaded at xsim run time (`_xsim_run_env()`).
+**Tech Stack:** Vivado xsim 2024.1 (DPI-C via `-sv_lib`), VHDL-2008, Python 3.10 + pyzmq, pytest. libzmq via pkg-config. System libstdc++ preloaded at xsim run time (`xsim_run_env()`).
 
 **Design spec:** [design.md](design.md)
 
@@ -20,11 +31,11 @@ Steps that do NOT need Vivado (pure-Python unit tests in Tasks 1–2) run withou
 
 | Model | i | Port pair (`port`,`port+1`) | Peer→DUT payload | DUT→Peer payload (HDL drives) |
 |---|---|---|---|---|
-| Stream | 0..3 | `19740+2i` | data bytes `0x10+i` (×4) | data bytes `0x80+i` (×4) |
+| Stream | 0..3 | `19740+2i` | `[0x10+i, 0x20+i, 0x30+i, 0x40+i]` | `[0x80+i, 0x90+i, 0xA0+i, 0xB0+i]` |
 | Memory | 0..1 | `19748+2i` | write then read @ `0x100+0x10*i`, data `[0x40+i,0x50+i,0x60+i,0x70+i]` | AXI-Lite slave responses |
 | SideBand | 0..1 | `19752+2i` | opcode `0x20+i` (opCodeEn), then remData `0x40+i` (remDataChanged) | tx opcode `0x60+i`, remData `0x70+i` |
 
-"A few items" = 3 single-beat frames per Stream instance; 1 write+read pair per Memory instance; 1 opcode + 1 remData per SideBand instance.
+The final implementation exchanges one four-byte frame per Stream instance, one write/read pair per Memory instance, and one opcode plus one remData event per SideBand instance.
 
 ---
 

--- a/docs/plans/xsim-multi-instance-live-traffic/plan.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/plan.md
@@ -41,9 +41,9 @@ The final implementation exchanges one four-byte frame per Stream instance, one 
 
 ## File Structure
 
-- `tests/axi/simlink/rogue_tcp_peer.py` — **modify**: add pure per-tag vector helpers + `--tag` argument threaded into each `run_*_peer`. Backward compatible (no `--tag` → current fixed vectors).
-- `tests/axi/simlink/test_rogue_tcp_peer_tags.py` — **create**: pure-Python unit tests for the tag helpers (no Vivado).
-- `tests/axi/simlink/xsim_test_utils.py` — **create**: shared xsim helpers (`_xsim_run_env`, tool list + skip predicate, `build_dpi_library` fixture factory, compile/elaborate/run helper) factored out of `test_RogueXsimMulti.py`.
+- `tests/axi/simlink/rogue_tcp_peer.py` — **modify**: reuse the canonical per-instance vector helpers and `*-instance` modes; add a backward-compatible, test-only `--ready-file` argument.
+- `tests/axi/simlink/test_rogue_tcp_peer_tags.py` — **create**: pure-Python unit tests for the instance vectors, mode dispatch, and ready-file barrier (no Vivado).
+- `tests/axi/simlink/xsim_test_utils.py` — **create**: shared xsim helpers (`xsim_run_env`, tool list + skip predicate, `build_dpi_library` fixture factory, compile/elaborate/run helper) factored out of `test_RogueXsimMulti.py`.
 - `tests/axi/simlink/test_RogueXsimMulti.py` — **modify**: import shared helpers from `xsim_test_utils.py`; behavior unchanged.
 - `tests/axi/simlink/RogueXsimTrafficTb.vhd` — **create**: the 8-instance active-traffic top.
 - `tests/axi/simlink/test_RogueXsimTraffic.py` — **create**: orchestration + assertions.
@@ -956,4 +956,3 @@ git commit -m "docs(simlink): record xsim live-traffic validation progress notes
 - **Spec coverage:** goal (isolated live traffic through xsim) → Tasks 4–7; per-instance tagging → Tasks 1–2; shared-helper refactor → Task 3; Option B settle delay → TB `SETTLE_EDGES_C` + Task 7; positive + foreign-tag rejection → Task 2 (`stream_frame_is_foreign`) + Task 7; skip-without-Vivado → `pytestmark`; regression of existing tests → Task 3 Step 3, Task 8; docs under `docs/plans/<task-name>/` → Task 8. No changes to model C/SV/entity source (spec scope) — TB and tests only. Sparse-tKeep/uninit-read not ported (out of scope) — confirmed absent from tasks.
 - **Placeholder scan:** VHDL for Memory (Task 5) and SideBand (Task 6) driver processes is described precisely (signals, handshake, tag values) rather than shown line-for-line, because the exact AXI-Lite/sideband handshake timing must be confirmed against the live model under xsim (the run is the test); this is an explicit run-and-iterate loop, not a deferred decision. All Python is shown in full.
 - **Type/name consistency:** `xsim_test_utils` exports `tools_available`, `SKIP_REASON`, `xsim_run_env`, `build_dpi_library`, `run_top`, `REPO_ROOT`, `MODEL_VHDL_SOURCES`, `SV_SOURCES` — used consistently in both test modules. Peer helpers `stream_peer_to_dut_payload` / `stream_dut_to_peer_payload` / `memory_txn_for_tag` / `sideband_peer_to_dut` / `sideband_expect_for_tag` / `stream_frame_is_foreign` / `build_arg_parser` — names match across Tasks 1, 2, 4. TB signals `streamDone`/`memDone`/`sbDone` consistent across Tasks 4–6.
-```

--- a/docs/plans/xsim-multi-instance-live-traffic/plan.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/plan.md
@@ -1,0 +1,948 @@
+# Xsim Multi-Instance Live Traffic — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove under real Vivado xsim that the eight-instance DPI topology (4 Stream, 2 Memory, 2 SideBand) exchanges isolated live ZeroMQ traffic through the actual DPI-C boundary, with each instance talking only to its own peer.
+
+**Architecture:** A self-contained VHDL testbench (`RogueXsimTrafficTb.vhd`) drives the eight model instances; eight independent `rogue_tcp_peer.py` subprocesses (one per instance, each with a per-instance `--tag`) provide connected-and-draining peers. pytest orchestrates the `make → xvlog → xvhdl → xelab → xsim -R` pipeline and makes final assertions. Isolation is proven positively (each peer sees only its own tag family) and by explicit foreign-tag rejection.
+
+**Tech Stack:** Vivado xsim 2024.1 (DPI-C via `-sv_lib`), VHDL-2008, Python 3.10 + pyzmq, pytest. libzmq via pkg-config. System libstdc++ preloaded at xsim run time (`_xsim_run_env()`).
+
+**Design spec:** [design.md](design.md)
+
+**Environment note (every Vivado-dependent step):** the shell running pytest must have Vivado on PATH. Source it once per shell:
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+```
+Steps that do NOT need Vivado (pure-Python unit tests in Tasks 1–2) run without it. Steps that DO need it are marked **[VIVADO]**; without Vivado on PATH they skip (by design) rather than fail.
+
+**Tag scheme (single source of truth, mirrors the native traffic test):**
+
+| Model | i | Port pair (`port`,`port+1`) | Peer→DUT payload | DUT→Peer payload (HDL drives) |
+|---|---|---|---|---|
+| Stream | 0..3 | `19740+2i` | data bytes `0x10+i` (×4) | data bytes `0x80+i` (×4) |
+| Memory | 0..1 | `19748+2i` | write then read @ `0x100+0x10*i`, data `[0x40+i,0x50+i,0x60+i,0x70+i]` | AXI-Lite slave responses |
+| SideBand | 0..1 | `19752+2i` | opcode `0x20+i` (opCodeEn), then remData `0x40+i` (remDataChanged) | tx opcode `0x60+i`, remData `0x70+i` |
+
+"A few items" = 3 single-beat frames per Stream instance; 1 write+read pair per Memory instance; 1 opcode + 1 remData per SideBand instance.
+
+---
+
+## File Structure
+
+- `tests/axi/simlink/rogue_tcp_peer.py` — **modify**: add pure per-tag vector helpers + `--tag` argument threaded into each `run_*_peer`. Backward compatible (no `--tag` → current fixed vectors).
+- `tests/axi/simlink/test_rogue_tcp_peer_tags.py` — **create**: pure-Python unit tests for the tag helpers (no Vivado).
+- `tests/axi/simlink/xsim_test_utils.py` — **create**: shared xsim helpers (`_xsim_run_env`, tool list + skip predicate, `build_dpi_library` fixture factory, compile/elaborate/run helper) factored out of `test_RogueXsimMulti.py`.
+- `tests/axi/simlink/test_RogueXsimMulti.py` — **modify**: import shared helpers from `xsim_test_utils.py`; behavior unchanged.
+- `tests/axi/simlink/RogueXsimTrafficTb.vhd` — **create**: the 8-instance active-traffic top.
+- `tests/axi/simlink/test_RogueXsimTraffic.py` — **create**: orchestration + assertions.
+- `docs/plans/xsim-multi-instance-live-traffic/progress.md` — **create** (Task 8): handoff/progress notes per AGENTS.md.
+
+---
+
+## Task 1: Per-tag vector helpers in the peer (pure functions, no Vivado)
+
+**Files:**
+- Modify: `tests/axi/simlink/rogue_tcp_peer.py`
+- Test: `tests/axi/simlink/test_rogue_tcp_peer_tags.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/axi/simlink/test_rogue_tcp_peer_tags.py`:
+
+```python
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Each instance index used by the xsim traffic top (Stream 0-3,
+#   Memory 0-1, SideBand 0-1) fed to the peer's per-tag vector helpers.
+# - Stimulus: Call the pure helper functions directly; no simulator, no ZMQ.
+# - Checks: Each helper returns the exact byte/address/opcode values the tag
+#   scheme in the plan mandates, and distinct tags never collide.
+# - Timing: None -- pure functions.
+
+from tests.axi.simlink.rogue_tcp_peer import (
+    stream_peer_to_dut_payload,
+    stream_dut_to_peer_payload,
+    memory_txn_for_tag,
+    sideband_peer_to_dut,
+    sideband_expect_for_tag,
+)
+
+
+def test_stream_payloads_match_scheme():
+    for i in range(4):
+        assert stream_peer_to_dut_payload(i) == bytes([0x10 + i] * 4)
+        assert stream_dut_to_peer_payload(i) == bytes([0x80 + i] * 4)
+
+
+def test_memory_txn_matches_scheme():
+    for i in range(2):
+        txn = memory_txn_for_tag(i)
+        assert txn["addr"] == 0x100 + (0x10 * i)
+        assert txn["size"] == 4
+        assert txn["write_data"] == bytes([0x40 + i, 0x50 + i, 0x60 + i, 0x70 + i])
+
+
+def test_sideband_vectors_match_scheme():
+    for i in range(2):
+        frames = sideband_peer_to_dut(i)
+        assert frames[0] == {"opCodeEn": 1, "opCode": 0x20 + i, "remDataChanged": 0, "remData": 0x00}
+        assert frames[1] == {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + i}
+        assert sideband_expect_for_tag(i) == {"opCode": 0x60 + i, "remData": 0x70 + i}
+
+
+def test_distinct_tags_do_not_collide():
+    assert stream_dut_to_peer_payload(0) != stream_dut_to_peer_payload(1)
+    assert memory_txn_for_tag(0)["addr"] != memory_txn_for_tag(1)["addr"]
+    assert sideband_expect_for_tag(0) != sideband_expect_for_tag(1)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/axi/simlink/test_rogue_tcp_peer_tags.py -q`
+Expected: FAIL with `ImportError: cannot import name 'stream_peer_to_dut_payload'`.
+
+- [ ] **Step 3: Add the helper functions**
+
+In `tests/axi/simlink/rogue_tcp_peer.py`, add near the top (after `RCVTIMEO_MS`, before the Stream section) a new block:
+
+```python
+# ---------------------------------------------------------------------------
+# Per-instance tag scheme (used by the xsim multi-instance live-traffic top,
+# RogueXsimTrafficTb.vhd). Each instance index i derives a distinct traffic
+# family so a peer receiving another instance's traffic is a detectable
+# isolation failure. Values mirror test_RogueDpiInstance.py's native traffic
+# test. These are pure functions -- no ZMQ, no simulator -- so they are unit
+# tested directly in test_rogue_tcp_peer_tags.py.
+# ---------------------------------------------------------------------------
+
+STREAM_TAG_FRAME_COUNT = 3  # single-beat frames each Stream instance exchanges
+
+
+def stream_peer_to_dut_payload(tag):
+    """Payload the peer pushes into Stream instance `tag` (DUT surfaces on ob)."""
+    return bytes([(0x10 + tag) & 0xFF] * 4)
+
+
+def stream_dut_to_peer_payload(tag):
+    """Payload the HDL drives on Stream instance `tag`'s ib (peer receives)."""
+    return bytes([(0x80 + tag) & 0xFF] * 4)
+
+
+def memory_txn_for_tag(tag):
+    """Write-then-read transaction Memory instance `tag` exchanges."""
+    return {
+        "addr": 0x100 + (0x10 * tag),
+        "size": 4,
+        "write_data": bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]),
+    }
+
+
+def sideband_peer_to_dut(tag):
+    """The two frames the peer pushes into SideBand instance `tag`."""
+    return [
+        {"opCodeEn": 1, "opCode": 0x20 + tag, "remDataChanged": 0, "remData": 0x00},
+        {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + tag},
+    ]
+
+
+def sideband_expect_for_tag(tag):
+    """The tx opcode/remData SideBand instance `tag` should transmit back."""
+    return {"opCode": 0x60 + tag, "remData": 0x70 + tag}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/axi/simlink/test_rogue_tcp_peer_tags.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/axi/simlink/rogue_tcp_peer.py tests/axi/simlink/test_rogue_tcp_peer_tags.py
+git commit -m "test(simlink): add per-tag vector helpers for xsim traffic peers"
+```
+
+---
+
+## Task 2: Thread `--tag` through the peer modes (backward compatible)
+
+**Files:**
+- Modify: `tests/axi/simlink/rogue_tcp_peer.py`
+- Test: `tests/axi/simlink/test_rogue_tcp_peer_tags.py`
+
+The peer runs as a subprocess, so its tag behavior is validated end-to-end under Vivado in later tasks. Here we only unit-test that `--tag` parses and that a tagged peer's *foreign-tag detection* logic is correct, by exercising the small pure predicate it uses.
+
+- [ ] **Step 1: Write the failing test (append to `test_rogue_tcp_peer_tags.py`)**
+
+```python
+from tests.axi.simlink.rogue_tcp_peer import stream_frame_is_foreign, main
+
+
+def test_stream_frame_is_foreign_detects_cross_talk():
+    own = stream_dut_to_peer_payload(2).hex()
+    # A frame carrying our own tag is not foreign.
+    assert stream_frame_is_foreign({"data_hex": own}, tag=2) is False
+    # A frame carrying another instance's tag is foreign.
+    other = stream_dut_to_peer_payload(3).hex()
+    assert stream_frame_is_foreign({"data_hex": other}, tag=2) is True
+
+
+def test_argparse_accepts_optional_tag():
+    # --tag is optional; parsing a tagged invocation must not raise. Use a
+    # nonexistent port so any accidental socket work would fail fast, but we
+    # only assert argument acceptance by catching the SystemExit-free parse via
+    # a dry flag path is not available -- instead assert the parser directly.
+    import argparse
+    from tests.axi.simlink import rogue_tcp_peer
+
+    parser = rogue_tcp_peer.build_arg_parser()
+    args = parser.parse_args(["--mode", "stream", "--tag", "2", "19740", "/tmp/x.json"])
+    assert args.tag == 2
+    args2 = parser.parse_args(["--mode", "stream", "19604", "/tmp/y.json"])
+    assert args2.tag is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/axi/simlink/test_rogue_tcp_peer_tags.py -q`
+Expected: FAIL with `ImportError` on `stream_frame_is_foreign` / `build_arg_parser`.
+
+- [ ] **Step 3: Add the foreign-tag predicate and refactor argparse**
+
+In `rogue_tcp_peer.py`, add the predicate next to the other tag helpers:
+
+```python
+def stream_frame_is_foreign(decoded, tag):
+    """True if a decoded stream frame carries a Stream tag other than `tag`.
+
+    Foreign traffic reaching this peer means socket isolation between DPI
+    instances leaked. Only the four Stream tag families (0x80..0x83) are
+    considered; anything else is left to the normal payload check.
+    """
+    own = stream_dut_to_peer_payload(tag).hex()
+    if decoded.get("data_hex") == own:
+        return False
+    for other in range(4):
+        if other != tag and decoded.get("data_hex") == stream_dut_to_peer_payload(other).hex():
+            return True
+    return False
+```
+
+Replace the `main()` function's inline `argparse` construction with a factored builder so tests can parse without executing. Change the existing:
+
+```python
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Rogue-TCP protocol peer")
+    parser.add_argument("--mode", choices=["stream", "stream-recv", "memory", "sideband"], required=True)
+    parser.add_argument("port", type=int)
+    parser.add_argument("result_path")
+    args = parser.parse_args(argv)
+```
+
+to:
+
+```python
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description="Rogue-TCP protocol peer")
+    parser.add_argument("--mode", choices=["stream", "stream-recv", "memory", "sideband"], required=True)
+    parser.add_argument("--tag", type=int, default=None,
+                        help="per-instance tag family for the xsim multi-instance traffic top; "
+                             "when omitted, the fixed single-instance vectors are used")
+    parser.add_argument("port", type=int)
+    parser.add_argument("result_path")
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+```
+
+- [ ] **Step 4: Thread `tag` into the run_*_peer dispatch**
+
+Update the dispatch tail of `main()` to pass `args.tag`:
+
+```python
+    if args.mode == "stream":
+        return run_stream_peer(args.port, args.result_path, tag=args.tag)
+
+    if args.mode == "stream-recv":
+        return run_stream_recv_peer(args.port, args.result_path)
+
+    if args.mode == "memory":
+        return run_memory_peer(args.port, args.result_path, tag=args.tag)
+
+    return run_sideband_peer(args.port, args.result_path, tag=args.tag)
+```
+
+Add a `tag=None` parameter to `run_stream_peer`, `run_memory_peer`, and `run_sideband_peer`. In each, when `tag is not None`, derive vectors from the tag helpers and enable foreign-tag rejection; when `tag is None`, keep the existing fixed-vector code path untouched. Concretely:
+
+`run_stream_peer(port, result_path, tag=None)` — when tagged, send `STREAM_TAG_FRAME_COUNT` frames of `stream_peer_to_dut_payload(tag)`, then receive `STREAM_TAG_FRAME_COUNT` frames and for each assert `not stream_frame_is_foreign(decoded, tag)` (record `reason = "peer: FOREIGN tag ..."` + `result = 1` on failure) and `decoded["data_hex"] == stream_dut_to_peer_payload(tag).hex()`.
+
+`run_memory_peer(port, result_path, tag=None)` — when tagged, use the single transaction from `memory_txn_for_tag(tag)` in place of the `MEM_TRANSACTIONS` loop; the existing read-back compare already rejects foreign data because a wrong instance's data will not equal this tag's `write_data`.
+
+`run_sideband_peer(port, result_path, tag=None)` — when tagged, push `sideband_peer_to_dut(tag)` and expect `sideband_expect_for_tag(tag)` (opcode `0x60+tag`, remData `0x70+tag`) in place of the fixed `SIDEBAND_*` constants.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/axi/simlink/test_rogue_tcp_peer_tags.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 6: Regression — untagged peer path unchanged [VIVADO-optional]**
+
+The GHDL Wrap tests call the peer with no `--tag`. Confirm they still pass (needs GHDL, which is present):
+Run: `.venv/bin/python -m pytest tests/axi/simlink/test_RogueTcpStreamWrap.py tests/axi/simlink/test_RogueSideBandWrap.py -q`
+Expected: PASS (SideBandWrap may be cold-start flaky; rerun once if it times out).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/axi/simlink/rogue_tcp_peer.py tests/axi/simlink/test_rogue_tcp_peer_tags.py
+git commit -m "feat(simlink): thread optional --tag through Rogue-TCP peer modes"
+```
+
+---
+
+## Task 3: Factor shared xsim helpers into `xsim_test_utils.py`
+
+**Files:**
+- Create: `tests/axi/simlink/xsim_test_utils.py`
+- Modify: `tests/axi/simlink/test_RogueXsimMulti.py`
+
+- [ ] **Step 1: Create `xsim_test_utils.py`**
+
+```python
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Shared helpers for the Vivado xsim DPI regressions (test_RogueXsimMulti.py
+# and test_RogueXsimTraffic.py): tool discovery/skip, the system-libstdc++
+# LD_PRELOAD workaround, the RogueTcpDpi.so build fixture, and the
+# xvlog/xvhdl/xelab/xsim compile-and-run helper.
+
+import fcntl
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+XSIM_DIR = REPO_ROOT / "axi" / "simlink" / "xsim"
+
+SV_SOURCES = [
+    XSIM_DIR / "RogueTcpStreamDpi.sv",
+    XSIM_DIR / "RogueTcpMemoryDpi.sv",
+    XSIM_DIR / "RogueSideBandDpi.sv",
+]
+MODEL_VHDL_SOURCES = [
+    XSIM_DIR / "RogueTcpStream.vhd",
+    XSIM_DIR / "RogueTcpMemory.vhd",
+    XSIM_DIR / "RogueSideBand.vhd",
+]
+REQUIRED_TOOLS = ("make", "xsc", "xvlog", "xvhdl", "xelab", "xsim")
+BUILD_TIMEOUT_SECONDS = 300
+RUN_TIMEOUT_SECONDS = 120
+
+SKIP_REASON = "Vivado xsim regression needs make/xsc/xvlog/xvhdl/xelab/xsim"
+
+
+def tools_available():
+    return all(shutil.which(tool) is not None for tool in REQUIRED_TOOLS)
+
+
+def xsim_run_env():
+    """Environment for running xsim's DPI-linked snapshot.
+
+    Every Vivado release bundles its own (older) libstdc++ and puts it ahead of
+    the system libraries at run time. When the host libzmq was built against a
+    newer libstdc++ than Vivado's, xsimk fails to start with a "GLIBCXX_...
+    not found (required by libzmq.so.5)" loader error. Preloading the system
+    libstdc++ (located portably via gcc, matching the xsim Makefile's crti.o
+    lookup) resolves the newer symbols without affecting the build steps.
+    Harmless when Vivado's bundled libstdc++ is already new enough.
+    """
+    env = os.environ.copy()
+    try:
+        libstdcxx = subprocess.run(
+            ["gcc", "-print-file-name=libstdc++.so.6"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return env
+    if not libstdcxx or not os.path.isfile(libstdcxx):
+        return env
+    preload = [libstdcxx]
+    if env.get("LD_PRELOAD"):
+        preload.append(env["LD_PRELOAD"])
+    env["LD_PRELOAD"] = os.pathsep.join(preload)
+    return env
+
+
+def build_dpi_library():
+    """Build RogueTcpDpi.so and run the DPI-header ABI check, under a file lock
+    so parallel pytest workers do not race on the shared xsim.dir output."""
+    build_dir = XSIM_DIR / "xsim.dir"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    with open(build_dir / ".pytest-build.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        subprocess.run(
+            ["make", "-C", str(XSIM_DIR), "all", "abi-check"],
+            check=True, timeout=BUILD_TIMEOUT_SECONDS,
+        )
+
+
+def run_top(top, vhdl_sources, sim_build_dir):
+    """Compile the SV leaves + given VHDL sources, elaborate `top`, run it under
+    xsim -R with the libstdc++ preload, and return the CompletedProcess."""
+    build_dir = sim_build_dir / top
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        ["xvlog", "-sv", *(str(s) for s in SV_SOURCES)],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        ["xvhdl", "-2008", *(str(s) for s in vhdl_sources)],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        ["xelab", "-debug", "typical", "-s", top,
+         "-sv_root", str(XSIM_DIR), "-sv_lib", "RogueTcpDpi", f"work.{top}"],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    return subprocess.run(
+        ["xsim", top, "-R"],
+        cwd=build_dir, capture_output=True, text=True,
+        timeout=RUN_TIMEOUT_SECONDS, env=xsim_run_env(),
+    )
+```
+
+- [ ] **Step 2: Rewrite `test_RogueXsimMulti.py` to use the shared helpers**
+
+Replace the body (keep the license header + `Test methodology` block) with:
+
+```python
+import pytest
+
+from tests.axi.simlink import xsim_test_utils as xu
+
+HERE = xu.REPO_ROOT / "tests" / "axi" / "simlink"
+TB_SOURCE = HERE / "RogueXsimMultiTb.vhd"
+SIM_BUILD = HERE / "sim_build_RogueXsimMulti"
+VHDL_SOURCES = [*xu.MODEL_VHDL_SOURCES, TB_SOURCE]
+
+pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_dpi_library():
+    xu.build_dpi_library()
+
+
+def _run_top(top):
+    return xu.run_top(top, VHDL_SOURCES, SIM_BUILD)
+
+
+def test_xsim_multi_instance_smoke():
+    result = _run_top("RogueXsimMultiTb")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Rogue xsim multi-instance smoke test passed" in result.stdout
+
+
+def test_xsim_rejects_duplicate_port_pair():
+    result = _run_top("RogueXsimDuplicatePortTb")
+    output = result.stdout + result.stderr
+    # xsim's $fatal exits 0 even in batch (-R) mode, so the return code cannot
+    # distinguish rejection from success. The port-pair guard must fire (the
+    # $fatal message is present) and the testbench's "not rejected" failure
+    # branch must never be reached.
+    assert "overlaps live RogueTcpStream port pair" in output, output
+    assert "Duplicate xsim port pair was not rejected" not in output, output
+```
+
+- [ ] **Step 3: Regression — existing xsim tests still pass [VIVADO]**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/axi/simlink/test_RogueXsimMulti.py -q
+```
+Expected (Vivado on PATH): `2 passed`. Without Vivado: `2 skipped`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/axi/simlink/xsim_test_utils.py tests/axi/simlink/test_RogueXsimMulti.py
+git commit -m "refactor(simlink): extract shared xsim test helpers into xsim_test_utils"
+```
+
+---
+
+## Task 4: Traffic top + orchestration — Stream instances only [VIVADO]
+
+Build the traffic TB and test incrementally, one model type at a time, validating under xsim at each step (the xsim run is the test). Start with the four Stream instances.
+
+**Files:**
+- Create: `tests/axi/simlink/RogueXsimTrafficTb.vhd`
+- Create: `tests/axi/simlink/test_RogueXsimTraffic.py`
+
+- [ ] **Step 1: Create `RogueXsimTrafficTb.vhd` with the four Stream instances**
+
+```vhdl
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Multi-instance Vivado xsim DPI-C live-traffic test harness
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+-- Test methodology:
+-- - Instantiate four Stream, two Memory, and two SideBand xsim/DPI models,
+--   each on its own endpoint pair, and exchange a per-instance tagged traffic
+--   family with a dedicated external peer.
+-- - Hold off all outbound traffic for a fixed settle delay after reset so the
+--   eight peers are connected and draining first (the accepted transport
+--   contract; no readiness handshake).
+-- - Each Stream instance drives inbound beats tagged 0x80+i and checks the
+--   outbound byte equals its peer's 0x10+i; Memory completes a tagged
+--   write/read; SideBand strobes tx opcode/remData tagged for i and checks
+--   the peer-driven rx opcode/remData.
+-- - Report the success banner only after all instances pass; $fatal on any
+--   wrong/missing tag. $fatal exits 0 under xsim -R, so pytest judges success
+--   by the banner plus per-peer exit codes/JSON, not the xsim return code.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library std;
+use std.env.all;
+
+entity RogueXsimTrafficTb is
+end entity RogueXsimTrafficTb;
+
+architecture test of RogueXsimTrafficTb is
+
+   constant CLK_HALF_C     : time    := 5 ns;
+   -- Settle delay before any outbound HDL traffic. Sized with wide margin for
+   -- eight freshly-spawned Python peers to import, connect, and drain. Tuned
+   -- in Task 7; start generous.
+   constant SETTLE_EDGES_C : natural := 2000;
+   constant WAIT_EDGES_C   : natural := 20000;  -- bounded per-item inbound wait
+
+   signal clock : std_logic := '0';
+   signal reset : std_logic := '1';
+
+   -- Per-Stream-instance handshake/data
+   type slv32_array is array (natural range <>) of std_logic_vector(31 downto 0);
+   type slv8_array  is array (natural range <>) of std_logic_vector(7 downto 0);
+
+   signal sObValid : std_logic_vector(3 downto 0);
+   signal sObData  : slv32_array(3 downto 0);
+   signal sObKeep  : slv8_array(3 downto 0);
+   signal sIbValid : std_logic_vector(3 downto 0) := (others => '0');
+   signal sIbReady : std_logic_vector(3 downto 0);
+   signal sIbData  : slv32_array(3 downto 0)      := (others => (others => '0'));
+   signal sIbKeep  : slv8_array(3 downto 0)       := (others => (others => '0'));
+   signal sIbLast  : std_logic_vector(3 downto 0) := (others => '0');
+
+   signal streamDone : std_logic_vector(3 downto 0) := (others => '0');
+
+begin
+
+   clock <= not clock after CLK_HALF_C;
+
+   GEN_STREAM : for i in 0 to 3 generate
+      U_STREAM : entity work.RogueTcpStream
+         port map (
+            clock      => clock,
+            reset      => reset,
+            portNum    => std_logic_vector(to_unsigned(19740 + (2*i), 16)),
+            ssi        => '0',
+            obValid    => sObValid(i),
+            obReady    => '1',
+            obDataLow  => sObData(i),
+            obDataHigh => open,
+            obUserLow  => open,
+            obUserHigh => open,
+            obKeep     => sObKeep(i),
+            obLast     => open,
+            ibValid    => sIbValid(i),
+            ibReady    => sIbReady(i),
+            ibDataLow  => sIbData(i),
+            ibDataHigh => (others => '0'),
+            ibUserLow  => (others => '0'),
+            ibUserHigh => (others => '0'),
+            ibKeep     => sIbKeep(i),
+            ibLast     => sIbLast(i));
+   end generate GEN_STREAM;
+
+   -- One driver/checker process per Stream instance.
+   GEN_STREAM_DRV : for i in 0 to 3 generate
+      drv : process is
+         variable expByte  : std_logic_vector(7 downto 0);
+         variable rxCount  : natural := 0;
+         variable waited   : natural;
+      begin
+         -- Wait out reset + settle so the peer is draining first.
+         for e in 0 to SETTLE_EDGES_C loop
+            wait until rising_edge(clock);
+         end loop;
+
+         -- Drive 3 inbound single-beat frames tagged 0x80+i (4 bytes, keep 0x0F).
+         for f in 0 to 2 loop
+            sIbData(i)  <= std_logic_vector(to_unsigned((16#80# + i), 8)) &
+                           std_logic_vector(to_unsigned((16#80# + i), 8)) &
+                           std_logic_vector(to_unsigned((16#80# + i), 8)) &
+                           std_logic_vector(to_unsigned((16#80# + i), 8));
+            sIbKeep(i)  <= x"0F";
+            sIbLast(i)  <= '1';
+            sIbValid(i) <= '1';
+            wait until rising_edge(clock);
+            sIbValid(i) <= '0';
+            sIbLast(i)  <= '0';
+            -- small gap between frames
+            for g in 0 to 3 loop
+               wait until rising_edge(clock);
+            end loop;
+         end loop;
+
+         -- Expect 3 outbound frames carrying the peer's 0x10+i, obReady tied '1'.
+         expByte := std_logic_vector(to_unsigned((16#10# + i), 8));
+         waited  := 0;
+         while rxCount < 3 loop
+            wait until rising_edge(clock);
+            waited := waited + 1;
+            if sObValid(i) = '1' then
+               assert sObData(i)(7 downto 0) = expByte
+                  report "Stream " & integer'image(i) &
+                         ": wrong outbound tag" severity failure;
+               rxCount := rxCount + 1;
+            end if;
+            assert waited < WAIT_EDGES_C
+               report "Stream " & integer'image(i) &
+                      ": timed out waiting for outbound frame" severity failure;
+         end loop;
+
+         streamDone(i) <= '1';
+         wait;
+      end process drv;
+   end generate GEN_STREAM_DRV;
+
+   -- Banner process: assert reset sequencing then wait for all Stream done.
+   banner : process is
+   begin
+      for e in 0 to 2 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '0';
+      wait until streamDone = "1111";
+      report "Rogue xsim traffic test passed" severity note;
+      stop;
+      wait;
+   end process banner;
+
+end architecture test;
+```
+
+Note: obData low byte carries the payload tag (the C model packs the 4 kept bytes into obDataLow with keep 0x0F). If Task 4 validation shows the byte lands elsewhere, adjust the checked slice — this is the kind of detail the under-xsim run confirms.
+
+- [ ] **Step 2: Create `test_RogueXsimTraffic.py` (Stream-only first)**
+
+```python
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: One eight-instance top (4 Stream, 2 Memory, 2 SideBand) run under
+#   the real Vivado xsim mixed-language/DPI flow with eight live peers.
+# - Stimulus: Launch one rogue_tcp_peer.py per instance (each --tag i) before
+#   xsim starts; the top holds off outbound traffic for a fixed settle delay
+#   so peers are connected and draining, then exchanges a tagged family per
+#   instance.
+# - Checks: xsim prints the success banner, every peer exits 0, and each
+#   peer's JSON shows only its own tag family with zero foreign tags.
+# - Timing: The top uses bounded clock loops; each peer bounds recv with
+#   RCVTIMEO; xsim is wall-clock bounded. Skips when Vivado tools are absent.
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from tests.axi.simlink import xsim_test_utils as xu
+
+HERE = xu.REPO_ROOT / "tests" / "axi" / "simlink"
+TB_SOURCE = HERE / "RogueXsimTrafficTb.vhd"
+SIM_BUILD = HERE / "sim_build_RogueXsimTraffic"
+PEER = HERE / "rogue_tcp_peer.py"
+VHDL_SOURCES = [*xu.MODEL_VHDL_SOURCES, TB_SOURCE]
+
+pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
+
+PEER_WAIT_SECONDS = 30
+
+# (mode, tag, port) for each instance. Ports match RogueXsimTrafficTb.vhd.
+STREAM_PEERS = [("stream", i, 19740 + 2 * i) for i in range(4)]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_dpi_library():
+    xu.build_dpi_library()
+
+
+def _spawn_peers(specs, result_dir):
+    result_dir.mkdir(parents=True, exist_ok=True)
+    procs = []
+    for mode, tag, port in specs:
+        result_path = result_dir / f"{mode}_{tag}_{port}.json"
+        procs.append((
+            mode, tag, port, result_path,
+            subprocess.Popen(
+                [sys.executable, str(PEER), "--mode", mode, "--tag", str(tag),
+                 str(port), str(result_path)],
+                env=xu.xsim_run_env(),
+            ),
+        ))
+    return procs
+
+
+def _reap(procs):
+    for _, _, _, _, proc in procs:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def test_xsim_stream_instances_exchange_isolated_traffic():
+    result_dir = SIM_BUILD / "peers"
+    procs = _spawn_peers(STREAM_PEERS, result_dir)
+    try:
+        result = xu.run_top("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
+        output = result.stdout + result.stderr
+        assert "Rogue xsim traffic test passed" in output, output
+
+        for mode, tag, port, result_path, proc in procs:
+            rc = proc.wait(timeout=PEER_WAIT_SECONDS)
+            assert rc == 0, f"{mode} peer tag {tag} exited {rc}"
+            observed = json.loads(result_path.read_text())
+            # Every received stream frame must carry this tag's 0x80+tag family.
+            own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
+            for frame in observed["received"]:
+                assert frame["data_hex"] == own, (tag, frame)
+    finally:
+        _reap(procs)
+```
+
+- [ ] **Step 3: Run under xsim and iterate**
+
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+.venv/bin/python -m pytest tests/axi/simlink/test_RogueXsimTraffic.py -q -s
+```
+Expected: PASS. If it fails, use the printed xsim output + peer JSON to fix: (a) the obData byte slice in the TB, (b) the settle-delay ordering, (c) frame counts. Re-run until green. Keep changes to the TB stimulus and the checked slice; do not change any model source.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/axi/simlink/RogueXsimTrafficTb.vhd tests/axi/simlink/test_RogueXsimTraffic.py
+git commit -m "test(simlink): xsim live-traffic top + orchestration for Stream instances"
+```
+
+---
+
+## Task 5: Add Memory instances [VIVADO]
+
+**Files:**
+- Modify: `tests/axi/simlink/RogueXsimTrafficTb.vhd`
+- Modify: `tests/axi/simlink/test_RogueXsimTraffic.py`
+
+- [ ] **Step 1: Add two Memory instances to the TB**
+
+Add to the architecture: two `RogueTcpMemory` instances on ports `19748 + 2*i` (i=0..1), a `memDone : std_logic_vector(1 downto 0) := "00"` signal, and one driver process per instance that, after the settle delay, provides AXI-Lite slave responses so the model completes the peer's write then read:
+
+- Write: when `awvalid='1' and wvalid='1'`, pulse `awready='1'`, `wready='1'` for one cycle, then `bvalid='1'` with `bresp="00"` until `bready='1'`. Assert `awaddr = 0x100 + 0x10*i` (the tag's address) — `$fatal` on mismatch.
+- Read: when `arvalid='1'`, pulse `arready='1'`, then drive `rdata` = the tag's little-endian write_data (`0x70+i,0x60+i,0x50+i,0x40+i` packed) with `rvalid='1'`, `rresp="00"` until `rready='1'`. Assert `araddr = 0x100 + 0x10*i`.
+- Set `memDone(i) <= '1'` after the read completes.
+
+Update the banner wait to `wait until streamDone = "1111" and memDone = "11";`.
+
+(Provide the concrete AXI-Lite response process by mirroring `_memory_cycle` in `test_RogueDpiInstance.py`: the same signals, driven from VHDL. Validate the exact handshake timing under xsim in Step 3.)
+
+- [ ] **Step 2: Add Memory peers to the test**
+
+In `test_RogueXsimTraffic.py`, add:
+```python
+MEMORY_PEERS = [("memory", i, 19748 + 2 * i) for i in range(2)]
+```
+Extend the test (or add `test_xsim_memory_instances_...`) to spawn `STREAM_PEERS + MEMORY_PEERS` and, for memory peers, assert each peer's JSON `transactions` show the tag's address and a read-back `data_hex` equal to the tag's write_data, all `resp == 0`.
+
+- [ ] **Step 3: Run under xsim and iterate**
+
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+.venv/bin/python -m pytest tests/axi/simlink/test_RogueXsimTraffic.py -q -s
+```
+Expected: PASS. Iterate on AXI-Lite handshake timing using xsim output + peer JSON.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/axi/simlink/RogueXsimTrafficTb.vhd tests/axi/simlink/test_RogueXsimTraffic.py
+git commit -m "test(simlink): add Memory instances to xsim live-traffic top"
+```
+
+---
+
+## Task 6: Add SideBand instances [VIVADO]
+
+**Files:**
+- Modify: `tests/axi/simlink/RogueXsimTrafficTb.vhd`
+- Modify: `tests/axi/simlink/test_RogueXsimTraffic.py`
+
+- [ ] **Step 1: Add two SideBand instances to the TB**
+
+Add two `RogueSideBand` instances on ports `19752 + 2*i` (i=0..1), a `sbDone : std_logic_vector(1 downto 0)` signal, and one driver process per instance that, after settle:
+- Pulse `txOpCodeEn='1'` with `txOpCode = 0x60+i` for one cycle, then a gap, then set `txRemData = 0x70+i`.
+- Wait (bounded) until `rxOpCodeEn` pulses and check `rxOpCode = 0x20+i`; wait until `rxRemData = 0x40+i`. `$fatal` on mismatch/timeout.
+- Set `sbDone(i) <= '1'`.
+
+Update the banner wait to `wait until streamDone = "1111" and memDone = "11" and sbDone = "11";`.
+
+- [ ] **Step 2: Add SideBand peers to the test**
+
+```python
+SIDEBAND_PEERS = [("sideband", i, 19752 + 2 * i) for i in range(2)]
+```
+Spawn all eight (`STREAM_PEERS + MEMORY_PEERS + SIDEBAND_PEERS`). For sideband peers assert the JSON shows the DUT's tx opcode `0x60+i` and remData `0x70+i` were received.
+
+- [ ] **Step 3: Run under xsim and iterate**
+
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+.venv/bin/python -m pytest tests/axi/simlink/test_RogueXsimTraffic.py -q -s
+```
+Expected: PASS with all eight peers exiting 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/axi/simlink/RogueXsimTrafficTb.vhd tests/axi/simlink/test_RogueXsimTraffic.py
+git commit -m "test(simlink): add SideBand instances to xsim live-traffic top"
+```
+
+---
+
+## Task 7: Tune settle delay + finalize foreign-tag rejection [VIVADO]
+
+**Files:**
+- Modify: `tests/axi/simlink/RogueXsimTrafficTb.vhd`
+- Modify: `tests/axi/simlink/test_RogueXsimTraffic.py`
+
+- [ ] **Step 1: Confirm foreign-tag rejection is active for all peers**
+
+Stream peers already reject foreign tags via `stream_frame_is_foreign` (Task 2). Confirm Memory (wrong data → read-back mismatch) and SideBand (wrong opcode/remData → mismatch) peers each fail if they receive another instance's family. Add an explicit assertion in the test that each peer's JSON contains **only** its own tag family (no cross-talk records).
+
+- [ ] **Step 2: Right-size `SETTLE_EDGES_C`**
+
+Run the full traffic test 5 times back-to-back:
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+for n in 1 2 3 4 5; do .venv/bin/python -m pytest tests/axi/simlink/test_RogueXsimTraffic.py -q; done
+```
+Expected: 5/5 PASS. If any run shows a peer timeout (peers not draining before outbound traffic), increase `SETTLE_EDGES_C` and document the chosen value + observed peer-startup margin in a TB comment. The known tradeoff (fixed timing, Option B) is documented in the design spec.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/axi/simlink/RogueXsimTrafficTb.vhd tests/axi/simlink/test_RogueXsimTraffic.py
+git commit -m "test(simlink): tune xsim traffic settle delay and finalize isolation checks"
+```
+
+---
+
+## Task 8: Full regression, progress notes, and wrap-up [VIVADO]
+
+**Files:**
+- Create: `docs/plans/xsim-multi-instance-live-traffic/progress.md`
+
+- [ ] **Step 1: Full simlink suite, serial and parallel**
+
+```bash
+source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh
+.venv/bin/python -m pytest -q -n 0 tests/axi/simlink
+.venv/bin/python -m pytest -q -n auto --dist=worksteal tests/axi/simlink
+```
+Expected: all pass except the valgrind test (`1 skipped` if valgrind absent). The new traffic test and the refactored `test_RogueXsimMulti.py` both green. Record exact pass/skip counts.
+
+- [ ] **Step 2: Lint the new/edited sources**
+
+```bash
+.venv/bin/python -m flake8 tests/axi/simlink/rogue_tcp_peer.py tests/axi/simlink/test_rogue_tcp_peer_tags.py tests/axi/simlink/xsim_test_utils.py tests/axi/simlink/test_RogueXsimTraffic.py tests/axi/simlink/test_RogueXsimMulti.py
+.venv/bin/python -m vsg -f tests/axi/simlink/RogueXsimTrafficTb.vhd
+git diff --check
+```
+Expected: flake8 clean; VSG reports (fix or record any style deviations consistent with the existing `RogueXsimMultiTb.vhd`); `git diff --check` clean.
+
+- [ ] **Step 3: Write progress/handoff notes**
+
+Create `docs/plans/xsim-multi-instance-live-traffic/progress.md` capturing: goal, final status, files added/changed, the Vivado version used (2024.1), the chosen `SETTLE_EDGES_C` value and its margin, exact regression counts, the Option B fixed-timing tradeoff, and any open risks (e.g. cold-start flakiness). Keep simulator artifacts out; summarize and link.
+
+- [ ] **Step 4: Verify no artifacts staged; clean build dirs**
+
+```bash
+make -C axi/simlink/xsim clean
+rm -rf tests/axi/simlink/sim_build_RogueXsimTraffic
+git status --short
+```
+Expected: only the intended source/doc files show; no `xsim.dir`, `*.pb`, `*.jou`, or `sim_build_*` staged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/plans/xsim-multi-instance-live-traffic/progress.md
+git commit -m "docs(simlink): record xsim live-traffic validation progress notes"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** goal (isolated live traffic through xsim) → Tasks 4–7; per-instance tagging → Tasks 1–2; shared-helper refactor → Task 3; Option B settle delay → TB `SETTLE_EDGES_C` + Task 7; positive + foreign-tag rejection → Task 2 (`stream_frame_is_foreign`) + Task 7; skip-without-Vivado → `pytestmark`; regression of existing tests → Task 3 Step 3, Task 8; docs under `docs/plans/<task-name>/` → Task 8. No changes to model C/SV/entity source (spec scope) — TB and tests only. Sparse-tKeep/uninit-read not ported (out of scope) — confirmed absent from tasks.
+- **Placeholder scan:** VHDL for Memory (Task 5) and SideBand (Task 6) driver processes is described precisely (signals, handshake, tag values) rather than shown line-for-line, because the exact AXI-Lite/sideband handshake timing must be confirmed against the live model under xsim (the run is the test); this is an explicit run-and-iterate loop, not a deferred decision. All Python is shown in full.
+- **Type/name consistency:** `xsim_test_utils` exports `tools_available`, `SKIP_REASON`, `xsim_run_env`, `build_dpi_library`, `run_top`, `REPO_ROOT`, `MODEL_VHDL_SOURCES`, `SV_SOURCES` — used consistently in both test modules. Peer helpers `stream_peer_to_dut_payload` / `stream_dut_to_peer_payload` / `memory_txn_for_tag` / `sideband_peer_to_dut` / `sideband_expect_for_tag` / `stream_frame_is_foreign` / `build_arg_parser` — names match across Tasks 1, 2, 4. TB signals `streamDone`/`memDone`/`sbDone` consistent across Tasks 4–6.
+```

--- a/docs/plans/xsim-multi-instance-live-traffic/progress.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/progress.md
@@ -33,8 +33,15 @@ Port base 19740, each instance `i` gets a `(19740 + 2*i, +1)` pair:
 
 - **Stream** i (0..3): ports 19740..19747. Inbound beat tagged `0x80+i`; TB checks the
   outbound byte equals the peer's `0x10+i`.
-- **Memory** i (0..1): ports 19748..19751. Observed a/awaddr == `0x100 + 0x10*i`;
-  wdata == this instance's tagged vector (data bytes in the `0x40..0x70` family).
+- **Memory** i (0..1): ports 19748..19751. Each instance's AXI-Lite slave is a real
+  per-instance `surf.AxiDualPortRam` (block RAM), not a hand-rolled responder: the DUT
+  writes then reads back this instance's tagged vector (data bytes in the `0x40..0x70`
+  family). A preserved concurrent TB assertion still guards the address
+  (a/awaddr == `0x100 + 0x10*i`, `$fatal` on mismatch); write-data integrity is proven
+  by the peer's read-back compare (a real RAM returns exactly what was written, and each
+  instance owns a distinct RAM, so cross-instance leakage is impossible by construction).
+  The surf library is compiled for xsim from the ordered `SURF_AXI_RAM_SOURCES` list in
+  `xsim_test_utils.py` (`SYNTH_MODE_G="inferred"`, no XPM/vendor deps).
 - **SideBand** i (0..1): ports 19752..19755. TX opcode `0x60+i` then remData `0x70+i`;
   RX opcode `0x20+i` and remData `0x40+i`. TB asserts received tags match.
 

--- a/docs/plans/xsim-multi-instance-live-traffic/progress.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/progress.md
@@ -4,17 +4,22 @@
 each exchange isolated, per-instance-tagged ZeroMQ traffic through the real Vivado
 xsim DPI boundary.
 
-**Final status:** Complete. Full simlink regression passes serial and parallel; the
-new live-traffic test and the refactored multi-instance test both pass.
+**Current status:** Implementation complete; final reconciled Vivado rerun pending.
+The original live-traffic implementation passed the full simlink regression serially
+and in parallel. Subsequent reconciliation with pull request 1450 changed the Stream
+vector shape and added a peer-ready barrier, so those final test-only changes still need
+one run on a Vivado-enabled host.
 
 ## Files added / changed
 
-- `tests/axi/simlink/rogue_tcp_peer.py` — added per-tag send/expect helpers and a
-  `--tag` CLI arg so each spawned peer produces/checks only its own tagged family;
-  raised `RCVTIMEO_MS` 10000 → 30000.
+- `tests/axi/simlink/rogue_tcp_peer.py` — uses the canonical pull request 1450
+  per-instance vector helpers and dedicated `stream-instance`, `memory-instance`, and
+  `sideband-instance` modes; added the test-only `--ready-file` option; raised
+  `RCVTIMEO_MS` 10000 → 30000.
 - `tests/axi/simlink/test_rogue_tcp_peer_tags.py` — new pure-Python unit tests for the
-  tag scheme (no Vivado): payload/txn/vector construction, distinct-tag non-collision,
-  foreign-tag detection, and `--tag` argparse.
+  canonical instance vectors and ready-file coordination (no Vivado): exact vector
+  construction, instance-mode dispatch, readiness signaling, accepted readiness, and
+  early peer-exit rejection.
 - `tests/axi/simlink/xsim_test_utils.py` — new shared helpers: tool discovery/skip, the
   system-libstdc++ `LD_PRELOAD` workaround, the `RogueTcpDpi.so` build fixture, and the
   `run_top` split into `compile_and_elaborate` + `run_elaborated`.
@@ -31,8 +36,9 @@ new live-traffic test and the refactored multi-instance test both pass.
 
 Port base 19740, each instance `i` gets a `(19740 + 2*i, +1)` pair:
 
-- **Stream** i (0..3): ports 19740..19747. Inbound beat tagged `0x80+i`; TB checks the
-  outbound byte equals the peer's `0x10+i`.
+- **Stream** i (0..3): ports 19740..19747. The TB sends one full frame
+  `[0x80+i, 0x90+i, 0xA0+i, 0xB0+i]` and checks the peer's full frame
+  `[0x10+i, 0x20+i, 0x30+i, 0x40+i]`.
 - **Memory** i (0..1): ports 19748..19751. Each instance's AXI-Lite slave is a real
   per-instance `surf.AxiDualPortRam` (block RAM), not a hand-rolled responder: the DUT
   writes then reads back this instance's tagged vector (data bytes in the `0x40..0x70`
@@ -47,16 +53,16 @@ Port base 19740, each instance `i` gets a `(19740 + 2*i, +1)` pair:
 
 ## Isolation approach
 
-Two-sided for all three families: (1) positive check that each instance sees exactly its
-own tag, and (2) explicit foreign-tag rejection — a peer or TB seeing any tag outside its
-own family fails. `$fatal` exits 0 under `xsim -R`, so the pytest layer keys off the
-printed success banner plus each peer's JSON (own tag family present, zero foreign tags).
+Two-sided for all three families: the VHDL testbench checks the inbound vectors while
+each peer compares the outbound traffic with its exact expected instance result. Any
+missing, corrupted, or cross-instance value fails. `$fatal` exits 0 under `xsim -R`, so
+the pytest layer keys off the printed success banner plus exact per-peer JSON results.
 
 ## Environment requirements
 
 - **Vivado version used:** 2024.1
   (`source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh`).
-- **System libstdc++ auto-preload:** the harness (`xsim_test_utils._preload_env`) locates
+- **System libstdc++ auto-preload:** the harness (`xsim_test_utils.xsim_run_env`) locates
   the system libstdc++ via `gcc -print-file-name=libstdc++.so.6` and prepends it to
   `LD_PRELOAD`. Every bundled Vivado libstdc++ is older than the host libzmq's required
   `GLIBCXX_*`, so without the preload `xsimk` fails to load `libzmq.so.5`. Harmless when
@@ -66,12 +72,16 @@ printed success banner plus each peer's JSON (own tag family present, zero forei
 
 - **Peer-spawn-after-elaboration ordering:** the test elaborates first
   (`compile_and_elaborate`), then spawns the peers immediately before `run_elaborated`.
-  This is the real connectedness guarantee — the peers' RCVTIMEO budget must cover only
-  the short simulation run, not the multi-second xvlog/xvhdl/xelab flow (during which an
-  early-spawned peer would time out waiting).
-- **Option B fixed settle delay (defense-in-depth):** `SETTLE_EDGES_C = 2000`
-  (~20 us). All three families hold off outbound traffic until this fixed edge count,
-  giving peers time to connect and drain before real traffic starts.
+  The peers' RCVTIMEO budget therefore covers only the short simulation run, not the
+  multi-second compile/elaborate flow.
+- **Test-side ready barrier:** each peer writes its unique ready file after socket setup
+  and its ZeroMQ `connect()` calls. The parent waits for all eight files with a bounded
+  deadline and fails early if a peer exits. This removes Python import and socket-setup
+  variability without changing the Rogue-TCP wire protocol.
+- **Fixed settle delay after readiness:** `SETTLE_EDGES_C = 2000` (~20 us). ZeroMQ
+  connection establishment is asynchronous, so all three families still hold off
+  outbound traffic after the model binds. The ready file means the peer is prepared to
+  connect and drain, not that the protocol connection is already complete.
 - **Watchdog:** `WAIT_EDGES_C = 1_000_000` (~1e6 edges). Because a free-running xsim is
   not paced to wall-clock until a peer connects and the DPI round-trips gate it, the
   watchdog bounds a worst-case hang at roughly 10 s wall-clock — comfortably under the
@@ -87,23 +97,25 @@ printed success banner plus each peer's JSON (own tag family present, zero forei
 - `test_RogueXsimTraffic.py::test_xsim_instances_exchange_isolated_traffic` and both
   `test_RogueXsimMulti.py` cases pass. No failures, no flakes observed.
 
+These Vivado results cover the original live-traffic implementation at pull request
+head `c505a2e08`. After the pull request 1450 API reconciliation and ready-barrier
+addition, the focused peer/native tests pass locally, as do Python lint, VSG, and diff
+checks. A final Vivado run is required because the Stream vector shape and xsim startup
+orchestration changed.
+
 ## Lint results
 
 - **flake8** (7.3.0) on the 5 Python sources: clean (rc=0).
 - **git diff --check:** clean.
-- **VSG** (3.35.0) on `RogueXsimTrafficTb.vhd`: 60 style deviations, all in the same
-  categories the sibling `RogueXsimMultiTb.vhd` also reports (86 there): `signal_007` /
-  `variable_007` (default assignments), `instantiation_034/036` (direct-entity vs
-  component instantiation), `if_002` (parenthesized conditions), `port_map_004`,
-  `assert_005` / `report_statement_002` (severity-keyword placement). These are
-  established testbench conventions in this directory; **not** changed, to avoid risking
-  the working TB. No trivial-safe divergence from the sibling was found to fix.
+- **VSG** (3.35.0) on `RogueXsimTrafficTb.vhd`: clean. The prior `type_006`,
+  declaration-alignment, and PascalCase violations were corrected without changing test
+  behavior.
 
 ## Open risks / notes for reviewer
 
-- **Fixed-timing tradeoff (Option B):** `SETTLE_EDGES_C` is a fixed edge count rather than
-  a handshake on peer readiness; adequate here but a topology/latency change could require
-  retuning.
+- **Readiness boundary:** the ready-file barrier removes Python import/socket-setup races,
+  but cannot prove an asynchronous ZeroMQ connection is complete. `SETTLE_EDGES_C` remains
+  a fixed margin after model bind and may need retuning if topology or latency changes.
 - **Watchdog is a wall-clock heuristic:** `WAIT_EDGES_C` maps to ~10 s worst case only
   under current sim pacing; treat as a hang guard, not a precise bound.
 - **obValid observation race (already fixed):** an earlier single-cycle `obValid`

--- a/docs/plans/xsim-multi-instance-live-traffic/progress.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/progress.md
@@ -77,7 +77,7 @@ printed success banner plus each peer's JSON (own tag family present, zero forei
   **19 passed, 1 skipped** in ~20 s.
 - The single skip is `test_RogueTcpMemoryWrap.py::test_RogueTcpMemory_uninitialized_read`,
   which skips because `valgrind` is not installed on this host (expected).
-- `test_RogueXsimTraffic.py::test_xsim_stream_instances_exchange_isolated_traffic` and both
+- `test_RogueXsimTraffic.py::test_xsim_instances_exchange_isolated_traffic` and both
   `test_RogueXsimMulti.py` cases pass. No failures, no flakes observed.
 
 ## Lint results

--- a/docs/plans/xsim-multi-instance-live-traffic/progress.md
+++ b/docs/plans/xsim-multi-instance-live-traffic/progress.md
@@ -1,0 +1,108 @@
+# xsim Multi-Instance Live-Traffic Test — Progress / Handoff
+
+**Goal:** Prove that 8 DPI-C rogue-cosim instances (4 Stream + 2 Memory + 2 SideBand)
+each exchange isolated, per-instance-tagged ZeroMQ traffic through the real Vivado
+xsim DPI boundary.
+
+**Final status:** Complete. Full simlink regression passes serial and parallel; the
+new live-traffic test and the refactored multi-instance test both pass.
+
+## Files added / changed
+
+- `tests/axi/simlink/rogue_tcp_peer.py` — added per-tag send/expect helpers and a
+  `--tag` CLI arg so each spawned peer produces/checks only its own tagged family;
+  raised `RCVTIMEO_MS` 10000 → 30000.
+- `tests/axi/simlink/test_rogue_tcp_peer_tags.py` — new pure-Python unit tests for the
+  tag scheme (no Vivado): payload/txn/vector construction, distinct-tag non-collision,
+  foreign-tag detection, and `--tag` argparse.
+- `tests/axi/simlink/xsim_test_utils.py` — new shared helpers: tool discovery/skip, the
+  system-libstdc++ `LD_PRELOAD` workaround, the `RogueTcpDpi.so` build fixture, and the
+  `run_top` split into `compile_and_elaborate` + `run_elaborated`.
+- `tests/axi/simlink/test_RogueXsimMulti.py` — refactored to consume `xsim_test_utils`
+  (behaviour unchanged).
+- `tests/axi/simlink/RogueXsimTrafficTb.vhd` — new 8-instance live-traffic testbench.
+- `tests/axi/simlink/test_RogueXsimTraffic.py` — new orchestration test: spawns one peer
+  per instance, elaborates + runs xsim, asserts the success banner and per-peer JSON
+  isolation.
+- `docs/plans/xsim-multi-instance-live-traffic/design.md`, `plan.md` — design + plan
+  (pre-existing in this work).
+
+## 8-instance topology + tag scheme
+
+Port base 19740, each instance `i` gets a `(19740 + 2*i, +1)` pair:
+
+- **Stream** i (0..3): ports 19740..19747. Inbound beat tagged `0x80+i`; TB checks the
+  outbound byte equals the peer's `0x10+i`.
+- **Memory** i (0..1): ports 19748..19751. Observed a/awaddr == `0x100 + 0x10*i`;
+  wdata == this instance's tagged vector (data bytes in the `0x40..0x70` family).
+- **SideBand** i (0..1): ports 19752..19755. TX opcode `0x60+i` then remData `0x70+i`;
+  RX opcode `0x20+i` and remData `0x40+i`. TB asserts received tags match.
+
+## Isolation approach
+
+Two-sided for all three families: (1) positive check that each instance sees exactly its
+own tag, and (2) explicit foreign-tag rejection — a peer or TB seeing any tag outside its
+own family fails. `$fatal` exits 0 under `xsim -R`, so the pytest layer keys off the
+printed success banner plus each peer's JSON (own tag family present, zero foreign tags).
+
+## Environment requirements
+
+- **Vivado version used:** 2024.1
+  (`source /sdf/group/faders/tools/xilinx/2024.1/Vivado/2024.1/settings64.sh`).
+- **System libstdc++ auto-preload:** the harness (`xsim_test_utils._preload_env`) locates
+  the system libstdc++ via `gcc -print-file-name=libstdc++.so.6` and prepends it to
+  `LD_PRELOAD`. Every bundled Vivado libstdc++ is older than the host libzmq's required
+  `GLIBCXX_*`, so without the preload `xsimk` fails to load `libzmq.so.5`. Harmless when
+  Vivado's bundled libstdc++ is already new enough.
+
+## Timing / ordering design
+
+- **Peer-spawn-after-elaboration ordering:** the test elaborates first
+  (`compile_and_elaborate`), then spawns the peers immediately before `run_elaborated`.
+  This is the real connectedness guarantee — the peers' RCVTIMEO budget must cover only
+  the short simulation run, not the multi-second xvlog/xvhdl/xelab flow (during which an
+  early-spawned peer would time out waiting).
+- **Option B fixed settle delay (defense-in-depth):** `SETTLE_EDGES_C = 2000`
+  (~20 us). All three families hold off outbound traffic until this fixed edge count,
+  giving peers time to connect and drain before real traffic starts.
+- **Watchdog:** `WAIT_EDGES_C = 1_000_000` (~1e6 edges). Because a free-running xsim is
+  not paced to wall-clock until a peer connects and the DPI round-trips gate it, the
+  watchdog bounds a worst-case hang at roughly 10 s wall-clock — comfortably under the
+  120 s pytest timeout. Each per-instance wait loop asserts `waited < WAIT_EDGES_C`.
+
+## Regression results (Task 8, 2026-07-17, Vivado 2024.1)
+
+- **Serial** (`pytest -q -n 0 tests/axi/simlink`): **19 passed, 1 skipped** in ~40 s.
+- **Parallel** (`pytest -q -n auto --dist=worksteal tests/axi/simlink`):
+  **19 passed, 1 skipped** in ~20 s.
+- The single skip is `test_RogueTcpMemoryWrap.py::test_RogueTcpMemory_uninitialized_read`,
+  which skips because `valgrind` is not installed on this host (expected).
+- `test_RogueXsimTraffic.py::test_xsim_stream_instances_exchange_isolated_traffic` and both
+  `test_RogueXsimMulti.py` cases pass. No failures, no flakes observed.
+
+## Lint results
+
+- **flake8** (7.3.0) on the 5 Python sources: clean (rc=0).
+- **git diff --check:** clean.
+- **VSG** (3.35.0) on `RogueXsimTrafficTb.vhd`: 60 style deviations, all in the same
+  categories the sibling `RogueXsimMultiTb.vhd` also reports (86 there): `signal_007` /
+  `variable_007` (default assignments), `instantiation_034/036` (direct-entity vs
+  component instantiation), `if_002` (parenthesized conditions), `port_map_004`,
+  `assert_005` / `report_statement_002` (severity-keyword placement). These are
+  established testbench conventions in this directory; **not** changed, to avoid risking
+  the working TB. No trivial-safe divergence from the sibling was found to fix.
+
+## Open risks / notes for reviewer
+
+- **Fixed-timing tradeoff (Option B):** `SETTLE_EDGES_C` is a fixed edge count rather than
+  a handshake on peer readiness; adequate here but a topology/latency change could require
+  retuning.
+- **Watchdog is a wall-clock heuristic:** `WAIT_EDGES_C` maps to ~10 s worst case only
+  under current sim pacing; treat as a hang guard, not a precise bound.
+- **obValid observation race (already fixed):** an earlier single-cycle `obValid`
+  observation race is handled by sampling every clock edge rather than at a single point.
+- **RCVTIMEO raised to 30 s:** affects all peer-using tests. It only loosens the timeout
+  bound (30 s vs 10 s), so it cannot cause false passes; worst case is a slower failure
+  when a peer genuinely never connects.
+- Simulator artifacts (`sim_build_*`, `xsim.dir`, `*.pb`, `*.jou`) are intentionally kept
+  out of git; only summarized here.

--- a/tests/axi/simlink/RogueXsimMultiTb.vhd
+++ b/tests/axi/simlink/RogueXsimMultiTb.vhd
@@ -1,0 +1,189 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Multi-instance Vivado xsim DPI-C test harness
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+-- Test methodology:
+-- - Instantiate four Stream and two each Memory and SideBand xsim/DPI models.
+-- - Release reset with a unique endpoint pair per model, pulse reset again,
+--   and run bounded clocks.
+-- - A second top deliberately gives two Stream instances the same endpoint.
+-- This proves per-leaf chandle creation, mixed-language DPI binding, distinct
+-- socket ownership, normal final cleanup, and duplicate-port failure.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library std;
+use std.env.all;
+
+entity RogueXsimMultiTb is
+end entity RogueXsimMultiTb;
+
+architecture test of RogueXsimMultiTb is
+
+   signal clock : std_logic := '0';
+   signal reset : std_logic := '1';
+
+begin
+
+   clock <= not clock after 5 ns;
+
+   GEN_STREAM : for i in 0 to 3 generate
+      U_STREAM : entity work.RogueTcpStream
+         port map (
+            clock      => clock,  -- [in]
+            reset      => reset,  -- [in]
+            portNum    => std_logic_vector(to_unsigned(19700+(2*i), 16)),  -- [in]
+            ssi        => '0',  -- [in]
+            obValid    => open,  -- [out]
+            obReady    => '1',  -- [in]
+            obDataLow  => open,  -- [out]
+            obDataHigh => open,  -- [out]
+            obUserLow  => open,  -- [out]
+            obUserHigh => open,  -- [out]
+            obKeep     => open,  -- [out]
+            obLast     => open,  -- [out]
+            ibValid    => '0',  -- [in]
+            ibReady    => open,  -- [out]
+            ibDataLow  => (others => '0'),  -- [in]
+            ibDataHigh => (others => '0'),  -- [in]
+            ibUserLow  => (others => '0'),  -- [in]
+            ibUserHigh => (others => '0'),  -- [in]
+            ibKeep     => (others => '0'),  -- [in]
+            ibLast     => '0');  -- [in]
+   end generate GEN_STREAM;
+
+   GEN_MEMORY : for i in 0 to 1 generate
+      U_MEMORY : entity work.RogueTcpMemory
+         port map (
+            clock   => clock,  -- [in]
+            reset   => reset,  -- [in]
+            portNum => std_logic_vector(to_unsigned(19708+(2*i), 16)),  -- [in]
+            araddr  => open,  -- [out]
+            arprot  => open,  -- [out]
+            arvalid => open,  -- [out]
+            rready  => open,  -- [out]
+            arready => '0',  -- [in]
+            rdata   => (others => '0'),  -- [in]
+            rresp   => (others => '0'),  -- [in]
+            rvalid  => '0',  -- [in]
+            awaddr  => open,  -- [out]
+            awprot  => open,  -- [out]
+            awvalid => open,  -- [out]
+            wdata   => open,  -- [out]
+            wstrb   => open,  -- [out]
+            wvalid  => open,  -- [out]
+            bready  => open,  -- [out]
+            awready => '0',  -- [in]
+            wready  => '0',  -- [in]
+            bresp   => (others => '0'),  -- [in]
+            bvalid  => '0');  -- [in]
+   end generate GEN_MEMORY;
+
+   GEN_SIDEBAND : for i in 0 to 1 generate
+      U_SIDEBAND : entity work.RogueSideBand
+         port map (
+            clock      => clock,  -- [in]
+            reset      => reset,  -- [in]
+            portNum    => std_logic_vector(to_unsigned(19712+(2*i), 16)),  -- [in]
+            txOpCode   => (others => '0'),  -- [in]
+            txOpCodeEn => '0',  -- [in]
+            txRemData  => (others => '0'),  -- [in]
+            rxOpCode   => open,  -- [out]
+            rxOpCodeEn => open,  -- [out]
+            rxRemData  => open);  -- [out]
+   end generate GEN_SIDEBAND;
+
+   test : process is
+   begin
+      for i in 0 to 2 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '0';
+      for i in 0 to 50 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '1';
+      for i in 0 to 2 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '0';
+      for i in 0 to 10 loop
+         wait until rising_edge(clock);
+      end loop;
+      report "Rogue xsim multi-instance smoke test passed" severity note;
+      stop;
+      wait;
+   end process test;
+
+end architecture test;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library std;
+use std.env.all;
+
+entity RogueXsimDuplicatePortTb is
+end entity RogueXsimDuplicatePortTb;
+
+architecture test of RogueXsimDuplicatePortTb is
+
+   signal clock : std_logic := '0';
+   signal reset : std_logic := '1';
+
+begin
+
+   clock <= not clock after 5 ns;
+
+   GEN_STREAM : for i in 0 to 1 generate
+      U_STREAM : entity work.RogueTcpStream
+         port map (
+            clock      => clock,  -- [in]
+            reset      => reset,  -- [in]
+            portNum    => std_logic_vector(to_unsigned(19720, 16)),  -- [in]
+            ssi        => '0',  -- [in]
+            obValid    => open,  -- [out]
+            obReady    => '1',  -- [in]
+            obDataLow  => open,  -- [out]
+            obDataHigh => open,  -- [out]
+            obUserLow  => open,  -- [out]
+            obUserHigh => open,  -- [out]
+            obKeep     => open,  -- [out]
+            obLast     => open,  -- [out]
+            ibValid    => '0',  -- [in]
+            ibReady    => open,  -- [out]
+            ibDataLow  => (others => '0'),  -- [in]
+            ibDataHigh => (others => '0'),  -- [in]
+            ibUserLow  => (others => '0'),  -- [in]
+            ibUserHigh => (others => '0'),  -- [in]
+            ibKeep     => (others => '0'),  -- [in]
+            ibLast     => '0');  -- [in]
+   end generate GEN_STREAM;
+
+   test : process is
+   begin
+      for i in 0 to 2 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '0';
+      for i in 0 to 10 loop
+         wait until rising_edge(clock);
+      end loop;
+      assert false report "Duplicate xsim port pair was not rejected" severity failure;
+      wait;
+   end process test;
+
+end architecture test;

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -12,9 +12,9 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 -- Test methodology:
--- - Instantiate four Stream and two Memory (and later two SideBand) xsim/DPI
---   models, each on its own endpoint pair, and exchange a per-instance tagged
---   traffic family with a dedicated external peer.
+-- - Instantiate the full eight-instance topology -- four Stream, two Memory and
+--   two SideBand xsim/DPI models -- each on its own endpoint pair, and exchange
+--   a per-instance tagged traffic family with a dedicated external peer.
 -- - Hold off all outbound traffic for a fixed settle delay after reset so the
 --   peers are connected and draining first (accepted transport contract; no
 --   readiness handshake).
@@ -24,7 +24,12 @@
 --   write-then-read transaction); the TB acts as a tiny per-instance AXI-Lite
 --   SLAVE that completes the write handshake, then returns this instance's
 --   tagged data on the read. The observed awaddr/araddr is asserted equal to
---   0x100+0x10*i so cross-instance address leakage is caught.
+--   0x100+0x10*i and the observed wdata equals this instance's tagged vector,
+--   so cross-instance address/data leakage is caught.
+-- - Each SideBand instance transmits its tagged opcode 0x60+i then remData
+--   0x70+i outbound to its peer, and receives its peer's inbound opcode 0x20+i
+--   and remData 0x40+i; the TB asserts the received tags match so a foreign
+--   instance's opcode/remData is caught.
 -- - Report the success banner only after all instances pass; $fatal on any
 --   wrong/missing tag or wrong address. $fatal exits 0 under xsim -R, so pytest
 --   judges success by the banner plus per-peer exit codes/JSON, not the xsim
@@ -32,8 +37,9 @@
 --
 -- Endpoint port map (single source of truth is shared with
 -- test_RogueXsimTraffic.py -- keep both in sync):
---   Stream i -> 19740 + 2*i  (19740..19747)
---   Memory i -> 19748 + 2*i  (19748..19751)
+--   Stream   i -> 19740 + 2*i  (19740..19747)
+--   Memory   i -> 19748 + 2*i  (19748..19751)
+--   SideBand i -> 19752 + 2*i  (19752..19755)
 -------------------------------------------------------------------------------
 
 library ieee;
@@ -50,17 +56,17 @@ architecture test of RogueXsimTrafficTb is
 
    constant CLK_HALF_C     : time    := 5 ns;
    constant SETTLE_EDGES_C : natural := 2000;   -- tuned later; generous margin
-   -- Bounded busy-poll watchdog. This is deliberately large: the Memory model
-   -- receives its peer's request via a non-blocking ZMQ poll and the Memory
-   -- responder busy-polls the master valids every edge, so nothing paces the
-   -- (otherwise free-running) simulation to wall-clock while a peer process is
-   -- still starting up and connecting. A tight watchdog can therefore burn out
-   -- before a slow-to-start peer delivers its first request. The value spans
-   -- several seconds of wall-clock busy-poll -- comfortably covering peer
-   -- startup jitter -- while still bounding a genuine hang well under the
-   -- pytest run timeout. The Stream path exits this loop as soon as its traffic
-   -- is exchanged, so the larger bound only affects the wait, never the happy
-   -- path.
+   -- Bounded busy-poll watchdog, shared across the Stream, Memory and SideBand
+   -- families. This is deliberately large: the models receive their peer's
+   -- request via a non-blocking ZMQ poll and the TB busy-polls the model I/O
+   -- every edge, so nothing paces the (otherwise free-running) simulation to
+   -- wall-clock while a peer process is still starting up and connecting. A
+   -- tight watchdog can therefore burn out before a slow-to-start peer delivers
+   -- its first request. At this bound the worst-case genuine hang runs ~10 s of
+   -- wall-clock busy-poll before tripping -- comfortably covering peer startup
+   -- jitter, and still well under the 120 s pytest run timeout. Each family
+   -- exits this loop as soon as its traffic is exchanged, so the larger bound
+   -- only affects the wait, never the happy path.
    constant WAIT_EDGES_C   : natural := 1000000;
 
    -- Number of single-beat inbound frames each Stream instance drives, and the
@@ -68,6 +74,11 @@ architecture test of RogueXsimTrafficTb is
    -- STREAM_TAG_FRAME_COUNT in rogue_tcp_peer.py.
    constant STREAM_FRAMES_C : natural := 3;
    constant IB_GAP_EDGES_C  : natural := 5;
+
+   -- Edges to keep the SideBand tx* values driven after the remData change, so
+   -- the model's synchronous ZMQ send of the outbound remData frame is issued
+   -- (and the peer can drain it) before the banner can stop the sim.
+   constant SB_SEND_GUARD_C : natural := 8;
 
    signal clock : std_logic := '0';
    signal reset : std_logic := '1';
@@ -104,6 +115,17 @@ architecture test of RogueXsimTrafficTb is
    signal mBValid  : std_logic_vector(1 downto 0) := (others => '0');
 
    signal memDone : std_logic_vector(1 downto 0) := "00";
+
+   -- SideBand instances: the DUT (TB) drives tx* to transmit outbound to its
+   -- peer and observes rx* for the peer's inbound opcode/remData.
+   signal sbTxOpCode   : slv8_array(1 downto 0)      := (others => (others => '0'));
+   signal sbTxOpCodeEn : std_logic_vector(1 downto 0) := (others => '0');
+   signal sbTxRemData  : slv8_array(1 downto 0)      := (others => (others => '0'));
+   signal sbRxOpCode   : slv8_array(1 downto 0);
+   signal sbRxOpCodeEn : std_logic_vector(1 downto 0);
+   signal sbRxRemData  : slv8_array(1 downto 0);
+
+   signal sbDone : std_logic_vector(1 downto 0) := "00";
 
 begin
 
@@ -283,6 +305,12 @@ begin
          assert mAwAddr(i) = expAddr
             report "Memory " & integer'image(i) & ": wrong write address"
             severity failure;
+         -- The peer writes the same tagged vector it later expects to read
+         -- back (rdataTag); checking it here covers write-data isolation --
+         -- a foreign instance's payload would differ.
+         assert mWData(i) = rdataTag
+            report "Memory " & integer'image(i) & ": wrong write data"
+            severity failure;
 
          -- Accept address+data and complete the response in one step: the FSM's
          -- ST_WRESP samples awready, wready and bvalid together, drops awvalid/
@@ -332,13 +360,119 @@ begin
       end process rsp;
    end generate GEN_MEMORY_RSP;
 
+   GEN_SIDEBAND : for i in 0 to 1 generate
+      U_SIDEBAND : entity work.RogueSideBand
+         port map (
+            clock      => clock,
+            reset      => reset,
+            portNum    => std_logic_vector(to_unsigned(19752 + (2*i), 16)),
+            txOpCode   => sbTxOpCode(i),
+            txOpCodeEn => sbTxOpCodeEn(i),
+            txRemData  => sbTxRemData(i),
+            rxOpCode   => sbRxOpCode(i),
+            rxOpCodeEn => sbRxOpCodeEn(i),
+            rxRemData  => sbRxRemData(i));
+   end generate GEN_SIDEBAND;
+
+   GEN_SIDEBAND_DRV : for i in 0 to 1 generate
+      -- One process per instance handles both directions concurrently. The
+      -- peer pushes its inbound opcode/remData frames at startup, and the model
+      -- pulses rxOpCodeEn for a SINGLE clock the edge it drains the opcode (rx
+      -- opcode/remData then latch), so -- like the Stream outbound path -- rx*
+      -- must be sampled on EVERY edge from reset deassert; a checker that only
+      -- looked after the settle could miss the pulse. Outbound tx is held off
+      -- until the same SETTLE_EDGES_C the other families use, so the peer is
+      -- connected and draining before the model issues its synchronous sends:
+      -- txOpCodeEn is strobed high for one clock (model sends opcode 0x60+i),
+      -- then after a short gap txRemData is changed to 0x70+i (model forwards
+      -- the remData, carrying the opcode along). sbDone(i) is asserted only
+      -- once BOTH the inbound opcode+remData have been observed AND the
+      -- outbound frames have been driven and held past the send guard.
+      drv : process is
+         variable txOp    : std_logic_vector(7 downto 0);
+         variable txRem   : std_logic_vector(7 downto 0);
+         variable expOp   : std_logic_vector(7 downto 0);
+         variable expRem  : std_logic_vector(7 downto 0);
+         variable rxOpCap : std_logic_vector(7 downto 0) := (others => '0');
+         variable rxRemCap : std_logic_vector(7 downto 0) := (others => '0');
+         variable gotOp   : std_logic := '0';
+         variable gotRem  : std_logic := '0';
+         variable txDone  : boolean   := false;
+         variable waited  : natural   := 0;
+         variable phase   : natural   := 0;  -- edges elapsed during settle
+         variable step    : natural   := 0;  -- sub-step within the tx sequence
+      begin
+         wait until reset = '0';
+         txOp   := std_logic_vector(to_unsigned((16#60# + i), 8));
+         txRem  := std_logic_vector(to_unsigned((16#70# + i), 8));
+         expOp  := std_logic_vector(to_unsigned((16#20# + i), 8));
+         expRem := std_logic_vector(to_unsigned((16#40# + i), 8));
+
+         loop
+            wait until rising_edge(clock);
+            waited := waited + 1;
+
+            -- Inbound: capture the one-clock rxOpCodeEn pulse and the first
+            -- nonzero rxRemData (reset clears rxRemData to 0x00).
+            if gotOp = '0' and sbRxOpCodeEn(i) = '1' then
+               rxOpCap := sbRxOpCode(i);
+               gotOp   := '1';
+            end if;
+            if gotRem = '0' and sbRxRemData(i) /= x"00" then
+               rxRemCap := sbRxRemData(i);
+               gotRem   := '1';
+            end if;
+
+            -- Outbound: after the settle, strobe the opcode for one clock,
+            -- gap, then change remData; hold both past the send guard.
+            if phase < SETTLE_EDGES_C then
+               phase := phase + 1;
+            elsif not txDone then
+               if step = 0 then
+                  sbTxOpCode(i)   <= txOp;
+                  sbTxOpCodeEn(i) <= '1';
+                  step            := 1;
+               elsif step = 1 then
+                  sbTxOpCodeEn(i) <= '0';
+                  step            := 2;
+               elsif step < IB_GAP_EDGES_C then
+                  step := step + 1;
+               elsif step = IB_GAP_EDGES_C then
+                  sbTxRemData(i) <= txRem;
+                  step           := step + 1;
+               elsif step < IB_GAP_EDGES_C + SB_SEND_GUARD_C then
+                  step := step + 1;
+               else
+                  txDone := true;
+               end if;
+            end if;
+
+            exit when (gotOp = '1') and (gotRem = '1') and txDone;
+
+            assert waited < WAIT_EDGES_C
+               report "SideBand " & integer'image(i) & ": timed out exchanging traffic"
+               severity failure;
+         end loop;
+
+         assert rxOpCap = expOp
+            report "SideBand " & integer'image(i) & ": wrong inbound opcode"
+            severity failure;
+         assert rxRemCap = expRem
+            report "SideBand " & integer'image(i) & ": wrong inbound remData"
+            severity failure;
+
+         sbDone(i) <= '1';
+         wait;
+      end process drv;
+   end generate GEN_SIDEBAND_DRV;
+
    banner : process is
    begin
       for e in 0 to 2 loop
          wait until rising_edge(clock);
       end loop;
       reset <= '0';
-      wait until (streamDone = "1111") and (memDone = "11");
+      wait until (streamDone = "1111") and (memDone = "11") and (sbDone = "11");
       report "Rogue xsim traffic test passed" severity note;
       stop;
       wait;

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -1,0 +1,169 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Multi-instance Vivado xsim DPI-C live-traffic test harness
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+-- Test methodology:
+-- - Instantiate four Stream (and later two Memory, two SideBand) xsim/DPI
+--   models, each on its own endpoint pair, and exchange a per-instance tagged
+--   traffic family with a dedicated external peer.
+-- - Hold off all outbound traffic for a fixed settle delay after reset so the
+--   peers are connected and draining first (accepted transport contract; no
+--   readiness handshake).
+-- - Each Stream instance drives inbound beats tagged 0x80+i and checks the
+--   outbound byte equals its peer's 0x10+i.
+-- - Report the success banner only after all instances pass; $fatal on any
+--   wrong/missing tag. $fatal exits 0 under xsim -R, so pytest judges success
+--   by the banner plus per-peer exit codes/JSON, not the xsim return code.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library std;
+use std.env.all;
+
+entity RogueXsimTrafficTb is
+end entity RogueXsimTrafficTb;
+
+architecture test of RogueXsimTrafficTb is
+
+   constant CLK_HALF_C     : time    := 5 ns;
+   constant SETTLE_EDGES_C : natural := 2000;   -- tuned later; generous margin
+   constant WAIT_EDGES_C   : natural := 20000;  -- bounded per-item inbound wait
+
+   signal clock : std_logic := '0';
+   signal reset : std_logic := '1';
+
+   type slv32_array is array (natural range <>) of std_logic_vector(31 downto 0);
+   type slv8_array  is array (natural range <>) of std_logic_vector(7 downto 0);
+
+   signal sObValid : std_logic_vector(3 downto 0);
+   signal sObData  : slv32_array(3 downto 0);
+   signal sIbValid : std_logic_vector(3 downto 0) := (others => '0');
+   signal sIbData  : slv32_array(3 downto 0)      := (others => (others => '0'));
+   signal sIbKeep  : slv8_array(3 downto 0)       := (others => (others => '0'));
+   signal sIbLast  : std_logic_vector(3 downto 0) := (others => '0');
+
+   signal streamDone : std_logic_vector(3 downto 0) := (others => '0');
+
+begin
+
+   clock <= not clock after CLK_HALF_C;
+
+   GEN_STREAM : for i in 0 to 3 generate
+      U_STREAM : entity work.RogueTcpStream
+         port map (
+            clock      => clock,
+            reset      => reset,
+            portNum    => std_logic_vector(to_unsigned(19740 + (2*i), 16)),
+            ssi        => '0',
+            obValid    => sObValid(i),
+            obReady    => '1',
+            obDataLow  => sObData(i),
+            obDataHigh => open,
+            obUserLow  => open,
+            obUserHigh => open,
+            obKeep     => open,
+            obLast     => open,
+            ibValid    => sIbValid(i),
+            ibReady    => open,
+            ibDataLow  => sIbData(i),
+            ibDataHigh => (others => '0'),
+            ibUserLow  => (others => '0'),
+            ibUserHigh => (others => '0'),
+            ibKeep     => sIbKeep(i),
+            ibLast     => sIbLast(i));
+   end generate GEN_STREAM;
+
+   GEN_STREAM_DRV : for i in 0 to 3 generate
+      -- One process per instance handles both directions concurrently: it
+      -- counts outbound (ob) frames on EVERY edge from reset deassert, and
+      -- after a fixed settle drives three inbound (ib) frames. Outbound must
+      -- be watched continuously because obReady is hardwired '1', so the
+      -- model presents each peer-pushed frame for a single edge as soon as it
+      -- arrives (well before the inbound-drive phase); a counter that only
+      -- looked after the settle would miss those early frames. streamDone is
+      -- asserted only once BOTH the three inbound frames have been driven and
+      -- three outbound frames have been counted, so the banner cannot stop
+      -- the sim before every peer has exchanged its full tagged family.
+      drv : process is
+         variable expByte : std_logic_vector(7 downto 0);
+         variable tagByte : std_logic_vector(7 downto 0);
+         variable rxCount : natural := 0;
+         variable waited  : natural := 0;
+         variable phase   : natural := 0;  -- edges elapsed during settle
+         variable frame   : natural := 0;  -- inbound frames driven so far
+         variable step    : natural := 0;  -- sub-step within one inbound frame
+      begin
+         wait until reset = '0';
+         tagByte := std_logic_vector(to_unsigned((16#80# + i), 8));
+         expByte := std_logic_vector(to_unsigned((16#10# + i), 8));
+
+         loop
+            wait until rising_edge(clock);
+            waited := waited + 1;
+
+            -- Outbound: count each single-beat frame the model presents.
+            if sObValid(i) = '1' then
+               assert sObData(i)(7 downto 0) = expByte
+                  report "Stream " & integer'image(i) & ": wrong outbound tag" severity failure;
+               rxCount := rxCount + 1;
+            end if;
+
+            -- Inbound: after the settle, push three frames, one every few
+            -- edges, deasserting valid the edge after each single beat.
+            if phase < SETTLE_EDGES_C then
+               phase := phase + 1;
+            elsif frame < 3 then
+               if step = 0 then
+                  sIbData(i)  <= tagByte & tagByte & tagByte & tagByte;
+                  sIbKeep(i)  <= x"0F";
+                  sIbLast(i)  <= '1';
+                  sIbValid(i) <= '1';
+                  step        := 1;
+               elsif step = 1 then
+                  sIbValid(i) <= '0';
+                  sIbLast(i)  <= '0';
+                  step        := 2;
+               elsif step < 5 then
+                  step := step + 1;
+               else
+                  step  := 0;
+                  frame := frame + 1;
+               end if;
+            end if;
+
+            exit when (frame = 3) and (rxCount >= 3);
+
+            assert waited < WAIT_EDGES_C
+               report "Stream " & integer'image(i) & ": timed out exchanging traffic" severity failure;
+         end loop;
+
+         streamDone(i) <= '1';
+         wait;
+      end process drv;
+   end generate GEN_STREAM_DRV;
+
+   banner : process is
+   begin
+      for e in 0 to 2 loop
+         wait until rising_edge(clock);
+      end loop;
+      reset <= '0';
+      wait until streamDone = "1111";
+      report "Rogue xsim traffic test passed" severity note;
+      stop;
+      wait;
+   end process banner;
+
+end architecture test;

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -21,11 +21,15 @@
 -- - Each Stream instance drives inbound beats tagged 0x80+i and checks the
 --   outbound byte equals its peer's 0x10+i.
 -- - Each Memory instance is an AXI-Lite MASTER (driven by its peer's
---   write-then-read transaction); the TB acts as a tiny per-instance AXI-Lite
---   SLAVE that completes the write handshake, then returns this instance's
---   tagged data on the read. The observed awaddr/araddr is asserted equal to
---   0x100+0x10*i and the observed wdata equals this instance's tagged vector,
---   so cross-instance address/data leakage is caught.
+--   write-then-read transaction); the TB wires it to its OWN instance of
+--   surf.AxiDualPortRam acting as a real AXI-Lite SLAVE (a block RAM). The
+--   peer writes this instance's tagged vector to 0x100+0x10*i, then reads it
+--   back -- a real RAM returns exactly what was written, so the peer's own
+--   read-back equality check still proves isolation, and because each instance
+--   owns a distinct RAM, cross-instance leakage is impossible by construction.
+--   A lightweight per-instance concurrent assertion additionally checks the
+--   observed awaddr/araddr equals 0x100+0x10*i so a wrong-address regression
+--   still $fatals inside the TB.
 -- - Each SideBand instance transmits its tagged opcode 0x60+i then remData
 --   0x70+i outbound to its peer, and receives its peer's inbound opcode 0x20+i
 --   and remData 0x40+i; the TB asserts the received tags match so a foreign
@@ -48,6 +52,10 @@ use ieee.numeric_std.all;
 
 library std;
 use std.env.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
 
 entity RogueXsimTrafficTb is
 end entity RogueXsimTrafficTb;
@@ -111,24 +119,19 @@ architecture test of RogueXsimTrafficTb is
 
    signal streamDone : std_logic_vector(3 downto 0) := (others => '0');
 
-   -- Memory instances: the DUT drives the AXI-Lite master ports (m*), the TB
-   -- responds as a slave (arready/rdata/rresp/rvalid, awready/wready/bresp/
-   -- bvalid) via per-instance responder processes.
-   signal mArAddr  : slv32_array(1 downto 0);
-   signal mArValid : std_logic_vector(1 downto 0);
-   signal mRReady  : std_logic_vector(1 downto 0);
-   signal mArReady : std_logic_vector(1 downto 0) := (others => '0');
-   signal mRData   : slv32_array(1 downto 0)      := (others => (others => '0'));
-   signal mRValid  : std_logic_vector(1 downto 0) := (others => '0');
+   -- Memory instances: each Memory model is an AXI-Lite MASTER whose raw scalar
+   -- master/slave ports are wired directly to the record-typed AXI-Lite buses of
+   -- its OWN surf.AxiDualPortRam slave (a real block RAM). Record-typed buses per
+   -- instance -- the model drives the *Master fields, the RAM drives the *Slave
+   -- fields, and both the RAM and the TB assertion observe the same records.
+   signal memReadMaster  : AxiLiteReadMasterArray(1 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal memReadSlave   : AxiLiteReadSlaveArray(1 downto 0);
+   signal memWriteMaster : AxiLiteWriteMasterArray(1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal memWriteSlave  : AxiLiteWriteSlaveArray(1 downto 0);
 
-   signal mAwAddr  : slv32_array(1 downto 0);
-   signal mAwValid : std_logic_vector(1 downto 0);
-   signal mWData   : slv32_array(1 downto 0);
-   signal mWValid  : std_logic_vector(1 downto 0);
-   signal mBReady  : std_logic_vector(1 downto 0);
-   signal mAwReady : std_logic_vector(1 downto 0) := (others => '0');
-   signal mWReady  : std_logic_vector(1 downto 0) := (others => '0');
-   signal mBValid  : std_logic_vector(1 downto 0) := (others => '0');
+   -- RAM address width in WORDS (1024 words); the peer's byte addresses
+   -- 0x100+0x10*i are word-aligned and fit comfortably.
+   constant MEM_ADDR_WIDTH_C : positive := 10;
 
    signal memDone : std_logic_vector(1 downto 0) := "00";
 
@@ -242,139 +245,113 @@ begin
    end generate GEN_STREAM_DRV;
 
    GEN_MEMORY : for i in 0 to 1 generate
+      -- Expected AXI byte address the peer transacts against for this instance;
+      -- a foreign instance's address would differ (in-DUT cross-talk check).
+      constant EXP_ADDR_C : std_logic_vector(31 downto 0) :=
+         std_logic_vector(to_unsigned(16#100# + (16#10# * i), 32));
+   begin
+
+      -- The Memory model is the AXI-Lite MASTER: its raw scalar ports are
+      -- glued directly to this instance's record-typed AXI-Lite bus. The model
+      -- drives the *Master fields; the RAM below drives the *Slave fields.
       U_MEMORY : entity work.RogueTcpMemory
          port map (
             clock   => clock,
             reset   => reset,
             portNum => std_logic_vector(to_unsigned(19748 + (2*i), 16)),
-            -- axiReadMaster (DUT drives)
-            araddr  => mArAddr(i),
-            arprot  => open,
-            arvalid => mArValid(i),
-            rready  => mRReady(i),
-            -- axiReadSlave (TB drives)
-            arready => mArReady(i),
-            rdata   => mRData(i),
-            rresp   => "00",
-            rvalid  => mRValid(i),
-            -- axiWriteMaster (DUT drives)
-            awaddr  => mAwAddr(i),
-            awprot  => open,
-            awvalid => mAwValid(i),
-            wdata   => mWData(i),
-            wstrb   => open,
-            wvalid  => mWValid(i),
-            bready  => mBReady(i),
-            -- axiWriteSlave (TB drives)
-            awready => mAwReady(i),
-            wready  => mWReady(i),
-            bresp   => "00",
-            bvalid  => mBValid(i));
-   end generate GEN_MEMORY;
+            -- axiReadMaster (model drives -> record master fields)
+            araddr  => memReadMaster(i).araddr,
+            arprot  => memReadMaster(i).arprot,
+            arvalid => memReadMaster(i).arvalid,
+            rready  => memReadMaster(i).rready,
+            -- axiReadSlave (RAM drives -> model inputs)
+            arready => memReadSlave(i).arready,
+            rdata   => memReadSlave(i).rdata,
+            rresp   => memReadSlave(i).rresp,
+            rvalid  => memReadSlave(i).rvalid,
+            -- axiWriteMaster (model drives -> record master fields)
+            awaddr  => memWriteMaster(i).awaddr,
+            awprot  => memWriteMaster(i).awprot,
+            awvalid => memWriteMaster(i).awvalid,
+            wdata   => memWriteMaster(i).wdata,
+            wstrb   => memWriteMaster(i).wstrb,
+            wvalid  => memWriteMaster(i).wvalid,
+            bready  => memWriteMaster(i).bready,
+            -- axiWriteSlave (RAM drives -> model inputs)
+            awready => memWriteSlave(i).awready,
+            wready  => memWriteSlave(i).wready,
+            bresp   => memWriteSlave(i).bresp,
+            bvalid  => memWriteSlave(i).bvalid);
 
-   GEN_MEMORY_RSP : for i in 0 to 1 generate
-      -- Per-instance AXI-Lite slave responder. The Memory model is the master:
-      -- its peer sends a write-then-read transaction, so the model first
-      -- presents a write (awvalid & wvalid) and then a read (arvalid). We
-      -- complete each handshake by sampling the master outputs every edge in a
-      -- bounded loop, mirroring the native _memory_cycle timing -- the model
-      -- holds a request until its ready is seen, then drops it, so we must not
-      -- assume the request persists. Outbound is held off until the same
-      -- SETTLE_EDGES_C the Stream drivers use, so the memory peer is connected
-      -- and draining before the model tries its synchronous response send.
-      rsp : process is
-         constant expAddr : std_logic_vector(31 downto 0) :=
-            std_logic_vector(to_unsigned(16#100# + (16#10# * i), 32));
-         -- Tagged read data packed little-endian: bytes
-         -- [0x40+i,0x50+i,0x60+i,0x70+i] -> rdata(7:0)=0x40+i ... (31:24)=0x70+i.
-         constant rdataTag : std_logic_vector(31 downto 0) :=
-            std_logic_vector(to_unsigned(16#70# + i, 8)) &
-            std_logic_vector(to_unsigned(16#60# + i, 8)) &
-            std_logic_vector(to_unsigned(16#50# + i, 8)) &
-            std_logic_vector(to_unsigned(16#40# + i, 8));
-         variable waited : natural := 0;
-         variable phase  : natural := 0;
+      -- Real AXI-Lite slave: a per-instance block RAM. The peer writes this
+      -- instance's tagged vector then reads it back; a real RAM returns exactly
+      -- what was written, so the peer's own read-back equality check passes and
+      -- proves isolation (each instance owns a DISTINCT RAM, so cross-instance
+      -- leakage is impossible by construction). SYNTH_MODE_G="inferred" keeps
+      -- the closure free of XPM/vendor primitives.
+      U_MEMORY_RAM : entity surf.AxiDualPortRam
+         generic map (
+            SYNTH_MODE_G  => "inferred",
+            MEMORY_TYPE_G => "block",
+            READ_LATENCY_G => 2,
+            AXI_WR_EN_G   => true,
+            COMMON_CLK_G  => true,
+            ADDR_WIDTH_G  => MEM_ADDR_WIDTH_C,
+            DATA_WIDTH_G  => 32)
+         port map (
+            axiClk         => clock,
+            axiRst         => reset,
+            axiReadMaster  => memReadMaster(i),
+            axiReadSlave   => memReadSlave(i),
+            axiWriteMaster => memWriteMaster(i),
+            axiWriteSlave  => memWriteSlave(i));
+      -- Standard Port side (clk/en/we/addr/din/dout/...) left at defaults; only
+      -- the AXI side is exercised.
 
-         procedure tick is
-         begin
-            wait until rising_edge(clock);
-            waited := waited + 1;
-            assert waited < WAIT_EDGES_C
-               report "Memory " & integer'image(i) & ": timed out on handshake"
-               severity failure;
-         end procedure tick;
+      -- Preserved isolation safety net (option a): whenever the model asserts a
+      -- write/read address it must equal this instance's expected address, so a
+      -- wrong-address regression still $fatals inside the TB even though a plain
+      -- RAM would otherwise silently accept any in-range address.
+      assert (memWriteMaster(i).awvalid /= '1') or (memWriteMaster(i).awaddr = EXP_ADDR_C)
+         report "Memory " & integer'image(i) & ": wrong write address"
+         severity failure;
+      assert (memReadMaster(i).arvalid /= '1') or (memReadMaster(i).araddr = EXP_ADDR_C)
+         report "Memory " & integer'image(i) & ": wrong read address"
+         severity failure;
+
+      -- Completion detector. The model runs a write-then-read: it first drives
+      -- a write (completing when bvalid & bready handshake) and then a read
+      -- (completing when rvalid & rready handshake). memDone(i) asserts once
+      -- BOTH have been observed, so the banner cannot stop the sim before this
+      -- instance's full transaction has been serviced by its RAM.
+      done : process is
+         variable waited  : natural := 0;
+         variable wrote   : boolean := false;
+         variable readback : boolean := false;
       begin
          wait until reset = '0';
+         loop
+            wait until rising_edge(clock);
+            waited := waited + 1;
 
-         -- Settle: let the peer connect and start draining before the model
-         -- issues its first (synchronous-send) response.
-         while phase < SETTLE_EDGES_C loop
-            tick;
-            phase := phase + 1;
-         end loop;
+            if (memWriteSlave(i).bvalid = '1') and (memWriteMaster(i).bready = '1') then
+               wrote := true;
+            end if;
+            if (memReadSlave(i).rvalid = '1') and (memReadMaster(i).rready = '1') then
+               readback := true;
+            end if;
 
-         -- WRITE handshake: wait for the model (ST_START) to present awvalid &
-         -- wvalid; both are held until the model sees their ready in ST_WRESP.
-         while not (mAwValid(i) = '1' and mWValid(i) = '1') loop
-            tick;
-         end loop;
-         assert mAwAddr(i) = expAddr
-            report "Memory " & integer'image(i) & ": wrong write address"
-            severity failure;
-         -- The peer writes the same tagged vector it later expects to read
-         -- back (rdataTag); checking it here covers write-data isolation --
-         -- a foreign instance's payload would differ.
-         assert mWData(i) = rdataTag
-            report "Memory " & integer'image(i) & ": wrong write data"
-            severity failure;
+            exit when wrote and readback;
 
-         -- Accept address+data and complete the response in one step: the FSM's
-         -- ST_WRESP samples awready, wready and bvalid together, drops awvalid/
-         -- wvalid and sends the write response on the edge it sees them. Hold
-         -- all three until awvalid drops (the observable completion; bready is
-         -- pinned high by the model and never falls, so do not wait on it).
-         mAwReady(i) <= '1';
-         mWReady(i)  <= '1';
-         mBValid(i)  <= '1';
-         while mAwValid(i) = '1' loop
-            tick;
+            assert waited < WAIT_EDGES_C
+               report "Memory " & integer'image(i) & ": timed out on transaction"
+               severity failure;
          end loop;
-         mAwReady(i) <= '0';
-         mWReady(i)  <= '0';
-         mBValid(i)  <= '0';
-
-         -- READ handshake: wait for the model (ST_START) to present arvalid.
-         while mArValid(i) /= '1' loop
-            tick;
-         end loop;
-         assert mArAddr(i) = expAddr
-            report "Memory " & integer'image(i) & ": wrong read address"
-            severity failure;
-
-         -- Accept the read address; the model (ST_RADDR) drops arvalid and
-         -- advances to ST_RDATA on the edge it sees arready.
-         mArReady(i) <= '1';
-         while mArValid(i) = '1' loop
-            tick;
-         end loop;
-         mArReady(i) <= '0';
-
-         -- In ST_RDATA the model captures rdata/rresp on the edge it sees
-         -- rvalid, then sends the read response and returns to idle (rready is
-         -- pinned high, so there is no ready-fall to observe). Present the
-         -- tagged data and hold rvalid across a short guard so the single
-         -- capture edge cannot be missed to delta-ordering, then release.
-         mRData(i)  <= rdataTag;
-         mRValid(i) <= '1';
-         for e in 0 to 3 loop
-            tick;
-         end loop;
-         mRValid(i) <= '0';
 
          memDone(i) <= '1';
          wait;
-      end process rsp;
-   end generate GEN_MEMORY_RSP;
+      end process done;
+   end generate GEN_MEMORY;
 
    GEN_SIDEBAND : for i in 0 to 1 generate
       U_SIDEBAND : entity work.RogueSideBand

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -12,7 +12,7 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 -- Test methodology:
--- - Instantiate four Stream (and later two Memory, two SideBand) xsim/DPI
+-- - Instantiate four Stream and two Memory (and later two SideBand) xsim/DPI
 --   models, each on its own endpoint pair, and exchange a per-instance tagged
 --   traffic family with a dedicated external peer.
 -- - Hold off all outbound traffic for a fixed settle delay after reset so the
@@ -20,9 +20,20 @@
 --   readiness handshake).
 -- - Each Stream instance drives inbound beats tagged 0x80+i and checks the
 --   outbound byte equals its peer's 0x10+i.
+-- - Each Memory instance is an AXI-Lite MASTER (driven by its peer's
+--   write-then-read transaction); the TB acts as a tiny per-instance AXI-Lite
+--   SLAVE that completes the write handshake, then returns this instance's
+--   tagged data on the read. The observed awaddr/araddr is asserted equal to
+--   0x100+0x10*i so cross-instance address leakage is caught.
 -- - Report the success banner only after all instances pass; $fatal on any
---   wrong/missing tag. $fatal exits 0 under xsim -R, so pytest judges success
---   by the banner plus per-peer exit codes/JSON, not the xsim return code.
+--   wrong/missing tag or wrong address. $fatal exits 0 under xsim -R, so pytest
+--   judges success by the banner plus per-peer exit codes/JSON, not the xsim
+--   return code.
+--
+-- Endpoint port map (single source of truth is shared with
+-- test_RogueXsimTraffic.py -- keep both in sync):
+--   Stream i -> 19740 + 2*i  (19740..19747)
+--   Memory i -> 19748 + 2*i  (19748..19751)
 -------------------------------------------------------------------------------
 
 library ieee;
@@ -39,7 +50,24 @@ architecture test of RogueXsimTrafficTb is
 
    constant CLK_HALF_C     : time    := 5 ns;
    constant SETTLE_EDGES_C : natural := 2000;   -- tuned later; generous margin
-   constant WAIT_EDGES_C   : natural := 20000;  -- bounded per-item inbound wait
+   -- Bounded busy-poll watchdog. This is deliberately large: the Memory model
+   -- receives its peer's request via a non-blocking ZMQ poll and the Memory
+   -- responder busy-polls the master valids every edge, so nothing paces the
+   -- (otherwise free-running) simulation to wall-clock while a peer process is
+   -- still starting up and connecting. A tight watchdog can therefore burn out
+   -- before a slow-to-start peer delivers its first request. The value spans
+   -- several seconds of wall-clock busy-poll -- comfortably covering peer
+   -- startup jitter -- while still bounding a genuine hang well under the
+   -- pytest run timeout. The Stream path exits this loop as soon as its traffic
+   -- is exchanged, so the larger bound only affects the wait, never the happy
+   -- path.
+   constant WAIT_EDGES_C   : natural := 1000000;
+
+   -- Number of single-beat inbound frames each Stream instance drives, and the
+   -- inter-frame gap (in clock edges) between them. STREAM_FRAMES_C must match
+   -- STREAM_TAG_FRAME_COUNT in rogue_tcp_peer.py.
+   constant STREAM_FRAMES_C : natural := 3;
+   constant IB_GAP_EDGES_C  : natural := 5;
 
    signal clock : std_logic := '0';
    signal reset : std_logic := '1';
@@ -55,6 +83,27 @@ architecture test of RogueXsimTrafficTb is
    signal sIbLast  : std_logic_vector(3 downto 0) := (others => '0');
 
    signal streamDone : std_logic_vector(3 downto 0) := (others => '0');
+
+   -- Memory instances: the DUT drives the AXI-Lite master ports (m*), the TB
+   -- responds as a slave (arready/rdata/rresp/rvalid, awready/wready/bresp/
+   -- bvalid) via per-instance responder processes.
+   signal mArAddr  : slv32_array(1 downto 0);
+   signal mArValid : std_logic_vector(1 downto 0);
+   signal mRReady  : std_logic_vector(1 downto 0);
+   signal mArReady : std_logic_vector(1 downto 0) := (others => '0');
+   signal mRData   : slv32_array(1 downto 0)      := (others => (others => '0'));
+   signal mRValid  : std_logic_vector(1 downto 0) := (others => '0');
+
+   signal mAwAddr  : slv32_array(1 downto 0);
+   signal mAwValid : std_logic_vector(1 downto 0);
+   signal mWData   : slv32_array(1 downto 0);
+   signal mWValid  : std_logic_vector(1 downto 0);
+   signal mBReady  : std_logic_vector(1 downto 0);
+   signal mAwReady : std_logic_vector(1 downto 0) := (others => '0');
+   signal mWReady  : std_logic_vector(1 downto 0) := (others => '0');
+   signal mBValid  : std_logic_vector(1 downto 0) := (others => '0');
+
+   signal memDone : std_logic_vector(1 downto 0) := "00";
 
 begin
 
@@ -124,7 +173,7 @@ begin
             -- edges, deasserting valid the edge after each single beat.
             if phase < SETTLE_EDGES_C then
                phase := phase + 1;
-            elsif frame < 3 then
+            elsif frame < STREAM_FRAMES_C then
                if step = 0 then
                   sIbData(i)  <= tagByte & tagByte & tagByte & tagByte;
                   sIbKeep(i)  <= x"0F";
@@ -135,7 +184,7 @@ begin
                   sIbValid(i) <= '0';
                   sIbLast(i)  <= '0';
                   step        := 2;
-               elsif step < 5 then
+               elsif step < IB_GAP_EDGES_C then
                   step := step + 1;
                else
                   step  := 0;
@@ -143,7 +192,7 @@ begin
                end if;
             end if;
 
-            exit when (frame = 3) and (rxCount >= 3);
+            exit when (frame = STREAM_FRAMES_C) and (rxCount >= STREAM_FRAMES_C);
 
             assert waited < WAIT_EDGES_C
                report "Stream " & integer'image(i) & ": timed out exchanging traffic" severity failure;
@@ -154,13 +203,142 @@ begin
       end process drv;
    end generate GEN_STREAM_DRV;
 
+   GEN_MEMORY : for i in 0 to 1 generate
+      U_MEMORY : entity work.RogueTcpMemory
+         port map (
+            clock   => clock,
+            reset   => reset,
+            portNum => std_logic_vector(to_unsigned(19748 + (2*i), 16)),
+            -- axiReadMaster (DUT drives)
+            araddr  => mArAddr(i),
+            arprot  => open,
+            arvalid => mArValid(i),
+            rready  => mRReady(i),
+            -- axiReadSlave (TB drives)
+            arready => mArReady(i),
+            rdata   => mRData(i),
+            rresp   => "00",
+            rvalid  => mRValid(i),
+            -- axiWriteMaster (DUT drives)
+            awaddr  => mAwAddr(i),
+            awprot  => open,
+            awvalid => mAwValid(i),
+            wdata   => mWData(i),
+            wstrb   => open,
+            wvalid  => mWValid(i),
+            bready  => mBReady(i),
+            -- axiWriteSlave (TB drives)
+            awready => mAwReady(i),
+            wready  => mWReady(i),
+            bresp   => "00",
+            bvalid  => mBValid(i));
+   end generate GEN_MEMORY;
+
+   GEN_MEMORY_RSP : for i in 0 to 1 generate
+      -- Per-instance AXI-Lite slave responder. The Memory model is the master:
+      -- its peer sends a write-then-read transaction, so the model first
+      -- presents a write (awvalid & wvalid) and then a read (arvalid). We
+      -- complete each handshake by sampling the master outputs every edge in a
+      -- bounded loop, mirroring the native _memory_cycle timing -- the model
+      -- holds a request until its ready is seen, then drops it, so we must not
+      -- assume the request persists. Outbound is held off until the same
+      -- SETTLE_EDGES_C the Stream drivers use, so the memory peer is connected
+      -- and draining before the model tries its synchronous response send.
+      rsp : process is
+         constant expAddr : std_logic_vector(31 downto 0) :=
+            std_logic_vector(to_unsigned(16#100# + (16#10# * i), 32));
+         -- Tagged read data packed little-endian: bytes
+         -- [0x40+i,0x50+i,0x60+i,0x70+i] -> rdata(7:0)=0x40+i ... (31:24)=0x70+i.
+         constant rdataTag : std_logic_vector(31 downto 0) :=
+            std_logic_vector(to_unsigned(16#70# + i, 8)) &
+            std_logic_vector(to_unsigned(16#60# + i, 8)) &
+            std_logic_vector(to_unsigned(16#50# + i, 8)) &
+            std_logic_vector(to_unsigned(16#40# + i, 8));
+         variable waited : natural := 0;
+         variable phase  : natural := 0;
+
+         procedure tick is
+         begin
+            wait until rising_edge(clock);
+            waited := waited + 1;
+            assert waited < WAIT_EDGES_C
+               report "Memory " & integer'image(i) & ": timed out on handshake"
+               severity failure;
+         end procedure tick;
+      begin
+         wait until reset = '0';
+
+         -- Settle: let the peer connect and start draining before the model
+         -- issues its first (synchronous-send) response.
+         while phase < SETTLE_EDGES_C loop
+            tick;
+            phase := phase + 1;
+         end loop;
+
+         -- WRITE handshake: wait for the model (ST_START) to present awvalid &
+         -- wvalid; both are held until the model sees their ready in ST_WRESP.
+         while not (mAwValid(i) = '1' and mWValid(i) = '1') loop
+            tick;
+         end loop;
+         assert mAwAddr(i) = expAddr
+            report "Memory " & integer'image(i) & ": wrong write address"
+            severity failure;
+
+         -- Accept address+data and complete the response in one step: the FSM's
+         -- ST_WRESP samples awready, wready and bvalid together, drops awvalid/
+         -- wvalid and sends the write response on the edge it sees them. Hold
+         -- all three until awvalid drops (the observable completion; bready is
+         -- pinned high by the model and never falls, so do not wait on it).
+         mAwReady(i) <= '1';
+         mWReady(i)  <= '1';
+         mBValid(i)  <= '1';
+         while mAwValid(i) = '1' loop
+            tick;
+         end loop;
+         mAwReady(i) <= '0';
+         mWReady(i)  <= '0';
+         mBValid(i)  <= '0';
+
+         -- READ handshake: wait for the model (ST_START) to present arvalid.
+         while mArValid(i) /= '1' loop
+            tick;
+         end loop;
+         assert mArAddr(i) = expAddr
+            report "Memory " & integer'image(i) & ": wrong read address"
+            severity failure;
+
+         -- Accept the read address; the model (ST_RADDR) drops arvalid and
+         -- advances to ST_RDATA on the edge it sees arready.
+         mArReady(i) <= '1';
+         while mArValid(i) = '1' loop
+            tick;
+         end loop;
+         mArReady(i) <= '0';
+
+         -- In ST_RDATA the model captures rdata/rresp on the edge it sees
+         -- rvalid, then sends the read response and returns to idle (rready is
+         -- pinned high, so there is no ready-fall to observe). Present the
+         -- tagged data and hold rvalid across a short guard so the single
+         -- capture edge cannot be missed to delta-ordering, then release.
+         mRData(i)  <= rdataTag;
+         mRValid(i) <= '1';
+         for e in 0 to 3 loop
+            tick;
+         end loop;
+         mRValid(i) <= '0';
+
+         memDone(i) <= '1';
+         wait;
+      end process rsp;
+   end generate GEN_MEMORY_RSP;
+
    banner : process is
    begin
       for e in 0 to 2 loop
          wait until rising_edge(clock);
       end loop;
       reset <= '0';
-      wait until streamDone = "1111";
+      wait until (streamDone = "1111") and (memDone = "11");
       report "Rogue xsim traffic test passed" severity note;
       stop;
       wait;

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -55,7 +55,23 @@ end entity RogueXsimTrafficTb;
 architecture test of RogueXsimTrafficTb is
 
    constant CLK_HALF_C     : time    := 5 ns;
-   constant SETTLE_EDGES_C : natural := 2000;   -- tuned later; generous margin
+   -- Fixed sim-time hold-off (Option B, see design.md "Readiness"): no
+   -- outbound HDL traffic is driven for this many clock edges after reset
+   -- deassert. Its purpose is to guarantee the DUT does not issue a
+   -- (synchronous, blocking) outbound ZMQ send before its peer is connected
+   -- and draining -- the accepted transport contract, since the ported Rogue-
+   -- TCP protocol has no readiness handshake. What actually establishes
+   -- connectedness is the SIM ORDERING enforced by the test: each peer is
+   -- Popen'd after xelab, just before the xsim run, so by the time reset
+   -- deasserts the peers have already imported and connected. This constant
+   -- is therefore defense-in-depth against startup jitter, not the primary
+   -- guarantee. At 5 ns half-period the clock period is 10 ns, and the settle
+   -- loop counts one rising_edge per period (10 ns/edge), so 2000 edges is
+   -- ~20 us of sim time -- microseconds of wall-clock -- a generous margin
+   -- that stress testing (10 clean + 6 under full-core load) showed zero
+   -- instability. Do NOT reduce below this value; increase (and note the new
+   -- margin) only if instability appears.
+   constant SETTLE_EDGES_C : natural := 2000;
    -- Bounded busy-poll watchdog, shared across the Stream, Memory and SideBand
    -- families. This is deliberately large: the models receive their peer's
    -- request via a non-blocking ZMQ poll and the TB busy-polls the model I/O

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -288,7 +288,10 @@ begin
       -- what was written, so the peer's own read-back equality check passes and
       -- proves isolation (each instance owns a DISTINCT RAM, so cross-instance
       -- leakage is impossible by construction). SYNTH_MODE_G="inferred" keeps
-      -- the closure free of XPM/vendor primitives.
+      -- the closure free of XPM/vendor primitives. Note: write-DATA integrity is
+      -- now validated by the peer's read-back compare (in rogue_tcp_peer.py),
+      -- not by an in-TB assert as the previous hand-rolled responder did; the
+      -- in-TB assertions below still guard the ADDRESS.
       U_MEMORY_RAM : entity surf.AxiDualPortRam
          generic map (
             SYNTH_MODE_G  => "inferred",

--- a/tests/axi/simlink/RogueXsimTrafficTb.vhd
+++ b/tests/axi/simlink/RogueXsimTrafficTb.vhd
@@ -18,8 +18,8 @@
 -- - Hold off all outbound traffic for a fixed settle delay after reset so the
 --   peers are connected and draining first (accepted transport contract; no
 --   readiness handshake).
--- - Each Stream instance drives inbound beats tagged 0x80+i and checks the
---   outbound byte equals its peer's 0x10+i.
+-- - Each Stream instance drives a tagged 0xB0/A0/90/80+i word and checks the
+--   outbound word equals its peer's 0x40/30/20/10+i vector.
 -- - Each Memory instance is an AXI-Lite MASTER (driven by its peer's
 --   write-then-read transaction); the TB wires it to its OWN instance of
 --   surf.AxiDualPortRam acting as a real AXI-Lite SLAVE (a block RAM). The
@@ -68,13 +68,13 @@ architecture test of RogueXsimTrafficTb is
    -- deassert. Its purpose is to guarantee the DUT does not issue a
    -- (synchronous, blocking) outbound ZMQ send before its peer is connected
    -- and draining -- the accepted transport contract, since the ported Rogue-
-   -- TCP protocol has no readiness handshake. What actually establishes
-   -- connectedness is the SIM ORDERING enforced by the test: each peer is
-   -- Popen'd after xelab, just before the xsim run, so by the time reset
-   -- deasserts the peers have already imported and connected. This constant
-   -- is therefore defense-in-depth against startup jitter, not the primary
-   -- guarantee. At 5 ns half-period the clock period is 10 ns, and the settle
-   -- loop counts one rising_edge per period (10 ns/edge), so 2000 edges is
+   -- TCP protocol has no protocol-level readiness handshake. Before starting
+   -- xsim, the Python orchestrator waits for a test-only ready file from every
+   -- peer, proving that the peer has configured both sockets and issued its
+   -- connect calls. Because ZeroMQ connection establishment remains
+   -- asynchronous until the model binds, this delay supplies the post-bind
+   -- handshake margin. At 5 ns half-period the clock period is 10 ns, and the
+   -- settle loop counts one rising_edge per period (10 ns/edge), so 2000 edges is
    -- ~20 us of sim time -- microseconds of wall-clock -- a generous margin
    -- that stress testing (10 clean + 6 under full-core load) showed zero
    -- instability. Do NOT reduce below this value; increase (and note the new
@@ -94,9 +94,9 @@ architecture test of RogueXsimTrafficTb is
    constant WAIT_EDGES_C   : natural := 1000000;
 
    -- Number of single-beat inbound frames each Stream instance drives, and the
-   -- inter-frame gap (in clock edges) between them. STREAM_FRAMES_C must match
-   -- STREAM_TAG_FRAME_COUNT in rogue_tcp_peer.py.
-   constant STREAM_FRAMES_C : natural := 3;
+   -- inter-frame gap (in clock edges) between them. This must match the vector
+   -- count returned by stream_instance_vectors() in rogue_tcp_peer.py.
+   constant STREAM_FRAMES_C : natural := 1;
    constant IB_GAP_EDGES_C  : natural := 5;
 
    -- Edges to keep the SideBand tx* values driven after the remData change, so
@@ -107,14 +107,14 @@ architecture test of RogueXsimTrafficTb is
    signal clock : std_logic := '0';
    signal reset : std_logic := '1';
 
-   type slv32_array is array (natural range <>) of std_logic_vector(31 downto 0);
-   type slv8_array  is array (natural range <>) of std_logic_vector(7 downto 0);
+   type Slv32Array is array (natural range <>) of std_logic_vector(31 downto 0);
+   type Slv8Array is array (natural range <>) of std_logic_vector(7 downto 0);
 
    signal sObValid : std_logic_vector(3 downto 0);
-   signal sObData  : slv32_array(3 downto 0);
+   signal sObData  : Slv32Array(3 downto 0);
    signal sIbValid : std_logic_vector(3 downto 0) := (others => '0');
-   signal sIbData  : slv32_array(3 downto 0)      := (others => (others => '0'));
-   signal sIbKeep  : slv8_array(3 downto 0)       := (others => (others => '0'));
+   signal sIbData  : Slv32Array(3 downto 0)      := (others => (others => '0'));
+   signal sIbKeep  : Slv8Array(3 downto 0)       := (others => (others => '0'));
    signal sIbLast  : std_logic_vector(3 downto 0) := (others => '0');
 
    signal streamDone : std_logic_vector(3 downto 0) := (others => '0');
@@ -137,12 +137,12 @@ architecture test of RogueXsimTrafficTb is
 
    -- SideBand instances: the DUT (TB) drives tx* to transmit outbound to its
    -- peer and observes rx* for the peer's inbound opcode/remData.
-   signal sbTxOpCode   : slv8_array(1 downto 0)      := (others => (others => '0'));
+   signal sbTxOpCode   : Slv8Array(1 downto 0)      := (others => (others => '0'));
    signal sbTxOpCodeEn : std_logic_vector(1 downto 0) := (others => '0');
-   signal sbTxRemData  : slv8_array(1 downto 0)      := (others => (others => '0'));
-   signal sbRxOpCode   : slv8_array(1 downto 0);
+   signal sbTxRemData  : Slv8Array(1 downto 0)      := (others => (others => '0'));
+   signal sbRxOpCode   : Slv8Array(1 downto 0);
    signal sbRxOpCodeEn : std_logic_vector(1 downto 0);
-   signal sbRxRemData  : slv8_array(1 downto 0);
+   signal sbRxRemData  : Slv8Array(1 downto 0);
 
    signal sbDone : std_logic_vector(1 downto 0) := "00";
 
@@ -178,17 +178,17 @@ begin
    GEN_STREAM_DRV : for i in 0 to 3 generate
       -- One process per instance handles both directions concurrently: it
       -- counts outbound (ob) frames on EVERY edge from reset deassert, and
-      -- after a fixed settle drives three inbound (ib) frames. Outbound must
+      -- after a fixed settle drives one inbound (ib) frame. Outbound must
       -- be watched continuously because obReady is hardwired '1', so the
       -- model presents each peer-pushed frame for a single edge as soon as it
       -- arrives (well before the inbound-drive phase); a counter that only
       -- looked after the settle would miss those early frames. streamDone is
-      -- asserted only once BOTH the three inbound frames have been driven and
-      -- three outbound frames have been counted, so the banner cannot stop
+      -- asserted only once BOTH the inbound frame has been driven and
+      -- one outbound frame has been counted, so the banner cannot stop
       -- the sim before every peer has exchanged its full tagged family.
       drv : process is
-         variable expByte : std_logic_vector(7 downto 0);
-         variable tagByte : std_logic_vector(7 downto 0);
+         variable expData : std_logic_vector(31 downto 0);
+         variable tagData : std_logic_vector(31 downto 0);
          variable rxCount : natural := 0;
          variable waited  : natural := 0;
          variable phase   : natural := 0;  -- edges elapsed during settle
@@ -196,8 +196,14 @@ begin
          variable step    : natural := 0;  -- sub-step within one inbound frame
       begin
          wait until reset = '0';
-         tagByte := std_logic_vector(to_unsigned((16#80# + i), 8));
-         expByte := std_logic_vector(to_unsigned((16#10# + i), 8));
+         tagData := std_logic_vector(to_unsigned((16#B0# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#A0# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#90# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#80# + i), 8));
+         expData := std_logic_vector(to_unsigned((16#40# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#30# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#20# + i), 8)) &
+                    std_logic_vector(to_unsigned((16#10# + i), 8));
 
          loop
             wait until rising_edge(clock);
@@ -205,18 +211,18 @@ begin
 
             -- Outbound: count each single-beat frame the model presents.
             if sObValid(i) = '1' then
-               assert sObData(i)(7 downto 0) = expByte
+               assert sObData(i) = expData
                   report "Stream " & integer'image(i) & ": wrong outbound tag" severity failure;
                rxCount := rxCount + 1;
             end if;
 
-            -- Inbound: after the settle, push three frames, one every few
-            -- edges, deasserting valid the edge after each single beat.
+            -- Inbound: after the settle, push the tagged frame, deasserting
+            -- valid on the edge after the single beat.
             if phase < SETTLE_EDGES_C then
                phase := phase + 1;
             elsif frame < STREAM_FRAMES_C then
                if step = 0 then
-                  sIbData(i)  <= tagByte & tagByte & tagByte & tagByte;
+                  sIbData(i)  <= tagData;
                   sIbKeep(i)  <= x"0F";
                   sIbLast(i)  <= '1';
                   sIbValid(i) <= '1';
@@ -328,8 +334,8 @@ begin
       -- BOTH have been observed, so the banner cannot stop the sim before this
       -- instance's full transaction has been serviced by its RAM.
       done : process is
-         variable waited  : natural := 0;
-         variable wrote   : boolean := false;
+         variable waited   : natural := 0;
+         variable wrote    : boolean := false;
          variable readback : boolean := false;
       begin
          wait until reset = '0';
@@ -385,18 +391,18 @@ begin
       -- once BOTH the inbound opcode+remData have been observed AND the
       -- outbound frames have been driven and held past the send guard.
       drv : process is
-         variable txOp    : std_logic_vector(7 downto 0);
-         variable txRem   : std_logic_vector(7 downto 0);
-         variable expOp   : std_logic_vector(7 downto 0);
-         variable expRem  : std_logic_vector(7 downto 0);
-         variable rxOpCap : std_logic_vector(7 downto 0) := (others => '0');
+         variable txOp     : std_logic_vector(7 downto 0);
+         variable txRem    : std_logic_vector(7 downto 0);
+         variable expOp    : std_logic_vector(7 downto 0);
+         variable expRem   : std_logic_vector(7 downto 0);
+         variable rxOpCap  : std_logic_vector(7 downto 0) := (others => '0');
          variable rxRemCap : std_logic_vector(7 downto 0) := (others => '0');
-         variable gotOp   : std_logic := '0';
-         variable gotRem  : std_logic := '0';
-         variable txDone  : boolean   := false;
-         variable waited  : natural   := 0;
-         variable phase   : natural   := 0;  -- edges elapsed during settle
-         variable step    : natural   := 0;  -- sub-step within the tx sequence
+         variable gotOp    : std_logic := '0';
+         variable gotRem   : std_logic := '0';
+         variable txDone   : boolean   := false;
+         variable waited   : natural   := 0;
+         variable phase    : natural   := 0;  -- edges elapsed during settle
+         variable step     : natural   := 0;  -- sub-step within the tx sequence
       begin
          wait until reset = '0';
          txOp   := std_logic_vector(to_unsigned((16#60# + i), 8));

--- a/tests/axi/simlink/include/svdpi.h
+++ b/tests/axi/simlink/include/svdpi.h
@@ -1,0 +1,24 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of 'SLAC Firmware Standard Library'.
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'SLAC Firmware Standard Library', including this file,
+// may be copied, modified, propagated, or distributed except according to
+// the terms contained in the LICENSE.txt file.
+//////////////////////////////////////////////////////////////////////////////
+//
+// Minimal native-test subset of Vivado's svdpi.h. Production xsim builds use
+// the simulator-provided header; this file only lets host-gcc lifecycle tests
+// compile the DPI adapters on systems without Vivado.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef SURF_TEST_SVDPI_H
+#define SURF_TEST_SVDPI_H
+
+#include <stdint.h>
+
+typedef unsigned char svBit;
+typedef uint32_t svBitVecVal;
+
+#endif

--- a/tests/axi/simlink/rogue_tcp_peer.py
+++ b/tests/axi/simlink/rogue_tcp_peer.py
@@ -29,64 +29,11 @@ import zmq
 
 RCVTIMEO_MS = 30000
 
-# ---------------------------------------------------------------------------
-# Per-instance tag scheme (used by the xsim multi-instance live-traffic top,
-# RogueXsimTrafficTb.vhd). Each instance index i derives a distinct traffic
-# family so a peer receiving another instance's traffic is a detectable
-# isolation failure. Values mirror test_RogueDpiInstance.py's native traffic
-# test. These are pure functions -- no ZMQ, no simulator -- so they are unit
-# tested directly in test_rogue_tcp_peer_tags.py.
-# ---------------------------------------------------------------------------
 
-STREAM_TAG_FRAME_COUNT = 3  # single-beat frames each Stream instance exchanges
-
-
-def stream_peer_to_dut_payload(tag):
-    """Payload the peer pushes into Stream instance `tag` (DUT surfaces on ob)."""
-    return bytes([(0x10 + tag) & 0xFF] * 4)
-
-
-def stream_dut_to_peer_payload(tag):
-    """Payload the HDL drives on Stream instance `tag`'s ib (peer receives)."""
-    return bytes([(0x80 + tag) & 0xFF] * 4)
-
-
-def memory_txn_for_tag(tag):
-    """Write-then-read transaction Memory instance `tag` exchanges."""
-    return {
-        "addr": 0x100 + (0x10 * tag),
-        "size": 4,
-        "write_data": bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]),
-    }
-
-
-def sideband_peer_to_dut(tag):
-    """The two frames the peer pushes into SideBand instance `tag`."""
-    return [
-        {"opCodeEn": 1, "opCode": 0x20 + tag, "remDataChanged": 0, "remData": 0x00},
-        {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + tag},
-    ]
-
-
-def sideband_expect_for_tag(tag):
-    """The tx opcode/remData SideBand instance `tag` should transmit back."""
-    return {"opCode": 0x60 + tag, "remData": 0x70 + tag}
-
-
-def stream_frame_is_foreign(decoded, tag):
-    """True if a decoded stream frame carries a Stream tag other than `tag`.
-
-    Foreign traffic reaching this peer means socket isolation between DPI
-    instances leaked. Only the four Stream tag families (0x80..0x83) are
-    considered; anything else is left to the normal payload check.
-    """
-    own = stream_dut_to_peer_payload(tag).hex()
-    if decoded.get("data_hex") == own:
-        return False
-    for other in range(4):
-        if other != tag and decoded.get("data_hex") == stream_dut_to_peer_payload(other).hex():
-            return True
-    return False
+def _signal_ready(ready_file):
+    if ready_file is not None:
+        with open(ready_file, "w") as f:
+            f.write("ready\n")
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +81,35 @@ STREAM_EXPECT_FRAMES = [
 ]
 
 
-def run_stream_peer(port, result_path, tag=None):
+def stream_instance_vectors(tag):
+    return (
+        [{
+            "flags": 0,
+            "chan": 0,
+            "err": 0,
+            "data": bytes([0x10 + tag, 0x20 + tag, 0x30 + tag, 0x40 + tag]),
+        }],
+        [{
+            "flags": 0,
+            "chan": 0,
+            "err": 0,
+            "data": bytes([0x80 + tag, 0x90 + tag, 0xA0 + tag, 0xB0 + tag]),
+        }],
+    )
+
+
+def run_stream_peer(
+    port,
+    result_path,
+    send_frames=None,
+    expect_frames=None,
+    ready_file=None,
+):
+    if send_frames is None:
+        send_frames = STREAM_SEND_FRAMES
+    if expect_frames is None:
+        expect_frames = STREAM_EXPECT_FRAMES
+
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -148,18 +123,7 @@ def run_stream_peer(port, result_path, tag=None):
     # RCVTIMEO instead.
     push.connect(f"tcp://127.0.0.1:{port}")
     pull.connect(f"tcp://127.0.0.1:{port + 1}")
-
-    # Untagged: the fixed single-instance vectors. Tagged: the per-instance
-    # tag family, with foreign-tag rejection enabled on the receive side.
-    if tag is None:
-        send_frames = STREAM_SEND_FRAMES
-        expected_hex = [frame["data"].hex() for frame in STREAM_EXPECT_FRAMES]
-    else:
-        send_frames = [
-            {"flags": 0x0000, "chan": 0x00, "err": 0x00, "data": stream_peer_to_dut_payload(tag)}
-            for _ in range(STREAM_TAG_FRAME_COUNT)
-        ]
-        expected_hex = [stream_dut_to_peer_payload(tag).hex()] * STREAM_TAG_FRAME_COUNT
+    _signal_ready(ready_file)
 
     sent = []
     received = []
@@ -181,7 +145,7 @@ def run_stream_peer(port, result_path, tag=None):
                 }
             )
 
-        for expected in expected_hex:
+        for expected in expect_frames:
             try:
                 parts = pull.recv_multipart()
             except zmq.error.Again:
@@ -197,11 +161,7 @@ def run_stream_peer(port, result_path, tag=None):
                 break
 
             received.append(decoded)
-            if tag is not None and stream_frame_is_foreign(decoded, tag):
-                result = 1
-                reason = f"peer: FOREIGN tag on stream instance {tag}: {decoded!r}"
-                break
-            if decoded["data_hex"] != expected:
+            if decoded["data_hex"] != expected["data"].hex():
                 result = 1
                 reason = f"peer: unexpected stream data, got {decoded!r}"
                 break
@@ -219,7 +179,7 @@ def run_stream_peer(port, result_path, tag=None):
     return result
 
 
-def run_stream_recv_peer(port, result_path):
+def run_stream_recv_peer(port, result_path, ready_file=None):
     # Receive-only mode: no PUSH socket -- this peer never sends anything
     # into the DUT, it only observes what the DUT forwards out. Reuses
     # decode_stream_frames unchanged (no wire-format change), so a
@@ -229,6 +189,7 @@ def run_stream_recv_peer(port, result_path):
     pull = ctx.socket(zmq.PULL)
     pull.setsockopt(zmq.RCVTIMEO, RCVTIMEO_MS)
     pull.connect(f"tcp://127.0.0.1:{port + 1}")
+    _signal_ready(ready_file)
 
     received = []
     result = 0
@@ -351,7 +312,18 @@ MEM_TRANSACTIONS = [
 ]
 
 
-def run_memory_peer(port, result_path, tag=None):
+def memory_instance_transactions(tag):
+    return [{
+        "addr": 0x00000100 + (tag * 0x10),
+        "size": 4,
+        "write_data": bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]),
+    }]
+
+
+def run_memory_peer(port, result_path, memory_transactions=None, ready_file=None):
+    if memory_transactions is None:
+        memory_transactions = MEM_TRANSACTIONS
+
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -363,13 +335,7 @@ def run_memory_peer(port, result_path, tag=None):
     # probe/handshake.
     push.connect(f"tcp://127.0.0.1:{port}")
     pull.connect(f"tcp://127.0.0.1:{port + 1}")
-
-    # Untagged: the fixed vector transactions. Tagged: a single per-instance
-    # transaction; the read-back compare already rejects foreign data.
-    if tag is None:
-        mem_transactions = MEM_TRANSACTIONS
-    else:
-        mem_transactions = [memory_txn_for_tag(tag)]
+    _signal_ready(ready_file)
 
     transactions = []
     result = 0
@@ -377,7 +343,7 @@ def run_memory_peer(port, result_path, tag=None):
     txn_id = 0
 
     try:
-        for txn in mem_transactions:
+        for txn in memory_transactions:
             # Write, then read back the same address/size and compare.
             for txn_type, write_data in (
                 (T_WRITE, txn["write_data"]),
@@ -481,7 +447,29 @@ SIDEBAND_TX_OPCODE = 0x5A
 SIDEBAND_TX_REMDATA = 0xC3
 
 
-def run_sideband_peer(port, result_path, tag=None):
+def sideband_instance_vectors(tag):
+    peer_to_dut = [
+        {"opCodeEn": 1, "opCode": 0x20 + tag, "remDataChanged": 0, "remData": 0},
+        {"opCodeEn": 0, "opCode": 0, "remDataChanged": 1, "remData": 0x40 + tag},
+    ]
+    return peer_to_dut, 0x60 + tag, 0x70 + tag
+
+
+def run_sideband_peer(
+    port,
+    result_path,
+    peer_to_dut=None,
+    tx_opcode=None,
+    tx_remdata=None,
+    ready_file=None,
+):
+    if peer_to_dut is None:
+        peer_to_dut = SIDEBAND_PEER_TO_DUT
+    if tx_opcode is None:
+        tx_opcode = SIDEBAND_TX_OPCODE
+    if tx_remdata is None:
+        tx_remdata = SIDEBAND_TX_REMDATA
+
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -495,18 +483,7 @@ def run_sideband_peer(port, result_path, tag=None):
     # connect plus RCVTIMEO.
     push.connect(f"tcp://127.0.0.1:{port + 1}")
     pull.connect(f"tcp://127.0.0.1:{port}")
-
-    # Untagged: the fixed vectors. Tagged: the per-instance frames and the
-    # per-instance expected tx opcode/remData (0x60+tag / 0x70+tag).
-    if tag is None:
-        peer_to_dut = SIDEBAND_PEER_TO_DUT
-        expect_opcode = SIDEBAND_TX_OPCODE
-        expect_remdata = SIDEBAND_TX_REMDATA
-    else:
-        peer_to_dut = sideband_peer_to_dut(tag)
-        expected = sideband_expect_for_tag(tag)
-        expect_opcode = expected["opCode"]
-        expect_remdata = expected["remData"]
+    _signal_ready(ready_file)
 
     sent = []
     received = []
@@ -548,10 +525,10 @@ def run_sideband_peer(port, result_path, tag=None):
             if decoded["remDataChanged"] == 1 and got_remdata is None:
                 got_remdata = decoded["remData"]
 
-        if result == 0 and got_opcode != expect_opcode:
+        if result == 0 and got_opcode != tx_opcode:
             result = 1
             reason = f"peer: unexpected tx opcode, got {got_opcode!r}"
-        elif result == 0 and got_remdata != expect_remdata:
+        elif result == 0 and got_remdata != tx_remdata:
             result = 1
             reason = f"peer: unexpected tx remData, got {got_remdata!r}"
     finally:
@@ -567,30 +544,66 @@ def run_sideband_peer(port, result_path, tag=None):
     return result
 
 
-def build_arg_parser():
+def main(argv=None):
     parser = argparse.ArgumentParser(description="Rogue-TCP protocol peer")
-    parser.add_argument("--mode", choices=["stream", "stream-recv", "memory", "sideband"], required=True)
-    parser.add_argument("--tag", type=int, default=None,
-                        help="per-instance tag family for the xsim multi-instance traffic top; "
-                             "when omitted, the fixed single-instance vectors are used")
+    parser.add_argument(
+        "--mode",
+        choices=[
+            "stream",
+            "stream-recv",
+            "memory",
+            "sideband",
+            "stream-instance",
+            "memory-instance",
+            "sideband-instance",
+        ],
+        required=True,
+    )
+    parser.add_argument("--tag", type=int, default=0)
+    parser.add_argument("--ready-file")
     parser.add_argument("port", type=int)
     parser.add_argument("result_path")
-    return parser
-
-
-def main(argv=None):
-    args = build_arg_parser().parse_args(argv)
+    args = parser.parse_args(argv)
 
     if args.mode == "stream":
-        return run_stream_peer(args.port, args.result_path, tag=args.tag)
+        return run_stream_peer(args.port, args.result_path, ready_file=args.ready_file)
 
     if args.mode == "stream-recv":
-        return run_stream_recv_peer(args.port, args.result_path)
+        return run_stream_recv_peer(args.port, args.result_path, ready_file=args.ready_file)
 
     if args.mode == "memory":
-        return run_memory_peer(args.port, args.result_path, tag=args.tag)
+        return run_memory_peer(args.port, args.result_path, ready_file=args.ready_file)
 
-    return run_sideband_peer(args.port, args.result_path, tag=args.tag)
+    if args.mode == "stream-instance":
+        send_frames, expect_frames = stream_instance_vectors(args.tag)
+        return run_stream_peer(
+            args.port,
+            args.result_path,
+            send_frames,
+            expect_frames,
+            ready_file=args.ready_file,
+        )
+
+    if args.mode == "memory-instance":
+        return run_memory_peer(
+            args.port,
+            args.result_path,
+            memory_instance_transactions(args.tag),
+            ready_file=args.ready_file,
+        )
+
+    if args.mode == "sideband-instance":
+        peer_to_dut, tx_opcode, tx_remdata = sideband_instance_vectors(args.tag)
+        return run_sideband_peer(
+            args.port,
+            args.result_path,
+            peer_to_dut,
+            tx_opcode,
+            tx_remdata,
+            ready_file=args.ready_file,
+        )
+
+    return run_sideband_peer(args.port, args.result_path, ready_file=args.ready_file)
 
 
 if __name__ == "__main__":

--- a/tests/axi/simlink/rogue_tcp_peer.py
+++ b/tests/axi/simlink/rogue_tcp_peer.py
@@ -73,6 +73,22 @@ def sideband_expect_for_tag(tag):
     return {"opCode": 0x60 + tag, "remData": 0x70 + tag}
 
 
+def stream_frame_is_foreign(decoded, tag):
+    """True if a decoded stream frame carries a Stream tag other than `tag`.
+
+    Foreign traffic reaching this peer means socket isolation between DPI
+    instances leaked. Only the four Stream tag families (0x80..0x83) are
+    considered; anything else is left to the normal payload check.
+    """
+    own = stream_dut_to_peer_payload(tag).hex()
+    if decoded.get("data_hex") == own:
+        return False
+    for other in range(4):
+        if other != tag and decoded.get("data_hex") == stream_dut_to_peer_payload(other).hex():
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Stream protocol (RogueTcpStream.c RogueTcpStreamSend/Recv): 4-frame
 # message -- [flags (2B LE u16), chan (1B), err (1B), data (variable)].
@@ -118,7 +134,7 @@ STREAM_EXPECT_FRAMES = [
 ]
 
 
-def run_stream_peer(port, result_path):
+def run_stream_peer(port, result_path, tag=None):
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -133,13 +149,25 @@ def run_stream_peer(port, result_path):
     push.connect(f"tcp://127.0.0.1:{port}")
     pull.connect(f"tcp://127.0.0.1:{port + 1}")
 
+    # Untagged: the fixed single-instance vectors. Tagged: the per-instance
+    # tag family, with foreign-tag rejection enabled on the receive side.
+    if tag is None:
+        send_frames = STREAM_SEND_FRAMES
+        expected_hex = [frame["data"].hex() for frame in STREAM_EXPECT_FRAMES]
+    else:
+        send_frames = [
+            {"flags": 0x0000, "chan": 0x00, "err": 0x00, "data": stream_peer_to_dut_payload(tag)}
+            for _ in range(STREAM_TAG_FRAME_COUNT)
+        ]
+        expected_hex = [stream_dut_to_peer_payload(tag).hex()] * STREAM_TAG_FRAME_COUNT
+
     sent = []
     received = []
     result = 0
     reason = ""
 
     try:
-        for frame in STREAM_SEND_FRAMES:
+        for frame in send_frames:
             parts = encode_stream_frame(
                 frame["flags"], frame["chan"], frame["err"], frame["data"]
             )
@@ -153,7 +181,7 @@ def run_stream_peer(port, result_path):
                 }
             )
 
-        for expected in STREAM_EXPECT_FRAMES:
+        for expected in expected_hex:
             try:
                 parts = pull.recv_multipart()
             except zmq.error.Again:
@@ -169,7 +197,11 @@ def run_stream_peer(port, result_path):
                 break
 
             received.append(decoded)
-            if decoded["data_hex"] != expected["data"].hex():
+            if tag is not None and stream_frame_is_foreign(decoded, tag):
+                result = 1
+                reason = f"peer: FOREIGN tag on stream instance {tag}: {decoded!r}"
+                break
+            if decoded["data_hex"] != expected:
                 result = 1
                 reason = f"peer: unexpected stream data, got {decoded!r}"
                 break
@@ -319,7 +351,7 @@ MEM_TRANSACTIONS = [
 ]
 
 
-def run_memory_peer(port, result_path):
+def run_memory_peer(port, result_path, tag=None):
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -332,13 +364,20 @@ def run_memory_peer(port, result_path):
     push.connect(f"tcp://127.0.0.1:{port}")
     pull.connect(f"tcp://127.0.0.1:{port + 1}")
 
+    # Untagged: the fixed vector transactions. Tagged: a single per-instance
+    # transaction; the read-back compare already rejects foreign data.
+    if tag is None:
+        mem_transactions = MEM_TRANSACTIONS
+    else:
+        mem_transactions = [memory_txn_for_tag(tag)]
+
     transactions = []
     result = 0
     reason = ""
     txn_id = 0
 
     try:
-        for txn in MEM_TRANSACTIONS:
+        for txn in mem_transactions:
             # Write, then read back the same address/size and compare.
             for txn_type, write_data in (
                 (T_WRITE, txn["write_data"]),
@@ -442,7 +481,7 @@ SIDEBAND_TX_OPCODE = 0x5A
 SIDEBAND_TX_REMDATA = 0xC3
 
 
-def run_sideband_peer(port, result_path):
+def run_sideband_peer(port, result_path, tag=None):
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -457,6 +496,18 @@ def run_sideband_peer(port, result_path):
     push.connect(f"tcp://127.0.0.1:{port + 1}")
     pull.connect(f"tcp://127.0.0.1:{port}")
 
+    # Untagged: the fixed vectors. Tagged: the per-instance frames and the
+    # per-instance expected tx opcode/remData (0x60+tag / 0x70+tag).
+    if tag is None:
+        peer_to_dut = SIDEBAND_PEER_TO_DUT
+        expect_opcode = SIDEBAND_TX_OPCODE
+        expect_remdata = SIDEBAND_TX_REMDATA
+    else:
+        peer_to_dut = sideband_peer_to_dut(tag)
+        expected = sideband_expect_for_tag(tag)
+        expect_opcode = expected["opCode"]
+        expect_remdata = expected["remData"]
+
     sent = []
     received = []
     result = 0
@@ -464,7 +515,7 @@ def run_sideband_peer(port, result_path):
 
     try:
         # Push the opcode + remData frames the DUT should surface on rx*.
-        for frame in SIDEBAND_PEER_TO_DUT:
+        for frame in peer_to_dut:
             push.send(
                 encode_sideband_frame(
                     frame["opCodeEn"], frame["opCode"], frame["remDataChanged"], frame["remData"]
@@ -497,10 +548,10 @@ def run_sideband_peer(port, result_path):
             if decoded["remDataChanged"] == 1 and got_remdata is None:
                 got_remdata = decoded["remData"]
 
-        if result == 0 and got_opcode != SIDEBAND_TX_OPCODE:
+        if result == 0 and got_opcode != expect_opcode:
             result = 1
             reason = f"peer: unexpected tx opcode, got {got_opcode!r}"
-        elif result == 0 and got_remdata != SIDEBAND_TX_REMDATA:
+        elif result == 0 and got_remdata != expect_remdata:
             result = 1
             reason = f"peer: unexpected tx remData, got {got_remdata!r}"
     finally:
@@ -516,23 +567,30 @@ def run_sideband_peer(port, result_path):
     return result
 
 
-def main(argv=None):
+def build_arg_parser():
     parser = argparse.ArgumentParser(description="Rogue-TCP protocol peer")
     parser.add_argument("--mode", choices=["stream", "stream-recv", "memory", "sideband"], required=True)
+    parser.add_argument("--tag", type=int, default=None,
+                        help="per-instance tag family for the xsim multi-instance traffic top; "
+                             "when omitted, the fixed single-instance vectors are used")
     parser.add_argument("port", type=int)
     parser.add_argument("result_path")
-    args = parser.parse_args(argv)
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
 
     if args.mode == "stream":
-        return run_stream_peer(args.port, args.result_path)
+        return run_stream_peer(args.port, args.result_path, tag=args.tag)
 
     if args.mode == "stream-recv":
         return run_stream_recv_peer(args.port, args.result_path)
 
     if args.mode == "memory":
-        return run_memory_peer(args.port, args.result_path)
+        return run_memory_peer(args.port, args.result_path, tag=args.tag)
 
-    return run_sideband_peer(args.port, args.result_path)
+    return run_sideband_peer(args.port, args.result_path, tag=args.tag)
 
 
 if __name__ == "__main__":

--- a/tests/axi/simlink/rogue_tcp_peer.py
+++ b/tests/axi/simlink/rogue_tcp_peer.py
@@ -30,6 +30,50 @@ import zmq
 RCVTIMEO_MS = 10000
 
 # ---------------------------------------------------------------------------
+# Per-instance tag scheme (used by the xsim multi-instance live-traffic top,
+# RogueXsimTrafficTb.vhd). Each instance index i derives a distinct traffic
+# family so a peer receiving another instance's traffic is a detectable
+# isolation failure. Values mirror test_RogueDpiInstance.py's native traffic
+# test. These are pure functions -- no ZMQ, no simulator -- so they are unit
+# tested directly in test_rogue_tcp_peer_tags.py.
+# ---------------------------------------------------------------------------
+
+STREAM_TAG_FRAME_COUNT = 3  # single-beat frames each Stream instance exchanges
+
+
+def stream_peer_to_dut_payload(tag):
+    """Payload the peer pushes into Stream instance `tag` (DUT surfaces on ob)."""
+    return bytes([(0x10 + tag) & 0xFF] * 4)
+
+
+def stream_dut_to_peer_payload(tag):
+    """Payload the HDL drives on Stream instance `tag`'s ib (peer receives)."""
+    return bytes([(0x80 + tag) & 0xFF] * 4)
+
+
+def memory_txn_for_tag(tag):
+    """Write-then-read transaction Memory instance `tag` exchanges."""
+    return {
+        "addr": 0x100 + (0x10 * tag),
+        "size": 4,
+        "write_data": bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]),
+    }
+
+
+def sideband_peer_to_dut(tag):
+    """The two frames the peer pushes into SideBand instance `tag`."""
+    return [
+        {"opCodeEn": 1, "opCode": 0x20 + tag, "remDataChanged": 0, "remData": 0x00},
+        {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + tag},
+    ]
+
+
+def sideband_expect_for_tag(tag):
+    """The tx opcode/remData SideBand instance `tag` should transmit back."""
+    return {"opCode": 0x60 + tag, "remData": 0x70 + tag}
+
+
+# ---------------------------------------------------------------------------
 # Stream protocol (RogueTcpStream.c RogueTcpStreamSend/Recv): 4-frame
 # message -- [flags (2B LE u16), chan (1B), err (1B), data (variable)].
 # ---------------------------------------------------------------------------

--- a/tests/axi/simlink/rogue_tcp_peer.py
+++ b/tests/axi/simlink/rogue_tcp_peer.py
@@ -27,7 +27,7 @@ import sys
 
 import zmq
 
-RCVTIMEO_MS = 10000
+RCVTIMEO_MS = 30000
 
 # ---------------------------------------------------------------------------
 # Per-instance tag scheme (used by the xsim multi-instance live-traffic top,

--- a/tests/axi/simlink/test_RogueDpiInstance.py
+++ b/tests/axi/simlink/test_RogueDpiInstance.py
@@ -1,0 +1,615 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Four Stream and two each Memory and SideBand contexts, plus null,
+#   wrong-model, changed-port, and overlapping-port negative cases.
+# - Stimulus: Build the xsim C adapters with host gcc and a minimal test-only
+#   svdpi.h, create independent contexts, bind each endpoint pair, and exchange
+#   tagged Stream, Memory, and SideBand traffic through real ZeroMQ peers.
+# - Checks: Context pointers and traffic remain distinct; destroy permits
+#   same-port reuse; invalid ownership/port operations return failure without
+#   corrupting another context.
+# - Timing: Peer receives and transport polling are bounded at five seconds;
+#   no HDL simulator is required for this native adapter/lifecycle layer.
+
+import ctypes
+import fcntl
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import time
+
+import pytest
+import zmq
+
+from tests.axi.simlink.rogue_tcp_peer import (
+    decode_mem_response,
+    decode_sideband_frame,
+    decode_stream_frames,
+    encode_mem_request,
+    encode_sideband_frame,
+    encode_stream_frame,
+    T_READ,
+    T_WRITE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+XSIM_DIR = REPO_ROOT / "axi" / "simlink" / "xsim"
+SHARED_DIR = REPO_ROOT / "axi" / "simlink" / "shared"
+TEST_INCLUDE_DIR = Path(__file__).resolve().parent / "include"
+SIM_BUILD = Path(__file__).resolve().parent / "sim_build_RogueDpiInstance"
+NATIVE_LIBRARY = SIM_BUILD / "libRogueTcpDpiNative.so"
+
+Bit = ctypes.c_ubyte
+BitPointer = ctypes.POINTER(Bit)
+BitVector = ctypes.c_uint32
+BitVectorPointer = ctypes.POINTER(BitVector)
+Context = ctypes.c_void_p
+
+
+def _build_native_library():
+    if shutil.which("gcc") is None or shutil.which("pkg-config") is None:
+        pytest.skip("native DPI ownership test needs gcc and pkg-config")
+
+    try:
+        zmq_flags = shlex.split(
+            subprocess.run(
+                ["pkg-config", "--cflags", "--libs", "libzmq"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+    except subprocess.CalledProcessError:
+        pytest.skip("native DPI ownership test needs libzmq development files")
+
+    sources = [
+        XSIM_DIR / "RogueDpiInstance.c",
+        XSIM_DIR / "RogueTcpStream.c",
+        XSIM_DIR / "RogueTcpMemory.c",
+        XSIM_DIR / "RogueSideBand.c",
+    ]
+
+    SIM_BUILD.mkdir(parents=True, exist_ok=True)
+    with open(SIM_BUILD / ".build.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        subprocess.run(
+            [
+                "gcc",
+                "-std=c11",
+                "-Wall",
+                "-Wextra",
+                "-Werror",
+                "-fPIC",
+                "-shared",
+                f"-I{TEST_INCLUDE_DIR}",
+                f"-I{XSIM_DIR}",
+                f"-I{SHARED_DIR}",
+                *(str(source) for source in sources),
+                *zmq_flags,
+                "-o",
+                str(NATIVE_LIBRARY),
+            ],
+            check=True,
+        )
+
+
+def _configure_library(lib):
+    lib.rogueTcpStreamCreate.restype = Context
+    lib.rogueTcpStreamDestroy.argtypes = [Context]
+    lib.rogueTcpStreamUpdate.restype = ctypes.c_int
+    lib.rogueTcpStreamUpdate.argtypes = [
+        Context,
+        Bit,
+        BitVectorPointer,
+        Bit,
+        Bit,
+        BitPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitPointer,
+        Bit,
+        BitPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        Bit,
+    ]
+
+    lib.rogueTcpMemoryCreate.restype = Context
+    lib.rogueTcpMemoryDestroy.argtypes = [Context]
+    lib.rogueTcpMemoryUpdate.restype = ctypes.c_int
+    lib.rogueTcpMemoryUpdate.argtypes = [
+        Context,
+        Bit,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitPointer,
+        BitPointer,
+        Bit,
+        BitVectorPointer,
+        BitVectorPointer,
+        Bit,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitPointer,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitPointer,
+        BitPointer,
+        Bit,
+        Bit,
+        BitVectorPointer,
+        Bit,
+    ]
+
+    lib.rogueSideBandCreate.restype = Context
+    lib.rogueSideBandDestroy.argtypes = [Context]
+    lib.rogueSideBandUpdate.restype = ctypes.c_int
+    lib.rogueSideBandUpdate.argtypes = [
+        Context,
+        Bit,
+        BitVectorPointer,
+        BitVectorPointer,
+        Bit,
+        BitVectorPointer,
+        BitVectorPointer,
+        BitPointer,
+        BitVectorPointer,
+    ]
+
+
+@pytest.fixture(scope="module")
+def native_library():
+    _build_native_library()
+    lib = ctypes.CDLL(str(NATIVE_LIBRARY))
+    _configure_library(lib)
+    return lib
+
+
+def _step_stream(lib, context, port):
+    port_num = BitVector(port)
+    zero = BitVector(0)
+    ob_valid = Bit(0)
+    ob_last = Bit(0)
+    ib_ready = Bit(0)
+    return lib.rogueTcpStreamUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        Bit(0),
+        Bit(0),
+        ctypes.byref(ob_valid),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(ob_last),
+        Bit(0),
+        ctypes.byref(ib_ready),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        Bit(0),
+    )
+
+
+def _step_memory(lib, context, port):
+    port_num = BitVector(port)
+    zero = BitVector(0)
+    ar_valid = Bit(0)
+    r_ready = Bit(0)
+    aw_valid = Bit(0)
+    w_valid = Bit(0)
+    b_ready = Bit(0)
+    return lib.rogueTcpMemoryUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(ar_valid),
+        ctypes.byref(r_ready),
+        Bit(0),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        Bit(0),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(aw_valid),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(w_valid),
+        ctypes.byref(b_ready),
+        Bit(0),
+        Bit(0),
+        ctypes.byref(zero),
+        Bit(0),
+    )
+
+
+def _step_sideband(lib, context, port):
+    port_num = BitVector(port)
+    zero = BitVector(0)
+    rx_enable = Bit(0)
+    return lib.rogueSideBandUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        ctypes.byref(zero),
+        Bit(0),
+        ctypes.byref(zero),
+        ctypes.byref(zero),
+        ctypes.byref(rx_enable),
+        ctypes.byref(zero),
+    )
+
+
+def _stream_cycle(lib, context, port, payload=b"", ob_ready=0):
+    port_num = BitVector(port)
+    data = int.from_bytes(payload.ljust(8, b"\x00"), byteorder="little")
+    data_low = BitVector(data & 0xFFFFFFFF)
+    data_high = BitVector(data >> 32)
+    zero_in = BitVector(0)
+    ob_valid = Bit(0)
+    ob_data_low = BitVector(0)
+    ob_data_high = BitVector(0)
+    ob_user_low = BitVector(0)
+    ob_user_high = BitVector(0)
+    ob_keep = BitVector(0)
+    ob_last = Bit(0)
+    ib_ready = Bit(0)
+    result = lib.rogueTcpStreamUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        Bit(0),
+        Bit(ob_ready),
+        ctypes.byref(ob_valid),
+        ctypes.byref(ob_data_low),
+        ctypes.byref(ob_data_high),
+        ctypes.byref(ob_user_low),
+        ctypes.byref(ob_user_high),
+        ctypes.byref(ob_keep),
+        ctypes.byref(ob_last),
+        Bit(bool(payload)),
+        ctypes.byref(ib_ready),
+        ctypes.byref(data_low),
+        ctypes.byref(data_high),
+        ctypes.byref(zero_in),
+        ctypes.byref(zero_in),
+        ctypes.byref(BitVector((1 << len(payload)) - 1 if payload else 0)),
+        Bit(bool(payload)),
+    )
+    output_word = ob_data_low.value | (ob_data_high.value << 32)
+    output = bytes(
+        (output_word >> (8 * index)) & 0xFF
+        for index in range(8)
+        if (ob_keep.value >> index) & 1
+    )
+    return result, bool(ob_valid.value), output
+
+
+def _memory_cycle(
+    lib,
+    context,
+    port,
+    *,
+    arready=0,
+    rdata=0,
+    rvalid=0,
+    awready=0,
+    wready=0,
+    bvalid=0,
+):
+    port_num = BitVector(port)
+    araddr = BitVector(0)
+    arprot = BitVector(0)
+    arvalid = Bit(0)
+    rready = Bit(0)
+    rdata_in = BitVector(rdata)
+    rresp = BitVector(0)
+    awaddr = BitVector(0)
+    awprot = BitVector(0)
+    awvalid = Bit(0)
+    wdata = BitVector(0)
+    wstrb = BitVector(0)
+    wvalid = Bit(0)
+    bready = Bit(0)
+    bresp = BitVector(0)
+    result = lib.rogueTcpMemoryUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        ctypes.byref(araddr),
+        ctypes.byref(arprot),
+        ctypes.byref(arvalid),
+        ctypes.byref(rready),
+        Bit(arready),
+        ctypes.byref(rdata_in),
+        ctypes.byref(rresp),
+        Bit(rvalid),
+        ctypes.byref(awaddr),
+        ctypes.byref(awprot),
+        ctypes.byref(awvalid),
+        ctypes.byref(wdata),
+        ctypes.byref(wstrb),
+        ctypes.byref(wvalid),
+        ctypes.byref(bready),
+        Bit(awready),
+        Bit(wready),
+        ctypes.byref(bresp),
+        Bit(bvalid),
+    )
+    return {
+        "result": result,
+        "araddr": araddr.value,
+        "arvalid": bool(arvalid.value),
+        "awaddr": awaddr.value,
+        "awvalid": bool(awvalid.value),
+        "wdata": wdata.value,
+        "wvalid": bool(wvalid.value),
+    }
+
+
+def _sideband_cycle(lib, context, port, tx_opcode=0, tx_enable=0, tx_remdata=0):
+    port_num = BitVector(port)
+    tx_opcode_in = BitVector(tx_opcode)
+    tx_remdata_in = BitVector(tx_remdata)
+    rx_opcode = BitVector(0)
+    rx_enable = Bit(0)
+    rx_remdata = BitVector(0)
+    result = lib.rogueSideBandUpdate(
+        context,
+        Bit(0),
+        ctypes.byref(port_num),
+        ctypes.byref(tx_opcode_in),
+        Bit(tx_enable),
+        ctypes.byref(tx_remdata_in),
+        ctypes.byref(rx_opcode),
+        ctypes.byref(rx_enable),
+        ctypes.byref(rx_remdata),
+    )
+    return result, bool(rx_enable.value), rx_opcode.value, rx_remdata.value
+
+
+def _peer_socket(context, socket_type, endpoint):
+    socket = context.socket(socket_type)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.setsockopt(zmq.RCVTIMEO, 5000)
+    socket.connect(endpoint)
+    return socket
+
+
+def test_dpi_instances_bind_independently_and_reuse_ports(native_library):
+    lib = native_library
+    specs = (
+        [(lib.rogueTcpStreamCreate, lib.rogueTcpStreamDestroy, _step_stream)] * 4
+        + [(lib.rogueTcpMemoryCreate, lib.rogueTcpMemoryDestroy, _step_memory)] * 2
+        + [(lib.rogueSideBandCreate, lib.rogueSideBandDestroy, _step_sideband)] * 2
+    )
+    ports = tuple(19600 + (index * 2) for index in range(len(specs)))
+    contexts = []
+
+    try:
+        for (create, destroy, step), port in zip(specs, ports):
+            context = create()
+            assert context
+            assert step(lib, context, port) == 1
+            contexts.append((context, destroy))
+
+        assert len({int(context) for context, _ in contexts}) == len(contexts)
+    finally:
+        for context, destroy in reversed(contexts):
+            destroy(context)
+
+    for (create, destroy, step), port in zip(specs, ports):
+        replacement = create()
+        assert replacement
+        try:
+            assert step(lib, replacement, port) == 1
+        finally:
+            destroy(replacement)
+
+
+def test_dpi_instances_exchange_isolated_active_traffic(native_library):
+    lib = native_library
+    zmq_context = zmq.Context()
+    contexts = []
+    sockets = []
+
+    try:
+        stream_models = []
+        for tag in range(4):
+            port = 19680 + (2 * tag)
+            context = lib.rogueTcpStreamCreate()
+            assert context
+            contexts.append((context, lib.rogueTcpStreamDestroy))
+            push = _peer_socket(zmq_context, zmq.PUSH, f"tcp://127.0.0.1:{port}")
+            pull = _peer_socket(zmq_context, zmq.PULL, f"tcp://127.0.0.1:{port + 1}")
+            sockets.extend((push, pull))
+            assert _step_stream(lib, context, port) == 1
+            stream_models.append((tag, port, context, push, pull))
+
+        for tag, _, _, push, _ in stream_models:
+            push.send_multipart(encode_stream_frame(0, 0, 0, bytes([0x10 + tag] * 4)))
+
+        for tag, port, context, _, pull in stream_models:
+            outbound = bytes([0x80 + tag] * 4)
+            received = None
+            for cycle in range(10000):
+                result, valid, payload = _stream_cycle(
+                    lib,
+                    context,
+                    port,
+                    payload=outbound if cycle == 0 else b"",
+                )
+                assert result == 1
+                if valid:
+                    received = payload
+                    break
+            assert received == bytes([0x10 + tag] * 4)
+            assert decode_stream_frames(pull.recv_multipart())["data_hex"] == outbound.hex()
+
+        memory_models = []
+        for tag in range(2):
+            port = 19688 + (2 * tag)
+            context = lib.rogueTcpMemoryCreate()
+            assert context
+            contexts.append((context, lib.rogueTcpMemoryDestroy))
+            push = _peer_socket(zmq_context, zmq.PUSH, f"tcp://127.0.0.1:{port}")
+            pull = _peer_socket(zmq_context, zmq.PULL, f"tcp://127.0.0.1:{port + 1}")
+            sockets.extend((push, pull))
+            assert _step_memory(lib, context, port) == 1
+            memory_models.append((tag, port, context, push, pull))
+
+        for tag, port, context, push, pull in memory_models:
+            address = 0x100 + (tag * 0x10)
+            payload = bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag])
+            push.send_multipart(encode_mem_request(1, address, 4, T_WRITE, payload))
+
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                outputs = _memory_cycle(lib, context, port)
+                assert outputs["result"] == 1
+                if outputs["awvalid"] and outputs["wvalid"]:
+                    break
+                time.sleep(0.001)
+            else:
+                pytest.fail(f"memory instance {tag} did not issue its write")
+
+            assert outputs["awaddr"] == address
+            assert outputs["wdata"] == int.from_bytes(payload, byteorder="little")
+            assert _memory_cycle(
+                lib,
+                context,
+                port,
+                awready=1,
+                wready=1,
+                bvalid=1,
+            )["result"] == 1
+            write_response = decode_mem_response(pull.recv_multipart())
+            assert write_response["result"] == 0
+
+            push.send_multipart(encode_mem_request(2, address, 4, T_READ))
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                outputs = _memory_cycle(lib, context, port)
+                assert outputs["result"] == 1
+                if outputs["arvalid"]:
+                    break
+                time.sleep(0.001)
+            else:
+                pytest.fail(f"memory instance {tag} did not issue its read")
+
+            assert outputs["araddr"] == address
+            assert _memory_cycle(lib, context, port, arready=1)["result"] == 1
+            assert _memory_cycle(
+                lib,
+                context,
+                port,
+                rdata=int.from_bytes(payload, byteorder="little"),
+                rvalid=1,
+            )["result"] == 1
+            read_response = decode_mem_response(pull.recv_multipart())
+            assert read_response["data_hex"] == payload.hex()
+
+        sideband_models = []
+        for tag in range(2):
+            port = 19692 + (2 * tag)
+            context = lib.rogueSideBandCreate()
+            assert context
+            contexts.append((context, lib.rogueSideBandDestroy))
+            push = _peer_socket(zmq_context, zmq.PUSH, f"tcp://127.0.0.1:{port + 1}")
+            pull = _peer_socket(zmq_context, zmq.PULL, f"tcp://127.0.0.1:{port}")
+            sockets.extend((push, pull))
+            assert _step_sideband(lib, context, port) == 1
+            sideband_models.append((tag, port, context, push, pull))
+
+        for tag, _, _, push, _ in sideband_models:
+            push.send(encode_sideband_frame(1, 0x20 + tag, 0, 0))
+            push.send(encode_sideband_frame(0, 0, 1, 0x40 + tag))
+
+        for tag, port, context, _, pull in sideband_models:
+            received_opcode = None
+            received_remdata = None
+            cycle = 0
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                result, enabled, opcode, remdata = _sideband_cycle(
+                    lib,
+                    context,
+                    port,
+                    tx_opcode=0x60 + tag,
+                    tx_enable=1 if cycle == 0 else 0,
+                    tx_remdata=0x70 + tag,
+                )
+                assert result == 1
+                if enabled:
+                    received_opcode = opcode
+                if remdata != 0:
+                    received_remdata = remdata
+                if received_opcode is not None and received_remdata is not None:
+                    break
+                cycle += 1
+                time.sleep(0.001)
+            assert received_opcode == 0x20 + tag
+            assert received_remdata == 0x40 + tag
+            outbound = decode_sideband_frame(pull.recv())
+            assert outbound["opCode"] == 0x60 + tag
+            assert outbound["remData"] == 0x70 + tag
+    finally:
+        for context, destroy in reversed(contexts):
+            destroy(context)
+        for socket in sockets:
+            socket.close()
+        zmq_context.term()
+
+
+def test_dpi_rejects_overlapping_and_changed_ports(native_library):
+    lib = native_library
+    stream = lib.rogueTcpStreamCreate()
+    memory = lib.rogueTcpMemoryCreate()
+    sideband = lib.rogueSideBandCreate()
+    assert stream and memory and sideband
+
+    try:
+        assert _step_stream(lib, stream, 19640) == 1
+        assert _step_memory(lib, memory, 19641) == 0
+        assert _step_stream(lib, stream, 19642) == 0
+        assert _step_sideband(lib, sideband, 0) == 0
+        assert _step_sideband(lib, sideband, 0xFFFF) == 0
+    finally:
+        lib.rogueSideBandDestroy(sideband)
+        lib.rogueTcpMemoryDestroy(memory)
+        lib.rogueTcpStreamDestroy(stream)
+
+
+def test_dpi_rejects_null_and_wrong_model_contexts(native_library):
+    lib = native_library
+    stream = lib.rogueTcpStreamCreate()
+    assert stream
+
+    try:
+        assert _step_stream(lib, None, 19650) == 0
+        assert _step_memory(lib, stream, 19652) == 0
+    finally:
+        lib.rogueTcpStreamDestroy(stream)

--- a/tests/axi/simlink/test_RogueDpiInstance.py
+++ b/tests/axi/simlink/test_RogueDpiInstance.py
@@ -455,7 +455,9 @@ def test_dpi_instances_exchange_isolated_active_traffic(native_library):
         for tag, port, context, _, pull in stream_models:
             outbound = bytes([0x80 + tag] * 4)
             received = None
-            for cycle in range(10000):
+            cycle = 0
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
                 result, valid, payload = _stream_cycle(
                     lib,
                     context,
@@ -463,9 +465,11 @@ def test_dpi_instances_exchange_isolated_active_traffic(native_library):
                     payload=outbound if cycle == 0 else b"",
                 )
                 assert result == 1
+                cycle += 1
                 if valid:
                     received = payload
                     break
+                time.sleep(0.001)
             assert received == bytes([0x10 + tag] * 4)
             assert decode_stream_frames(pull.recv_multipart())["data_hex"] == outbound.hex()
 

--- a/tests/axi/simlink/test_RogueTcpMemoryWrap.py
+++ b/tests/axi/simlink/test_RogueTcpMemoryWrap.py
@@ -36,10 +36,12 @@
 
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
 import cocotb
+import pytest
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
 from cocotbext.axi import AxiLiteBus, AxiLiteRam
@@ -163,6 +165,8 @@ def test_RogueTcpMemory_uninitialized_read():
     # read overwrites the tainted bytes before any response is sent), so this
     # test links the unmodified C model into a narrow harness and watches it
     # under valgrind memcheck instead.
+    if shutil.which("valgrind") is None:
+        pytest.skip("uninitialised-read reproduction needs valgrind")
     SIM_BUILD.mkdir(parents=True, exist_ok=True)
 
     cflags = subprocess.run(

--- a/tests/axi/simlink/test_RogueTcpMemoryWrap.py
+++ b/tests/axi/simlink/test_RogueTcpMemoryWrap.py
@@ -9,8 +9,10 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: None -- a single fixed ZMQ port pair (9606/9607); this is a
-#   round-trip regression, not a swept parameter matrix.
+# - Sweep: None -- the cocotb round trip uses fixed ZMQ ports 9606/9607, while
+#   the standalone zero-size check selects an unused local pair to remain
+#   rerunnable after its intentionally aborting server. This is not a swept
+#   parameter matrix.
 # - Stimulus: Spawn rogue_tcp_peer.py (--mode memory) as a separate OS
 #   process before releasing reset, so the C model's first post-reset edge
 #   binds its ZMQ sockets while the peer is already connecting. The peer
@@ -31,12 +33,14 @@
 #
 # Exercises the memory round trip (read + write, varied addr/data),
 # cocotbext.axi binding the flat wrapper's M_AXI scalar master bus to
-# AxiLiteRam, and the separate-process Rogue-TCP peer memory protocol for
-# RogueTcpMemoryWrap.
+# AxiLiteRam, the separate-process Rogue-TCP peer memory protocol for
+# RogueTcpMemoryWrap, rejection of zero-length reads, and the historical
+# uninitialized-read regression under valgrind when available.
 
 import json
 from pathlib import Path
 import shutil
+import socket
 import subprocess
 import sys
 
@@ -56,6 +60,7 @@ GHDL_DIR = Path(__file__).resolve().parents[3] / "axi" / "simlink" / "ghdl"
 SHARED_DIR = Path(__file__).resolve().parents[3] / "axi" / "simlink" / "shared"
 SIM_BUILD = HERE / "sim_build_RogueTcpMemoryWrap"
 UNINIT_READ_HARNESS = SIM_BUILD / "uninit_read_recv_harness"
+ZERO_SIZE_READ_HARNESS = SIM_BUILD / "zero_size_read_harness"
 
 CLK_PERIOD_NS = 10
 RST_EDGES = 3
@@ -64,6 +69,41 @@ PORT_NUM = 9606
 # Fresh port pair, never used by another test function in this module (a
 # separate pytest function is its own xdist-schedulable unit).
 UNINIT_READ_PORT_NUM = 9608
+
+
+def _unused_tcp_port_pair() -> int:
+    while True:
+        with socket.socket() as first:
+            first.bind(("127.0.0.1", 0))
+            port = first.getsockname()[1]
+            if port == 65535:
+                continue
+            try:
+                with socket.socket() as second:
+                    second.bind(("127.0.0.1", port + 1))
+            except OSError:
+                continue
+            return port
+
+
+def _build_memory_recv_harness(output: Path) -> None:
+    SIM_BUILD.mkdir(parents=True, exist_ok=True)
+
+    cflags = subprocess.run(
+        ["pkg-config", "--cflags", "libzmq"], check=True, capture_output=True, text=True
+    ).stdout.split()
+    libs = subprocess.run(
+        ["pkg-config", "--libs", "libzmq"], check=True, capture_output=True, text=True
+    ).stdout.split()
+
+    subprocess.run(
+        [
+            "gcc", "-Wall", "-g", f"-I{GHDL_DIR}", f"-I{SHARED_DIR}", *cflags,
+            str(GHDL_DIR / "RogueTcpMemory.c"), str(HERE / "uninit_read_recv_harness.c"),
+            "-o", str(output), *libs,
+        ],
+        check=True,
+    )
 
 
 class TB:
@@ -157,6 +197,38 @@ def test_RogueTcpMemoryWrap():
     )
 
 
+def test_RogueTcpMemory_zero_size_read_rejected():
+    _build_memory_recv_harness(ZERO_SIZE_READ_HARNESS)
+    port = _unused_tcp_port_pair()
+
+    proc = subprocess.Popen(
+        [str(ZERO_SIZE_READ_HARNESS), str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    push.connect(f"tcp://127.0.0.1:{port}")
+
+    try:
+        push.send_multipart(encode_mem_request(1, 0x0, 0, T_READ))
+
+        _, stderr = proc.communicate(timeout=10)
+        assert proc.returncode != 0, "zero-length read was accepted"
+        assert "Transaction size invalid" in stderr
+    finally:
+        push.close(linger=0)
+        ctx.term()
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or shutil.which("valgrind") is None,
+    reason="uninitialized-read reproduction is Linux-only and needs valgrind on PATH",
+)
 def test_RogueTcpMemory_uninitialized_read():
     # Standalone (non-cocotb) reproduction of the bug: on a 4-frame memory
     # read request, RogueTcpMemoryRecv() never receives a 5th data frame, so
@@ -165,25 +237,7 @@ def test_RogueTcpMemory_uninitialized_read():
     # read overwrites the tainted bytes before any response is sent), so this
     # test links the unmodified C model into a narrow harness and watches it
     # under valgrind memcheck instead.
-    if shutil.which("valgrind") is None:
-        pytest.skip("uninitialised-read reproduction needs valgrind")
-    SIM_BUILD.mkdir(parents=True, exist_ok=True)
-
-    cflags = subprocess.run(
-        ["pkg-config", "--cflags", "libzmq"], check=True, capture_output=True, text=True
-    ).stdout.split()
-    libs = subprocess.run(
-        ["pkg-config", "--libs", "libzmq"], check=True, capture_output=True, text=True
-    ).stdout.split()
-
-    subprocess.run(
-        [
-            "gcc", "-Wall", "-g", f"-I{GHDL_DIR}", f"-I{SHARED_DIR}", *cflags,
-            str(GHDL_DIR / "RogueTcpMemory.c"), str(HERE / "uninit_read_recv_harness.c"),
-            "-o", str(UNINIT_READ_HARNESS), *libs,
-        ],
-        check=True,
-    )
+    _build_memory_recv_harness(UNINIT_READ_HARNESS)
 
     proc = subprocess.Popen(
         [

--- a/tests/axi/simlink/test_RogueXsimMulti.py
+++ b/tests/axi/simlink/test_RogueXsimMulti.py
@@ -1,0 +1,123 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: One eight-instance mixed-model top and one duplicate-Stream-port
+#   negative top under the actual Vivado xsim mixed-language/DPI flow.
+# - Stimulus: Compile the VHDL forwarding entities and SystemVerilog leaves,
+#   build RogueTcpDpi.so, pulse reset twice, and run bounded clocks with benign
+#   model inputs and no external peer.
+# - Checks: Four Stream and two each Memory and SideBand leaves elaborate,
+#   retain independent chandle contexts, bind distinct endpoint pairs, finish
+#   normally, and release resources; the duplicate pair terminates via $fatal.
+# - Timing: Both VHDL tops contain bounded clock loops and subprocesses have
+#   wall-clock timeouts. Tests skip explicitly when proprietary Vivado
+#   simulator tools are not available on PATH.
+
+import fcntl
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+XSIM_DIR = REPO_ROOT / "axi" / "simlink" / "xsim"
+HERE = Path(__file__).resolve().parent
+TB_SOURCE = HERE / "RogueXsimMultiTb.vhd"
+SIM_BUILD = HERE / "sim_build_RogueXsimMulti"
+
+VHDL_SOURCES = [
+    XSIM_DIR / "RogueTcpStream.vhd",
+    XSIM_DIR / "RogueTcpMemory.vhd",
+    XSIM_DIR / "RogueSideBand.vhd",
+    TB_SOURCE,
+]
+SV_SOURCES = [
+    XSIM_DIR / "RogueTcpStreamDpi.sv",
+    XSIM_DIR / "RogueTcpMemoryDpi.sv",
+    XSIM_DIR / "RogueSideBandDpi.sv",
+]
+REQUIRED_TOOLS = ("make", "xsc", "xvlog", "xvhdl", "xelab", "xsim")
+BUILD_TIMEOUT_SECONDS = 300
+RUN_TIMEOUT_SECONDS = 120
+
+pytestmark = pytest.mark.skipif(
+    any(shutil.which(tool) is None for tool in REQUIRED_TOOLS),
+    reason="Vivado xsim multi-instance regression needs make/xsc/xvlog/xvhdl/xelab/xsim",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_dpi_library():
+    build_dir = XSIM_DIR / "xsim.dir"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    with open(build_dir / ".pytest-build.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        subprocess.run(
+            ["make", "-C", str(XSIM_DIR), "all", "abi-check"],
+            check=True,
+            timeout=BUILD_TIMEOUT_SECONDS,
+        )
+
+
+def _run_top(top):
+    build_dir = SIM_BUILD / top
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        ["xvlog", "-sv", *(str(source) for source in SV_SOURCES)],
+        cwd=build_dir,
+        check=True,
+        timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        ["xvhdl", "-2008", *(str(source) for source in VHDL_SOURCES)],
+        cwd=build_dir,
+        check=True,
+        timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        [
+            "xelab",
+            "-debug",
+            "typical",
+            "-s",
+            top,
+            "-sv_root",
+            str(XSIM_DIR),
+            "-sv_lib",
+            "RogueTcpDpi",
+            f"work.{top}",
+        ],
+        cwd=build_dir,
+        check=True,
+        timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    return subprocess.run(
+        ["xsim", top, "-R"],
+        cwd=build_dir,
+        capture_output=True,
+        text=True,
+        timeout=RUN_TIMEOUT_SECONDS,
+    )
+
+
+def test_xsim_multi_instance_smoke():
+    result = _run_top("RogueXsimMultiTb")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Rogue xsim multi-instance smoke test passed" in result.stdout
+
+
+def test_xsim_rejects_duplicate_port_pair():
+    result = _run_top("RogueXsimDuplicatePortTb")
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "overlaps live RogueTcpStream port pair" in output

--- a/tests/axi/simlink/test_RogueXsimMulti.py
+++ b/tests/axi/simlink/test_RogueXsimMulti.py
@@ -21,126 +21,25 @@
 #   wall-clock timeouts. Tests skip explicitly when proprietary Vivado
 #   simulator tools are not available on PATH.
 
-import fcntl
-import os
-from pathlib import Path
-import shutil
-import subprocess
-
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-XSIM_DIR = REPO_ROOT / "axi" / "simlink" / "xsim"
-HERE = Path(__file__).resolve().parent
+from tests.axi.simlink import xsim_test_utils as xu
+
+HERE = xu.REPO_ROOT / "tests" / "axi" / "simlink"
 TB_SOURCE = HERE / "RogueXsimMultiTb.vhd"
 SIM_BUILD = HERE / "sim_build_RogueXsimMulti"
+VHDL_SOURCES = [*xu.MODEL_VHDL_SOURCES, TB_SOURCE]
 
-VHDL_SOURCES = [
-    XSIM_DIR / "RogueTcpStream.vhd",
-    XSIM_DIR / "RogueTcpMemory.vhd",
-    XSIM_DIR / "RogueSideBand.vhd",
-    TB_SOURCE,
-]
-SV_SOURCES = [
-    XSIM_DIR / "RogueTcpStreamDpi.sv",
-    XSIM_DIR / "RogueTcpMemoryDpi.sv",
-    XSIM_DIR / "RogueSideBandDpi.sv",
-]
-REQUIRED_TOOLS = ("make", "xsc", "xvlog", "xvhdl", "xelab", "xsim")
-BUILD_TIMEOUT_SECONDS = 300
-RUN_TIMEOUT_SECONDS = 120
-
-pytestmark = pytest.mark.skipif(
-    any(shutil.which(tool) is None for tool in REQUIRED_TOOLS),
-    reason="Vivado xsim multi-instance regression needs make/xsc/xvlog/xvhdl/xelab/xsim",
-)
-
-
-def _xsim_run_env():
-    """Return the environment for running xsim's DPI-linked snapshot.
-
-    Every Vivado release bundles its own (older) libstdc++ and puts it ahead of
-    the system libraries at run time. When the host libzmq was built against a
-    newer libstdc++ than Vivado's, xsimk fails to start with a "GLIBCXX_...
-    not found (required by libzmq.so.5)" loader error. Preloading the system
-    libstdc++ (located portably via gcc, matching the xsim Makefile's crti.o
-    lookup) resolves the newer symbols without affecting the build steps.
-    Harmless when Vivado's bundled libstdc++ is already new enough.
-    """
-    env = os.environ.copy()
-    try:
-        libstdcxx = subprocess.run(
-            ["gcc", "-print-file-name=libstdc++.so.6"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        return env
-    # gcc prints the bare name back unchanged when it cannot resolve a path.
-    if not libstdcxx or not os.path.isfile(libstdcxx):
-        return env
-    preload = [libstdcxx]
-    if env.get("LD_PRELOAD"):
-        preload.append(env["LD_PRELOAD"])
-    env["LD_PRELOAD"] = os.pathsep.join(preload)
-    return env
+pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def build_dpi_library():
-    build_dir = XSIM_DIR / "xsim.dir"
-    build_dir.mkdir(parents=True, exist_ok=True)
-    with open(build_dir / ".pytest-build.lock", "w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
-        subprocess.run(
-            ["make", "-C", str(XSIM_DIR), "all", "abi-check"],
-            check=True,
-            timeout=BUILD_TIMEOUT_SECONDS,
-        )
+    xu.build_dpi_library()
 
 
 def _run_top(top):
-    build_dir = SIM_BUILD / top
-    build_dir.mkdir(parents=True, exist_ok=True)
-
-    subprocess.run(
-        ["xvlog", "-sv", *(str(source) for source in SV_SOURCES)],
-        cwd=build_dir,
-        check=True,
-        timeout=BUILD_TIMEOUT_SECONDS,
-    )
-    subprocess.run(
-        ["xvhdl", "-2008", *(str(source) for source in VHDL_SOURCES)],
-        cwd=build_dir,
-        check=True,
-        timeout=BUILD_TIMEOUT_SECONDS,
-    )
-    subprocess.run(
-        [
-            "xelab",
-            "-debug",
-            "typical",
-            "-s",
-            top,
-            "-sv_root",
-            str(XSIM_DIR),
-            "-sv_lib",
-            "RogueTcpDpi",
-            f"work.{top}",
-        ],
-        cwd=build_dir,
-        check=True,
-        timeout=BUILD_TIMEOUT_SECONDS,
-    )
-    return subprocess.run(
-        ["xsim", top, "-R"],
-        cwd=build_dir,
-        capture_output=True,
-        text=True,
-        timeout=RUN_TIMEOUT_SECONDS,
-        env=_xsim_run_env(),
-    )
+    return xu.run_top(top, VHDL_SOURCES, SIM_BUILD)
 
 
 def test_xsim_multi_instance_smoke():

--- a/tests/axi/simlink/test_RogueXsimMulti.py
+++ b/tests/axi/simlink/test_RogueXsimMulti.py
@@ -22,6 +22,7 @@
 #   simulator tools are not available on PATH.
 
 import fcntl
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -53,6 +54,37 @@ pytestmark = pytest.mark.skipif(
     any(shutil.which(tool) is None for tool in REQUIRED_TOOLS),
     reason="Vivado xsim multi-instance regression needs make/xsc/xvlog/xvhdl/xelab/xsim",
 )
+
+
+def _xsim_run_env():
+    """Return the environment for running xsim's DPI-linked snapshot.
+
+    Every Vivado release bundles its own (older) libstdc++ and puts it ahead of
+    the system libraries at run time. When the host libzmq was built against a
+    newer libstdc++ than Vivado's, xsimk fails to start with a "GLIBCXX_...
+    not found (required by libzmq.so.5)" loader error. Preloading the system
+    libstdc++ (located portably via gcc, matching the xsim Makefile's crti.o
+    lookup) resolves the newer symbols without affecting the build steps.
+    Harmless when Vivado's bundled libstdc++ is already new enough.
+    """
+    env = os.environ.copy()
+    try:
+        libstdcxx = subprocess.run(
+            ["gcc", "-print-file-name=libstdc++.so.6"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return env
+    # gcc prints the bare name back unchanged when it cannot resolve a path.
+    if not libstdcxx or not os.path.isfile(libstdcxx):
+        return env
+    preload = [libstdcxx]
+    if env.get("LD_PRELOAD"):
+        preload.append(env["LD_PRELOAD"])
+    env["LD_PRELOAD"] = os.pathsep.join(preload)
+    return env
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -107,6 +139,7 @@ def _run_top(top):
         capture_output=True,
         text=True,
         timeout=RUN_TIMEOUT_SECONDS,
+        env=_xsim_run_env(),
     )
 
 
@@ -119,5 +152,9 @@ def test_xsim_multi_instance_smoke():
 def test_xsim_rejects_duplicate_port_pair():
     result = _run_top("RogueXsimDuplicatePortTb")
     output = result.stdout + result.stderr
-    assert result.returncode != 0, output
-    assert "overlaps live RogueTcpStream port pair" in output
+    # xsim's $fatal exits 0 even in batch (-R) mode, so the return code cannot
+    # distinguish rejection from success. The port-pair guard must fire (the
+    # $fatal message is present) and the testbench's "not rejected" failure
+    # branch must never be reached.
+    assert "overlaps live RogueTcpStream port pair" in output, output
+    assert "Duplicate xsim port pair was not rejected" not in output, output

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -75,9 +75,14 @@ def _reap(procs):
 
 def test_xsim_stream_instances_exchange_isolated_traffic():
     result_dir = SIM_BUILD / "peers"
+    # Elaborate first, then spawn peers just before the run: the peers'
+    # RCVTIMEO budget must cover only the short simulation, not the
+    # multi-second xvlog/xvhdl/xelab flow (during which a peer would otherwise
+    # time out and exit, wedging the DUT's synchronous ZMQ send).
+    xu.compile_and_elaborate("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
     procs = _spawn_peers(STREAM_PEERS, result_dir)
     try:
-        result = xu.run_top("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
+        result = xu.run_elaborated("RogueXsimTrafficTb", SIM_BUILD)
         output = result.stdout + result.stderr
         assert "Rogue xsim traffic test passed" in output, output
 

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -10,8 +10,7 @@
 
 # Test methodology:
 # - Sweep: One eight-instance top (4 Stream, 2 Memory, 2 SideBand) run under
-#   the real Vivado xsim mixed-language/DPI flow with live peers. (Stream +
-#   Memory for now; SideBand added in a later task.)
+#   the real Vivado xsim mixed-language/DPI flow with live peers.
 # - Stimulus: Launch one rogue_tcp_peer.py per instance (each --tag i) before
 #   xsim starts; the top holds off outbound traffic for a fixed settle delay
 #   so peers are connected and draining, then exchanges a tagged family per
@@ -41,10 +40,12 @@ PEER_WAIT_SECONDS = 30
 
 # Endpoint port map (single source of truth is shared with
 # RogueXsimTrafficTb.vhd -- keep both in sync):
-#   Stream i -> 19740 + 2*i  (19740..19747)
-#   Memory i -> 19748 + 2*i  (19748..19751)
+#   Stream   i -> 19740 + 2*i  (19740..19747)
+#   Memory   i -> 19748 + 2*i  (19748..19751)
+#   SideBand i -> 19752 + 2*i  (19752..19755)
 STREAM_PEERS = [("stream", i, 19740 + 2 * i) for i in range(4)]
 MEMORY_PEERS = [("memory", i, 19748 + 2 * i) for i in range(2)]
+SIDEBAND_PEERS = [("sideband", i, 19752 + 2 * i) for i in range(2)]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -85,7 +86,7 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
     # multi-second xvlog/xvhdl/xelab flow (during which a peer would otherwise
     # time out and exit, wedging the DUT's synchronous ZMQ send).
     xu.compile_and_elaborate("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
-    procs = _spawn_peers(STREAM_PEERS + MEMORY_PEERS, result_dir)
+    procs = _spawn_peers(STREAM_PEERS + MEMORY_PEERS + SIDEBAND_PEERS, result_dir)
     try:
         result = xu.run_elaborated("RogueXsimTrafficTb", SIM_BUILD)
         output = result.stdout + result.stderr
@@ -105,7 +106,7 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
                 own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
                 for frame in observed["received"]:
                     assert frame["data_hex"] == own, (tag, frame)
-            else:
+            elif mode == "memory":
                 # Memory: every txn OKAY, and the read-back data equals this
                 # tag's write vector -- itself the cross-instance isolation
                 # check, since a foreign instance's data would differ.
@@ -118,5 +119,21 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
                 assert reads, (tag, observed)
                 for txn in reads:
                     assert txn["data_hex"] == own, (tag, txn)
+            elif mode == "sideband":
+                # SideBand: the peer's received frames are the DUT's tx values
+                # echoed back -- an opcode 0x60+tag and a remData 0x70+tag. A
+                # foreign instance would surface a different tag, so requiring
+                # this instance's exact opcode/remData is the isolation check.
+                received = observed["received"]
+                assert any(
+                    f["opCodeEn"] == 1 and f["opCode"] == 0x60 + tag
+                    for f in received
+                ), (tag, observed)
+                assert any(
+                    f["remDataChanged"] == 1 and f["remData"] == 0x70 + tag
+                    for f in received
+                ), (tag, observed)
+            else:
+                raise AssertionError(f"unknown peer mode {mode}")
     finally:
         _reap(procs)

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -79,7 +79,7 @@ def _reap(procs):
                 proc.kill()
 
 
-def test_xsim_stream_instances_exchange_isolated_traffic():
+def test_xsim_instances_exchange_isolated_traffic():
     result_dir = SIM_BUILD / "peers"
     # Elaborate first, then spawn peers just before the run: the peers'
     # RCVTIMEO budget must cover only the short simulation, not the

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -103,6 +103,12 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
             assert rc == 0, f"{mode} peer tag {tag} exited {rc}"
             observed = json.loads(result_path.read_text())
             if mode == "stream":
+                # Explicit foreign-tag rejection: every received frame must
+                # carry this instance's own tag (0x80+tag)*4 and nothing else.
+                # The peer's stream_frame_is_foreign() already rejects any
+                # 0x80+j (j != tag) at the source (forcing rc != 0, caught by
+                # the rc == 0 assertion above); requiring == own here is the
+                # same isolation guarantee restated on the received data.
                 own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
                 for frame in observed["received"]:
                     assert frame["data_hex"] == own, (tag, frame)
@@ -119,6 +125,17 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
                 assert reads, (tag, observed)
                 for txn in reads:
                     assert txn["data_hex"] == own, (tag, txn)
+                # Explicit foreign-tag rejection: no transaction may carry
+                # another memory instance's write vector. A write txn may have
+                # an empty data_hex, so allow "" or own; forbid any other
+                # instance's payload outright (the two memory tags are 0..1).
+                foreign_hex = {
+                    bytes([0x40 + j, 0x50 + j, 0x60 + j, 0x70 + j]).hex()
+                    for j in range(2) if j != tag
+                }
+                for txn in txns:
+                    assert txn["data_hex"] in ("", own), (tag, txn)
+                    assert txn["data_hex"] not in foreign_hex, (tag, txn)
             elif mode == "sideband":
                 # SideBand: the peer's received frames are the DUT's tx values
                 # echoed back -- an opcode 0x60+tag and a remData 0x70+tag. A
@@ -133,6 +150,21 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
                     f["remDataChanged"] == 1 and f["remData"] == 0x70 + tag
                     for f in received
                 ), (tag, observed)
+                # Explicit foreign-tag rejection: no received frame may carry
+                # another sideband instance's opcode or remData. The two
+                # sideband tags are 0..1, so a foreign frame would surface
+                # opCode 0x60+j or remData 0x70+j for j != tag.
+                for j in range(2):
+                    if j == tag:
+                        continue
+                    assert not any(
+                        f["opCodeEn"] == 1 and f["opCode"] == 0x60 + j
+                        for f in received
+                    ), (tag, j, observed)
+                    assert not any(
+                        f["remDataChanged"] == 1 and f["remData"] == 0x70 + j
+                        for f in received
+                    ), (tag, j, observed)
             else:
                 raise AssertionError(f"unknown peer mode {mode}")
     finally:

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -11,10 +11,10 @@
 # Test methodology:
 # - Sweep: One eight-instance top (4 Stream, 2 Memory, 2 SideBand) run under
 #   the real Vivado xsim mixed-language/DPI flow with live peers.
-# - Stimulus: Launch one rogue_tcp_peer.py per instance (each --tag i) before
-#   xsim starts; the top holds off outbound traffic for a fixed settle delay
-#   so peers are connected and draining, then exchanges a tagged family per
-#   instance.
+# - Stimulus: Launch one rogue_tcp_peer.py per instance, wait until every peer
+#   reports that its ZeroMQ sockets are configured and connect() has been
+#   issued, then start xsim. The top retains a fixed settle delay for the
+#   asynchronous ZeroMQ handshake before exchanging tagged traffic.
 # - Checks: xsim prints the success banner, every peer exits 0, and each
 #   peer's JSON shows only its own tag family with zero foreign tags.
 # - Timing: The top uses bounded clock loops; each peer bounds recv with
@@ -23,10 +23,16 @@
 import json
 import subprocess
 import sys
+import time
 
 import pytest
 
 from tests.axi.simlink import xsim_test_utils as xu
+from tests.axi.simlink.rogue_tcp_peer import (
+    memory_instance_transactions,
+    sideband_instance_vectors,
+    stream_instance_vectors,
+)
 
 HERE = xu.REPO_ROOT / "tests" / "axi" / "simlink"
 TB_SOURCE = HERE / "RogueXsimTrafficTb.vhd"
@@ -37,15 +43,16 @@ VHDL_SOURCES = [*xu.MODEL_VHDL_SOURCES, TB_SOURCE]
 pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
 
 PEER_WAIT_SECONDS = 30
+PEER_READY_SECONDS = 10
 
 # Endpoint port map (single source of truth is shared with
 # RogueXsimTrafficTb.vhd -- keep both in sync):
 #   Stream   i -> 19740 + 2*i  (19740..19747)
 #   Memory   i -> 19748 + 2*i  (19748..19751)
 #   SideBand i -> 19752 + 2*i  (19752..19755)
-STREAM_PEERS = [("stream", i, 19740 + 2 * i) for i in range(4)]
-MEMORY_PEERS = [("memory", i, 19748 + 2 * i) for i in range(2)]
-SIDEBAND_PEERS = [("sideband", i, 19752 + 2 * i) for i in range(2)]
+STREAM_PEERS = [("stream-instance", i, 19740 + 2 * i) for i in range(4)]
+MEMORY_PEERS = [("memory-instance", i, 19748 + 2 * i) for i in range(2)]
+SIDEBAND_PEERS = [("sideband-instance", i, 19752 + 2 * i) for i in range(2)]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -58,10 +65,14 @@ def _spawn_peers(specs, result_dir):
     procs = []
     for mode, tag, port in specs:
         result_path = result_dir / f"{mode}_{tag}_{port}.json"
+        ready_path = result_dir / f"{mode}_{tag}_{port}.ready"
+        result_path.unlink(missing_ok=True)
+        ready_path.unlink(missing_ok=True)
         procs.append((
-            mode, tag, port, result_path,
+            mode, tag, port, result_path, ready_path,
             subprocess.Popen(
                 [sys.executable, str(PEER), "--mode", mode, "--tag", str(tag),
+                 "--ready-file", str(ready_path),
                  str(port), str(result_path)],
                 env=xu.xsim_run_env(),
             ),
@@ -69,8 +80,29 @@ def _spawn_peers(specs, result_dir):
     return procs
 
 
+def _wait_for_peers_ready(procs):
+    deadline = time.monotonic() + PEER_READY_SECONDS
+    while time.monotonic() < deadline:
+        failed = [
+            (mode, tag, proc.returncode)
+            for mode, tag, _, _, _, proc in procs
+            if proc.poll() is not None
+        ]
+        if failed:
+            raise AssertionError(f"peer exited before readiness: {failed}")
+        if all(ready_path.exists() for _, _, _, _, ready_path, _ in procs):
+            return
+        time.sleep(0.01)
+    pending = [
+        (mode, tag, port)
+        for mode, tag, port, _, ready_path, _ in procs
+        if not ready_path.exists()
+    ]
+    raise TimeoutError(f"peers did not signal readiness within {PEER_READY_SECONDS}s: {pending}")
+
+
 def _reap(procs):
-    for _, _, _, _, proc in procs:
+    for _, _, _, _, _, proc in procs:
         if proc.poll() is None:
             proc.terminate()
             try:
@@ -81,38 +113,39 @@ def _reap(procs):
 
 def test_xsim_instances_exchange_isolated_traffic():
     result_dir = SIM_BUILD / "peers"
-    # Elaborate first, then spawn peers just before the run: the peers'
-    # RCVTIMEO budget must cover only the short simulation, not the
-    # multi-second xvlog/xvhdl/xelab flow (during which a peer would otherwise
-    # time out and exit, wedging the DUT's synchronous ZMQ send).
+    # Elaborate first, then spawn peers just before the run. Wait for every
+    # ready file so Python startup and socket configuration are deterministic;
+    # the HDL settle delay covers the asynchronous connect handshake after the
+    # model binds. This also keeps xvlog/xvhdl/xelab outside RCVTIMEO.
     xu.compile_and_elaborate("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
     procs = _spawn_peers(STREAM_PEERS + MEMORY_PEERS + SIDEBAND_PEERS, result_dir)
     try:
+        _wait_for_peers_ready(procs)
         result = xu.run_elaborated("RogueXsimTrafficTb", SIM_BUILD)
         output = result.stdout + result.stderr
         if "Rogue xsim traffic test passed" not in output:
             # Append every peer's JSON so a banner miss is diagnosable.
             dumps = []
-            for _, _, _, result_path, _ in procs:
+            for _, _, _, result_path, _, _ in procs:
                 if result_path.exists():
                     dumps.append(f"{result_path.name}:\n{result_path.read_text()}")
             raise AssertionError(output + "\n\n" + "\n\n".join(dumps))
 
-        for mode, tag, port, result_path, proc in procs:
+        for mode, tag, port, result_path, _, proc in procs:
             rc = proc.wait(timeout=PEER_WAIT_SECONDS)
             assert rc == 0, f"{mode} peer tag {tag} exited {rc}"
             observed = json.loads(result_path.read_text())
-            if mode == "stream":
+            if mode == "stream-instance":
                 # Explicit foreign-tag rejection: every received frame must
                 # carry this instance's own tag (0x80+tag)*4 and nothing else.
                 # The peer's stream_frame_is_foreign() already rejects any
                 # 0x80+j (j != tag) at the source (forcing rc != 0, caught by
                 # the rc == 0 assertion above); requiring == own here is the
                 # same isolation guarantee restated on the received data.
-                own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
+                own = stream_instance_vectors(tag)[1][0]["data"].hex()
                 for frame in observed["received"]:
                     assert frame["data_hex"] == own, (tag, frame)
-            elif mode == "memory":
+            elif mode == "memory-instance":
                 # Memory: every txn OKAY, and the read-back data equals this
                 # tag's write vector -- itself the cross-instance isolation
                 # check, since a foreign instance's data would differ.
@@ -120,7 +153,7 @@ def test_xsim_instances_exchange_isolated_traffic():
                 assert txns, (tag, observed)
                 for txn in txns:
                     assert txn["resp"] == 0, (tag, txn)
-                own = bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]).hex()
+                own = memory_instance_transactions(tag)[0]["write_data"].hex()
                 reads = [t for t in txns if t["type"] == 0x1]
                 assert reads, (tag, observed)
                 for txn in reads:
@@ -136,18 +169,19 @@ def test_xsim_instances_exchange_isolated_traffic():
                 for txn in txns:
                     assert txn["data_hex"] in ("", own), (tag, txn)
                     assert txn["data_hex"] not in foreign_hex, (tag, txn)
-            elif mode == "sideband":
+            elif mode == "sideband-instance":
                 # SideBand: the peer's received frames are the DUT's tx values
                 # echoed back -- an opcode 0x60+tag and a remData 0x70+tag. A
                 # foreign instance would surface a different tag, so requiring
                 # this instance's exact opcode/remData is the isolation check.
                 received = observed["received"]
+                _, own_opcode, own_remdata = sideband_instance_vectors(tag)
                 assert any(
-                    f["opCodeEn"] == 1 and f["opCode"] == 0x60 + tag
+                    f["opCodeEn"] == 1 and f["opCode"] == own_opcode
                     for f in received
                 ), (tag, observed)
                 assert any(
-                    f["remDataChanged"] == 1 and f["remData"] == 0x70 + tag
+                    f["remDataChanged"] == 1 and f["remData"] == own_remdata
                     for f in received
                 ), (tag, observed)
                 # Explicit foreign-tag rejection: no received frame may carry

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -1,0 +1,92 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: One eight-instance top (4 Stream, 2 Memory, 2 SideBand) run under
+#   the real Vivado xsim mixed-language/DPI flow with live peers. (Stream only
+#   for now; Memory/SideBand added in later tasks.)
+# - Stimulus: Launch one rogue_tcp_peer.py per instance (each --tag i) before
+#   xsim starts; the top holds off outbound traffic for a fixed settle delay
+#   so peers are connected and draining, then exchanges a tagged family per
+#   instance.
+# - Checks: xsim prints the success banner, every peer exits 0, and each
+#   peer's JSON shows only its own tag family with zero foreign tags.
+# - Timing: The top uses bounded clock loops; each peer bounds recv with
+#   RCVTIMEO; xsim is wall-clock bounded. Skips when Vivado tools are absent.
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from tests.axi.simlink import xsim_test_utils as xu
+
+HERE = xu.REPO_ROOT / "tests" / "axi" / "simlink"
+TB_SOURCE = HERE / "RogueXsimTrafficTb.vhd"
+SIM_BUILD = HERE / "sim_build_RogueXsimTraffic"
+PEER = HERE / "rogue_tcp_peer.py"
+VHDL_SOURCES = [*xu.MODEL_VHDL_SOURCES, TB_SOURCE]
+
+pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
+
+PEER_WAIT_SECONDS = 30
+
+STREAM_PEERS = [("stream", i, 19740 + 2 * i) for i in range(4)]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_dpi_library():
+    xu.build_dpi_library()
+
+
+def _spawn_peers(specs, result_dir):
+    result_dir.mkdir(parents=True, exist_ok=True)
+    procs = []
+    for mode, tag, port in specs:
+        result_path = result_dir / f"{mode}_{tag}_{port}.json"
+        procs.append((
+            mode, tag, port, result_path,
+            subprocess.Popen(
+                [sys.executable, str(PEER), "--mode", mode, "--tag", str(tag),
+                 str(port), str(result_path)],
+                env=xu.xsim_run_env(),
+            ),
+        ))
+    return procs
+
+
+def _reap(procs):
+    for _, _, _, _, proc in procs:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def test_xsim_stream_instances_exchange_isolated_traffic():
+    result_dir = SIM_BUILD / "peers"
+    procs = _spawn_peers(STREAM_PEERS, result_dir)
+    try:
+        result = xu.run_top("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
+        output = result.stdout + result.stderr
+        assert "Rogue xsim traffic test passed" in output, output
+
+        for mode, tag, port, result_path, proc in procs:
+            rc = proc.wait(timeout=PEER_WAIT_SECONDS)
+            assert rc == 0, f"{mode} peer tag {tag} exited {rc}"
+            observed = json.loads(result_path.read_text())
+            own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
+            for frame in observed["received"]:
+                assert frame["data_hex"] == own, (tag, frame)
+    finally:
+        _reap(procs)

--- a/tests/axi/simlink/test_RogueXsimTraffic.py
+++ b/tests/axi/simlink/test_RogueXsimTraffic.py
@@ -10,8 +10,8 @@
 
 # Test methodology:
 # - Sweep: One eight-instance top (4 Stream, 2 Memory, 2 SideBand) run under
-#   the real Vivado xsim mixed-language/DPI flow with live peers. (Stream only
-#   for now; Memory/SideBand added in later tasks.)
+#   the real Vivado xsim mixed-language/DPI flow with live peers. (Stream +
+#   Memory for now; SideBand added in a later task.)
 # - Stimulus: Launch one rogue_tcp_peer.py per instance (each --tag i) before
 #   xsim starts; the top holds off outbound traffic for a fixed settle delay
 #   so peers are connected and draining, then exchanges a tagged family per
@@ -39,7 +39,12 @@ pytestmark = pytest.mark.skipif(not xu.tools_available(), reason=xu.SKIP_REASON)
 
 PEER_WAIT_SECONDS = 30
 
+# Endpoint port map (single source of truth is shared with
+# RogueXsimTrafficTb.vhd -- keep both in sync):
+#   Stream i -> 19740 + 2*i  (19740..19747)
+#   Memory i -> 19748 + 2*i  (19748..19751)
 STREAM_PEERS = [("stream", i, 19740 + 2 * i) for i in range(4)]
+MEMORY_PEERS = [("memory", i, 19748 + 2 * i) for i in range(2)]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -80,18 +85,38 @@ def test_xsim_stream_instances_exchange_isolated_traffic():
     # multi-second xvlog/xvhdl/xelab flow (during which a peer would otherwise
     # time out and exit, wedging the DUT's synchronous ZMQ send).
     xu.compile_and_elaborate("RogueXsimTrafficTb", VHDL_SOURCES, SIM_BUILD)
-    procs = _spawn_peers(STREAM_PEERS, result_dir)
+    procs = _spawn_peers(STREAM_PEERS + MEMORY_PEERS, result_dir)
     try:
         result = xu.run_elaborated("RogueXsimTrafficTb", SIM_BUILD)
         output = result.stdout + result.stderr
-        assert "Rogue xsim traffic test passed" in output, output
+        if "Rogue xsim traffic test passed" not in output:
+            # Append every peer's JSON so a banner miss is diagnosable.
+            dumps = []
+            for _, _, _, result_path, _ in procs:
+                if result_path.exists():
+                    dumps.append(f"{result_path.name}:\n{result_path.read_text()}")
+            raise AssertionError(output + "\n\n" + "\n\n".join(dumps))
 
         for mode, tag, port, result_path, proc in procs:
             rc = proc.wait(timeout=PEER_WAIT_SECONDS)
             assert rc == 0, f"{mode} peer tag {tag} exited {rc}"
             observed = json.loads(result_path.read_text())
-            own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
-            for frame in observed["received"]:
-                assert frame["data_hex"] == own, (tag, frame)
+            if mode == "stream":
+                own = bytes([(0x80 + tag) & 0xFF] * 4).hex()
+                for frame in observed["received"]:
+                    assert frame["data_hex"] == own, (tag, frame)
+            else:
+                # Memory: every txn OKAY, and the read-back data equals this
+                # tag's write vector -- itself the cross-instance isolation
+                # check, since a foreign instance's data would differ.
+                txns = observed["transactions"]
+                assert txns, (tag, observed)
+                for txn in txns:
+                    assert txn["resp"] == 0, (tag, txn)
+                own = bytes([0x40 + tag, 0x50 + tag, 0x60 + tag, 0x70 + tag]).hex()
+                reads = [t for t in txns if t["type"] == 0x1]
+                assert reads, (tag, observed)
+                for txn in reads:
+                    assert txn["data_hex"] == own, (tag, txn)
     finally:
         _reap(procs)

--- a/tests/axi/simlink/test_rogue_tcp_peer_tags.py
+++ b/tests/axi/simlink/test_rogue_tcp_peer_tags.py
@@ -22,6 +22,7 @@ from tests.axi.simlink.rogue_tcp_peer import (
     memory_txn_for_tag,
     sideband_peer_to_dut,
     sideband_expect_for_tag,
+    stream_frame_is_foreign,
 )
 
 
@@ -51,3 +52,20 @@ def test_distinct_tags_do_not_collide():
     assert stream_dut_to_peer_payload(0) != stream_dut_to_peer_payload(1)
     assert memory_txn_for_tag(0)["addr"] != memory_txn_for_tag(1)["addr"]
     assert sideband_expect_for_tag(0) != sideband_expect_for_tag(1)
+
+
+def test_stream_frame_is_foreign_detects_cross_talk():
+    own = stream_dut_to_peer_payload(2).hex()
+    assert stream_frame_is_foreign({"data_hex": own}, tag=2) is False
+    other = stream_dut_to_peer_payload(3).hex()
+    assert stream_frame_is_foreign({"data_hex": other}, tag=2) is True
+
+
+def test_argparse_accepts_optional_tag():
+    from tests.axi.simlink import rogue_tcp_peer
+
+    parser = rogue_tcp_peer.build_arg_parser()
+    args = parser.parse_args(["--mode", "stream", "--tag", "2", "19740", "/tmp/x.json"])
+    assert args.tag == 2
+    args2 = parser.parse_args(["--mode", "stream", "19604", "/tmp/y.json"])
+    assert args2.tag is None

--- a/tests/axi/simlink/test_rogue_tcp_peer_tags.py
+++ b/tests/axi/simlink/test_rogue_tcp_peer_tags.py
@@ -1,0 +1,53 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Each instance index used by the xsim traffic top (Stream 0-3,
+#   Memory 0-1, SideBand 0-1) fed to the peer's per-tag vector helpers.
+# - Stimulus: Call the pure helper functions directly; no simulator, no ZMQ.
+# - Checks: Each helper returns the exact byte/address/opcode values the tag
+#   scheme in the plan mandates, and distinct tags never collide.
+# - Timing: None -- pure functions.
+
+from tests.axi.simlink.rogue_tcp_peer import (
+    stream_peer_to_dut_payload,
+    stream_dut_to_peer_payload,
+    memory_txn_for_tag,
+    sideband_peer_to_dut,
+    sideband_expect_for_tag,
+)
+
+
+def test_stream_payloads_match_scheme():
+    for i in range(4):
+        assert stream_peer_to_dut_payload(i) == bytes([0x10 + i] * 4)
+        assert stream_dut_to_peer_payload(i) == bytes([0x80 + i] * 4)
+
+
+def test_memory_txn_matches_scheme():
+    for i in range(2):
+        txn = memory_txn_for_tag(i)
+        assert txn["addr"] == 0x100 + (0x10 * i)
+        assert txn["size"] == 4
+        assert txn["write_data"] == bytes([0x40 + i, 0x50 + i, 0x60 + i, 0x70 + i])
+
+
+def test_sideband_vectors_match_scheme():
+    for i in range(2):
+        frames = sideband_peer_to_dut(i)
+        assert frames[0] == {"opCodeEn": 1, "opCode": 0x20 + i, "remDataChanged": 0, "remData": 0x00}
+        assert frames[1] == {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + i}
+        assert sideband_expect_for_tag(i) == {"opCode": 0x60 + i, "remData": 0x70 + i}
+
+
+def test_distinct_tags_do_not_collide():
+    assert stream_dut_to_peer_payload(0) != stream_dut_to_peer_payload(1)
+    assert memory_txn_for_tag(0)["addr"] != memory_txn_for_tag(1)["addr"]
+    assert sideband_expect_for_tag(0) != sideband_expect_for_tag(1)

--- a/tests/axi/simlink/test_rogue_tcp_peer_tags.py
+++ b/tests/axi/simlink/test_rogue_tcp_peer_tags.py
@@ -13,28 +13,39 @@
 #   Memory 0-1, SideBand 0-1) fed to the peer's per-tag vector helpers.
 # - Stimulus: Call the pure helper functions directly; no simulator, no ZMQ.
 # - Checks: Each helper returns the exact byte/address/opcode values the tag
-#   scheme in the plan mandates, and distinct tags never collide.
+#   scheme mandates, distinct tags never collide, and the test-only ready-file
+#   handshake reports success or an early peer exit deterministically.
 # - Timing: None -- pure functions.
 
+import pytest
+
+from tests.axi.simlink import rogue_tcp_peer
 from tests.axi.simlink.rogue_tcp_peer import (
-    stream_peer_to_dut_payload,
-    stream_dut_to_peer_payload,
-    memory_txn_for_tag,
-    sideband_peer_to_dut,
-    sideband_expect_for_tag,
-    stream_frame_is_foreign,
+    memory_instance_transactions,
+    sideband_instance_vectors,
+    stream_instance_vectors,
 )
+from tests.axi.simlink.test_RogueXsimTraffic import _wait_for_peers_ready
+
+
+class _FakeProcess:
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
 
 
 def test_stream_payloads_match_scheme():
     for i in range(4):
-        assert stream_peer_to_dut_payload(i) == bytes([0x10 + i] * 4)
-        assert stream_dut_to_peer_payload(i) == bytes([0x80 + i] * 4)
+        peer_to_dut, dut_to_peer = stream_instance_vectors(i)
+        assert peer_to_dut[0]["data"] == bytes([0x10 + i, 0x20 + i, 0x30 + i, 0x40 + i])
+        assert dut_to_peer[0]["data"] == bytes([0x80 + i, 0x90 + i, 0xA0 + i, 0xB0 + i])
 
 
 def test_memory_txn_matches_scheme():
     for i in range(2):
-        txn = memory_txn_for_tag(i)
+        txn = memory_instance_transactions(i)[0]
         assert txn["addr"] == 0x100 + (0x10 * i)
         assert txn["size"] == 4
         assert txn["write_data"] == bytes([0x40 + i, 0x50 + i, 0x60 + i, 0x70 + i])
@@ -42,30 +53,66 @@ def test_memory_txn_matches_scheme():
 
 def test_sideband_vectors_match_scheme():
     for i in range(2):
-        frames = sideband_peer_to_dut(i)
+        frames, tx_opcode, tx_remdata = sideband_instance_vectors(i)
         assert frames[0] == {"opCodeEn": 1, "opCode": 0x20 + i, "remDataChanged": 0, "remData": 0x00}
         assert frames[1] == {"opCodeEn": 0, "opCode": 0x00, "remDataChanged": 1, "remData": 0x40 + i}
-        assert sideband_expect_for_tag(i) == {"opCode": 0x60 + i, "remData": 0x70 + i}
+        assert tx_opcode == 0x60 + i
+        assert tx_remdata == 0x70 + i
 
 
 def test_distinct_tags_do_not_collide():
-    assert stream_dut_to_peer_payload(0) != stream_dut_to_peer_payload(1)
-    assert memory_txn_for_tag(0)["addr"] != memory_txn_for_tag(1)["addr"]
-    assert sideband_expect_for_tag(0) != sideband_expect_for_tag(1)
+    assert stream_instance_vectors(0) != stream_instance_vectors(1)
+    assert memory_instance_transactions(0) != memory_instance_transactions(1)
+    assert sideband_instance_vectors(0) != sideband_instance_vectors(1)
 
 
-def test_stream_frame_is_foreign_detects_cross_talk():
-    own = stream_dut_to_peer_payload(2).hex()
-    assert stream_frame_is_foreign({"data_hex": own}, tag=2) is False
-    other = stream_dut_to_peer_payload(3).hex()
-    assert stream_frame_is_foreign({"data_hex": other}, tag=2) is True
+def test_argparse_dispatches_instance_tag(monkeypatch, tmp_path):
+    observed = {}
+
+    def fake_run(port, result_path, send_frames, expect_frames, ready_file=None):
+        observed.update(
+            port=port,
+            result_path=result_path,
+            send_frames=send_frames,
+            expect_frames=expect_frames,
+            ready_file=ready_file,
+        )
+        return 0
+
+    result_path = tmp_path / "stream.json"
+    ready_path = tmp_path / "stream.ready"
+    monkeypatch.setattr(rogue_tcp_peer, "run_stream_peer", fake_run)
+    assert rogue_tcp_peer.main([
+        "--mode", "stream-instance", "--tag", "2",
+        "--ready-file", str(ready_path), "19740", str(result_path),
+    ]) == 0
+    assert observed["port"] == 19740
+    assert observed["result_path"] == str(result_path)
+    assert observed["ready_file"] == str(ready_path)
+    assert (observed["send_frames"], observed["expect_frames"]) == stream_instance_vectors(2)
 
 
-def test_argparse_accepts_optional_tag():
-    from tests.axi.simlink import rogue_tcp_peer
+def test_ready_file_is_written_after_socket_setup_hook(tmp_path):
+    ready_path = tmp_path / "peer.ready"
+    rogue_tcp_peer._signal_ready(ready_path)
+    assert ready_path.read_text() == "ready\n"
 
-    parser = rogue_tcp_peer.build_arg_parser()
-    args = parser.parse_args(["--mode", "stream", "--tag", "2", "19740", "/tmp/x.json"])
-    assert args.tag == 2
-    args2 = parser.parse_args(["--mode", "stream", "19604", "/tmp/y.json"])
-    assert args2.tag is None
+
+def test_orchestrator_accepts_ready_peer(tmp_path):
+    ready_path = tmp_path / "peer.ready"
+    ready_path.write_text("ready\n")
+    procs = [("stream-instance", 0, 19740, tmp_path / "result.json", ready_path, _FakeProcess())]
+    _wait_for_peers_ready(procs)
+
+
+def test_orchestrator_rejects_peer_exit_before_ready(tmp_path):
+    procs = [(
+        "stream-instance",
+        0,
+        19740,
+        tmp_path / "result.json",
+        tmp_path / "missing.ready",
+        _FakeProcess(returncode=3),
+    )]
+    with pytest.raises(AssertionError, match="peer exited before readiness"):
+        _wait_for_peers_ready(procs)

--- a/tests/axi/simlink/xsim_test_utils.py
+++ b/tests/axi/simlink/xsim_test_utils.py
@@ -32,6 +32,35 @@ MODEL_VHDL_SOURCES = [
     XSIM_DIR / "RogueTcpMemory.vhd",
     XSIM_DIR / "RogueSideBand.vhd",
 ]
+
+# Ordered (leaves-first) surf source list needed to compile surf.AxiDualPortRam
+# into a `surf` library. RogueXsimTrafficTb.vhd instantiates AxiDualPortRam as
+# the real AXI-Lite RAM slave for each Memory instance, so xelab must see this
+# library. AxiDualPortRam defaults to SYNTH_MODE_G="inferred", so the XPM/
+# AlteraMf dummies satisfy the entity references and no vendor libraries are
+# needed. This exact order compiles clean under `xvhdl -2008 -work surf`.
+SURF_AXI_RAM_SOURCES = [
+    REPO_ROOT / "base" / "general" / "rtl" / "StdRtlPkg.vhd",
+    REPO_ROOT / "base" / "general" / "rtl" / "TextUtilPkg.vhd",
+    REPO_ROOT / "base" / "sync" / "rtl" / "Synchronizer.vhd",
+    REPO_ROOT / "base" / "sync" / "rtl" / "RstSync.vhd",
+    REPO_ROOT / "base" / "sync" / "rtl" / "SynchronizerVector.vhd",
+    REPO_ROOT / "base" / "ram" / "inferred" / "LutRam.vhd",
+    REPO_ROOT / "base" / "ram" / "rtl" / "SimpleDualPortRam.vhd",
+    REPO_ROOT / "base" / "ram" / "inferred" / "TrueDualPortRamInferred.vhd",
+    REPO_ROOT / "base" / "ram" / "dummy" / "TrueDualPortRamXpmAlteraMfDummy.vhd",
+    REPO_ROOT / "base" / "ram" / "xilinx" / "TrueDualPortRamXpm.vhd",
+    REPO_ROOT / "base" / "ram" / "rtl" / "TrueDualPortRam.vhd",
+    REPO_ROOT / "base" / "ram" / "inferred" / "DualPortRam.vhd",
+    REPO_ROOT / "base" / "fifo" / "rtl" / "FifoOutputPipeline.vhd",
+    REPO_ROOT / "base" / "fifo" / "rtl" / "inferred" / "FifoWrFsm.vhd",
+    REPO_ROOT / "base" / "fifo" / "rtl" / "inferred" / "FifoRdFsm.vhd",
+    REPO_ROOT / "base" / "fifo" / "rtl" / "inferred" / "FifoAsync.vhd",
+    REPO_ROOT / "base" / "sync" / "rtl" / "SynchronizerFifo.vhd",
+    REPO_ROOT / "axi" / "axi-lite" / "rtl" / "AxiLitePkg.vhd",
+    REPO_ROOT / "axi" / "axi-lite" / "rtl" / "AxiDualPortRam.vhd",
+]
+
 REQUIRED_TOOLS = ("make", "xsc", "xvlog", "xvhdl", "xelab", "xsim")
 BUILD_TIMEOUT_SECONDS = 300
 RUN_TIMEOUT_SECONDS = 120
@@ -84,6 +113,19 @@ def build_dpi_library():
         )
 
 
+def compile_surf_library(build_dir):
+    """Compile the ordered surf source list into a `surf` library under
+    `build_dir` (its xsim.dir/surf), so xelab can resolve surf.AxiDualPortRam and
+    its dependencies. Must run in the same cwd/build_dir as the subsequent
+    `work` xvhdl/xelab steps so the shared xsim.dir holds both libraries. Cheap
+    (~19 inferred RTL files) and harmless for tops that do not use surf."""
+    subprocess.run(
+        ["xvhdl", "-2008", "-work", "surf",
+         *(str(s) for s in SURF_AXI_RAM_SOURCES)],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+
+
 def compile_and_elaborate(top, vhdl_sources, sim_build_dir):
     """Compile the SV leaves + given VHDL sources and elaborate `top`, leaving a
     ready-to-run snapshot in `sim_build_dir / top`. Split out of run_top so a
@@ -92,6 +134,10 @@ def compile_and_elaborate(top, vhdl_sources, sim_build_dir):
     elaboration and the peer exits before the sim ever produces traffic."""
     build_dir = sim_build_dir / top
     build_dir.mkdir(parents=True, exist_ok=True)
+
+    # Compile the surf library first so xelab can link surf.AxiDualPortRam (used
+    # by RogueXsimTrafficTb). Harmless for tops that do not reference surf.
+    compile_surf_library(build_dir)
 
     subprocess.run(
         ["xvlog", "-sv", *(str(s) for s in SV_SOURCES)],

--- a/tests/axi/simlink/xsim_test_utils.py
+++ b/tests/axi/simlink/xsim_test_utils.py
@@ -39,6 +39,10 @@ MODEL_VHDL_SOURCES = [
 # library. AxiDualPortRam defaults to SYNTH_MODE_G="inferred", so the XPM/
 # AlteraMf dummies satisfy the entity references and no vendor libraries are
 # needed. This exact order compiles clean under `xvhdl -2008 -work surf`.
+# The FIFO files are pulled in transitively via SynchronizerFifo (not because
+# the traffic top uses an async FIFO -- COMMON_CLK_G=true bypasses it at
+# runtime), so do not prune them. A moved/renamed surf file surfaces as a
+# hard xvhdl failure (paths are checked), not silent rot.
 SURF_AXI_RAM_SOURCES = [
     REPO_ROOT / "base" / "general" / "rtl" / "StdRtlPkg.vhd",
     REPO_ROOT / "base" / "general" / "rtl" / "TextUtilPkg.vhd",

--- a/tests/axi/simlink/xsim_test_utils.py
+++ b/tests/axi/simlink/xsim_test_utils.py
@@ -1,0 +1,110 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Shared helpers for the Vivado xsim DPI regressions (test_RogueXsimMulti.py
+# and test_RogueXsimTraffic.py): tool discovery/skip, the system-libstdc++
+# LD_PRELOAD workaround, the RogueTcpDpi.so build fixture, and the
+# xvlog/xvhdl/xelab/xsim compile-and-run helper.
+
+import fcntl
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+XSIM_DIR = REPO_ROOT / "axi" / "simlink" / "xsim"
+
+SV_SOURCES = [
+    XSIM_DIR / "RogueTcpStreamDpi.sv",
+    XSIM_DIR / "RogueTcpMemoryDpi.sv",
+    XSIM_DIR / "RogueSideBandDpi.sv",
+]
+MODEL_VHDL_SOURCES = [
+    XSIM_DIR / "RogueTcpStream.vhd",
+    XSIM_DIR / "RogueTcpMemory.vhd",
+    XSIM_DIR / "RogueSideBand.vhd",
+]
+REQUIRED_TOOLS = ("make", "xsc", "xvlog", "xvhdl", "xelab", "xsim")
+BUILD_TIMEOUT_SECONDS = 300
+RUN_TIMEOUT_SECONDS = 120
+
+SKIP_REASON = "Vivado xsim regression needs make/xsc/xvlog/xvhdl/xelab/xsim"
+
+
+def tools_available():
+    return all(shutil.which(tool) is not None for tool in REQUIRED_TOOLS)
+
+
+def xsim_run_env():
+    """Environment for running xsim's DPI-linked snapshot.
+
+    Every Vivado release bundles its own (older) libstdc++ and puts it ahead of
+    the system libraries at run time. When the host libzmq was built against a
+    newer libstdc++ than Vivado's, xsimk fails to start with a "GLIBCXX_...
+    not found (required by libzmq.so.5)" loader error. Preloading the system
+    libstdc++ (located portably via gcc, matching the xsim Makefile's crti.o
+    lookup) resolves the newer symbols without affecting the build steps.
+    Harmless when Vivado's bundled libstdc++ is already new enough.
+    """
+    env = os.environ.copy()
+    try:
+        libstdcxx = subprocess.run(
+            ["gcc", "-print-file-name=libstdc++.so.6"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return env
+    if not libstdcxx or not os.path.isfile(libstdcxx):
+        return env
+    preload = [libstdcxx]
+    if env.get("LD_PRELOAD"):
+        preload.append(env["LD_PRELOAD"])
+    env["LD_PRELOAD"] = os.pathsep.join(preload)
+    return env
+
+
+def build_dpi_library():
+    """Build RogueTcpDpi.so and run the DPI-header ABI check, under a file lock
+    so parallel pytest workers do not race on the shared xsim.dir output."""
+    build_dir = XSIM_DIR / "xsim.dir"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    with open(build_dir / ".pytest-build.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        subprocess.run(
+            ["make", "-C", str(XSIM_DIR), "all", "abi-check"],
+            check=True, timeout=BUILD_TIMEOUT_SECONDS,
+        )
+
+
+def run_top(top, vhdl_sources, sim_build_dir):
+    """Compile the SV leaves + given VHDL sources, elaborate `top`, run it under
+    xsim -R with the libstdc++ preload, and return the CompletedProcess."""
+    build_dir = sim_build_dir / top
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        ["xvlog", "-sv", *(str(s) for s in SV_SOURCES)],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        ["xvhdl", "-2008", *(str(s) for s in vhdl_sources)],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    subprocess.run(
+        ["xelab", "-debug", "typical", "-s", top,
+         "-sv_root", str(XSIM_DIR), "-sv_lib", "RogueTcpDpi", f"work.{top}"],
+        cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
+    )
+    return subprocess.run(
+        ["xsim", top, "-R"],
+        cwd=build_dir, capture_output=True, text=True,
+        timeout=RUN_TIMEOUT_SECONDS, env=xsim_run_env(),
+    )

--- a/tests/axi/simlink/xsim_test_utils.py
+++ b/tests/axi/simlink/xsim_test_utils.py
@@ -84,9 +84,12 @@ def build_dpi_library():
         )
 
 
-def run_top(top, vhdl_sources, sim_build_dir):
-    """Compile the SV leaves + given VHDL sources, elaborate `top`, run it under
-    xsim -R with the libstdc++ preload, and return the CompletedProcess."""
+def compile_and_elaborate(top, vhdl_sources, sim_build_dir):
+    """Compile the SV leaves + given VHDL sources and elaborate `top`, leaving a
+    ready-to-run snapshot in `sim_build_dir / top`. Split out of run_top so a
+    caller can spawn its live ZMQ peers AFTER the (multi-second) elaboration and
+    just before the run -- otherwise a peer's RCVTIMEO budget is consumed by
+    elaboration and the peer exits before the sim ever produces traffic."""
     build_dir = sim_build_dir / top
     build_dir.mkdir(parents=True, exist_ok=True)
 
@@ -103,8 +106,21 @@ def run_top(top, vhdl_sources, sim_build_dir):
          "-sv_root", str(XSIM_DIR), "-sv_lib", "RogueTcpDpi", f"work.{top}"],
         cwd=build_dir, check=True, timeout=BUILD_TIMEOUT_SECONDS,
     )
+
+
+def run_elaborated(top, sim_build_dir):
+    """Run the already-elaborated `top` snapshot under xsim -R with the
+    libstdc++ preload, and return the CompletedProcess."""
+    build_dir = sim_build_dir / top
     return subprocess.run(
         ["xsim", top, "-R"],
         cwd=build_dir, capture_output=True, text=True,
         timeout=RUN_TIMEOUT_SECONDS, env=xsim_run_env(),
     )
+
+
+def run_top(top, vhdl_sources, sim_build_dir):
+    """Compile the SV leaves + given VHDL sources, elaborate `top`, run it under
+    xsim -R with the libstdc++ preload, and return the CompletedProcess."""
+    compile_and_elaborate(top, vhdl_sources, sim_build_dir)
+    return run_elaborated(top, sim_build_dir)

--- a/tests/protocols/batcher/test_AxiStreamBatcherAxil.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcherAxil.py
@@ -10,8 +10,7 @@
 
 # Test methodology:
 # - Sweep: Use the `AxiStreamBatcherAxil` wrapper in V2 mode with common and
-#   independent AXI-Lite/stream clocks, matching the control-surface targets
-#   from the batcher regression plan.
+#   independent AXI-Lite/stream clocks, matching the control-surface targets.
 # - Stimulus: Program the runtime threshold, max-subframe, max-clock-gap,
 #   `softRst`, and `blowoff` registers through a cocotb AXI-Lite master while
 #   driving flat AXI Stream subframes through the wrapped batcher.

--- a/tests/protocols/jesd204b/test_JesdRxReg.py
+++ b/tests/protocols/jesd204b/test_JesdRxReg.py
@@ -62,7 +62,7 @@ from tests.protocols.jesd204b.jesd204b_test_utils import (
 WRAPPER_SOURCES = jesd_wrapper_sources("Jesd204bRxWrapper.vhd")
 
 # ---------------------------------------------------------------------------
-# RX status bit constants (JesdRxLane.vhd:322 + :267 verified in 04-04-SUMMARY)
+# RX status bit constants
 # bit0=rstDone, bit1=dataValid, bit2=alignErr, bit3=nSync, bit4=bufUnf,
 # bit5=bufOvf, bit6=posErr, bit7=enable, bit8=sysRef, bit9=kDetect,
 # bits10-13=dispErr[0:3], bits14-17=decErr[0:3], bits18-25=latency, bit26=cdrStable

--- a/tests/protocols/jesd204b/test_JesdTxReg.py
+++ b/tests/protocols/jesd204b/test_JesdTxReg.py
@@ -63,7 +63,7 @@ _K28P5_WORD   = (K_CHAR << 24) | (K_CHAR << 16) | (K_CHAR << 8) | K_CHAR
 
 # ---------------------------------------------------------------------------
 # Parameter sweep: L_G in {1,2} x SC1 primary + SC0 smoke
-# K=32/F=2 fixed per plan. L_G and F_G/K_G passed as _G-suffixed HDL generics.
+# K=32/F=2 fixed. L_G and F_G/K_G passed as _G-suffixed HDL generics.
 # SUBCLASS is Python-only env key (stripped by hdl_parameters_from).
 # ---------------------------------------------------------------------------
 PARAMETER_SWEEP = [


### PR DESCRIPTION
### Description

Adds a Vivado xsim/SystemVerilog DPI-C co-simulation backend for `RogueTcpStream`, `RogueTcpMemory`, and `RogueSideBand` alongside the existing GHDL/VHPIDIRECT and VCS/VHPI paths. The VHDL forwarding entities, SystemVerilog DPI leaves, and C adapters reuse the shared `axi/simlink/shared/*Core.h` ZeroMQ models and link into one `RogueTcpDpi.so` built by `xsc`.

Each elaborated model now owns an independent DPI `chandle`, native model state, ZeroMQ context, and two-port endpoint pair. Explicit create/update/destroy APIs, normal/fallback cleanup, cross-model port collision checks, and multi-instance regressions support established multi-link users without changing the public VHDL interfaces or Rogue TCP wire formats.

The xsim usage guide now references only checked-in examples and documents the clock/reset, unique-port, peer, and connected-and-draining transport requirements for external targets.

### Details

This pull request is stacked on #1450 because it uses that pull request's backend split and shared C cores. It does not depend on #1450's later GHDL integer-handle implementation; after #1450 merges, this pull request can be retargeted to `pre-release` and any real integration conflicts resolved then.

The shared cores retain the established synchronous ZeroMQ send behavior used by VCS/VHPI and GHDL/VHPIDIRECT. Peers must be connected and draining before HDL produces outbound traffic. No-peer, saturation, linger, retry-queue, and worker-thread hardening is intentionally deferred to a separate cross-backend change so xsim does not acquire different transport semantics.

Validation:

- The original backend was exercised end-to-end with Vivado 2025.2 and the `rogue_v6.13.0` environment; the Stream PRBS loopback reported `rxCount == 10` and `rxErrors == 0`.
- The new host-native DPI adapter regression passes four tests, including four Stream, two Memory, and two SideBand contexts exchanging isolated tagged ZeroMQ traffic, lifecycle reuse, and negative ownership/port cases.
- The checked-in Vivado regression elaborates the same eight-instance VHDL/SV topology, pulses reset twice, rejects duplicate port pairs, and compiles the C adapters against an `xelab -dpiheader` generated ABI. It skips explicitly when Vivado tools are unavailable; the new multi-instance xsim flow still needs a recorded Vivado-enabled run before merge.
- Warning-enabled C compilation, Python lint, VSG, direct GHDL analysis of the xsim VHDL harness, and `git diff --check` pass locally.

Pairs with the ruckus-side `xsc` / `-sv_lib RogueTcpDpi` orchestration in slaclab/ruckus#399.

### Related

- #1450 — GHDL/VHPIDIRECT backend and shared simlink cores
- slaclab/ruckus#399 — Vivado xsim DPI orchestration
