### PR TITLE
Add RSSI regression foundation

### DIFF
--- a/protocols/rssi/README.md
+++ b/protocols/rssi/README.md
@@ -146,8 +146,8 @@ For direct `RssiCore`, keep these relationships valid:
 
 ## Regression Coverage
 
-Default cocotb coverage under `tests/protocols/rssi/` includes:
-
+Cocotb regression coverage under `tests/protocols/rssi/` includes:
+Only `test_RssiChksum.py` and `test_RssiHeaderReg.py` are intended to run in default CI; set `RUN_RSSI_KNOWN_ISSUE_TESTS=1` to enable the remaining characterization tests.
 - Module-level checksum, header, RX FSM, TX FSM, monitor, connection FSM, and
   AXI-Lite register-interface tests.
 - `test_RssiCore.py`: direct `RssiCore` client/server integration with

--- a/protocols/rssi/README.md
+++ b/protocols/rssi/README.md
@@ -172,8 +172,7 @@ Only `test_RssiChksum.py` and `test_RssiHeaderReg.py` are intended to run in def
   initializing its per-`TDEST` route state. Extended coverage covers
   bidirectional routing, routed partial-`TKEEP` and EOFE preservation through
   the packetizer2 application boundary, one routed DATA loss/retransmit case,
-  and a second window/segment-size parameter set. Run it with
-  `RUN_RSSI_EXTENDED_TESTS=1`.
+and a second window/segment-size parameter set. Run it with `RUN_RSSI_KNOWN_ISSUE_TESTS=1` (and `RUN_RSSI_EXTENDED_TESTS=1` for extended cases).
 
 Current EOFE behavior is path-specific in the regression suite: direct
 `RssiCore` and the one-stream legacy wrapper path clear application EOFE on

--- a/protocols/rssi/README.md
+++ b/protocols/rssi/README.md
@@ -1,0 +1,190 @@
+# RSSI
+
+This directory contains the Reliable SLAC Streaming Interface implementation.
+Most firmware applications should instantiate `v1/rtl/RssiCoreWrapper.vhd`
+rather than `RssiCore.vhd` directly.
+
+`RssiCoreWrapper` adds the user-facing AXI Stream mux/demux and optional
+packetizer/depacketizer layer around `RssiCore`. `RssiCore` is still useful for
+focused protocol integration tests or custom wrappers that already own stream
+chunking and routing.
+
+## Typical Instantiation
+
+Common SLAC application patterns instantiate one `RssiCoreWrapper` server behind
+an Ethernet/UDP server path, or a matched client/server pair in a testbench.
+Most designs drive `openRq_i` high after reset and use AXI-Lite only when they
+need runtime parameter control or status access.
+
+Set these generics deliberately:
+
+- `SERVER_G`: `true` for a passive listener, `false` for an active opener.
+- `APP_AXIS_CONFIG_G`: one entry per application stream. Use an SSI-compatible
+  config. Multi-stream routed applications should include enough `TDEST` bits
+  for the route table.
+- `TSP_AXIS_CONFIG_G`: match the lower transport stream, usually the Ethernet
+  or UDP engine AXI Stream config.
+- `APP_STREAMS_G`: number of application streams exposed by the wrapper.
+- `APP_STREAM_ROUTES_G`: route table used by the wrapper mux/demux. A common
+  pattern is `0 => x"00"`, `1 => x"01"`, and so on.
+- `BYPASS_CHUNKER_G`: `true` when the application already provides frames that
+  fit the negotiated RSSI segment size; `false` to use the wrapper
+  packetizer/depacketizer.
+- `APP_ILEAVE_EN_G`: enables the packetizer2/depacketizer2 path for interleaved
+  multi-stream traffic. Leave `false` for the simpler legacy packetizer path.
+- `WINDOW_ADDR_SIZE_G`: transmit/receive window depth is
+  `2**WINDOW_ADDR_SIZE_G` segments. Reducing this lowers buffer depth and can
+  reduce memory use, at the cost of fewer outstanding segments.
+- `MAX_SEG_SIZE_G`: maximum RSSI segment size in bytes. It must be a power of
+  two. `RssiCoreWrapper` derives the core segment-buffer address width from
+  this value.
+- `ACK_TOUT_G`, `RETRANS_TOUT_G`, `NULL_TOUT_G`, `MAX_RETRANS_CNT_G`, and
+  `MAX_CUM_ACK_CNT_G`: local defaults advertised during negotiation unless
+  AXI-Lite register mode is enabled.
+
+The wrapper currently forces `MAX_NUM_OUTS_SEG_G` passed into `RssiCore` to
+`2**WINDOW_ADDR_SIZE_G`; the legacy wrapper generic with the same name is not
+used.
+
+## Segment Size Selection
+
+`MAX_SEG_SIZE_G` is the maximum RSSI DATA payload size, in bytes, that this
+endpoint can advertise and buffer. It is not the full Ethernet frame size. A
+DATA segment sent on the transport stream also carries the 8-byte RSSI DATA
+header, and lower layers may add UDP/IP/Ethernet headers.
+
+When using `RssiCoreWrapper`, configure `MAX_SEG_SIZE_G` and leave
+`SEGMENT_ADDR_SIZE_G` alone. The wrapper's `SEGMENT_ADDR_SIZE_G` generic is a
+legacy generic and is not passed through; the wrapper derives the core value
+from `MAX_SEG_SIZE_G`.
+
+For UDP/IPv4 over Ethernet, choose a value that fits inside the path MTU:
+
+```text
+MAX_SEG_SIZE_G + 8 <= UDP payload budget
+UDP payload budget = Ethernet MTU - 20-byte IPv4 header - 8-byte UDP header
+```
+
+For a standard 1500-byte Ethernet MTU, the UDP payload budget is 1472 bytes, so
+the RSSI payload budget is 1464 bytes. Because `MAX_SEG_SIZE_G` must be a power
+of two, `1024` is the usual safe choice.
+
+For a 9000-byte jumbo Ethernet MTU, the UDP payload budget is 8972 bytes, so
+the RSSI payload budget is 8964 bytes. The usual power-of-two choice is `8192`.
+Only use a jumbo-sized RSSI segment when every relevant MAC, UDP/IP block, peer,
+switch path, and software endpoint is configured for jumbo frames. Otherwise the
+design may rely on IP fragmentation or drop oversized frames, depending on the
+transport.
+
+Smaller values such as `64`, `128`, or `256` are useful when minimizing memory
+or testing constrained links, but they increase per-payload overhead and may
+reduce throughput. Larger values improve efficiency for bulk transfer, but
+increase per-endpoint buffer memory. With `RssiCoreWrapper`, the segment buffer
+depth scales with both `MAX_SEG_SIZE_G` and `WINDOW_ADDR_SIZE_G`; each side has
+TX and RX segment storage sized roughly by:
+
+```text
+2**WINDOW_ADDR_SIZE_G * MAX_SEG_SIZE_G
+```
+
+per direction, before implementation overhead and extra FIFOs.
+
+When `BYPASS_CHUNKER_G=false`, the wrapper packetizer uses the negotiated RSSI
+segment size as its maximum output packet size. The packetizer header/tail words
+fit inside the RSSI payload budget, so the maximum original application payload
+per RSSI DATA segment is smaller than `MAX_SEG_SIZE_G`. When
+`BYPASS_CHUNKER_G=true`, the application must already keep each transmitted
+frame within the negotiated RSSI segment size.
+
+## Direct Core Buffer Sizing
+
+`SEGMENT_ADDR_SIZE_G` only matters when instantiating `RssiCore` directly. It is
+the address width of one segment buffer, measured in 64-bit RSSI words:
+
+```text
+segment capacity in bytes = 2**SEGMENT_ADDR_SIZE_G * 8
+```
+
+For direct `RssiCore` use, set it to the smallest value that can hold
+`MAX_SEG_SIZE_G`:
+
+```text
+2**SEGMENT_ADDR_SIZE_G * 8 >= MAX_SEG_SIZE_G
+```
+
+For power-of-two segment sizes, this means:
+
+```text
+SEGMENT_ADDR_SIZE_G = log2(MAX_SEG_SIZE_G / 8)
+```
+
+Common examples:
+
+- `MAX_SEG_SIZE_G=64` uses `SEGMENT_ADDR_SIZE_G=3`
+- `MAX_SEG_SIZE_G=128` uses `SEGMENT_ADDR_SIZE_G=4`
+- `MAX_SEG_SIZE_G=256` uses `SEGMENT_ADDR_SIZE_G=5`
+- `MAX_SEG_SIZE_G=1024` uses `SEGMENT_ADDR_SIZE_G=7`
+- `MAX_SEG_SIZE_G=8192` uses `SEGMENT_ADDR_SIZE_G=10`
+
+So an application using `SEGMENT_ADDR_SIZE_G=7` is sized for 128 64-bit words,
+or 1024 bytes per RSSI segment. That is the natural direct-core pairing for
+`MAX_SEG_SIZE_G=1024`; it is not independently tuned beyond matching the segment
+size. A larger value wastes buffer memory unless `MAX_SEG_SIZE_G` is also
+larger.
+
+## Direct `RssiCore` Use
+
+Instantiate `RssiCore` directly only when the surrounding design already
+handles application stream resizing, packetization, and routing. Direct use
+requires one application AXI Stream and one transport AXI Stream.
+
+For direct `RssiCore`, keep these relationships valid:
+
+- `MAX_NUM_OUTS_SEG_G <= 2**WINDOW_ADDR_SIZE_G`
+- `MAX_SEG_SIZE_G <= (2**SEGMENT_ADDR_SIZE_G)*8`
+- `SEGMENT_ADDR_SIZE_G` is the number of 64-bit payload words per segment.
+
+## Regression Coverage
+
+Default cocotb coverage under `tests/protocols/rssi/` includes:
+
+- Module-level checksum, header, RX FSM, TX FSM, monitor, connection FSM, and
+  AXI-Lite register-interface tests.
+- `test_RssiCore.py`: direct `RssiCore` client/server integration with
+  connection, parameter negotiation, payload delivery, retransmission,
+  checksum-corruption recovery, keepalive, missing-keepalive close, explicit
+  close, close/reopen lifecycle, partial `TKEEP` delivery, transport
+  backpressure stalls, and backpressure-driven BUSY reporting. Focused pytest
+  entries also cover duplicate-free BUSY recovery, AXI-Lite controlled
+  open/parameter writes/status/counter reads/checksum injection/close, and
+  `HEADER_CHKSUM_EN_G=false` connection/payload delivery.
+- `test_RssiCoreWrapper.py`: one-stream `RssiCoreWrapper` smoke coverage across
+  bypass-chunker and legacy packetizer/depacketizer modes, including
+  `WINDOW_ADDR_SIZE_G` values 1, 2, and 3 and `MAX_SEG_SIZE_G` values 64, 128,
+  and 256. Partial-`TKEEP` coverage compares only bytes selected by `TKEEP`;
+  bytes outside `TKEEP` are not part of the payload contract and may be changed
+  by the packetizer path.
+- `test_RssiCoreWrapperMultiStream.py`: two-stream `RssiCoreWrapper` active-open
+  and routed client-to-server payload coverage with `APP_STREAMS_G=2`, routed
+  stream destinations, `APP_ILEAVE_EN_G=true`, and the
+  packetizer2/depacketizer2 path. The routed payload test waits after RSSI
+  connection so the server-side `AxiStreamDepacketizer2` can finish
+  initializing its per-`TDEST` route state. Extended coverage covers
+  bidirectional routing, routed partial-`TKEEP` and EOFE preservation through
+  the packetizer2 application boundary, one routed DATA loss/retransmit case,
+  and a second window/segment-size parameter set. Run it with
+  `RUN_RSSI_EXTENDED_TESTS=1`.
+
+Current EOFE behavior is path-specific in the regression suite: direct
+`RssiCore` and the one-stream legacy wrapper path clear application EOFE on
+receive, while the packetizer2 routed wrapper path preserves EOFE at the routed
+application boundary.
+
+Known remaining test gaps:
+
+- Hardware resource reduction from smaller `WINDOW_ADDR_SIZE_G` values still
+  needs synthesis or target-level validation. The cocotb tests prove
+  elaboration and basic behavior, not BRAM inference.
+- Repeated same-direction DATA loss without an intervening clean ACK/drain
+  interval remains a future characterization item if that behavior becomes part
+  of the hardware contract.

--- a/protocols/rssi/v1/ruckus.tcl
+++ b/protocols/rssi/v1/ruckus.tcl
@@ -6,3 +6,4 @@ loadSource -lib surf -dir "$::DIR_PATH/rtl"
 
 # Load Simulation
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/tb"
+loadSource -lib surf -sim_only -dir "$::DIR_PATH/wrappers" -fileType "VHDL 2008"

--- a/protocols/rssi/v1/wrappers/RssiAxiLiteRegItfWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiAxiLiteRegItfWrapper.vhd
@@ -1,0 +1,262 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI AXI-Lite register tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.RssiPkg.all;
+
+entity RssiAxiLiteRegItfWrapper is
+   generic (
+      TPD_G                 : time     := 1 ns;
+      SEGMENT_ADDR_SIZE_G   : positive := 7;
+      TIMEOUT_UNIT_G        : real     := 1.0E-6;
+      INIT_SEQ_N_G          : natural  := 16#80#;
+      CONN_ID_G             : positive := 16#12345678#;
+      VERSION_G             : positive := 1;
+      HEADER_CHKSUM_EN_G    : boolean  := true;
+      MAX_NUM_OUTS_SEG_G    : positive := 8;
+      MAX_SEG_SIZE_G        : positive := 1024;
+      RETRANS_TOUT_G        : positive := 50;
+      ACK_TOUT_G            : positive := 25;
+      NULL_TOUT_G           : positive := 200;
+      MAX_RETRANS_CNT_G     : positive := 2;
+      MAX_CUM_ACK_CNT_G     : positive := 3;
+      MAX_OUT_OF_SEQUENCE_G : natural  := 3
+   );
+   port (
+      axilClk : in sl;
+      axilRst : in sl;
+
+      S_AXI_AWADDR  : in  slv(9 downto 0);
+      S_AXI_AWPROT  : in  slv(2 downto 0);
+      S_AXI_AWVALID : in  sl;
+      S_AXI_AWREADY : out sl;
+      S_AXI_WDATA   : in  slv(31 downto 0);
+      S_AXI_WSTRB   : in  slv(3 downto 0);
+      S_AXI_WVALID  : in  sl;
+      S_AXI_WREADY  : out sl;
+      S_AXI_BRESP   : out slv(1 downto 0);
+      S_AXI_BVALID  : out sl;
+      S_AXI_BREADY  : in  sl;
+      S_AXI_ARADDR  : in  slv(9 downto 0);
+      S_AXI_ARPROT  : in  slv(2 downto 0);
+      S_AXI_ARVALID : in  sl;
+      S_AXI_ARREADY : out sl;
+      S_AXI_RDATA   : out slv(31 downto 0);
+      S_AXI_RRESP   : out slv(1 downto 0);
+      S_AXI_RVALID  : out sl;
+      S_AXI_RREADY  : in  sl;
+
+      openRq_o      : out sl;
+      closeRq_o     : out sl;
+      mode_o        : out sl;
+      injectFault_o : out sl;
+      initSeqN_o    : out slv(7 downto 0);
+
+      appParamVersion_o      : out slv(3 downto 0);
+      appParamChksumEn_o     : out slv(0 downto 0);
+      appParamTimeoutUnit_o  : out slv(7 downto 0);
+      appParamMaxOutsSeg_o   : out slv(7 downto 0);
+      appParamMaxSegSize_o   : out slv(15 downto 0);
+      appParamRetransTout_o  : out slv(15 downto 0);
+      appParamCumulAckTout_o : out slv(15 downto 0);
+      appParamNullSegTout_o  : out slv(15 downto 0);
+      appParamMaxRetrans_o   : out slv(7 downto 0);
+      appParamMaxCumAck_o    : out slv(7 downto 0);
+      appParamMaxOutofseq_o  : out slv(7 downto 0);
+      appParamConnectionId_o : out slv(31 downto 0);
+
+      negParamVersion_i      : in slv(3 downto 0);
+      negParamChksumEn_i     : in slv(0 downto 0);
+      negParamTimeoutUnit_i  : in slv(7 downto 0);
+      negParamMaxOutsSeg_i   : in slv(7 downto 0);
+      negParamMaxSegSize_i   : in slv(15 downto 0);
+      negParamRetransTout_i  : in slv(15 downto 0);
+      negParamCumulAckTout_i : in slv(15 downto 0);
+      negParamNullSegTout_i  : in slv(15 downto 0);
+      negParamMaxRetrans_i   : in slv(7 downto 0);
+      negParamMaxCumAck_i    : in slv(7 downto 0);
+      negParamMaxOutofseq_i  : in slv(7 downto 0);
+      negParamConnectionId_i : in slv(31 downto 0);
+
+      txLastAckN_i : in slv(7 downto 0);
+      rxSeqN_i     : in slv(7 downto 0);
+      rxAckN_i     : in slv(7 downto 0);
+      rxLastSeqN_i : in slv(7 downto 0);
+      txTspState_i : in slv(7 downto 0);
+      txAppState_i : in slv(3 downto 0);
+      txAckState_i : in slv(3 downto 0);
+      rxTspState_i : in slv(3 downto 0);
+      rxAppState_i : in slv(3 downto 0);
+      connState_i  : in slv(3 downto 0);
+      frameRate0_i : in slv(31 downto 0);
+      frameRate1_i : in slv(31 downto 0);
+      bandwidth0_i : in slv(63 downto 0);
+      bandwidth1_i : in slv(63 downto 0);
+      status_i     : in slv(8 downto 0);
+      dropCnt_i    : in slv(31 downto 0);
+      validCnt_i   : in slv(31 downto 0);
+      resendCnt_i  : in slv(31 downto 0);
+      reconCnt_i   : in slv(31 downto 0)
+   );
+end entity RssiAxiLiteRegItfWrapper;
+
+architecture mapping of RssiAxiLiteRegItfWrapper is
+
+   signal axilRstN        : sl;
+   signal axilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal axilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal axilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal axilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+   signal appRssiParam    : RssiParamType          := RSSI_PARAM_INIT_C;
+   signal negRssiParam    : RssiParamType          := RSSI_PARAM_INIT_C;
+   signal frameRate       : Slv32Array(1 downto 0);
+   signal bandwidth       : Slv64Array(1 downto 0);
+
+begin
+
+   axilRstN <= not axilRst;
+
+   -----------------------
+   -- AXI-Lite bus shim --
+   -----------------------
+   U_AXIL : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         EN_ERROR_RESP => true,
+         HAS_PROT      => 1,
+         HAS_WSTRB     => 1,
+         ADDR_WIDTH    => 10)
+      port map (
+         S_AXI_ACLK      => axilClk,          -- [in]
+         S_AXI_ARESETN   => axilRstN,         -- [in]
+         S_AXI_AWADDR    => S_AXI_AWADDR,     -- [in]
+         S_AXI_AWPROT    => S_AXI_AWPROT,     -- [in]
+         S_AXI_AWVALID   => S_AXI_AWVALID,    -- [in]
+         S_AXI_AWREADY   => S_AXI_AWREADY,    -- [out]
+         S_AXI_WDATA     => S_AXI_WDATA,      -- [in]
+         S_AXI_WSTRB     => S_AXI_WSTRB,      -- [in]
+         S_AXI_WVALID    => S_AXI_WVALID,     -- [in]
+         S_AXI_WREADY    => S_AXI_WREADY,     -- [out]
+         S_AXI_BRESP     => S_AXI_BRESP,      -- [out]
+         S_AXI_BVALID    => S_AXI_BVALID,     -- [out]
+         S_AXI_BREADY    => S_AXI_BREADY,     -- [in]
+         S_AXI_ARADDR    => S_AXI_ARADDR,     -- [in]
+         S_AXI_ARPROT    => S_AXI_ARPROT,     -- [in]
+         S_AXI_ARVALID   => S_AXI_ARVALID,    -- [in]
+         S_AXI_ARREADY   => S_AXI_ARREADY,    -- [out]
+         S_AXI_RDATA     => S_AXI_RDATA,      -- [out]
+         S_AXI_RRESP     => S_AXI_RRESP,      -- [out]
+         S_AXI_RVALID    => S_AXI_RVALID,     -- [out]
+         S_AXI_RREADY    => S_AXI_RREADY,     -- [in]
+         axilClk         => open,             -- [out]
+         axilRst         => open,             -- [out]
+         axilReadMaster  => axilReadMaster,   -- [out]
+         axilReadSlave   => axilReadSlave,    -- [in]
+         axilWriteMaster => axilWriteMaster,  -- [out]
+         axilWriteSlave  => axilWriteSlave);  -- [in]
+
+   ----------------------
+   -- Flattened records --
+   ----------------------
+   negRssiParam.version      <= negParamVersion_i;
+   negRssiParam.chksumEn     <= negParamChksumEn_i;
+   negRssiParam.timeoutUnit  <= negParamTimeoutUnit_i;
+   negRssiParam.maxOutsSeg   <= negParamMaxOutsSeg_i;
+   negRssiParam.maxSegSize   <= negParamMaxSegSize_i;
+   negRssiParam.retransTout  <= negParamRetransTout_i;
+   negRssiParam.cumulAckTout <= negParamCumulAckTout_i;
+   negRssiParam.nullSegTout  <= negParamNullSegTout_i;
+   negRssiParam.maxRetrans   <= negParamMaxRetrans_i;
+   negRssiParam.maxCumAck    <= negParamMaxCumAck_i;
+   negRssiParam.maxOutofseq  <= negParamMaxOutofseq_i;
+   negRssiParam.connectionId <= negParamConnectionId_i;
+
+   appParamVersion_o      <= appRssiParam.version;
+   appParamChksumEn_o     <= appRssiParam.chksumEn;
+   appParamTimeoutUnit_o  <= appRssiParam.timeoutUnit;
+   appParamMaxOutsSeg_o   <= appRssiParam.maxOutsSeg;
+   appParamMaxSegSize_o   <= appRssiParam.maxSegSize;
+   appParamRetransTout_o  <= appRssiParam.retransTout;
+   appParamCumulAckTout_o <= appRssiParam.cumulAckTout;
+   appParamNullSegTout_o  <= appRssiParam.nullSegTout;
+   appParamMaxRetrans_o   <= appRssiParam.maxRetrans;
+   appParamMaxCumAck_o    <= appRssiParam.maxCumAck;
+   appParamMaxOutofseq_o  <= appRssiParam.maxOutofseq;
+   appParamConnectionId_o <= appRssiParam.connectionId;
+
+   frameRate(0) <= frameRate0_i;
+   frameRate(1) <= frameRate1_i;
+   bandwidth(0) <= bandwidth0_i;
+   bandwidth(1) <= bandwidth1_i;
+
+   -------------------
+   -- DUT instancing --
+   -------------------
+   U_DUT : entity surf.RssiAxiLiteRegItf
+      generic map (
+         TPD_G                 => TPD_G,
+         COMMON_CLK_G          => true,
+         SEGMENT_ADDR_SIZE_G   => SEGMENT_ADDR_SIZE_G,
+         TIMEOUT_UNIT_G        => TIMEOUT_UNIT_G,
+         INIT_SEQ_N_G          => INIT_SEQ_N_G,
+         CONN_ID_G             => CONN_ID_G,
+         VERSION_G             => VERSION_G,
+         HEADER_CHKSUM_EN_G    => HEADER_CHKSUM_EN_G,
+         MAX_NUM_OUTS_SEG_G    => MAX_NUM_OUTS_SEG_G,
+         MAX_SEG_SIZE_G        => MAX_SEG_SIZE_G,
+         RETRANS_TOUT_G        => RETRANS_TOUT_G,
+         ACK_TOUT_G            => ACK_TOUT_G,
+         NULL_TOUT_G           => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G     => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G     => MAX_CUM_ACK_CNT_G,
+         MAX_OUT_OF_SEQUENCE_G => MAX_OUT_OF_SEQUENCE_G)
+      port map (
+         axiClk_i        => axilClk,           -- [in]
+         axiRst_i        => axilRst,           -- [in]
+         axilReadMaster  => axilReadMaster,    -- [in]
+         axilReadSlave   => axilReadSlave,     -- [out]
+         axilWriteMaster => axilWriteMaster,   -- [in]
+         axilWriteSlave  => axilWriteSlave,    -- [out]
+         devClk_i        => axilClk,           -- [in]
+         devRst_i        => axilRst,           -- [in]
+         openRq_o        => openRq_o,          -- [out]
+         closeRq_o       => closeRq_o,         -- [out]
+         mode_o          => mode_o,            -- [out]
+         injectFault_o   => injectFault_o,     -- [out]
+         initSeqN_o      => initSeqN_o,        -- [out]
+         appRssiParam_o  => appRssiParam,      -- [out]
+         negRssiParam_i  => negRssiParam,      -- [in]
+         txLastAckN_i    => txLastAckN_i,      -- [in]
+         rxSeqN_i        => rxSeqN_i,          -- [in]
+         rxAckN_i        => rxAckN_i,          -- [in]
+         rxLastSeqN_i    => rxLastSeqN_i,      -- [in]
+         txTspState_i    => txTspState_i,      -- [in]
+         txAppState_i    => txAppState_i,      -- [in]
+         txAckState_i    => txAckState_i,      -- [in]
+         rxTspState_i    => rxTspState_i,      -- [in]
+         rxAppState_i    => rxAppState_i,      -- [in]
+         connState_i     => connState_i,       -- [in]
+         frameRate_i     => frameRate,         -- [in]
+         bandwidth_i     => bandwidth,         -- [in]
+         status_i        => status_i,          -- [in]
+         dropCnt_i       => dropCnt_i,         -- [in]
+         validCnt_i      => validCnt_i,        -- [in]
+         resendCnt_i     => resendCnt_i,       -- [in]
+         reconCnt_i      => reconCnt_i);       -- [in]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiConnFsmWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiConnFsmWrapper.vhd
@@ -1,0 +1,205 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI connection FSM tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.RssiPkg.all;
+
+entity RssiConnFsmWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      SERVER_G            : boolean  := true;
+      TIMEOUT_UNIT_G      : real     := 1.0;
+      CLK_FREQUENCY_G     : real     := 1.0;
+      RETRANS_TOUT_G      : positive := 4;
+      MAX_RETRANS_CNT_G   : positive := 1;
+      WINDOW_ADDR_SIZE_G  : positive := 3;
+      SEGMENT_ADDR_SIZE_G : positive := 7
+   );
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      connRq_i  : in sl;
+      closeRq_i : in sl;
+
+      rxParamVersion_i      : in slv(3 downto 0);
+      rxParamChksumEn_i     : in slv(0 downto 0);
+      rxParamTimeoutUnit_i  : in slv(7 downto 0);
+      rxParamMaxOutsSeg_i   : in slv(7 downto 0);
+      rxParamMaxSegSize_i   : in slv(15 downto 0);
+      rxParamRetransTout_i  : in slv(15 downto 0);
+      rxParamCumulAckTout_i : in slv(15 downto 0);
+      rxParamNullSegTout_i  : in slv(15 downto 0);
+      rxParamMaxRetrans_i   : in slv(7 downto 0);
+      rxParamMaxCumAck_i    : in slv(7 downto 0);
+      rxParamMaxOutofseq_i  : in slv(7 downto 0);
+      rxParamConnectionId_i : in slv(31 downto 0);
+
+      appParamVersion_i      : in slv(3 downto 0);
+      appParamChksumEn_i     : in slv(0 downto 0);
+      appParamTimeoutUnit_i  : in slv(7 downto 0);
+      appParamMaxOutsSeg_i   : in slv(7 downto 0);
+      appParamMaxSegSize_i   : in slv(15 downto 0);
+      appParamRetransTout_i  : in slv(15 downto 0);
+      appParamCumulAckTout_i : in slv(15 downto 0);
+      appParamNullSegTout_i  : in slv(15 downto 0);
+      appParamMaxRetrans_i   : in slv(7 downto 0);
+      appParamMaxCumAck_i    : in slv(7 downto 0);
+      appParamMaxOutofseq_i  : in slv(7 downto 0);
+      appParamConnectionId_i : in slv(31 downto 0);
+
+      paramVersion_o      : out slv(3 downto 0);
+      paramChksumEn_o     : out slv(0 downto 0);
+      paramTimeoutUnit_o  : out slv(7 downto 0);
+      paramMaxOutsSeg_o   : out slv(7 downto 0);
+      paramMaxSegSize_o   : out slv(15 downto 0);
+      paramRetransTout_o  : out slv(15 downto 0);
+      paramCumulAckTout_o : out slv(15 downto 0);
+      paramNullSegTout_o  : out slv(15 downto 0);
+      paramMaxRetrans_o   : out slv(7 downto 0);
+      paramMaxCumAck_o    : out slv(7 downto 0);
+      paramMaxOutofseq_o  : out slv(7 downto 0);
+      paramConnectionId_o : out slv(31 downto 0);
+
+      rxFlagsSyn_i  : in sl;
+      rxFlagsAck_i  : in sl;
+      rxFlagsEack_i : in sl;
+      rxFlagsRst_i  : in sl;
+      rxFlagsNul_i  : in sl;
+      rxFlagsData_i : in sl;
+      rxFlagsBusy_i : in sl;
+      rxFlagsEofe_i : in sl;
+
+      rxValid_i   : in sl;
+      synHeadSt_i : in sl;
+      ackHeadSt_i : in sl;
+      rstHeadSt_i : in sl;
+
+      connActive_o : out sl;
+      closed_o     : out sl;
+      sndSyn_o     : out sl;
+      sndAck_o     : out sl;
+      sndRst_o     : out sl;
+      txAckF_o     : out sl;
+
+      rxBufferSize_o : out integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
+      rxWindowSize_o : out integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      txBufferSize_o : out integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
+      txWindowSize_o : out integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+
+      connState_o   : out slv(3 downto 0);
+      peerTout_o    : out sl;
+      paramReject_o : out sl
+   );
+end entity RssiConnFsmWrapper;
+
+architecture mapping of RssiConnFsmWrapper is
+
+   signal rxRssiParam  : RssiParamType := RSSI_PARAM_INIT_C;
+   signal appRssiParam : RssiParamType := RSSI_PARAM_INIT_C;
+   signal rssiParam    : RssiParamType;
+   signal rxFlags      : FlagsType;
+
+begin
+
+   rxRssiParam.version      <= rxParamVersion_i;
+   rxRssiParam.chksumEn     <= rxParamChksumEn_i;
+   rxRssiParam.timeoutUnit  <= rxParamTimeoutUnit_i;
+   rxRssiParam.maxOutsSeg   <= rxParamMaxOutsSeg_i;
+   rxRssiParam.maxSegSize   <= rxParamMaxSegSize_i;
+   rxRssiParam.retransTout  <= rxParamRetransTout_i;
+   rxRssiParam.cumulAckTout <= rxParamCumulAckTout_i;
+   rxRssiParam.nullSegTout  <= rxParamNullSegTout_i;
+   rxRssiParam.maxRetrans   <= rxParamMaxRetrans_i;
+   rxRssiParam.maxCumAck    <= rxParamMaxCumAck_i;
+   rxRssiParam.maxOutofseq  <= rxParamMaxOutofseq_i;
+   rxRssiParam.connectionId <= rxParamConnectionId_i;
+
+   appRssiParam.version      <= appParamVersion_i;
+   appRssiParam.chksumEn     <= appParamChksumEn_i;
+   appRssiParam.timeoutUnit  <= appParamTimeoutUnit_i;
+   appRssiParam.maxOutsSeg   <= appParamMaxOutsSeg_i;
+   appRssiParam.maxSegSize   <= appParamMaxSegSize_i;
+   appRssiParam.retransTout  <= appParamRetransTout_i;
+   appRssiParam.cumulAckTout <= appParamCumulAckTout_i;
+   appRssiParam.nullSegTout  <= appParamNullSegTout_i;
+   appRssiParam.maxRetrans   <= appParamMaxRetrans_i;
+   appRssiParam.maxCumAck    <= appParamMaxCumAck_i;
+   appRssiParam.maxOutofseq  <= appParamMaxOutofseq_i;
+   appRssiParam.connectionId <= appParamConnectionId_i;
+
+   paramVersion_o      <= rssiParam.version;
+   paramChksumEn_o     <= rssiParam.chksumEn;
+   paramTimeoutUnit_o  <= rssiParam.timeoutUnit;
+   paramMaxOutsSeg_o   <= rssiParam.maxOutsSeg;
+   paramMaxSegSize_o   <= rssiParam.maxSegSize;
+   paramRetransTout_o  <= rssiParam.retransTout;
+   paramCumulAckTout_o <= rssiParam.cumulAckTout;
+   paramNullSegTout_o  <= rssiParam.nullSegTout;
+   paramMaxRetrans_o   <= rssiParam.maxRetrans;
+   paramMaxCumAck_o    <= rssiParam.maxCumAck;
+   paramMaxOutofseq_o  <= rssiParam.maxOutofseq;
+   paramConnectionId_o <= rssiParam.connectionId;
+
+   rxFlags.syn  <= rxFlagsSyn_i;
+   rxFlags.ack  <= rxFlagsAck_i;
+   rxFlags.eack <= rxFlagsEack_i;
+   rxFlags.rst  <= rxFlagsRst_i;
+   rxFlags.nul  <= rxFlagsNul_i;
+   rxFlags.data <= rxFlagsData_i;
+   rxFlags.busy <= rxFlagsBusy_i;
+   rxFlags.eofe <= rxFlagsEofe_i;
+
+   U_DUT : entity surf.RssiConnFsm
+      generic map (
+         TPD_G               => TPD_G,
+         SERVER_G            => SERVER_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         SEGMENT_ADDR_SIZE_G => SEGMENT_ADDR_SIZE_G)
+      port map (
+         clk_i          => axisClk,        -- [in]
+         rst_i          => axisRst,        -- [in]
+         connRq_i       => connRq_i,       -- [in]
+         closeRq_i      => closeRq_i,      -- [in]
+         rxRssiParam_i  => rxRssiParam,    -- [in]
+         appRssiParam_i => appRssiParam,   -- [in]
+         rssiParam_o    => rssiParam,      -- [out]
+         rxFlags_i      => rxFlags,        -- [in]
+         rxValid_i      => rxValid_i,      -- [in]
+         synHeadSt_i    => synHeadSt_i,    -- [in]
+         ackHeadSt_i    => ackHeadSt_i,    -- [in]
+         rstHeadSt_i    => rstHeadSt_i,    -- [in]
+         connActive_o   => connActive_o,   -- [out]
+         closed_o       => closed_o,       -- [out]
+         sndSyn_o       => sndSyn_o,       -- [out]
+         sndAck_o       => sndAck_o,       -- [out]
+         sndRst_o       => sndRst_o,       -- [out]
+         txAckF_o       => txAckF_o,       -- [out]
+         rxBufferSize_o => rxBufferSize_o, -- [out]
+         rxWindowSize_o => rxWindowSize_o, -- [out]
+         txBufferSize_o => txBufferSize_o, -- [out]
+         txWindowSize_o => txWindowSize_o, -- [out]
+         connState_o    => connState_o,    -- [out]
+         peerTout_o     => peerTout_o,     -- [out]
+         paramReject_o  => paramReject_o); -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd
@@ -1,0 +1,422 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing client/server RSSI core integration wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.SsiPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.RssiPkg.all;
+
+entity RssiCoreIntegrationWrapper is
+   generic (
+      TPD_G                 : time     := 1 ns;
+      CLK_FREQUENCY_G       : real     := 1.0E6;
+      TIMEOUT_UNIT_G        : real     := 1.0E-6;
+      WINDOW_ADDR_SIZE_G    : positive := 2;
+      SEGMENT_ADDR_SIZE_G   : positive := 5;
+      MAX_NUM_OUTS_SEG_G    : positive := 4;
+      MAX_SEG_SIZE_G        : positive := 32;
+      ACK_TOUT_G            : positive := 4;
+      RETRANS_TOUT_G        : positive := 16;
+      NULL_TOUT_G           : positive := 48;
+      MAX_RETRANS_CNT_G     : positive := 2;
+      MAX_CUM_ACK_CNT_G     : positive := 2;
+      CLIENT_INIT_SEQ_N_G   : natural  := 16#20#;
+      SERVER_INIT_SEQ_N_G   : natural  := 16#80#;
+      CONN_ID_G             : positive := 16#12345678#;
+      VERSION_G             : positive := 1;
+      HEADER_CHKSUM_EN_G    : boolean  := true;
+      RETRANSMIT_ENABLE_G   : boolean  := true);
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      cltOpen_i    : in sl;
+      cltClose_i   : in sl;
+      cltInject_i  : in sl;
+      srvOpen_i    : in sl;
+      srvClose_i   : in sl;
+      srvInject_i  : in sl;
+
+      cltSAppTValid : in  sl;
+      cltSAppTReady : out sl;
+      cltSAppTData  : in  slv(63 downto 0);
+      cltSAppTKeep  : in  slv(7 downto 0);
+      cltSAppTLast  : in  sl;
+      cltSAppSof    : in  sl;
+      cltSAppEofe   : in  sl;
+
+      cltMAppTValid : out sl;
+      cltMAppTReady : in  sl;
+      cltMAppTData  : out slv(63 downto 0);
+      cltMAppTKeep  : out slv(7 downto 0);
+      cltMAppTLast  : out sl;
+      cltMAppSof    : out sl;
+      cltMAppEofe   : out sl;
+
+      srvSAppTValid : in  sl;
+      srvSAppTReady : out sl;
+      srvSAppTData  : in  slv(63 downto 0);
+      srvSAppTKeep  : in  slv(7 downto 0);
+      srvSAppTLast  : in  sl;
+      srvSAppSof    : in  sl;
+      srvSAppEofe   : in  sl;
+
+      srvMAppTValid : out sl;
+      srvMAppTReady : in  sl;
+      srvMAppTData  : out slv(63 downto 0);
+      srvMAppTKeep  : out slv(7 downto 0);
+      srvMAppTLast  : out sl;
+      srvMAppSof    : out sl;
+      srvMAppEofe   : out sl;
+
+      cltSTspTValid : in  sl;
+      cltSTspTReady : out sl;
+      cltSTspTData  : in  slv(63 downto 0);
+      cltSTspTKeep  : in  slv(7 downto 0);
+      cltSTspTLast  : in  sl;
+      cltSTspSof    : in  sl;
+      cltSTspEofe   : in  sl;
+
+      cltMTspTValid : out sl;
+      cltMTspTReady : in  sl;
+      cltMTspTData  : out slv(63 downto 0);
+      cltMTspTKeep  : out slv(7 downto 0);
+      cltMTspTLast  : out sl;
+      cltMTspSof    : out sl;
+      cltMTspEofe   : out sl;
+
+      srvSTspTValid : in  sl;
+      srvSTspTReady : out sl;
+      srvSTspTData  : in  slv(63 downto 0);
+      srvSTspTKeep  : in  slv(7 downto 0);
+      srvSTspTLast  : in  sl;
+      srvSTspSof    : in  sl;
+      srvSTspEofe   : in  sl;
+
+      srvMTspTValid : out sl;
+      srvMTspTReady : in  sl;
+      srvMTspTData  : out slv(63 downto 0);
+      srvMTspTKeep  : out slv(7 downto 0);
+      srvMTspTLast  : out sl;
+      srvMTspSof    : out sl;
+      srvMTspEofe   : out sl;
+
+      S_AXI_AWADDR  : in  slv(9 downto 0);
+      S_AXI_AWPROT  : in  slv(2 downto 0);
+      S_AXI_AWVALID : in  sl;
+      S_AXI_AWREADY : out sl;
+      S_AXI_WDATA   : in  slv(31 downto 0);
+      S_AXI_WSTRB   : in  slv(3 downto 0);
+      S_AXI_WVALID  : in  sl;
+      S_AXI_WREADY  : out sl;
+      S_AXI_BRESP   : out slv(1 downto 0);
+      S_AXI_BVALID  : out sl;
+      S_AXI_BREADY  : in  sl;
+      S_AXI_ARADDR  : in  slv(9 downto 0);
+      S_AXI_ARPROT  : in  slv(2 downto 0);
+      S_AXI_ARVALID : in  sl;
+      S_AXI_ARREADY : out sl;
+      S_AXI_RDATA   : out slv(31 downto 0);
+      S_AXI_RRESP   : out slv(1 downto 0);
+      S_AXI_RVALID  : out sl;
+      S_AXI_RREADY  : in  sl;
+
+      cltStatusReg_o  : out slv(8 downto 0);
+      srvStatusReg_o  : out slv(8 downto 0);
+      cltConnected_o  : out sl;
+      srvConnected_o  : out sl;
+      cltMaxSegSize_o : out slv(15 downto 0);
+      srvMaxSegSize_o : out slv(15 downto 0));
+end entity RssiCoreIntegrationWrapper;
+
+architecture mapping of RssiCoreIntegrationWrapper is
+
+   signal axilRstN : sl;
+
+   signal cltSAppMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltSAppSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal cltMAppMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltMAppSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal srvSAppMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvSAppSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvMAppMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvMAppSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal cltTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal cltRxTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltRxTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvRxTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvRxTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal cltAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal cltAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal cltAxilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal cltAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+   signal srvAxilReadSlave   : AxiLiteReadSlaveType;
+   signal srvAxilWriteSlave  : AxiLiteWriteSlaveType;
+
+   signal cltStatusReg : slv(8 downto 0);
+   signal srvStatusReg : slv(8 downto 0);
+
+begin
+
+   axilRstN <= not axisRst;
+
+   ------------------------------
+   -- Client AXI-Lite bus shim --
+   ------------------------------
+   U_AXIL : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         EN_ERROR_RESP => true,
+         HAS_PROT      => 1,
+         HAS_WSTRB     => 1,
+         ADDR_WIDTH    => 10)
+      port map (
+         S_AXI_ACLK      => axisClk,             -- [in]
+         S_AXI_ARESETN   => axilRstN,            -- [in]
+         S_AXI_AWADDR    => S_AXI_AWADDR,        -- [in]
+         S_AXI_AWPROT    => S_AXI_AWPROT,        -- [in]
+         S_AXI_AWVALID   => S_AXI_AWVALID,       -- [in]
+         S_AXI_AWREADY   => S_AXI_AWREADY,       -- [out]
+         S_AXI_WDATA     => S_AXI_WDATA,         -- [in]
+         S_AXI_WSTRB     => S_AXI_WSTRB,         -- [in]
+         S_AXI_WVALID    => S_AXI_WVALID,        -- [in]
+         S_AXI_WREADY    => S_AXI_WREADY,        -- [out]
+         S_AXI_BRESP     => S_AXI_BRESP,         -- [out]
+         S_AXI_BVALID    => S_AXI_BVALID,        -- [out]
+         S_AXI_BREADY    => S_AXI_BREADY,        -- [in]
+         S_AXI_ARADDR    => S_AXI_ARADDR,        -- [in]
+         S_AXI_ARPROT    => S_AXI_ARPROT,        -- [in]
+         S_AXI_ARVALID   => S_AXI_ARVALID,       -- [in]
+         S_AXI_ARREADY   => S_AXI_ARREADY,       -- [out]
+         S_AXI_RDATA     => S_AXI_RDATA,         -- [out]
+         S_AXI_RRESP     => S_AXI_RRESP,         -- [out]
+         S_AXI_RVALID    => S_AXI_RVALID,        -- [out]
+         S_AXI_RREADY    => S_AXI_RREADY,        -- [in]
+         axilClk         => open,                -- [out]
+         axilRst         => open,                -- [out]
+         axilReadMaster  => cltAxilReadMaster,   -- [out]
+         axilReadSlave   => cltAxilReadSlave,    -- [in]
+         axilWriteMaster => cltAxilWriteMaster,  -- [out]
+         axilWriteSlave  => cltAxilWriteSlave);  -- [in]
+
+   -- Flattened client application input.
+   cltSAppComb : process (cltSAppEofe, cltSAppSof, cltSAppTData, cltSAppTKeep,
+                          cltSAppTLast, cltSAppTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSAppTValid;
+      v.tData(63 downto 0) := cltSAppTData;
+      v.tStrb(7 downto 0)  := cltSAppTKeep;
+      v.tKeep(7 downto 0)  := cltSAppTKeep;
+      v.tLast              := cltSAppTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSAppSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSAppEofe);
+      cltSAppMaster <= v;
+   end process cltSAppComb;
+
+   -- Flattened server application input.
+   srvSAppComb : process (srvSAppEofe, srvSAppSof, srvSAppTData, srvSAppTKeep,
+                          srvSAppTLast, srvSAppTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSAppTValid;
+      v.tData(63 downto 0) := srvSAppTData;
+      v.tStrb(7 downto 0)  := srvSAppTKeep;
+      v.tKeep(7 downto 0)  := srvSAppTKeep;
+      v.tLast              := srvSAppTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSAppSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSAppEofe);
+      srvSAppMaster <= v;
+   end process srvSAppComb;
+
+   cltSAppTReady <= cltSAppSlave.tReady;
+   srvSAppTReady <= srvSAppSlave.tReady;
+
+   -- Flattened client application output.
+   cltMAppSlave.tReady <= cltMAppTReady;
+   cltMAppTValid       <= cltMAppMaster.tValid;
+   cltMAppTData        <= cltMAppMaster.tData(63 downto 0);
+   cltMAppTKeep        <= cltMAppMaster.tKeep(7 downto 0);
+   cltMAppTLast        <= cltMAppMaster.tLast;
+   cltMAppSof          <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltMAppMaster);
+   cltMAppEofe         <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltMAppMaster);
+
+   -- Flattened server application output.
+   srvMAppSlave.tReady <= srvMAppTReady;
+   srvMAppTValid       <= srvMAppMaster.tValid;
+   srvMAppTData        <= srvMAppMaster.tData(63 downto 0);
+   srvMAppTKeep        <= srvMAppMaster.tKeep(7 downto 0);
+   srvMAppTLast        <= srvMAppMaster.tLast;
+   srvMAppSof          <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvMAppMaster);
+   srvMAppEofe         <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvMAppMaster);
+
+   -- Flattened client transport input.
+   cltSTspComb : process (cltSTspEofe, cltSTspSof, cltSTspTData,
+                          cltSTspTKeep, cltSTspTLast, cltSTspTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSTspTValid;
+      v.tData(63 downto 0) := cltSTspTData;
+      v.tStrb(7 downto 0)  := cltSTspTKeep;
+      v.tKeep(7 downto 0)  := cltSTspTKeep;
+      v.tLast              := cltSTspTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSTspSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSTspEofe);
+      cltRxTspMaster <= v;
+   end process cltSTspComb;
+
+   -- Flattened server transport input.
+   srvSTspComb : process (srvSTspEofe, srvSTspSof, srvSTspTData,
+                          srvSTspTKeep, srvSTspTLast, srvSTspTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSTspTValid;
+      v.tData(63 downto 0) := srvSTspTData;
+      v.tStrb(7 downto 0)  := srvSTspTKeep;
+      v.tKeep(7 downto 0)  := srvSTspTKeep;
+      v.tLast              := srvSTspTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSTspSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSTspEofe);
+      srvRxTspMaster <= v;
+   end process srvSTspComb;
+
+   cltSTspTReady <= cltRxTspSlave.tReady;
+   srvSTspTReady <= srvRxTspSlave.tReady;
+
+   -- Flattened transport outputs for cocotb loopback/perturbation.
+   cltTspSlave.tReady <= cltMTspTReady;
+   cltMTspTValid <= cltTspMaster.tValid;
+   cltMTspTData  <= cltTspMaster.tData(63 downto 0);
+   cltMTspTKeep  <= cltTspMaster.tKeep(7 downto 0);
+   cltMTspTLast  <= cltTspMaster.tLast;
+   cltMTspSof    <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltTspMaster);
+   cltMTspEofe   <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltTspMaster);
+
+   srvTspSlave.tReady <= srvMTspTReady;
+   srvMTspTValid <= srvTspMaster.tValid;
+   srvMTspTData  <= srvTspMaster.tData(63 downto 0);
+   srvMTspTKeep  <= srvTspMaster.tKeep(7 downto 0);
+   srvMTspTLast  <= srvTspMaster.tLast;
+   srvMTspSof    <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvTspMaster);
+   srvMTspEofe   <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvTspMaster);
+
+   cltStatusReg_o <= cltStatusReg;
+   srvStatusReg_o <= srvStatusReg;
+   cltConnected_o <= cltStatusReg(0);
+   srvConnected_o <= srvStatusReg(0);
+
+   -- Client core with transport exposed to cocotb for loopback.
+   U_Client : entity surf.RssiCore
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => false,
+         RETRANSMIT_ENABLE_G => RETRANSMIT_ENABLE_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         SEGMENT_ADDR_SIZE_G => SEGMENT_ADDR_SIZE_G,
+         APP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => CLIENT_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_NUM_OUTS_SEG_G  => MAX_NUM_OUTS_SEG_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i            => axisClk, -- [in]
+         rst_i            => axisRst, -- [in]
+         openRq_i         => cltOpen_i, -- [in]
+         closeRq_i        => cltClose_i, -- [in]
+         inject_i         => cltInject_i, -- [in]
+         sAppAxisMaster_i => cltSAppMaster, -- [in]
+         sAppAxisSlave_o  => cltSAppSlave, -- [out]
+         mAppAxisMaster_o => cltMAppMaster, -- [out]
+         mAppAxisSlave_i  => cltMAppSlave, -- [in]
+         sTspAxisMaster_i => cltRxTspMaster, -- [in]
+         sTspAxisSlave_o  => cltRxTspSlave, -- [out]
+         mTspAxisMaster_o => cltTspMaster, -- [out]
+         mTspAxisSlave_i  => cltTspSlave, -- [in]
+         axiClk_i         => axisClk, -- [in]
+         axiRst_i         => axisRst, -- [in]
+         axilReadMaster   => cltAxilReadMaster, -- [in]
+         axilReadSlave    => cltAxilReadSlave, -- [out]
+         axilWriteMaster  => cltAxilWriteMaster, -- [in]
+         axilWriteSlave   => cltAxilWriteSlave, -- [out]
+         statusReg_o      => cltStatusReg, -- [out]
+         maxSegSize_o     => cltMaxSegSize_o); -- [out]
+
+   -- Server core with transport exposed to cocotb for loopback.
+   U_Server : entity surf.RssiCore
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => true,
+         RETRANSMIT_ENABLE_G => RETRANSMIT_ENABLE_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         SEGMENT_ADDR_SIZE_G => SEGMENT_ADDR_SIZE_G,
+         APP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => SERVER_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_NUM_OUTS_SEG_G  => MAX_NUM_OUTS_SEG_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i            => axisClk, -- [in]
+         rst_i            => axisRst, -- [in]
+         openRq_i         => srvOpen_i, -- [in]
+         closeRq_i        => srvClose_i, -- [in]
+         inject_i         => srvInject_i, -- [in]
+         sAppAxisMaster_i => srvSAppMaster, -- [in]
+         sAppAxisSlave_o  => srvSAppSlave, -- [out]
+         mAppAxisMaster_o => srvMAppMaster, -- [out]
+         mAppAxisSlave_i  => srvMAppSlave, -- [in]
+         sTspAxisMaster_i => srvRxTspMaster, -- [in]
+         sTspAxisSlave_o  => srvRxTspSlave, -- [out]
+         mTspAxisMaster_o => srvTspMaster, -- [out]
+         mTspAxisSlave_i  => srvTspSlave, -- [in]
+         axilReadSlave    => srvAxilReadSlave, -- [out]
+         axilWriteSlave   => srvAxilWriteSlave, -- [out]
+         statusReg_o      => srvStatusReg, -- [out]
+         maxSegSize_o     => srvMaxSegSize_o); -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiCoreWrapperIntegrationWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiCoreWrapperIntegrationWrapper.vhd
@@ -1,0 +1,245 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing client/server RSSI core-wrapper integration wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.SsiPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.RssiPkg.all;
+
+entity RssiCoreWrapperIntegrationWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      CLK_FREQUENCY_G     : real     := 1.0E6;
+      TIMEOUT_UNIT_G      : real     := 1.0E-6;
+      WINDOW_ADDR_SIZE_G  : positive := 2;
+      MAX_SEG_SIZE_G      : positive := 256;
+      BYPASS_CHUNKER_G    : boolean  := true;
+      ACK_TOUT_G          : positive := 4;
+      RETRANS_TOUT_G      : positive := 16;
+      NULL_TOUT_G         : positive := 48;
+      MAX_RETRANS_CNT_G   : positive := 2;
+      MAX_CUM_ACK_CNT_G   : positive := 2;
+      CLIENT_INIT_SEQ_N_G : natural  := 16#20#;
+      SERVER_INIT_SEQ_N_G : natural  := 16#80#;
+      CONN_ID_G           : positive := 16#12345678#;
+      VERSION_G           : positive := 1;
+      HEADER_CHKSUM_EN_G  : boolean  := true);
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      cltOpen_i  : in sl;
+      cltClose_i : in sl;
+      srvOpen_i  : in sl;
+      srvClose_i : in sl;
+
+      cltSAppTValid : in  sl;
+      cltSAppTReady : out sl;
+      cltSAppTData  : in  slv(63 downto 0);
+      cltSAppTKeep  : in  slv(7 downto 0);
+      cltSAppTLast  : in  sl;
+      cltSAppSof    : in  sl;
+      cltSAppEofe   : in  sl;
+
+      cltMAppTValid : out sl;
+      cltMAppTReady : in  sl;
+      cltMAppTData  : out slv(63 downto 0);
+      cltMAppTKeep  : out slv(7 downto 0);
+      cltMAppTLast  : out sl;
+      cltMAppSof    : out sl;
+      cltMAppEofe   : out sl;
+
+      srvSAppTValid : in  sl;
+      srvSAppTReady : out sl;
+      srvSAppTData  : in  slv(63 downto 0);
+      srvSAppTKeep  : in  slv(7 downto 0);
+      srvSAppTLast  : in  sl;
+      srvSAppSof    : in  sl;
+      srvSAppEofe   : in  sl;
+
+      srvMAppTValid : out sl;
+      srvMAppTReady : in  sl;
+      srvMAppTData  : out slv(63 downto 0);
+      srvMAppTKeep  : out slv(7 downto 0);
+      srvMAppTLast  : out sl;
+      srvMAppSof    : out sl;
+      srvMAppEofe   : out sl;
+
+      cltConnected_o : out sl;
+      srvConnected_o : out sl;
+      cltStatusReg_o : out slv(8 downto 0);
+      srvStatusReg_o : out slv(8 downto 0));
+end entity RssiCoreWrapperIntegrationWrapper;
+
+architecture mapping of RssiCoreWrapperIntegrationWrapper is
+
+   signal cltSAppMasters : AxiStreamMasterArray(0 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal cltSAppSlaves  : AxiStreamSlaveArray(0 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+   signal cltMAppMasters : AxiStreamMasterArray(0 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal cltMAppSlaves  : AxiStreamSlaveArray(0 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+
+   signal srvSAppMasters : AxiStreamMasterArray(0 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal srvSAppSlaves  : AxiStreamSlaveArray(0 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+   signal srvMAppMasters : AxiStreamMasterArray(0 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal srvMAppSlaves  : AxiStreamSlaveArray(0 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+
+   signal cltTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal cltAxilReadSlave   : AxiLiteReadSlaveType;
+   signal cltAxilWriteSlave  : AxiLiteWriteSlaveType;
+   signal srvAxilReadSlave   : AxiLiteReadSlaveType;
+   signal srvAxilWriteSlave  : AxiLiteWriteSlaveType;
+
+begin
+
+   -- Flattened client application input.
+   cltSAppComb : process (cltSAppEofe, cltSAppSof, cltSAppTData, cltSAppTKeep,
+                          cltSAppTLast, cltSAppTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSAppTValid;
+      v.tData(63 downto 0) := cltSAppTData;
+      v.tStrb(7 downto 0)  := cltSAppTKeep;
+      v.tKeep(7 downto 0)  := cltSAppTKeep;
+      v.tLast              := cltSAppTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSAppSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSAppEofe);
+      cltSAppMasters(0) <= v;
+   end process cltSAppComb;
+
+   -- Flattened server application input.
+   srvSAppComb : process (srvSAppEofe, srvSAppSof, srvSAppTData, srvSAppTKeep,
+                          srvSAppTLast, srvSAppTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSAppTValid;
+      v.tData(63 downto 0) := srvSAppTData;
+      v.tStrb(7 downto 0)  := srvSAppTKeep;
+      v.tKeep(7 downto 0)  := srvSAppTKeep;
+      v.tLast              := srvSAppTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSAppSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSAppEofe);
+      srvSAppMasters(0) <= v;
+   end process srvSAppComb;
+
+   cltSAppTReady <= cltSAppSlaves(0).tReady;
+   srvSAppTReady <= srvSAppSlaves(0).tReady;
+
+   -- Flattened client application output.
+   cltMAppSlaves(0).tReady <= cltMAppTReady;
+   cltMAppTValid           <= cltMAppMasters(0).tValid;
+   cltMAppTData            <= cltMAppMasters(0).tData(63 downto 0);
+   cltMAppTKeep            <= cltMAppMasters(0).tKeep(7 downto 0);
+   cltMAppTLast            <= cltMAppMasters(0).tLast;
+   cltMAppSof              <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltMAppMasters(0));
+   cltMAppEofe             <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltMAppMasters(0));
+
+   -- Flattened server application output.
+   srvMAppSlaves(0).tReady <= srvMAppTReady;
+   srvMAppTValid           <= srvMAppMasters(0).tValid;
+   srvMAppTData            <= srvMAppMasters(0).tData(63 downto 0);
+   srvMAppTKeep            <= srvMAppMasters(0).tKeep(7 downto 0);
+   srvMAppTLast            <= srvMAppMasters(0).tLast;
+   srvMAppSof              <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvMAppMasters(0));
+   srvMAppEofe             <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvMAppMasters(0));
+
+   -- Client wrapper with transport connected directly to the server wrapper.
+   U_Client : entity surf.RssiCoreWrapper
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => false,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         BYPASS_CHUNKER_G    => BYPASS_CHUNKER_G,
+         APP_AXIS_CONFIG_G   => (0 => RSSI_AXIS_CONFIG_C),
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => CLIENT_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i             => axisClk, -- [in]
+         rst_i             => axisRst, -- [in]
+         sAppAxisMasters_i => cltSAppMasters, -- [in]
+         sAppAxisSlaves_o  => cltSAppSlaves, -- [out]
+         mAppAxisMasters_o => cltMAppMasters, -- [out]
+         mAppAxisSlaves_i  => cltMAppSlaves, -- [in]
+         sTspAxisMaster_i  => srvTspMaster, -- [in]
+         sTspAxisSlave_o   => srvTspSlave, -- [out]
+         mTspAxisMaster_o  => cltTspMaster, -- [out]
+         mTspAxisSlave_i   => cltTspSlave, -- [in]
+         openRq_i          => cltOpen_i, -- [in]
+         closeRq_i         => cltClose_i, -- [in]
+         rssiConnected_o   => cltConnected_o, -- [out]
+         axilReadSlave     => cltAxilReadSlave, -- [out]
+         axilWriteSlave    => cltAxilWriteSlave, -- [out]
+         statusReg_o       => cltStatusReg_o); -- [out]
+
+   -- Server wrapper with transport connected directly to the client wrapper.
+   U_Server : entity surf.RssiCoreWrapper
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => true,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         BYPASS_CHUNKER_G    => BYPASS_CHUNKER_G,
+         APP_AXIS_CONFIG_G   => (0 => RSSI_AXIS_CONFIG_C),
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => SERVER_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i             => axisClk, -- [in]
+         rst_i             => axisRst, -- [in]
+         sAppAxisMasters_i => srvSAppMasters, -- [in]
+         sAppAxisSlaves_o  => srvSAppSlaves, -- [out]
+         mAppAxisMasters_o => srvMAppMasters, -- [out]
+         mAppAxisSlaves_i  => srvMAppSlaves, -- [in]
+         sTspAxisMaster_i  => cltTspMaster, -- [in]
+         sTspAxisSlave_o   => cltTspSlave, -- [out]
+         mTspAxisMaster_o  => srvTspMaster, -- [out]
+         mTspAxisSlave_i   => srvTspSlave, -- [in]
+         openRq_i          => srvOpen_i, -- [in]
+         closeRq_i         => srvClose_i, -- [in]
+         rssiConnected_o   => srvConnected_o, -- [out]
+         axilReadSlave     => srvAxilReadSlave, -- [out]
+         axilWriteSlave    => srvAxilWriteSlave, -- [out]
+         statusReg_o       => srvStatusReg_o); -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiCoreWrapperMultiStreamIntegrationWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiCoreWrapperMultiStreamIntegrationWrapper.vhd
@@ -1,0 +1,439 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing multi-stream RSSI core-wrapper integration wrapper
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.SsiPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.RssiPkg.all;
+
+entity RssiCoreWrapperMultiStreamIntegrationWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      CLK_FREQUENCY_G     : real     := 1.0E6;
+      TIMEOUT_UNIT_G      : real     := 1.0E-6;
+      WINDOW_ADDR_SIZE_G  : positive := 3;
+      MAX_SEG_SIZE_G      : positive := 128;
+      BYPASS_CHUNKER_G    : boolean  := false;
+      APP_ILEAVE_EN_G     : boolean  := true;
+      ACK_TOUT_G          : positive := 4;
+      RETRANS_TOUT_G      : positive := 16;
+      NULL_TOUT_G         : positive := 48;
+      MAX_RETRANS_CNT_G   : positive := 2;
+      MAX_CUM_ACK_CNT_G   : positive := 2;
+      CLIENT_INIT_SEQ_N_G : natural  := 16#20#;
+      SERVER_INIT_SEQ_N_G : natural  := 16#80#;
+      CONN_ID_G           : positive := 16#12345678#;
+      VERSION_G           : positive := 1;
+      HEADER_CHKSUM_EN_G  : boolean  := true);
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      cltOpen_i  : in sl;
+      cltClose_i : in sl;
+      srvOpen_i  : in sl;
+      srvClose_i : in sl;
+
+      cltSApp0TValid : in  sl;
+      cltSApp0TReady : out sl;
+      cltSApp0TData  : in  slv(63 downto 0);
+      cltSApp0TKeep  : in  slv(7 downto 0);
+      cltSApp0TLast  : in  sl;
+      cltSApp0Sof    : in  sl;
+      cltSApp0Eofe   : in  sl;
+
+      cltSApp1TValid : in  sl;
+      cltSApp1TReady : out sl;
+      cltSApp1TData  : in  slv(63 downto 0);
+      cltSApp1TKeep  : in  slv(7 downto 0);
+      cltSApp1TLast  : in  sl;
+      cltSApp1Sof    : in  sl;
+      cltSApp1Eofe   : in  sl;
+
+      cltMApp0TValid : out sl;
+      cltMApp0TReady : in  sl;
+      cltMApp0TData  : out slv(63 downto 0);
+      cltMApp0TKeep  : out slv(7 downto 0);
+      cltMApp0TLast  : out sl;
+      cltMApp0Sof    : out sl;
+      cltMApp0Eofe   : out sl;
+
+      cltMApp1TValid : out sl;
+      cltMApp1TReady : in  sl;
+      cltMApp1TData  : out slv(63 downto 0);
+      cltMApp1TKeep  : out slv(7 downto 0);
+      cltMApp1TLast  : out sl;
+      cltMApp1Sof    : out sl;
+      cltMApp1Eofe   : out sl;
+
+      srvSApp0TValid : in  sl;
+      srvSApp0TReady : out sl;
+      srvSApp0TData  : in  slv(63 downto 0);
+      srvSApp0TKeep  : in  slv(7 downto 0);
+      srvSApp0TLast  : in  sl;
+      srvSApp0Sof    : in  sl;
+      srvSApp0Eofe   : in  sl;
+
+      srvSApp1TValid : in  sl;
+      srvSApp1TReady : out sl;
+      srvSApp1TData  : in  slv(63 downto 0);
+      srvSApp1TKeep  : in  slv(7 downto 0);
+      srvSApp1TLast  : in  sl;
+      srvSApp1Sof    : in  sl;
+      srvSApp1Eofe   : in  sl;
+
+      srvMApp0TValid : out sl;
+      srvMApp0TReady : in  sl;
+      srvMApp0TData  : out slv(63 downto 0);
+      srvMApp0TKeep  : out slv(7 downto 0);
+      srvMApp0TLast  : out sl;
+      srvMApp0Sof    : out sl;
+      srvMApp0Eofe   : out sl;
+
+      srvMApp1TValid : out sl;
+      srvMApp1TReady : in  sl;
+      srvMApp1TData  : out slv(63 downto 0);
+      srvMApp1TKeep  : out slv(7 downto 0);
+      srvMApp1TLast  : out sl;
+      srvMApp1Sof    : out sl;
+      srvMApp1Eofe   : out sl;
+
+      cltSTspTValid : in  sl;
+      cltSTspTReady : out sl;
+      cltSTspTData  : in  slv(63 downto 0);
+      cltSTspTKeep  : in  slv(7 downto 0);
+      cltSTspTLast  : in  sl;
+      cltSTspSof    : in  sl;
+      cltSTspEofe   : in  sl;
+
+      cltMTspTValid : out sl;
+      cltMTspTReady : in  sl;
+      cltMTspTData  : out slv(63 downto 0);
+      cltMTspTKeep  : out slv(7 downto 0);
+      cltMTspTLast  : out sl;
+      cltMTspSof    : out sl;
+      cltMTspEofe   : out sl;
+
+      srvSTspTValid : in  sl;
+      srvSTspTReady : out sl;
+      srvSTspTData  : in  slv(63 downto 0);
+      srvSTspTKeep  : in  slv(7 downto 0);
+      srvSTspTLast  : in  sl;
+      srvSTspSof    : in  sl;
+      srvSTspEofe   : in  sl;
+
+      srvMTspTValid : out sl;
+      srvMTspTReady : in  sl;
+      srvMTspTData  : out slv(63 downto 0);
+      srvMTspTKeep  : out slv(7 downto 0);
+      srvMTspTLast  : out sl;
+      srvMTspSof    : out sl;
+      srvMTspEofe   : out sl;
+
+      cltConnected_o : out sl;
+      srvConnected_o : out sl;
+      cltStatusReg_o : out slv(8 downto 0);
+      srvStatusReg_o : out slv(8 downto 0));
+end entity RssiCoreWrapperMultiStreamIntegrationWrapper;
+
+architecture mapping of RssiCoreWrapperMultiStreamIntegrationWrapper is
+
+   constant APP_STREAM_ROUTES_C : Slv8Array(1 downto 0) := (
+      0 => x"00",
+      1 => x"01");
+   constant APP_AXIS_BASE_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(
+      dataBytes => RSSI_WORD_WIDTH_C,
+      tKeepMode => TKEEP_COMP_C,
+      tUserMode => TUSER_FIRST_LAST_C,
+      tDestBits => 8);
+   constant APP_AXIS_CONFIG_C : AxiStreamConfigArray(1 downto 0) := (
+      others => APP_AXIS_BASE_CONFIG_C);
+
+   signal cltSAppMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal cltSAppSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+   signal cltMAppMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal cltMAppSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+
+   signal srvSAppMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal srvSAppSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+   signal srvMAppMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal srvMAppSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_INIT_C);
+
+   signal cltSTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltSTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal cltMTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal cltMTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvSTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvSTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+   signal srvMTspMaster : AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+   signal srvMTspSlave  : AxiStreamSlaveType  := AXI_STREAM_SLAVE_INIT_C;
+
+   signal cltAxilReadSlave  : AxiLiteReadSlaveType;
+   signal cltAxilWriteSlave : AxiLiteWriteSlaveType;
+   signal srvAxilReadSlave  : AxiLiteReadSlaveType;
+   signal srvAxilWriteSlave : AxiLiteWriteSlaveType;
+
+begin
+
+   -- Flattened client application inputs.
+   cltSApp0Comb : process (cltSApp0Eofe, cltSApp0Sof, cltSApp0TData,
+                           cltSApp0TKeep, cltSApp0TLast,
+                           cltSApp0TValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSApp0TValid;
+      v.tData(63 downto 0) := cltSApp0TData;
+      v.tStrb(7 downto 0)  := cltSApp0TKeep;
+      v.tKeep(7 downto 0)  := cltSApp0TKeep;
+      v.tLast              := cltSApp0TLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSApp0Sof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSApp0Eofe);
+      cltSAppMasters(0) <= v;
+   end process cltSApp0Comb;
+
+   cltSApp1Comb : process (cltSApp1Eofe, cltSApp1Sof, cltSApp1TData,
+                           cltSApp1TKeep, cltSApp1TLast,
+                           cltSApp1TValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSApp1TValid;
+      v.tData(63 downto 0) := cltSApp1TData;
+      v.tStrb(7 downto 0)  := cltSApp1TKeep;
+      v.tKeep(7 downto 0)  := cltSApp1TKeep;
+      v.tLast              := cltSApp1TLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSApp1Sof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSApp1Eofe);
+      cltSAppMasters(1) <= v;
+   end process cltSApp1Comb;
+
+   -- Flattened server application inputs.
+   srvSApp0Comb : process (srvSApp0Eofe, srvSApp0Sof, srvSApp0TData,
+                           srvSApp0TKeep, srvSApp0TLast,
+                           srvSApp0TValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSApp0TValid;
+      v.tData(63 downto 0) := srvSApp0TData;
+      v.tStrb(7 downto 0)  := srvSApp0TKeep;
+      v.tKeep(7 downto 0)  := srvSApp0TKeep;
+      v.tLast              := srvSApp0TLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSApp0Sof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSApp0Eofe);
+      srvSAppMasters(0) <= v;
+   end process srvSApp0Comb;
+
+   srvSApp1Comb : process (srvSApp1Eofe, srvSApp1Sof, srvSApp1TData,
+                           srvSApp1TKeep, srvSApp1TLast,
+                           srvSApp1TValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSApp1TValid;
+      v.tData(63 downto 0) := srvSApp1TData;
+      v.tStrb(7 downto 0)  := srvSApp1TKeep;
+      v.tKeep(7 downto 0)  := srvSApp1TKeep;
+      v.tLast              := srvSApp1TLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSApp1Sof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSApp1Eofe);
+      srvSAppMasters(1) <= v;
+   end process srvSApp1Comb;
+
+   cltSApp0TReady <= cltSAppSlaves(0).tReady;
+   cltSApp1TReady <= cltSAppSlaves(1).tReady;
+   srvSApp0TReady <= srvSAppSlaves(0).tReady;
+   srvSApp1TReady <= srvSAppSlaves(1).tReady;
+
+   -- Flattened client application outputs.
+   cltMAppSlaves(0).tReady <= cltMApp0TReady;
+   cltMApp0TValid          <= cltMAppMasters(0).tValid;
+   cltMApp0TData           <= cltMAppMasters(0).tData(63 downto 0);
+   cltMApp0TKeep           <= cltMAppMasters(0).tKeep(7 downto 0);
+   cltMApp0TLast           <= cltMAppMasters(0).tLast;
+   cltMApp0Sof             <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltMAppMasters(0));
+   cltMApp0Eofe            <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltMAppMasters(0));
+
+   cltMAppSlaves(1).tReady <= cltMApp1TReady;
+   cltMApp1TValid          <= cltMAppMasters(1).tValid;
+   cltMApp1TData           <= cltMAppMasters(1).tData(63 downto 0);
+   cltMApp1TKeep           <= cltMAppMasters(1).tKeep(7 downto 0);
+   cltMApp1TLast           <= cltMAppMasters(1).tLast;
+   cltMApp1Sof             <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltMAppMasters(1));
+   cltMApp1Eofe            <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltMAppMasters(1));
+
+   -- Flattened server application outputs.
+   srvMAppSlaves(0).tReady <= srvMApp0TReady;
+   srvMApp0TValid          <= srvMAppMasters(0).tValid;
+   srvMApp0TData           <= srvMAppMasters(0).tData(63 downto 0);
+   srvMApp0TKeep           <= srvMAppMasters(0).tKeep(7 downto 0);
+   srvMApp0TLast           <= srvMAppMasters(0).tLast;
+   srvMApp0Sof             <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvMAppMasters(0));
+   srvMApp0Eofe            <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvMAppMasters(0));
+
+   srvMAppSlaves(1).tReady <= srvMApp1TReady;
+   srvMApp1TValid          <= srvMAppMasters(1).tValid;
+   srvMApp1TData           <= srvMAppMasters(1).tData(63 downto 0);
+   srvMApp1TKeep           <= srvMAppMasters(1).tKeep(7 downto 0);
+   srvMApp1TLast           <= srvMAppMasters(1).tLast;
+   srvMApp1Sof             <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvMAppMasters(1));
+   srvMApp1Eofe            <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvMAppMasters(1));
+
+   -- Flattened client transport input.
+   cltSTspComb : process (cltSTspEofe, cltSTspSof, cltSTspTData,
+                          cltSTspTKeep, cltSTspTLast,
+                          cltSTspTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := cltSTspTValid;
+      v.tData(63 downto 0) := cltSTspTData;
+      v.tStrb(7 downto 0)  := cltSTspTKeep;
+      v.tKeep(7 downto 0)  := cltSTspTKeep;
+      v.tLast              := cltSTspTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, cltSTspSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, cltSTspEofe);
+      cltSTspMaster <= v;
+   end process cltSTspComb;
+
+   cltSTspTReady <= cltSTspSlave.tReady;
+
+   -- Flattened server transport input.
+   srvSTspComb : process (srvSTspEofe, srvSTspSof, srvSTspTData,
+                          srvSTspTKeep, srvSTspTLast,
+                          srvSTspTValid) is
+      variable v : AxiStreamMasterType;
+   begin
+      v                    := AXI_STREAM_MASTER_INIT_C;
+      v.tValid             := srvSTspTValid;
+      v.tData(63 downto 0) := srvSTspTData;
+      v.tStrb(7 downto 0)  := srvSTspTKeep;
+      v.tKeep(7 downto 0)  := srvSTspTKeep;
+      v.tLast              := srvSTspTLast;
+      ssiSetUserSof(RSSI_AXIS_CONFIG_C, v, srvSTspSof);
+      ssiSetUserEofe(RSSI_AXIS_CONFIG_C, v, srvSTspEofe);
+      srvSTspMaster <= v;
+   end process srvSTspComb;
+
+   srvSTspTReady <= srvSTspSlave.tReady;
+
+   -- Flattened client transport output.
+   cltMTspSlave.tReady <= cltMTspTReady;
+   cltMTspTValid       <= cltMTspMaster.tValid;
+   cltMTspTData        <= cltMTspMaster.tData(63 downto 0);
+   cltMTspTKeep        <= cltMTspMaster.tKeep(7 downto 0);
+   cltMTspTLast        <= cltMTspMaster.tLast;
+   cltMTspSof          <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, cltMTspMaster);
+   cltMTspEofe         <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, cltMTspMaster);
+
+   -- Flattened server transport output.
+   srvMTspSlave.tReady <= srvMTspTReady;
+   srvMTspTValid       <= srvMTspMaster.tValid;
+   srvMTspTData        <= srvMTspMaster.tData(63 downto 0);
+   srvMTspTKeep        <= srvMTspMaster.tKeep(7 downto 0);
+   srvMTspTLast        <= srvMTspMaster.tLast;
+   srvMTspSof          <= ssiGetUserSof(RSSI_AXIS_CONFIG_C, srvMTspMaster);
+   srvMTspEofe         <= ssiGetUserEofe(RSSI_AXIS_CONFIG_C, srvMTspMaster);
+
+   -- Client wrapper with flattened transport ports driven by cocotb.
+   U_Client : entity surf.RssiCoreWrapper
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => false,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         BYPASS_CHUNKER_G    => BYPASS_CHUNKER_G,
+         APP_STREAMS_G       => 2,
+         APP_STREAM_ROUTES_G => APP_STREAM_ROUTES_C,
+         APP_ILEAVE_EN_G     => APP_ILEAVE_EN_G,
+         APP_AXIS_CONFIG_G   => APP_AXIS_CONFIG_C,
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => CLIENT_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i             => axisClk, -- [in]
+         rst_i             => axisRst, -- [in]
+         sAppAxisMasters_i => cltSAppMasters, -- [in]
+         sAppAxisSlaves_o  => cltSAppSlaves, -- [out]
+         mAppAxisMasters_o => cltMAppMasters, -- [out]
+         mAppAxisSlaves_i  => cltMAppSlaves, -- [in]
+         sTspAxisMaster_i  => cltSTspMaster, -- [in]
+         sTspAxisSlave_o   => cltSTspSlave, -- [out]
+         mTspAxisMaster_o  => cltMTspMaster, -- [out]
+         mTspAxisSlave_i   => cltMTspSlave, -- [in]
+         openRq_i          => cltOpen_i, -- [in]
+         closeRq_i         => cltClose_i, -- [in]
+         rssiConnected_o   => cltConnected_o, -- [out]
+         axilReadSlave     => cltAxilReadSlave, -- [out]
+         axilWriteSlave    => cltAxilWriteSlave, -- [out]
+         statusReg_o       => cltStatusReg_o); -- [out]
+
+   -- Server wrapper with flattened transport ports driven by cocotb.
+   U_Server : entity surf.RssiCoreWrapper
+      generic map (
+         TPD_G               => TPD_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         SERVER_G            => true,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         BYPASS_CHUNKER_G    => BYPASS_CHUNKER_G,
+         APP_STREAMS_G       => 2,
+         APP_STREAM_ROUTES_G => APP_STREAM_ROUTES_C,
+         APP_ILEAVE_EN_G     => APP_ILEAVE_EN_G,
+         APP_AXIS_CONFIG_G   => APP_AXIS_CONFIG_C,
+         TSP_AXIS_CONFIG_G   => RSSI_AXIS_CONFIG_C,
+         INIT_SEQ_N_G        => SERVER_INIT_SEQ_N_G,
+         CONN_ID_G           => CONN_ID_G,
+         VERSION_G           => VERSION_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         MAX_SEG_SIZE_G      => MAX_SEG_SIZE_G,
+         ACK_TOUT_G          => ACK_TOUT_G,
+         RETRANS_TOUT_G      => RETRANS_TOUT_G,
+         NULL_TOUT_G         => NULL_TOUT_G,
+         MAX_RETRANS_CNT_G   => MAX_RETRANS_CNT_G,
+         MAX_CUM_ACK_CNT_G   => MAX_CUM_ACK_CNT_G)
+      port map (
+         clk_i             => axisClk, -- [in]
+         rst_i             => axisRst, -- [in]
+         sAppAxisMasters_i => srvSAppMasters, -- [in]
+         sAppAxisSlaves_o  => srvSAppSlaves, -- [out]
+         mAppAxisMasters_o => srvMAppMasters, -- [out]
+         mAppAxisSlaves_i  => srvMAppSlaves, -- [in]
+         sTspAxisMaster_i  => srvSTspMaster, -- [in]
+         sTspAxisSlave_o   => srvSTspSlave, -- [out]
+         mTspAxisMaster_o  => srvMTspMaster, -- [out]
+         mTspAxisSlave_i   => srvMTspSlave, -- [in]
+         openRq_i          => srvOpen_i, -- [in]
+         closeRq_i         => srvClose_i, -- [in]
+         rssiConnected_o   => srvConnected_o, -- [out]
+         axilReadSlave     => srvAxilReadSlave, -- [out]
+         axilWriteSlave    => srvAxilWriteSlave, -- [out]
+         statusReg_o       => srvStatusReg_o); -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiHeaderRegWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiHeaderRegWrapper.vhd
@@ -1,0 +1,104 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI header register tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.RssiPkg.all;
+
+entity RssiHeaderRegWrapper is
+   generic (
+      TPD_G : time := 1 ns
+   );
+   port (
+      clk_i : in sl;
+      rst_i : in sl;
+
+      synHeadSt_i  : in sl;
+      rstHeadSt_i  : in sl;
+      dataHeadSt_i : in sl;
+      nullHeadSt_i : in sl;
+      ackHeadSt_i  : in sl;
+      busyHeadSt_i : in sl;
+
+      ack_i    : in sl;
+      txSeqN_i : in slv(7 downto 0);
+      rxAckN_i : in slv(7 downto 0);
+
+      paramVersion_i      : in slv(3 downto 0);
+      paramChksumEn_i     : in slv(0 downto 0);
+      paramTimeoutUnit_i  : in slv(7 downto 0);
+      paramMaxOutsSeg_i   : in slv(7 downto 0);
+      paramMaxSegSize_i   : in slv(15 downto 0);
+      paramRetransTout_i  : in slv(15 downto 0);
+      paramCumulAckTout_i : in slv(15 downto 0);
+      paramNullSegTout_i  : in slv(15 downto 0);
+      paramMaxRetrans_i   : in slv(7 downto 0);
+      paramMaxCumAck_i    : in slv(7 downto 0);
+      paramMaxOutofseq_i  : in slv(7 downto 0);
+      paramConnectionId_i : in slv(31 downto 0);
+
+      addr_i         : in  slv(7 downto 0);
+      headerData_o   : out slv((RSSI_WORD_WIDTH_C * 8)-1 downto 0);
+      ready_o        : out sl;
+      headerLength_o : out positive
+   );
+end entity RssiHeaderRegWrapper;
+
+architecture mapping of RssiHeaderRegWrapper is
+
+   signal headerValues : RssiParamType;
+
+begin
+
+   -- Flatten the RSSI parameter record so cocotb can drive deterministic
+   -- SYN-header values through simulator-visible scalar/vector ports.
+   headerValues.version      <= paramVersion_i;
+   headerValues.chksumEn     <= paramChksumEn_i;
+   headerValues.timeoutUnit  <= paramTimeoutUnit_i;
+   headerValues.maxOutsSeg   <= paramMaxOutsSeg_i;
+   headerValues.maxSegSize   <= paramMaxSegSize_i;
+   headerValues.retransTout  <= paramRetransTout_i;
+   headerValues.cumulAckTout <= paramCumulAckTout_i;
+   headerValues.nullSegTout  <= paramNullSegTout_i;
+   headerValues.maxRetrans   <= paramMaxRetrans_i;
+   headerValues.maxCumAck    <= paramMaxCumAck_i;
+   headerValues.maxOutofseq  <= paramMaxOutofseq_i;
+   headerValues.connectionId <= paramConnectionId_i;
+
+   -- Real DUT hookup.
+   U_DUT : entity surf.RssiHeaderReg
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk_i          => clk_i,        -- [in]
+         rst_i          => rst_i,        -- [in]
+         synHeadSt_i    => synHeadSt_i,  -- [in]
+         rstHeadSt_i    => rstHeadSt_i,  -- [in]
+         dataHeadSt_i   => dataHeadSt_i, -- [in]
+         nullHeadSt_i   => nullHeadSt_i, -- [in]
+         ackHeadSt_i    => ackHeadSt_i,  -- [in]
+         busyHeadSt_i   => busyHeadSt_i, -- [in]
+         ack_i          => ack_i,        -- [in]
+         txSeqN_i       => txSeqN_i,     -- [in]
+         rxAckN_i       => rxAckN_i,     -- [in]
+         headerValues_i => headerValues, -- [in]
+         addr_i         => addr_i,       -- [in]
+         headerData_o   => headerData_o, -- [out]
+         ready_o        => ready_o,      -- [out]
+         headerLength_o => headerLength_o); -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiMonitorWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiMonitorWrapper.vhd
@@ -1,0 +1,162 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI monitor tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.RssiPkg.all;
+
+entity RssiMonitorWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      TIMEOUT_UNIT_G      : real     := 1.0;
+      CLK_FREQUENCY_G     : real     := 1.0;
+      SERVER_G            : boolean  := true;
+      WINDOW_ADDR_SIZE_G  : positive := 3;
+      STATUS_WIDTH_G      : positive := 8;
+      CNT_WIDTH_G         : positive := 16;
+      RETRANSMIT_ENABLE_G : boolean  := true
+   );
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      connActive_i : in sl;
+      localBusy_i  : in sl;
+
+      paramVersion_i      : in slv(3 downto 0);
+      paramChksumEn_i     : in slv(0 downto 0);
+      paramTimeoutUnit_i  : in slv(7 downto 0);
+      paramMaxOutsSeg_i   : in slv(7 downto 0);
+      paramMaxSegSize_i   : in slv(15 downto 0);
+      paramRetransTout_i  : in slv(15 downto 0);
+      paramCumulAckTout_i : in slv(15 downto 0);
+      paramNullSegTout_i  : in slv(15 downto 0);
+      paramMaxRetrans_i   : in slv(7 downto 0);
+      paramMaxCumAck_i    : in slv(7 downto 0);
+      paramMaxOutofseq_i  : in slv(7 downto 0);
+      paramConnectionId_i : in slv(31 downto 0);
+
+      rxFlagsSyn_i  : in sl;
+      rxFlagsAck_i  : in sl;
+      rxFlagsEack_i : in sl;
+      rxFlagsRst_i  : in sl;
+      rxFlagsNul_i  : in sl;
+      rxFlagsData_i : in sl;
+      rxFlagsBusy_i : in sl;
+      rxFlagsEofe_i : in sl;
+
+      rxLastSeqN_i    : in slv(7 downto 0);
+      rxWindowSize_i  : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      txBufferEmpty_i : in sl;
+      rxValid_i       : in sl;
+      rxDrop_i        : in sl;
+
+      ackHeadSt_i  : in sl;
+      rstHeadSt_i  : in sl;
+      dataHeadSt_i : in sl;
+      nullHeadSt_i : in sl;
+
+      lenErr_i       : in sl;
+      ackErr_i       : in sl;
+      peerConnTout_i : in sl;
+      paramReject_i  : in sl;
+
+      sndResend_o : out sl;
+      sndNull_o   : out sl;
+      sndAck_o    : out sl;
+      closeRq_o   : out sl;
+
+      statusReg_o : out slv(STATUS_WIDTH_G downto 0);
+      dropCnt_o   : out slv(CNT_WIDTH_G-1 downto 0);
+      validCnt_o  : out slv(CNT_WIDTH_G-1 downto 0);
+      resendCnt_o : out slv(CNT_WIDTH_G-1 downto 0);
+      reconCnt_o  : out slv(CNT_WIDTH_G-1 downto 0)
+   );
+end entity RssiMonitorWrapper;
+
+architecture mapping of RssiMonitorWrapper is
+
+   signal rssiParam : RssiParamType := RSSI_PARAM_INIT_C;
+   signal rxFlags   : FlagsType;
+
+begin
+
+   -- Flattened RSSI parameter record.
+   rssiParam.version      <= paramVersion_i;
+   rssiParam.chksumEn     <= paramChksumEn_i;
+   rssiParam.timeoutUnit  <= paramTimeoutUnit_i;
+   rssiParam.maxOutsSeg   <= paramMaxOutsSeg_i;
+   rssiParam.maxSegSize   <= paramMaxSegSize_i;
+   rssiParam.retransTout  <= paramRetransTout_i;
+   rssiParam.cumulAckTout <= paramCumulAckTout_i;
+   rssiParam.nullSegTout  <= paramNullSegTout_i;
+   rssiParam.maxRetrans   <= paramMaxRetrans_i;
+   rssiParam.maxCumAck    <= paramMaxCumAck_i;
+   rssiParam.maxOutofseq  <= paramMaxOutofseq_i;
+   rssiParam.connectionId <= paramConnectionId_i;
+
+   -- Flattened received-header flags.
+   rxFlags.syn  <= rxFlagsSyn_i;
+   rxFlags.ack  <= rxFlagsAck_i;
+   rxFlags.eack <= rxFlagsEack_i;
+   rxFlags.rst  <= rxFlagsRst_i;
+   rxFlags.nul  <= rxFlagsNul_i;
+   rxFlags.data <= rxFlagsData_i;
+   rxFlags.busy <= rxFlagsBusy_i;
+   rxFlags.eofe <= rxFlagsEofe_i;
+
+   U_DUT : entity surf.RssiMonitor
+      generic map (
+         TPD_G               => TPD_G,
+         TIMEOUT_UNIT_G      => TIMEOUT_UNIT_G,
+         CLK_FREQUENCY_G     => CLK_FREQUENCY_G,
+         SERVER_G            => SERVER_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         STATUS_WIDTH_G      => STATUS_WIDTH_G,
+         CNT_WIDTH_G         => CNT_WIDTH_G,
+         RETRANSMIT_ENABLE_G => RETRANSMIT_ENABLE_G)
+      port map (
+         clk_i          => axisClk,        -- [in]
+         rst_i          => axisRst,        -- [in]
+         connActive_i   => connActive_i,   -- [in]
+         localBusy_i    => localBusy_i,    -- [in]
+         rssiParam_i    => rssiParam,      -- [in]
+         rxFlags_i      => rxFlags,        -- [in]
+         rxLastSeqN_i   => rxLastSeqN_i,   -- [in]
+         rxWindowSize_i => rxWindowSize_i, -- [in]
+         txBufferEmpty_i => txBufferEmpty_i, -- [in]
+         rxValid_i      => rxValid_i,      -- [in]
+         rxDrop_i       => rxDrop_i,       -- [in]
+         ackHeadSt_i    => ackHeadSt_i,    -- [in]
+         rstHeadSt_i    => rstHeadSt_i,    -- [in]
+         dataHeadSt_i   => dataHeadSt_i,   -- [in]
+         nullHeadSt_i   => nullHeadSt_i,   -- [in]
+         lenErr_i       => lenErr_i,       -- [in]
+         ackErr_i       => ackErr_i,       -- [in]
+         peerConnTout_i => peerConnTout_i, -- [in]
+         paramReject_i  => paramReject_i,  -- [in]
+         sndResend_o    => sndResend_o,    -- [out]
+         sndNull_o      => sndNull_o,      -- [out]
+         sndAck_o       => sndAck_o,       -- [out]
+         closeRq_o      => closeRq_o,      -- [out]
+         statusReg_o    => statusReg_o,    -- [out]
+         dropCnt_o      => dropCnt_o,      -- [out]
+         validCnt_o     => validCnt_o,     -- [out]
+         resendCnt_o    => resendCnt_o,    -- [out]
+         reconCnt_o     => reconCnt_o);    -- [out]
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiRxFsmWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiRxFsmWrapper.vhd
@@ -1,0 +1,190 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI receive FSM tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.RssiPkg.all;
+use surf.SsiPkg.all;
+
+entity RssiRxFsmWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      WINDOW_ADDR_SIZE_G  : positive := 3;
+      HEADER_CHKSUM_EN_G  : boolean  := true;
+      SEGMENT_ADDR_SIZE_G : positive := 2
+   );
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      connActive_i   : in sl;
+      rxWindowSize_i : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      rxBufferSize_i : in integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
+      txWindowSize_i : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      lastAckN_i     : in slv(7 downto 0);
+
+      sAxisTValid : in  sl;
+      sAxisTReady : out sl;
+      sAxisTData  : in  slv(63 downto 0);
+      sAxisTKeep  : in  slv(7 downto 0);
+      sAxisTLast  : in  sl;
+      sAxisSof    : in  sl;
+      sAxisEofe   : in  sl;
+
+      mAxisTValid : out sl;
+      mAxisTReady : in  sl;
+      mAxisTData  : out slv(63 downto 0);
+      mAxisTKeep  : out slv(7 downto 0);
+      mAxisTLast  : out sl;
+      mAxisSof    : out sl;
+      mAxisEofe   : out sl;
+
+      chksumValid_i : in sl;
+      chksumOk_i    : in sl;
+
+      rxSeqN_o        : out slv(7 downto 0);
+      rxAckN_o        : out slv(7 downto 0);
+      rxLastSeqN_o    : out slv(7 downto 0);
+      rxValidSeg_o    : out sl;
+      rxDropSeg_o     : out sl;
+      rxFlagSyn_o     : out sl;
+      rxFlagAck_o     : out sl;
+      rxFlagRst_o     : out sl;
+      rxFlagNull_o    : out sl;
+      rxFlagData_o    : out sl;
+      rxFlagBusy_o    : out sl;
+      chksumEnable_o  : out sl;
+      chksumStrobe_o  : out sl;
+      chksumLength_o  : out positive;
+      rxTspState_o    : out slv(3 downto 0);
+      rxAppState_o    : out slv(3 downto 0);
+      paramVersion_o  : out slv(3 downto 0);
+      paramChksumEn_o : out slv(0 downto 0);
+      paramConnId_o   : out slv(31 downto 0)
+   );
+end entity RssiRxFsmWrapper;
+
+architecture mapping of RssiRxFsmWrapper is
+
+   subtype MemoryAddrType is natural range 0 to 2 ** (WINDOW_ADDR_SIZE_G+SEGMENT_ADDR_SIZE_G)-1;
+   type MemoryType is array (MemoryAddrType) of slv(63 downto 0);
+
+   signal mem : MemoryType := (others => (others => '0'));
+
+   signal tspSsiMaster : SsiMasterType;
+   signal tspSsiSlave  : SsiSlaveType;
+   signal appSsiMaster : SsiMasterType;
+   signal appSsiSlave  : SsiSlaveType;
+   signal rxFlags      : flagsType;
+   signal rxParam      : RssiParamType;
+   signal wrBuffWe     : sl;
+   signal wrBuffAddr   : slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+   signal wrBuffData   : slv(63 downto 0);
+   signal rdBuffAddr   : slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+   signal rdBuffData   : slv(63 downto 0) := (others => '0');
+
+begin
+
+   -- Flattened transport-side SSI input.
+   tspSsiMaster.valid             <= sAxisTValid;
+   tspSsiMaster.data(63 downto 0) <= sAxisTData;
+   tspSsiMaster.data(tspSsiMaster.data'high downto 64) <= (others => '0');
+   tspSsiMaster.strb              <= (others => '1');
+   tspSsiMaster.keep(tspSsiMaster.keep'high downto RSSI_WORD_WIDTH_C) <= (others => '0');
+   tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0) <= sAxisTKeep;
+   tspSsiMaster.dest              <= (others => '0');
+   tspSsiMaster.packed            <= '0';
+   tspSsiMaster.sof               <= sAxisSof;
+   tspSsiMaster.eof               <= sAxisTLast;
+   tspSsiMaster.eofe              <= sAxisEofe;
+   sAxisTReady                    <= tspSsiSlave.ready;
+
+   -- Flattened application-side SSI output.
+   mAxisTValid <= appSsiMaster.valid;
+   mAxisTData  <= appSsiMaster.data(63 downto 0);
+   mAxisTKeep  <= appSsiMaster.keep(7 downto 0);
+   mAxisTLast  <= appSsiMaster.eof;
+   mAxisSof    <= appSsiMaster.sof;
+   mAxisEofe   <= appSsiMaster.eofe;
+
+   appSsiSlave.ready    <= mAxisTReady;
+   appSsiSlave.pause    <= not mAxisTReady;
+   appSsiSlave.overflow <= '0';
+
+   -- Small behavioral RAM that represents the segment buffer attached to
+   -- `RssiRxFsm` in `RssiCore`.
+   seq : process (axisClk) is
+   begin
+      if rising_edge(axisClk) then
+         if wrBuffWe = '1' then
+            mem(to_integer(unsigned(wrBuffAddr))) <= wrBuffData after TPD_G;
+         end if;
+         rdBuffData <= mem(to_integer(unsigned(rdBuffAddr))) after TPD_G;
+      end if;
+   end process seq;
+
+   -- Real DUT hookup.
+   U_DUT : entity surf.RssiRxFsm
+      generic map (
+         TPD_G               => TPD_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G,
+         SEGMENT_ADDR_SIZE_G => SEGMENT_ADDR_SIZE_G)
+      port map (
+         clk_i          => axisClk,      -- [in]
+         rst_i          => axisRst,      -- [in]
+         connActive_i   => connActive_i, -- [in]
+         rxWindowSize_i => rxWindowSize_i, -- [in]
+         rxBufferSize_i => rxBufferSize_i, -- [in]
+         txWindowSize_i => txWindowSize_i, -- [in]
+         lastAckN_i     => lastAckN_i,   -- [in]
+         rxSeqN_o       => rxSeqN_o,     -- [out]
+         rxAckN_o       => rxAckN_o,     -- [out]
+         rxLastSeqN_o   => rxLastSeqN_o, -- [out]
+         rxValidSeg_o   => rxValidSeg_o, -- [out]
+         rxDropSeg_o    => rxDropSeg_o,  -- [out]
+         rxFlags_o      => rxFlags,      -- [out]
+         rxParam_o      => rxParam,      -- [out]
+         rxTspState_o   => rxTspState_o, -- [out]
+         rxAppState_o   => rxAppState_o, -- [out]
+         chksumValid_i  => chksumValid_i, -- [in]
+         chksumOk_i     => chksumOk_i,   -- [in]
+         chksumEnable_o => chksumEnable_o, -- [out]
+         chksumStrobe_o => chksumStrobe_o, -- [out]
+         chksumLength_o => chksumLength_o, -- [out]
+         wrBuffWe_o     => wrBuffWe,     -- [out]
+         wrBuffAddr_o   => wrBuffAddr,   -- [out]
+         wrBuffData_o   => wrBuffData,   -- [out]
+         rdBuffAddr_o   => rdBuffAddr,   -- [out]
+         rdBuffData_i   => rdBuffData,   -- [in]
+         tspSsiMaster_i => tspSsiMaster, -- [in]
+         tspSsiSlave_o  => tspSsiSlave,  -- [out]
+         appSsiMaster_o => appSsiMaster, -- [out]
+         appSsiSlave_i  => appSsiSlave); -- [in]
+
+   rxFlagSyn_o     <= rxFlags.syn;
+   rxFlagAck_o     <= rxFlags.ack;
+   rxFlagRst_o     <= rxFlags.rst;
+   rxFlagNull_o    <= rxFlags.nul;
+   rxFlagData_o    <= rxFlags.data;
+   rxFlagBusy_o    <= rxFlags.busy;
+   paramVersion_o  <= rxParam.version;
+   paramChksumEn_o <= rxParam.chksumEn;
+   paramConnId_o   <= rxParam.connectionId;
+
+end architecture mapping;

--- a/protocols/rssi/v1/wrappers/RssiTxFsmWrapper.vhd
+++ b/protocols/rssi/v1/wrappers/RssiTxFsmWrapper.vhd
@@ -1,0 +1,236 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for RSSI transmit FSM tests
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.RssiPkg.all;
+use surf.SsiPkg.all;
+
+entity RssiTxFsmWrapper is
+   generic (
+      TPD_G               : time     := 1 ns;
+      WINDOW_ADDR_SIZE_G  : positive := 3;
+      HEADER_CHKSUM_EN_G  : boolean  := true;
+      SEGMENT_ADDR_SIZE_G : positive := 2
+   );
+   port (
+      axisClk : in sl;
+      axisRst : in sl;
+
+      connActive_i  : in sl;
+      closed_i      : in sl;
+      injectFault_i : in sl;
+
+      sndSyn_i    : in sl;
+      sndAck_i    : in sl;
+      sndRst_i    : in sl;
+      sndResend_i : in sl;
+      sndNull_i   : in sl;
+
+      windowSize_i : in integer range 1 to 2 ** (WINDOW_ADDR_SIZE_G);
+      bufferSize_i : in integer range 1 to 2 ** (SEGMENT_ADDR_SIZE_G);
+
+      initSeqN_i  : in slv(7 downto 0);
+      txAckFlag_i : in sl;
+      rxAckN_i    : in slv(7 downto 0);
+      localBusy_i : in sl;
+
+      ack_i  : in sl;
+      ackN_i : in slv(7 downto 0);
+
+      sAxisTValid : in  sl;
+      sAxisTReady : out sl;
+      sAxisTData  : in  slv(63 downto 0);
+      sAxisTKeep  : in  slv(7 downto 0);
+      sAxisTLast  : in  sl;
+      sAxisSof    : in  sl;
+      sAxisEofe   : in  sl;
+
+      mAxisTValid : out sl;
+      mAxisTReady : in  sl;
+      mAxisTData  : out slv(63 downto 0);
+      mAxisTKeep  : out slv(7 downto 0);
+      mAxisTLast  : out sl;
+      mAxisSof    : out sl;
+      mAxisEofe   : out sl;
+
+      chksumValid_i  : in  sl;
+      chksum_i       : in  slv(15 downto 0);
+      chksumEnable_o : out sl;
+      chksumStrobe_o : out sl;
+
+      txSeqN_o      : out slv(7 downto 0);
+      lastAckN_o    : out slv(7 downto 0);
+      synHeadSt_o   : out sl;
+      ackHeadSt_o   : out sl;
+      dataHeadSt_o  : out sl;
+      dataSt_o      : out sl;
+      rstHeadSt_o   : out sl;
+      nullHeadSt_o  : out sl;
+      txTspState_o  : out slv(7 downto 0);
+      txAppState_o  : out slv(3 downto 0);
+      txAckState_o  : out slv(3 downto 0);
+      lenErr_o      : out sl;
+      ackErr_o      : out sl;
+      bufferEmpty_o : out sl
+   );
+end entity RssiTxFsmWrapper;
+
+architecture mapping of RssiTxFsmWrapper is
+
+   subtype MemoryAddrType is natural range 0 to 2 ** (WINDOW_ADDR_SIZE_G+SEGMENT_ADDR_SIZE_G)-1;
+   type MemoryType is array (MemoryAddrType) of slv(63 downto 0);
+
+   signal mem : MemoryType := (others => (others => '0'));
+
+   signal appSsiMaster : SsiMasterType;
+   signal appSsiSlave  : SsiSlaveType;
+   signal tspSsiMaster : SsiMasterType;
+   signal tspSsiSlave  : SsiSlaveType;
+   signal wrBuffWe     : sl;
+   signal wrBuffAddr   : slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+   signal wrBuffData   : slv(63 downto 0);
+   signal rdBuffAddr   : slv((SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G)-1 downto 0);
+   signal rdBuffData   : slv(63 downto 0);
+   signal rdHeaderAddr : slv(7 downto 0);
+   signal rdHeaderData : slv(63 downto 0);
+   signal headerRdy    : sl;
+   signal headerLength : positive;
+   signal txSeqN       : slv(7 downto 0);
+   signal headerValues : RssiParamType := RSSI_PARAM_INIT_C;
+
+begin
+
+   -- Flattened application-side SSI input.
+   appSsiMaster.valid             <= sAxisTValid;
+   appSsiMaster.data(63 downto 0) <= sAxisTData;
+   appSsiMaster.data(appSsiMaster.data'high downto 64) <= (others => '0');
+   appSsiMaster.strb              <= (others => '1');
+   appSsiMaster.keep(appSsiMaster.keep'high downto RSSI_WORD_WIDTH_C) <= (others => '0');
+   appSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0) <= sAxisTKeep;
+   appSsiMaster.dest              <= (others => '0');
+   appSsiMaster.packed            <= '0';
+   appSsiMaster.sof               <= sAxisSof;
+   appSsiMaster.eof               <= sAxisTLast;
+   appSsiMaster.eofe              <= sAxisEofe;
+   sAxisTReady                    <= appSsiSlave.ready;
+
+   -- Flattened transport-side SSI output.
+   mAxisTValid <= tspSsiMaster.valid;
+   mAxisTData  <= tspSsiMaster.data(63 downto 0);
+   mAxisTKeep  <= tspSsiMaster.keep(7 downto 0);
+   mAxisTLast  <= tspSsiMaster.eof;
+   mAxisSof    <= tspSsiMaster.sof;
+   mAxisEofe   <= tspSsiMaster.eofe;
+
+   tspSsiSlave.ready    <= mAxisTReady;
+   tspSsiSlave.pause    <= not mAxisTReady;
+   tspSsiSlave.overflow <= '0';
+
+   -- Small behavioral RAM for DATA and resend path tests.
+   seq : process (axisClk) is
+   begin
+      if rising_edge(axisClk) then
+         if wrBuffWe = '1' then
+            mem(to_integer(unsigned(wrBuffAddr))) <= wrBuffData after TPD_G;
+         end if;
+         rdBuffData <= mem(to_integer(unsigned(rdBuffAddr))) after TPD_G;
+      end if;
+   end process seq;
+
+   -- Header generator wired as it is in RssiCore, with flattened control
+   -- values that make standalone ACK/DATA/NULL/RST requests deterministic.
+   U_Header : entity surf.RssiHeaderReg
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk_i          => axisClk,       -- [in]
+         rst_i          => axisRst,       -- [in]
+         synHeadSt_i    => synHeadSt_o,   -- [in]
+         rstHeadSt_i    => rstHeadSt_o,   -- [in]
+         dataHeadSt_i   => dataHeadSt_o,  -- [in]
+         nullHeadSt_i   => nullHeadSt_o,  -- [in]
+         ackHeadSt_i    => ackHeadSt_o,   -- [in]
+         busyHeadSt_i   => localBusy_i,   -- [in]
+         ack_i          => txAckFlag_i,   -- [in]
+         txSeqN_i       => txSeqN,        -- [in]
+         rxAckN_i       => rxAckN_i,      -- [in]
+         headerValues_i => headerValues,  -- [in]
+         addr_i         => rdHeaderAddr,  -- [in]
+         headerData_o   => rdHeaderData,  -- [out]
+         ready_o        => headerRdy,     -- [out]
+         headerLength_o => headerLength); -- [out]
+
+   -- Real DUT hookup.
+   U_DUT : entity surf.RssiTxFsm
+      generic map (
+         TPD_G               => TPD_G,
+         WINDOW_ADDR_SIZE_G  => WINDOW_ADDR_SIZE_G,
+         SEGMENT_ADDR_SIZE_G => SEGMENT_ADDR_SIZE_G,
+         HEADER_CHKSUM_EN_G  => HEADER_CHKSUM_EN_G)
+      port map (
+         clk_i          => axisClk,       -- [in]
+         rst_i          => axisRst,       -- [in]
+         connActive_i   => connActive_i,  -- [in]
+         closed_i       => closed_i,      -- [in]
+         injectFault_i  => injectFault_i, -- [in]
+         sndSyn_i       => sndSyn_i,      -- [in]
+         sndAck_i       => sndAck_i,      -- [in]
+         sndRst_i       => sndRst_i,      -- [in]
+         sndResend_i    => sndResend_i,   -- [in]
+         sndNull_i      => sndNull_i,     -- [in]
+         windowSize_i   => windowSize_i,  -- [in]
+         bufferSize_i   => bufferSize_i,  -- [in]
+         wrBuffWe_o     => wrBuffWe,      -- [out]
+         wrBuffAddr_o   => wrBuffAddr,    -- [out]
+         wrBuffData_o   => wrBuffData,    -- [out]
+         rdBuffAddr_o   => rdBuffAddr,    -- [out]
+         rdBuffData_i   => rdBuffData,    -- [in]
+         rdHeaderAddr_o => rdHeaderAddr,  -- [out]
+         rdHeaderData_i => rdHeaderData,  -- [in]
+         headerRdy_i    => headerRdy,     -- [in]
+         headerLength_i => headerLength,  -- [in]
+         chksumValid_i  => chksumValid_i, -- [in]
+         chksumEnable_o => chksumEnable_o, -- [out]
+         chksumStrobe_o => chksumStrobe_o, -- [out]
+         chksum_i       => chksum_i,      -- [in]
+         initSeqN_i     => initSeqN_i,    -- [in]
+         txSeqN_o       => txSeqN,        -- [out]
+         synHeadSt_o    => synHeadSt_o,   -- [out]
+         ackHeadSt_o    => ackHeadSt_o,   -- [out]
+         dataHeadSt_o   => dataHeadSt_o,  -- [out]
+         dataSt_o       => dataSt_o,      -- [out]
+         rstHeadSt_o    => rstHeadSt_o,   -- [out]
+         nullHeadSt_o   => nullHeadSt_o,  -- [out]
+         txTspState_o   => txTspState_o,  -- [out]
+         txAppState_o   => txAppState_o,  -- [out]
+         txAckState_o   => txAckState_o,  -- [out]
+         lastAckN_o     => lastAckN_o,    -- [out]
+         ack_i          => ack_i,         -- [in]
+         ackN_i         => ackN_i,        -- [in]
+         appSsiMaster_i => appSsiMaster,  -- [in]
+         appSsiSlave_o  => appSsiSlave,   -- [out]
+         tspSsiSlave_i  => tspSsiSlave,   -- [in]
+         tspSsiMaster_o => tspSsiMaster,  -- [out]
+         lenErr_o       => lenErr_o,      -- [out]
+         ackErr_o       => ackErr_o,      -- [out]
+         bufferEmpty_o  => bufferEmpty_o); -- [out]
+
+   txSeqN_o <= txSeqN;
+
+end architecture mapping;

--- a/tests/common/regression_utils.py
+++ b/tests/common/regression_utils.py
@@ -226,6 +226,7 @@ def run_surf_vhdl_test(
     extra_env: dict[str, object] | None = None,
     extra_vhdl_sources: dict[str, list[str]] | None = None,
     sim_build_key: str | None = None,
+    force_compile: bool = False,
 ) -> None:
     test_file = Path(test_file)
     simulator_env = None
@@ -249,4 +250,5 @@ def run_surf_vhdl_test(
         extra_env=simulator_env,
         simulator="ghdl",
         vhdl_compile_args=COMMON_VHDL_COMPILE_ARGS,
+        force_compile=force_compile,
     )

--- a/tests/protocols/rssi/__init__.py
+++ b/tests/protocols/rssi/__init__.py
@@ -1,0 +1,9 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################

--- a/tests/protocols/rssi/rssi_test_utils.py
+++ b/tests/protocols/rssi/rssi_test_utils.py
@@ -1,0 +1,413 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cocotb.triggers import FallingEdge, Timer
+
+RSSI_HEADER_SIZE = 8
+RSSI_SYN_HEADER_SIZE = 24
+
+RSSI_FLAG_SYN = 0x80
+RSSI_FLAG_ACK = 0x40
+RSSI_FLAG_EACK = 0x20
+RSSI_FLAG_RST = 0x10
+RSSI_FLAG_NULL = 0x08
+RSSI_FLAG_BUSY = 0x01
+
+RSSI_VERSION = 0x1
+
+RSSI_CORE_VHDL_SOURCES = [
+    "protocols/rssi/v1/rtl/RssiConnFsm.vhd",
+    "protocols/rssi/v1/rtl/RssiMonitor.vhd",
+    "protocols/rssi/v1/rtl/RssiRxFsm.vhd",
+    "protocols/rssi/v1/rtl/RssiTxFsm.vhd",
+    "protocols/rssi/v1/rtl/RssiCore.vhd",
+]
+
+RSSI_CORE_WRAPPER_VHDL_SOURCES = RSSI_CORE_VHDL_SOURCES + [
+    "protocols/rssi/v1/rtl/RssiCoreWrapper.vhd",
+]
+
+
+@dataclass(frozen=True)
+class RssiParams:
+    # Defaults are ordinary valid negotiation values, not reset values.  Tests
+    # override fields when they need to pin an exact SYN encoding.
+    version: int = RSSI_VERSION
+    chksum_en: int = 1
+    max_outs_seg: int = 8
+    max_seg_size: int = 1024
+    retrans_tout: int = 1000
+    cumul_ack_tout: int = 10
+    null_seg_tout: int = 100
+    max_retrans: int = 4
+    max_cum_ack: int = 3
+    max_outofseq: int = 0
+    timeout_unit: int = 1
+    connection_id: int = 0x1234_5678
+
+
+@dataclass(frozen=True)
+class RssiHeader:
+    flags: int
+    header_length: int
+    sequence: int
+    acknowledge: int
+    checksum: int
+    params: RssiParams | None = None
+
+    @property
+    def syn(self) -> bool:
+        return bool(self.flags & RSSI_FLAG_SYN)
+
+    @property
+    def ack(self) -> bool:
+        return bool(self.flags & RSSI_FLAG_ACK)
+
+    @property
+    def rst(self) -> bool:
+        return bool(self.flags & RSSI_FLAG_RST)
+
+    @property
+    def nul(self) -> bool:
+        return bool(self.flags & RSSI_FLAG_NULL)
+
+    @property
+    def busy(self) -> bool:
+        return bool(self.flags & RSSI_FLAG_BUSY)
+
+
+def ones_complement_checksum(data: bytes) -> int:
+    # RSSI follows the RUDP/RFC 1151 style 16-bit one's-complement sum over the
+    # header bytes in network order.  Folding after each add keeps the Python
+    # model aligned with the hardware's carry behavior.
+    if len(data) % 2:
+        data += b"\x00"
+
+    total = 0
+    for index in range(0, len(data), 2):
+        total += int.from_bytes(data[index : index + 2], "big")
+        total = (total & 0xFFFF) + (total >> 16)
+
+    total = (total & 0xFFFF) + (total >> 16)
+    return (~total) & 0xFFFF
+
+
+def checksum_is_valid(header: bytes) -> bool:
+    # A header with its checksum field included validates when the folded sum is
+    # all ones.  This is the receive-side check that `RssiChksum.check_o`
+    # exposes after the module complements the accumulated sum.
+    total = 0
+    for index in range(0, len(header), 2):
+        total += int.from_bytes(header[index : index + 2], "big")
+        total = (total & 0xFFFF) + (total >> 16)
+    total = (total & 0xFFFF) + (total >> 16)
+    return total == 0xFFFF
+
+
+def _u8(value: int) -> int:
+    return value & 0xFF
+
+
+def _u16(value: int) -> bytes:
+    return (value & 0xFFFF).to_bytes(2, "big")
+
+
+def _u32(value: int) -> bytes:
+    return (value & 0xFFFF_FFFF).to_bytes(4, "big")
+
+
+def _with_checksum(header: bytes, *, enable_checksum: bool = True) -> bytes:
+    # Builders support zeroed checksum fields so header-format tests can compare
+    # `RssiHeaderReg` output before `RssiTxFsm` appends the computed checksum.
+    if not enable_checksum:
+        return header
+    checksum = ones_complement_checksum(header)
+    return header[:-2] + _u16(checksum)
+
+
+def build_non_syn_header(
+    *,
+    flags: int,
+    sequence: int,
+    acknowledge: int,
+    enable_checksum: bool = True,
+) -> bytes:
+    # Non-SYN RSSI headers are exactly one 64-bit word.  Bytes 4 and 5 are
+    # reserved, and bytes 6 and 7 are the checksum placeholder.
+    header = bytes(
+        [
+            _u8(flags),
+            RSSI_HEADER_SIZE,
+            _u8(sequence),
+            _u8(acknowledge),
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ]
+    )
+    return _with_checksum(header, enable_checksum=enable_checksum)
+
+
+def build_ack_header(
+    *,
+    sequence: int,
+    acknowledge: int,
+    busy: bool = False,
+    enable_checksum: bool = True,
+) -> bytes:
+    flags = RSSI_FLAG_ACK | (RSSI_FLAG_BUSY if busy else 0)
+    return build_non_syn_header(
+        flags=flags,
+        sequence=sequence,
+        acknowledge=acknowledge,
+        enable_checksum=enable_checksum,
+    )
+
+
+def build_data_header(
+    *,
+    sequence: int,
+    acknowledge: int,
+    ack: bool = True,
+    busy: bool = False,
+    enable_checksum: bool = True,
+) -> bytes:
+    flags = (RSSI_FLAG_ACK if ack else 0) | (RSSI_FLAG_BUSY if busy else 0)
+    return build_non_syn_header(
+        flags=flags,
+        sequence=sequence,
+        acknowledge=acknowledge,
+        enable_checksum=enable_checksum,
+    )
+
+
+def build_null_header(
+    *,
+    sequence: int,
+    acknowledge: int,
+    ack: bool = True,
+    busy: bool = False,
+    enable_checksum: bool = True,
+) -> bytes:
+    flags = RSSI_FLAG_NULL | (RSSI_FLAG_ACK if ack else 0) | (RSSI_FLAG_BUSY if busy else 0)
+    return build_non_syn_header(
+        flags=flags,
+        sequence=sequence,
+        acknowledge=acknowledge,
+        enable_checksum=enable_checksum,
+    )
+
+
+def build_rst_header(
+    *,
+    sequence: int,
+    acknowledge: int,
+    busy: bool = False,
+    enable_checksum: bool = True,
+) -> bytes:
+    flags = RSSI_FLAG_RST | (RSSI_FLAG_BUSY if busy else 0)
+    return build_non_syn_header(
+        flags=flags,
+        sequence=sequence,
+        acknowledge=acknowledge,
+        enable_checksum=enable_checksum,
+    )
+
+
+def build_syn_header(
+    *,
+    sequence: int,
+    acknowledge: int,
+    ack: bool = False,
+    params: RssiParams = RssiParams(),
+    enable_checksum: bool = True,
+) -> bytes:
+    # SYN adds two more 64-bit words of negotiation parameters.  The byte order
+    # here is protocol/network order; the RTL stream path byte-swaps separately.
+    flags = RSSI_FLAG_SYN | (RSSI_FLAG_ACK if ack else 0)
+    word0 = bytes(
+        [
+            flags,
+            RSSI_SYN_HEADER_SIZE,
+            _u8(sequence),
+            _u8(acknowledge),
+            ((params.version & 0xF) << 4) | 0x08 | ((params.chksum_en & 0x1) << 2),
+            _u8(params.max_outs_seg),
+        ]
+    ) + _u16(params.max_seg_size)
+    word1 = (
+        _u16(params.retrans_tout)
+        + _u16(params.cumul_ack_tout)
+        + _u16(params.null_seg_tout)
+        + bytes([_u8(params.max_retrans), _u8(params.max_cum_ack)])
+    )
+    word2 = (
+        bytes([_u8(params.max_outofseq), _u8(params.timeout_unit)])
+        + _u32(params.connection_id)
+        + b"\x00\x00"
+    )
+    return _with_checksum(word0 + word1 + word2, enable_checksum=enable_checksum)
+
+
+def build_data_frame(
+    payload: bytes,
+    *,
+    sequence: int,
+    acknowledge: int,
+    ack: bool = True,
+    busy: bool = False,
+    enable_checksum: bool = True,
+) -> bytes:
+    return build_data_header(
+        sequence=sequence,
+        acknowledge=acknowledge,
+        ack=ack,
+        busy=busy,
+        enable_checksum=enable_checksum,
+    ) + payload
+
+
+def parse_header(frame: bytes) -> RssiHeader:
+    # Keep parsing deliberately strict so helper misuse fails at the protocol
+    # boundary instead of producing misleading test expectations.
+    if len(frame) < RSSI_HEADER_SIZE:
+        raise ValueError("RSSI frame is shorter than the fixed header")
+
+    flags = frame[0]
+    header_length = frame[1]
+    if flags & RSSI_FLAG_SYN:
+        if header_length != RSSI_SYN_HEADER_SIZE or len(frame) < RSSI_SYN_HEADER_SIZE:
+            raise ValueError("Malformed RSSI SYN header length")
+        checksum = int.from_bytes(frame[22:24], "big")
+        params = RssiParams(
+            version=(frame[4] >> 4) & 0xF,
+            chksum_en=(frame[4] >> 2) & 0x1,
+            max_outs_seg=frame[5],
+            max_seg_size=int.from_bytes(frame[6:8], "big"),
+            retrans_tout=int.from_bytes(frame[8:10], "big"),
+            cumul_ack_tout=int.from_bytes(frame[10:12], "big"),
+            null_seg_tout=int.from_bytes(frame[12:14], "big"),
+            max_retrans=frame[14],
+            max_cum_ack=frame[15],
+            max_outofseq=frame[16],
+            timeout_unit=frame[17],
+            connection_id=int.from_bytes(frame[18:22], "big"),
+        )
+    else:
+        if header_length != RSSI_HEADER_SIZE:
+            raise ValueError("Malformed RSSI non-SYN header length")
+        checksum = int.from_bytes(frame[6:8], "big")
+        params = None
+
+    return RssiHeader(
+        flags=flags,
+        header_length=header_length,
+        sequence=frame[2],
+        acknowledge=frame[3],
+        checksum=checksum,
+        params=params,
+    )
+
+
+def header_words(header: bytes) -> list[int]:
+    # Direct `RssiHeaderReg` output is compared as big-endian 64-bit protocol
+    # words.  Later stream-facing tests can byte-swap at the AXI Stream layer.
+    if len(header) % 8:
+        raise ValueError("RSSI headers are expected to be 64-bit aligned")
+    return [int.from_bytes(header[index : index + 8], "big") for index in range(0, len(header), 8)]
+
+
+def stream_word_from_header_word(header_word: int) -> int:
+    # `RssiRxFsm` applies `endianSwap64()` to the incoming 64-bit stream word
+    # before decoding it.  Drive the byte-reversed value on the flattened SSI
+    # port so the internal protocol word matches `header_words()`.
+    return int.from_bytes(header_word.to_bytes(8, "big")[::-1], "big")
+
+
+def stream_words_from_header(header: bytes) -> list[int]:
+    return [stream_word_from_header_word(word) for word in header_words(header)]
+
+
+def protocol_bytes_from_stream_word(word: int) -> bytes:
+    # RSSI transport headers are byte-swapped onto the 64-bit AXI Stream data
+    # bus.  Reverse the stream word before parsing it as protocol-order bytes.
+    return word.to_bytes(8, "big")[::-1]
+
+
+def stream_word_from_protocol_bytes(protocol_bytes: bytes) -> int:
+    if len(protocol_bytes) != 8:
+        raise ValueError("RSSI stream words must be exactly 8 bytes")
+    return int.from_bytes(protocol_bytes[::-1], "big")
+
+
+def format_transport_frame(beats) -> str:
+    header = parse_header(protocol_bytes_from_stream_word(beats[0].data))
+    return (
+        f"flags=0x{header.flags:02x}, seq={header.sequence}, "
+        f"ack={header.acknowledge}, beats={[f'0x{beat.data:016x}' for beat in beats]}"
+    )
+
+
+async def recv_matching_transport_frame(
+    endpoint,
+    *,
+    clk,
+    match,
+    timeout_cycles: int = 512,
+):
+    beats = []
+    seen = []
+    for _ in range(timeout_cycles):
+        await FallingEdge(clk)
+        await Timer(1, unit="ns")
+        if int(endpoint._sig("TValid").value) == 1 and int(endpoint._sig("TReady").value) == 1:
+            beat = endpoint.snapshot()
+            if not beats and beat.sof != 1:
+                continue
+            beats.append(beat)
+            if beat.last == 1:
+                try:
+                    header = parse_header(protocol_bytes_from_stream_word(beats[0].data))
+                except ValueError:
+                    seen.append(f"malformed beats={[f'0x{item.data:016x}' for item in beats]}")
+                else:
+                    seen.append(format_transport_frame(beats))
+                    if match(header, beats):
+                        return beats
+                beats = []
+    raise AssertionError(f"Timed out waiting for matching {endpoint.prefix} frame; seen={seen}")
+
+
+async def recv_transport_data_frame(
+    endpoint,
+    *,
+    clk,
+    timeout_cycles: int = 512,
+):
+    return await recv_matching_transport_frame(
+        endpoint,
+        clk=clk,
+        match=lambda header, beats: not header.syn and not header.nul and len(beats) > 1,
+        timeout_cycles=timeout_cycles,
+    )
+
+
+def header_without_checksum(header: bytes) -> bytes:
+    # Checksum-generation tests need the same header content with only the final
+    # checksum field cleared.
+    parsed = parse_header(header)
+    if parsed.syn:
+        return header[:22] + b"\x00\x00"
+    return header[:6] + b"\x00\x00"

--- a/tests/protocols/rssi/test_RssiAxiLiteRegItf.py
+++ b/tests/protocols/rssi/test_RssiAxiLiteRegItf.py
@@ -1,0 +1,343 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file, may be
+## copied, modified, propagated, or distributed except according to the terms
+## contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify the user-visible RSSI AXI-Lite register contract at the
+#   `RssiAxiLiteRegItf` boundary.  These tests are intentionally register-map
+#   tests, not protocol-flow tests; they prove that software-facing fields
+#   match the RTL register layout and that device-domain control/status wiring
+#   is packed into the documented offsets.
+# - DUT shape: Run `RssiAxiLiteRegItf` through a thin wrapper that flattens the
+#   RSSI parameter, status, counter, state, and sequence records.  The wrapper
+#   uses one AXI/device clock so the test can focus on register semantics
+#   instead of CDC timing.  CDC behavior is covered by the production
+#   synchronizers inside the RTL and by integration tests that exercise
+#   `RssiCore`.
+# - Stimulus: Use `cocotbext.axi` to issue ordinary AXI-Lite reads and writes.
+#   Drive flattened negotiated-parameter, status, counter, state, and sequence
+#   inputs directly to model the rest of the RSSI core.  Keep stimulus values
+#   deliberately nonzero and visually distinct so bit packing mistakes are
+#   obvious in assertion failures.
+# - Checks: Cover reset defaults, writable local parameter readback, clamping of
+#   illegal or too-small local parameter values, negotiated/current readback,
+#   status/counter packing, FSM state packing, sequence/ack readback, and
+#   `DECERR` propagation for unmapped addresses.  These checks align the RTL
+#   with `python/surf/protocols/rssi/_RssiCore.py`.
+# - Timing: Readback checks wait a few AXI clocks after writes before sampling
+#   flattened device outputs.  This keeps the test tolerant of the wrapper's
+#   synchronization pipeline while still making register behavior deterministic.
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiResp
+
+from tests.axi.utils import axil_read_u32, axil_write_u32
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+
+
+REG_CONTROL = 0x00
+REG_INIT_SEQ = 0x04
+REG_VERSION = 0x08
+REG_MAX_OUTS_SEG = 0x0C
+REG_MAX_SEG_SIZE = 0x10
+REG_RETRANS_TOUT = 0x14
+REG_CUMUL_ACK_TOUT = 0x18
+REG_NULL_SEG_TOUT = 0x1C
+REG_MAX_RETRANS = 0x20
+REG_MAX_CUM_ACK = 0x24
+REG_MAX_OUTOFSEQ = 0x28
+REG_CONNECTION_ID = 0x2C
+REG_NEG_CONNECTION_ID = 0x30
+REG_STATUS = 0x40
+REG_VALID_CNT = 0x44
+REG_DROP_CNT = 0x48
+REG_RESEND_CNT = 0x4C
+REG_RECON_CNT = 0x50
+REG_FRAME_RATE_0 = 0x54
+REG_FRAME_RATE_1 = 0x58
+REG_BANDWIDTH_0_LOW = 0x5C
+REG_BANDWIDTH_0_HIGH = 0x60
+REG_BANDWIDTH_1_LOW = 0x64
+REG_BANDWIDTH_1_HIGH = 0x68
+REG_STATES = 0x6C
+REG_SEQUENCES = 0x70
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.axil = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "S_AXI"), dut.axilClk, dut.axilRst)
+        cocotb.start_soon(Clock(dut.axilClk, 5.0, unit="ns").start())
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.axilClk)
+            await Timer(1, unit="ns")
+
+    def _set_defaults(self) -> None:
+        self.dut.negParamVersion_i.value = 1
+        self.dut.negParamChksumEn_i.value = 1
+        self.dut.negParamTimeoutUnit_i.value = 6
+        self.dut.negParamMaxOutsSeg_i.value = 5
+        self.dut.negParamMaxSegSize_i.value = 512
+        self.dut.negParamRetransTout_i.value = 60
+        self.dut.negParamCumulAckTout_i.value = 12
+        self.dut.negParamNullSegTout_i.value = 180
+        self.dut.negParamMaxRetrans_i.value = 3
+        self.dut.negParamMaxCumAck_i.value = 4
+        self.dut.negParamMaxOutofseq_i.value = 0
+        self.dut.negParamConnectionId_i.value = 0xCAFE_BABE
+
+        self.dut.txLastAckN_i.value = 0
+        self.dut.rxSeqN_i.value = 0
+        self.dut.rxAckN_i.value = 0
+        self.dut.rxLastSeqN_i.value = 0
+        self.dut.txTspState_i.value = 0
+        self.dut.txAppState_i.value = 0
+        self.dut.txAckState_i.value = 0
+        self.dut.rxTspState_i.value = 0
+        self.dut.rxAppState_i.value = 0
+        self.dut.connState_i.value = 0
+        self.dut.frameRate0_i.value = 0
+        self.dut.frameRate1_i.value = 0
+        self.dut.bandwidth0_i.value = 0
+        self.dut.bandwidth1_i.value = 0
+        self.dut.status_i.value = 0
+        self.dut.dropCnt_i.value = 0
+        self.dut.validCnt_i.value = 0
+        self.dut.resendCnt_i.value = 0
+        self.dut.reconCnt_i.value = 0
+
+    async def reset(self) -> None:
+        self.dut.axilRst.setimmediatevalue(1)
+        self._set_defaults()
+        await self.cycle(4)
+        self.dut.axilRst.value = 0
+        await self.cycle(4)
+
+    async def write(self, address: int, value: int) -> None:
+        await axil_write_u32(self.axil, address, value)
+        await self.cycle(2)
+
+    async def read(self, address: int) -> int:
+        return await axil_read_u32(self.axil, address)
+
+
+@cocotb.test()
+async def defaults_and_writable_parameters_read_back_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Default control enables header checksums, and generic-derived defaults
+    # should be visible both through AXI-Lite reads and device-domain outputs.
+    assert await tb.read(REG_CONTROL) == 0x8
+    assert await tb.read(REG_INIT_SEQ) == 0x80
+    assert await tb.read(REG_VERSION) & 0xF == 1
+    assert await tb.read(REG_MAX_OUTS_SEG) & 0xFF == 8
+    assert await tb.read(REG_MAX_SEG_SIZE) & 0xFFFF == 1024
+    assert int(dut.appParamChksumEn_o.value) == 1
+
+    await tb.write(REG_CONTROL, 0x1D)
+    assert await tb.read(REG_CONTROL) == 0x1D
+    assert int(dut.openRq_o.value) == 1
+    assert int(dut.closeRq_o.value) == 0
+    assert int(dut.mode_o.value) == 1
+    assert int(dut.injectFault_o.value) == 1
+    assert int(dut.appParamChksumEn_o.value) == 1
+
+    await tb.write(REG_INIT_SEQ, 0x5A)
+    await tb.write(REG_VERSION, 0x2)
+    await tb.write(REG_MAX_OUTS_SEG, 0x6)
+    await tb.write(REG_RETRANS_TOUT, 0x1234)
+    await tb.write(REG_CUMUL_ACK_TOUT, 0x0056)
+    await tb.write(REG_NULL_SEG_TOUT, 0x0789)
+    await tb.write(REG_MAX_RETRANS, 0x04)
+    await tb.write(REG_MAX_CUM_ACK, 0x09)
+    await tb.write(REG_MAX_OUTOFSEQ, 0x0A)
+    await tb.write(REG_CONNECTION_ID, 0x1357_9BDF)
+
+    assert await tb.read(REG_INIT_SEQ) == 0x5A
+    assert await tb.read(REG_VERSION) & 0xF == 0x2
+    assert await tb.read(REG_MAX_OUTS_SEG) & 0xFF == 0x6
+    assert await tb.read(REG_RETRANS_TOUT) & 0xFFFF == 0x1234
+    assert await tb.read(REG_CUMUL_ACK_TOUT) & 0xFFFF == 0x0056
+    assert await tb.read(REG_NULL_SEG_TOUT) & 0xFFFF == 0x0789
+    assert await tb.read(REG_MAX_RETRANS) & 0xFF == 0x04
+    assert await tb.read(REG_MAX_CUM_ACK) & 0xFF == 0x09
+    assert await tb.read(REG_MAX_OUTOFSEQ) & 0xFF == 0x0A
+    assert await tb.read(REG_CONNECTION_ID) == 0x1357_9BDF
+
+    assert int(dut.initSeqN_o.value) == 0x5A
+    assert int(dut.appParamVersion_o.value) == 0x2
+    assert int(dut.appParamMaxOutsSeg_o.value) == 0x6
+    assert int(dut.appParamRetransTout_o.value) == 0x1234
+    assert int(dut.appParamConnectionId_o.value) == 0x1357_9BDF
+
+
+@cocotb.test()
+async def max_segment_size_clamps_to_supported_range_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    await tb.write(REG_MAX_SEG_SIZE, 4)
+    assert await tb.read(REG_MAX_SEG_SIZE) & 0xFFFF == 8
+    assert int(dut.appParamMaxSegSize_o.value) == 8
+
+    await tb.write(REG_MAX_SEG_SIZE, 2048)
+    assert await tb.read(REG_MAX_SEG_SIZE) & 0xFFFF == 1024
+    assert int(dut.appParamMaxSegSize_o.value) == 1024
+
+    await tb.write(REG_MAX_SEG_SIZE, 128)
+    assert await tb.read(REG_MAX_SEG_SIZE) & 0xFFFF == 128
+    assert int(dut.appParamMaxSegSize_o.value) == 128
+
+
+@cocotb.test()
+async def writable_parameter_ranges_clamp_to_valid_runtime_values_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    await tb.write(REG_MAX_OUTS_SEG, 0)
+    assert await tb.read(REG_MAX_OUTS_SEG) & 0xFF == 1
+    assert int(dut.appParamMaxOutsSeg_o.value) == 1
+
+    await tb.write(REG_MAX_OUTS_SEG, 0xFF)
+    assert await tb.read(REG_MAX_OUTS_SEG) & 0xFF == 8
+    assert int(dut.appParamMaxOutsSeg_o.value) == 8
+
+    for address, signal_name in (
+        (REG_RETRANS_TOUT, "appParamRetransTout_o"),
+        (REG_CUMUL_ACK_TOUT, "appParamCumulAckTout_o"),
+        (REG_NULL_SEG_TOUT, "appParamNullSegTout_o"),
+    ):
+        await tb.write(address, 0)
+        assert await tb.read(address) & 0xFFFF == 1
+        assert int(getattr(dut, signal_name).value) == 1
+
+
+@cocotb.test()
+async def status_counters_states_and_negotiated_parameters_read_back_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    dut.negParamVersion_i.value = 3
+    dut.negParamMaxOutsSeg_i.value = 7
+    dut.negParamMaxSegSize_i.value = 0x0200
+    dut.negParamRetransTout_i.value = 0x0101
+    dut.negParamCumulAckTout_i.value = 0x0202
+    dut.negParamNullSegTout_i.value = 0x0303
+    dut.negParamMaxRetrans_i.value = 5
+    dut.negParamMaxCumAck_i.value = 6
+    dut.negParamMaxOutofseq_i.value = 2
+    dut.negParamConnectionId_i.value = 0xCAFE_BABE
+
+    dut.status_i.value = 0x155
+    dut.validCnt_i.value = 0x1111_2222
+    dut.dropCnt_i.value = 0x3333_4444
+    dut.resendCnt_i.value = 0x5555_6666
+    dut.reconCnt_i.value = 0x7777_8888
+    dut.frameRate0_i.value = 0x0102_0304
+    dut.frameRate1_i.value = 0x0506_0708
+    dut.bandwidth0_i.value = 0x1122_3344_5566_7788
+    dut.bandwidth1_i.value = 0x99AA_BBCC_DDEE_FF00
+    dut.txTspState_i.value = 0x12
+    dut.txAppState_i.value = 0x3
+    dut.txAckState_i.value = 0x4
+    dut.rxTspState_i.value = 0x5
+    dut.rxAppState_i.value = 0x6
+    dut.connState_i.value = 0x7
+    dut.txLastAckN_i.value = 0x89
+    dut.rxSeqN_i.value = 0xAB
+    dut.rxAckN_i.value = 0xCD
+    dut.rxLastSeqN_i.value = 0xEF
+    await tb.cycle(4)
+
+    assert (await tb.read(REG_VERSION) >> 16) & 0xF == 3
+    assert (await tb.read(REG_MAX_OUTS_SEG) >> 16) & 0xFF == 7
+    assert (await tb.read(REG_MAX_SEG_SIZE) >> 16) & 0xFFFF == 0x0200
+    assert (await tb.read(REG_RETRANS_TOUT) >> 16) & 0xFFFF == 0x0101
+    assert (await tb.read(REG_CUMUL_ACK_TOUT) >> 16) & 0xFFFF == 0x0202
+    assert (await tb.read(REG_NULL_SEG_TOUT) >> 16) & 0xFFFF == 0x0303
+    assert (await tb.read(REG_MAX_RETRANS) >> 16) & 0xFF == 5
+    assert (await tb.read(REG_MAX_CUM_ACK) >> 16) & 0xFF == 6
+    assert (await tb.read(REG_MAX_OUTOFSEQ) >> 16) & 0xFF == 2
+    assert await tb.read(REG_NEG_CONNECTION_ID) == 0xCAFE_BABE
+
+    assert await tb.read(REG_STATUS) & 0x1FF == 0x155
+    assert await tb.read(REG_VALID_CNT) == 0x1111_2222
+    assert await tb.read(REG_DROP_CNT) == 0x3333_4444
+    assert await tb.read(REG_RESEND_CNT) == 0x5555_6666
+    assert await tb.read(REG_RECON_CNT) == 0x7777_8888
+    assert await tb.read(REG_FRAME_RATE_0) == 0x0102_0304
+    assert await tb.read(REG_FRAME_RATE_1) == 0x0506_0708
+    assert await tb.read(REG_BANDWIDTH_0_LOW) == 0x5566_7788
+    assert await tb.read(REG_BANDWIDTH_0_HIGH) == 0x1122_3344
+    assert await tb.read(REG_BANDWIDTH_1_LOW) == 0xDDEE_FF00
+    assert await tb.read(REG_BANDWIDTH_1_HIGH) == 0x99AA_BBCC
+
+    assert await tb.read(REG_STATES) == 0x0765_4312
+    assert await tb.read(REG_SEQUENCES) == 0xEFCD_AB89
+
+
+@cocotb.test()
+async def unmapped_and_unaligned_accesses_return_decerr_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    bad_read = await tb.axil.read(0x200, 4)
+    assert bad_read.resp == AxiResp.DECERR
+
+    bad_write = await tb.axil.write(0x200, (0xA5A5_5A5A).to_bytes(4, "little"))
+    assert bad_write.resp == AxiResp.DECERR
+
+    unaligned_read = await tb.axil.read(0x02, 4)
+    assert unaligned_read.resp == AxiResp.DECERR
+
+    unaligned_write = await tb.axil.write(0x02, (0x1234_5678).to_bytes(4, "little"))
+    assert unaligned_write.resp == AxiResp.DECERR
+
+
+@cocotb.test()
+async def build_time_capability_advertised_in_upper_byte_test(dut):
+    # The upper byte of REG_MAX_OUTS_SEG advertises MAX_NUM_OUTS_SEG_G and the
+    # upper byte of REG_MAX_OUTOFSEQ advertises SEGMENT_ADDR_SIZE_G so that
+    # software can auto-discover firmware capability without per-app generics.
+    tb = TB(dut)
+    await tb.reset()
+
+    expected_max_num_outs_seg = int(dut.MAX_NUM_OUTS_SEG_G.value)
+    expected_segment_addr_size = int(dut.SEGMENT_ADDR_SIZE_G.value)
+
+    assert (await tb.read(REG_MAX_OUTS_SEG) >> 24) & 0xFF == expected_max_num_outs_seg
+    assert (await tb.read(REG_MAX_OUTOFSEQ) >> 24) & 0xFF == expected_segment_addr_size
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="axi_lite")]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiAxiLiteRegItf(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssiaxiliteregitfwrapper",
+        parameters=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiAxiLiteRegItf.vhd",
+                "protocols/rssi/v1/wrappers/RssiAxiLiteRegItfWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiChksum.py
+++ b/tests/protocols/rssi/test_RssiChksum.py
@@ -1,0 +1,218 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Treat `RssiChksum` as the checksum oracle used by the RSSI
+#   transmit and receive paths.  The tests pin the one's-complement arithmetic
+#   independently of the higher-level FSMs so header-format or state-machine
+#   failures are not confused with checksum datapath failures.
+# - DUT shape: Run the production 64-bit checksum engine with the normal RSSI
+#   checksum width.  No RSSI FSMs are instantiated here; the test drives raw
+#   header words directly and compares the block against the Python helper in
+#   `rssi_test_utils.py`.
+# - Stimulus: Feed ACK, DATA, and multi-word SYN headers with the checksum field
+#   cleared for generation mode, then feed complete headers with the checksum
+#   included for validation mode.  Additional cases cover enable gaps and reset
+#   interruptions so the accumulator restart behavior is explicit.
+# - Checks: Generated checksums must match the Python one's-complement oracle.
+#   Complete valid headers must assert `check_o`; headers with one altered byte
+#   must leave `check_o` deasserted.  Dropping enable or asserting reset must
+#   restart accumulation and prevent stale partial sums from leaking into the
+#   next header.
+# - Timing: The bench drives one 64-bit word per strobe and then waits for the
+#   registered `valid_o` response before sampling `chksum_o` and `check_o`.
+#   This matches the way the RSSI header path observes checksum completion in
+#   the TX and RX FSM tests.
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer, with_timeout
+
+from tests.common.regression_utils import run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RssiParams,
+    build_ack_header,
+    build_data_header,
+    build_syn_header,
+    checksum_is_valid,
+    header_without_checksum,
+    header_words,
+    ones_complement_checksum,
+)
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        # The checksum block is a simple registered datapath, so a single free
+        # running clock is enough for all tests in this module.
+        cocotb.start_soon(Clock(dut.clk_i, 5.0, unit="ns").start())
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.clk_i)
+            # Most RSSI RTL uses `after TPD_G`; wait past the default 1 ns
+            # transport delay before sampling outputs.
+            await Timer(2, unit="ns")
+
+    async def reset(self) -> None:
+        # Hold all data/control inputs in a benign state during reset so the
+        # first transaction starts from only the explicit init value.
+        self.dut.rst_i.setimmediatevalue(1)
+        self.dut.enable_i.setimmediatevalue(0)
+        self.dut.strobe_i.setimmediatevalue(0)
+        self.dut.length_i.setimmediatevalue(1)
+        self.dut.init_i.setimmediatevalue(0)
+        self.dut.data_i.setimmediatevalue(0)
+        await self.cycle(4)
+        self.dut.rst_i.value = 0
+        await self.cycle(2)
+
+    async def run_words(self, words: list[int], *, init: int = 0) -> tuple[int, int]:
+        # Load the initial checksum state while enable is low, then present one
+        # strobe per 64-bit header word.
+        self.dut.enable_i.value = 0
+        self.dut.strobe_i.value = 0
+        self.dut.init_i.value = init
+        self.dut.length_i.value = len(words)
+        await self.cycle()
+
+        self.dut.enable_i.value = 1
+        for word in words:
+            # The RTL sums all four 16-bit lanes in a 64-bit word whenever
+            # strobe is high, so keep the word stable for the accepting edge.
+            self.dut.data_i.value = word
+            self.dut.strobe_i.value = 1
+            await self.cycle()
+
+        self.dut.strobe_i.value = 0
+        await with_timeout(self.wait_valid(), 1, "us")
+        return int(self.dut.chksum_o.value), int(self.dut.check_o.value)
+
+    async def wait_valid(self) -> None:
+        # Valid remains asserted once the requested word count has been
+        # accumulated; the caller bounds this wait with `with_timeout`.
+        while int(self.dut.valid_o.value) != 1:
+            await self.cycle()
+
+
+@cocotb.test()
+async def known_header_vectors_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    vectors = [
+        build_ack_header(sequence=0x12, acknowledge=0x34),
+        build_data_header(sequence=0x56, acknowledge=0x78, ack=True, busy=True),
+        build_syn_header(
+            sequence=0x9A,
+            acknowledge=0xBC,
+            ack=True,
+            params=RssiParams(
+                version=1,
+                chksum_en=1,
+                max_outs_seg=7,
+                max_seg_size=0x05DC,
+                retrans_tout=0x0123,
+                cumul_ack_tout=0x0045,
+                null_seg_tout=0x0678,
+                max_retrans=9,
+                max_cum_ack=10,
+                max_outofseq=0,
+                timeout_unit=4,
+                connection_id=0x89AB_CDEF,
+            ),
+        ),
+    ]
+
+    for header in vectors:
+        # Generation mode feeds the header with the checksum bytes cleared and
+        # expects `chksum_o` to produce the value that belongs in those bytes.
+        expected = ones_complement_checksum(header_without_checksum(header))
+        observed, check_ok = await tb.run_words(header_words(header_without_checksum(header)))
+        assert observed == expected
+        assert check_ok == 0
+
+
+@cocotb.test()
+async def validation_mode_accepts_good_and_rejects_bad_headers_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    good_header = build_syn_header(sequence=0x01, acknowledge=0x02)
+    assert checksum_is_valid(good_header)
+
+    # Validation mode feeds the complete header, including checksum.  A correct
+    # header should reduce to zero after the RTL's final one's complement.
+    observed, check_ok = await tb.run_words(header_words(good_header))
+    assert observed == 0
+    assert check_ok == 1
+
+    bad_header = bytearray(good_header)
+    # Flip a negotiated field without updating the checksum; the same length and
+    # structure should now fail only the checksum validation.
+    bad_header[5] ^= 0x20
+    observed, check_ok = await tb.run_words(header_words(bytes(bad_header)))
+    assert observed != 0
+    assert check_ok == 0
+
+
+@cocotb.test()
+async def enable_low_and_reset_restart_accumulation_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    first = header_words(header_without_checksum(build_ack_header(sequence=0x01, acknowledge=0x02)))
+    second = header_words(header_without_checksum(build_ack_header(sequence=0xAA, acknowledge=0x55)))
+
+    observed, _ = await tb.run_words(first)
+    assert observed == ones_complement_checksum(header_without_checksum(build_ack_header(sequence=0x01, acknowledge=0x02)))
+
+    # Leaving enable low between transactions must discard the previous sum.
+    observed, _ = await tb.run_words(second)
+    assert observed == ones_complement_checksum(header_without_checksum(build_ack_header(sequence=0xAA, acknowledge=0x55)))
+
+    self_test_header = build_data_header(sequence=0x33, acknowledge=0x44, ack=True)
+    self_test_words = header_words(header_without_checksum(self_test_header))
+    self_test_expected = ones_complement_checksum(header_without_checksum(self_test_header))
+
+    self_test_word = self_test_words[0]
+    # Start a transaction, interrupt it with reset, then prove the next complete
+    # transaction is independent of any partial sum.
+    dut.enable_i.value = 0
+    dut.length_i.value = 1
+    dut.init_i.value = 0
+    await tb.cycle()
+    dut.enable_i.value = 1
+    dut.strobe_i.value = 1
+    dut.data_i.value = self_test_word
+    await tb.cycle()
+    dut.rst_i.value = 1
+    dut.strobe_i.value = 0
+    await tb.cycle(2)
+    dut.rst_i.value = 0
+    await tb.cycle(2)
+
+    observed, _ = await tb.run_words(self_test_words)
+    assert observed == self_test_expected
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="rssi_64b_checksum")]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiChksum(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssichksum",
+        parameters=parameters,
+        extra_env=parameters,
+    )

--- a/tests/protocols/rssi/test_RssiConnFsm.py
+++ b/tests/protocols/rssi/test_RssiConnFsm.py
@@ -1,0 +1,443 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file, may be
+## copied, modified, propagated, or distributed except according to the terms
+## contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify RSSI connection-state behavior at the `RssiConnFsm` leaf
+#   boundary before it is composed with TX, RX, monitor, and AXI-Lite logic in
+#   `RssiCore`.  These tests focus on active/passive open, SYN negotiation,
+#   retry/timeout behavior, and parameter rejection decisions.
+# - DUT shape: Run the FSM through a thin wrapper in both server and client
+#   modes.  The wrapper flattens `RssiParamType` and header flag records so the
+#   test can drive exact peer proposals and observe accepted/current parameter
+#   outputs without depending on the header decoder or register map.
+# - Stimulus: Drive connection requests, received SYN/SYN+ACK/ACK/RST flags,
+#   peer parameter records, and header-sent strobes directly.  Tests model the
+#   minimum surrounding handshake needed to advance the FSM and intentionally
+#   avoid sending SSI traffic or encoded header bytes.
+# - Checks: Matching parameters open the connection.  Legal peer window and
+#   segment-size proposals are accepted or clamped as the SURF hardware profile
+#   defines.  Non-negotiable mismatches and out-of-range peer parameters reject
+#   the proposal and, on the client side, request RST.  Retry cases verify that
+#   missing peer responses cause bounded SYN retransmission attempts followed
+#   by close rather than counter overflow.
+# - Timing: Status checks wait past the default `TPD_G` output delay after each
+#   clock edge.  Timeout generics are kept small so retries and peer-timeout
+#   closure remain deterministic within a directed cocotb test.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import RssiParams
+from tests.protocols.ssi.ssi_test_utils import (
+    cycle as ssi_cycle,
+    setup_flat_ssi_testbench,
+)
+
+
+PARAM_FIELDS = (
+    ("Version", "version"),
+    ("ChksumEn", "chksum_en"),
+    ("TimeoutUnit", "timeout_unit"),
+    ("MaxOutsSeg", "max_outs_seg"),
+    ("MaxSegSize", "max_seg_size"),
+    ("RetransTout", "retrans_tout"),
+    ("CumulAckTout", "cumul_ack_tout"),
+    ("NullSegTout", "null_seg_tout"),
+    ("MaxRetrans", "max_retrans"),
+    ("MaxCumAck", "max_cum_ack"),
+    ("MaxOutofseq", "max_outofseq"),
+    ("ConnectionId", "connection_id"),
+)
+
+
+class TB:
+    def __init__(self, dut, bench):
+        self.dut = dut
+        self.clk = bench.clk
+
+    @classmethod
+    async def create(cls, dut):
+        initial_values = {
+            "connRq_i": 0,
+            "closeRq_i": 0,
+            "rxValid_i": 0,
+            "synHeadSt_i": 0,
+            "ackHeadSt_i": 0,
+            "rstHeadSt_i": 0,
+            "rxFlagsSyn_i": 0,
+            "rxFlagsAck_i": 0,
+            "rxFlagsEack_i": 0,
+            "rxFlagsRst_i": 0,
+            "rxFlagsNul_i": 0,
+            "rxFlagsData_i": 0,
+            "rxFlagsBusy_i": 0,
+            "rxFlagsEofe_i": 0,
+        }
+        for prefix in ("appParam", "rxParam"):
+            for suffix, _ in PARAM_FIELDS:
+                initial_values[f"{prefix}{suffix}_i"] = 0
+
+        bench = await setup_flat_ssi_testbench(
+            dut,
+            initial_values=initial_values,
+        )
+        tb = cls(dut, bench)
+        tb.set_app_params(RssiParams(max_outs_seg=4, max_seg_size=64))
+        tb.set_rx_params(RssiParams(max_outs_seg=2, max_seg_size=32))
+        await tb.cycle()
+        return tb
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    def set_params(self, prefix: str, params: RssiParams) -> None:
+        for suffix, attr in PARAM_FIELDS:
+            getattr(self.dut, f"{prefix}{suffix}_i").value = getattr(params, attr)
+
+    def set_app_params(self, params: RssiParams) -> None:
+        self.set_params("appParam", params)
+
+    def set_rx_params(self, params: RssiParams) -> None:
+        self.set_params("rxParam", params)
+
+    def clear_rx_flags(self) -> None:
+        for signal_name in (
+            "rxFlagsSyn_i",
+            "rxFlagsAck_i",
+            "rxFlagsEack_i",
+            "rxFlagsRst_i",
+            "rxFlagsNul_i",
+            "rxFlagsData_i",
+            "rxFlagsBusy_i",
+            "rxFlagsEofe_i",
+        ):
+            getattr(self.dut, signal_name).value = 0
+
+    async def pulse(self, signal_name: str) -> None:
+        getattr(self.dut, signal_name).value = 1
+        await self.cycle()
+        getattr(self.dut, signal_name).value = 0
+        await self.cycle()
+
+    async def receive_segment(self, *, syn: int = 0, ack: int = 0, rst: int = 0) -> None:
+        self.clear_rx_flags()
+        self.dut.rxFlagsSyn_i.value = syn
+        self.dut.rxFlagsAck_i.value = ack
+        self.dut.rxFlagsRst_i.value = rst
+        self.dut.rxValid_i.value = 1
+        await self.cycle()
+        self.dut.rxValid_i.value = 0
+        self.clear_rx_flags()
+        await self.cycle()
+
+    async def wait_high(self, signal_name: str, *, cycles: int = 16) -> None:
+        signal = getattr(self.dut, signal_name)
+        await Timer(1, unit="ns")
+        if int(signal.value) == 1:
+            return
+        for _ in range(cycles):
+            await self.cycle()
+            if int(signal.value) == 1:
+                return
+        raise AssertionError(f"Timed out waiting for {signal_name}")
+
+    async def wait_state(self, expected: int, *, cycles: int = 16) -> None:
+        await Timer(1, unit="ns")
+        if int(self.dut.connState_o.value) == expected:
+            return
+        for _ in range(cycles):
+            await self.cycle()
+            if int(self.dut.connState_o.value) == expected:
+                return
+        raise AssertionError(f"Timed out waiting for connState_o={expected:#x}")
+
+
+def server_mode() -> bool:
+    return os.environ.get("SERVER_G", "true").lower() == "true"
+
+
+@cocotb.test()
+async def server_accepts_syn_ack_and_opens_test(dut):
+    if not server_mode():
+        return
+
+    tb = await TB.create(dut)
+    tb.dut.connRq_i.value = 1
+    await tb.cycle()
+
+    await tb.receive_segment(syn=1)
+    await tb.wait_high("sndSyn_o")
+
+    assert int(dut.txAckF_o.value) == 1
+    assert int(dut.paramReject_o.value) == 0
+    assert int(dut.paramMaxOutsSeg_o.value) == 2
+    assert int(dut.paramMaxSegSize_o.value) == 32
+    assert int(dut.txWindowSize_o.value) == 2
+    assert int(dut.txBufferSize_o.value) == 4
+
+    await tb.pulse("synHeadSt_i")
+    await tb.receive_segment(ack=1)
+    await tb.wait_high("connActive_o")
+
+    assert int(dut.connState_o.value) == 0x7
+
+
+@cocotb.test()
+async def server_proposes_local_required_parameters_on_mismatch_test(dut):
+    if not server_mode():
+        return
+
+    tb = await TB.create(dut)
+    app_params = RssiParams(
+        version=1,
+        chksum_en=1,
+        timeout_unit=1,
+        max_outs_seg=4,
+        max_seg_size=64,
+    )
+    peer_params = RssiParams(
+        version=2,
+        chksum_en=0,
+        timeout_unit=3,
+        max_outs_seg=8,
+        max_seg_size=128,
+    )
+    tb.set_app_params(app_params)
+    tb.set_rx_params(peer_params)
+
+    tb.dut.connRq_i.value = 1
+    await tb.cycle()
+    await tb.receive_segment(syn=1)
+
+    assert int(dut.paramReject_o.value) == 1
+    assert int(dut.paramVersion_o.value) == app_params.version
+    assert int(dut.paramChksumEn_o.value) == app_params.chksum_en
+    assert int(dut.paramTimeoutUnit_o.value) == app_params.timeout_unit
+    assert int(dut.paramMaxOutsSeg_o.value) == app_params.max_outs_seg
+    assert int(dut.paramMaxSegSize_o.value) == app_params.max_seg_size
+
+    await tb.wait_high("sndSyn_o")
+    assert int(dut.txAckF_o.value) == 1
+
+
+@cocotb.test()
+async def server_rejects_out_of_range_syn_parameters_test(dut):
+    if not server_mode():
+        return
+
+    tb = await TB.create(dut)
+    app_params = RssiParams(
+        version=1,
+        chksum_en=1,
+        timeout_unit=1,
+        max_outs_seg=4,
+        max_seg_size=64,
+        retrans_tout=12,
+        cumul_ack_tout=4,
+        null_seg_tout=24,
+    )
+    tb.set_app_params(app_params)
+    tb.set_rx_params(
+        RssiParams(
+            version=1,
+            chksum_en=1,
+            timeout_unit=1,
+            max_outs_seg=0,
+            max_seg_size=4,
+            retrans_tout=0,
+            cumul_ack_tout=0,
+            null_seg_tout=0,
+        )
+    )
+
+    tb.dut.connRq_i.value = 1
+    await tb.cycle()
+    await tb.receive_segment(syn=1)
+
+    assert int(dut.paramReject_o.value) == 1
+    assert int(dut.paramMaxOutsSeg_o.value) == app_params.max_outs_seg
+    assert int(dut.paramMaxSegSize_o.value) == app_params.max_seg_size
+    assert int(dut.paramRetransTout_o.value) == app_params.retrans_tout
+    assert int(dut.paramCumulAckTout_o.value) == app_params.cumul_ack_tout
+    assert int(dut.paramNullSegTout_o.value) == app_params.null_seg_tout
+    assert int(dut.txWindowSize_o.value) == app_params.max_outs_seg
+    assert int(dut.txBufferSize_o.value) == app_params.max_seg_size // 8
+    await tb.wait_high("sndSyn_o")
+
+
+@cocotb.test()
+async def server_retries_syn_ack_then_times_out_waiting_for_ack_test(dut):
+    if not server_mode():
+        return
+
+    tb = await TB.create(dut)
+    tb.dut.connRq_i.value = 1
+    await tb.cycle()
+
+    await tb.receive_segment(syn=1)
+    await tb.wait_high("sndSyn_o")
+    await tb.pulse("synHeadSt_i")
+    await tb.wait_state(0x6)
+
+    await tb.wait_high("closed_o", cycles=10)
+    assert int(dut.peerTout_o.value) == 0
+    await tb.wait_high("sndSyn_o", cycles=4)
+
+    await tb.pulse("synHeadSt_i")
+    tb.dut.connRq_i.value = 0
+    await tb.wait_state(0x6)
+    await tb.wait_high("peerTout_o", cycles=10)
+    await tb.cycle()
+
+    assert int(dut.connActive_o.value) == 0
+    assert int(dut.closed_o.value) == 1
+
+
+@cocotb.test()
+async def client_accepts_syn_ack_clamps_and_opens_test(dut):
+    if server_mode():
+        return
+
+    tb = await TB.create(dut)
+    app_params = RssiParams(max_outs_seg=4, max_seg_size=64)
+    peer_params = RssiParams(max_outs_seg=8, max_seg_size=128)
+    tb.set_app_params(app_params)
+    tb.set_rx_params(peer_params)
+
+    tb.dut.connRq_i.value = 1
+    await tb.wait_high("sndSyn_o")
+    await tb.pulse("synHeadSt_i")
+
+    await tb.receive_segment(syn=1, ack=1)
+    await tb.wait_high("sndAck_o")
+
+    assert int(dut.paramReject_o.value) == 0
+    assert int(dut.paramMaxOutsSeg_o.value) == app_params.max_outs_seg
+    assert int(dut.paramMaxSegSize_o.value) == app_params.max_seg_size
+    assert int(dut.txWindowSize_o.value) == app_params.max_outs_seg
+    assert int(dut.txBufferSize_o.value) == app_params.max_seg_size // 8
+
+    await tb.pulse("ackHeadSt_i")
+    await tb.wait_high("connActive_o")
+
+    assert int(dut.connState_o.value) == 0x7
+
+
+@cocotb.test()
+async def client_rejects_mismatched_syn_ack_with_rst_test(dut):
+    if server_mode():
+        return
+
+    tb = await TB.create(dut)
+    tb.set_app_params(RssiParams(version=1, chksum_en=1, timeout_unit=1))
+    tb.set_rx_params(RssiParams(version=2, chksum_en=1, timeout_unit=1))
+
+    tb.dut.connRq_i.value = 1
+    await tb.wait_high("sndSyn_o")
+    await tb.pulse("synHeadSt_i")
+
+    reject_wait = cocotb.start_soon(tb.wait_high("paramReject_o"))
+    await tb.receive_segment(syn=1, ack=1)
+    await reject_wait
+    await tb.wait_high("sndRst_o")
+
+    await tb.pulse("rstHeadSt_i")
+    await tb.wait_high("closed_o")
+
+    assert int(dut.connActive_o.value) == 0
+
+
+@cocotb.test()
+async def client_rejects_out_of_range_syn_ack_with_rst_test(dut):
+    if server_mode():
+        return
+
+    tb = await TB.create(dut)
+    tb.set_app_params(RssiParams(version=1, chksum_en=1, timeout_unit=1))
+    tb.set_rx_params(
+        RssiParams(
+            version=1,
+            chksum_en=1,
+            timeout_unit=1,
+            max_outs_seg=0,
+            max_seg_size=4,
+            retrans_tout=0,
+            cumul_ack_tout=0,
+            null_seg_tout=0,
+        )
+    )
+
+    tb.dut.connRq_i.value = 1
+    await tb.wait_high("sndSyn_o")
+    await tb.pulse("synHeadSt_i")
+
+    reject_wait = cocotb.start_soon(tb.wait_high("paramReject_o"))
+    await tb.receive_segment(syn=1, ack=1)
+    await reject_wait
+    await tb.wait_high("sndRst_o")
+
+    await tb.pulse("rstHeadSt_i")
+    await tb.wait_high("closed_o")
+    assert int(dut.connActive_o.value) == 0
+
+
+@cocotb.test()
+async def client_retries_syn_then_times_out_waiting_for_syn_ack_test(dut):
+    if server_mode():
+        return
+
+    tb = await TB.create(dut)
+    tb.dut.connRq_i.value = 1
+    await tb.wait_high("sndSyn_o")
+    await tb.pulse("synHeadSt_i")
+    await tb.wait_state(0x2)
+
+    await tb.wait_high("closed_o", cycles=10)
+    assert int(dut.peerTout_o.value) == 0
+    await tb.wait_high("sndSyn_o", cycles=4)
+
+    await tb.pulse("synHeadSt_i")
+    tb.dut.connRq_i.value = 0
+    await tb.wait_state(0x2)
+    await tb.wait_high("peerTout_o", cycles=10)
+    await tb.cycle()
+
+    assert int(dut.connActive_o.value) == 0
+    assert int(dut.closed_o.value) == 1
+
+
+PARAMETER_SWEEP = [
+    pytest.param({"SERVER_G": True}, id="server"),
+    pytest.param({"SERVER_G": False}, id="client"),
+]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiConnFsm(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssiconnfsmwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiConnFsm.vhd",
+                "protocols/rssi/v1/wrappers/RssiConnFsmWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiCore.py
+++ b/tests/protocols/rssi/test_RssiCore.py
@@ -1,0 +1,1453 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file, may be
+## copied, modified, propagated, or distributed except according to the terms
+## contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Exercise the integrated `RssiCore` contract with one client and
+#   one server connected back-to-back.  Leaf-FSM tests prove individual decode,
+#   transmit, monitor, and connection decisions; this file proves that the
+#   composed core behaves like an RSSI endpoint pair at the flattened
+#   application and transport boundaries.
+# - DUT shape: `RssiCoreIntegrationWrapper` instantiates a client `RssiCore`
+#   and a server `RssiCore`.  The wrapper exposes flattened SSI-style
+#   application streams, flattened RSSI transport streams, status registers,
+#   negotiated segment-size outputs, and open/close/inject controls.  Cocotb
+#   owns the transport loopback so tests can drop or observe individual RSSI
+#   frames without embedding traffic perturbation logic in VHDL.
+# - Stimulus: The default run holds both endpoints open, waits for the
+#   active-open handshake, drains reset-release application output, and sends
+#   application frames from either side.  Directed transport hooks can drop
+#   SYN, SYN+ACK, final ACK, DATA, NULL, or ACK-only frames, corrupt one client
+#   DATA header with the production injection input, or suppress all client
+#   transport traffic to model missing keepalives and max-retransmit closure.
+# - Protocol checks: The suite covers negotiated connection status, max segment
+#   readback, bidirectional payload delivery with SSI sidebands preserved,
+#   handshake retransmission, DATA loss/corruption recovery, duplicate-free ACK
+#   loss behavior, out-of-order DATA recovery, sequence-number wraparound, NULL
+#   keepalive acknowledgment, idle keepalive liveness, missing-keepalive server
+#   close, max-retransmit client close/RST emission, explicit close, and
+#   backpressure-driven BUSY reporting.  The stricter BUSY recovery test that
+#   proves no lost or duplicate server frames is extended coverage and also
+#   runs when selected directly with `COCOTB_TESTCASE`.
+# - Parameter strategy: The default pytest entry uses small but valid timeout
+#   generics so the full integration batch remains bounded.  Separate pytest
+#   entries enable narrower cocotb tests for sequence wrap, bidirectional DATA
+#   loss in one connection, and out-of-order recovery with longer retransmit
+#   spacing.  Environment flags keep those specialized cocotb tests inert
+#   during unrelated parameter runs.
+# - Timing and scoreboarding: Transport monitors sample accepted RSSI frames at
+#   the source side before optional loopback drops.  Application scoreboards
+#   assert both absence of premature output and exact recovered frames.  Quiet
+#   output drains account for reset-release FIFO behavior so payload assertions
+#   are about RSSI DATA delivery rather than wrapper initialization.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.triggers import FallingEdge, RisingEdge, Timer
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster
+
+from tests.axi.utils import axil_read_u32, axil_write_u32
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RSSI_CORE_VHDL_SOURCES,
+    RSSI_FLAG_ACK,
+    RSSI_FLAG_NULL,
+    RSSI_FLAG_RST,
+    RSSI_FLAG_SYN,
+    checksum_is_valid,
+    format_transport_frame,
+    parse_header,
+    protocol_bytes_from_stream_word,
+    recv_matching_transport_frame,
+    recv_transport_data_frame,
+)
+from tests.protocols.ssi.ssi_test_utils import (
+    FlatSsiEndpoint,
+    SsiBeat,
+    assert_beat_views,
+    cycle as ssi_cycle,
+    reset_dut,
+    start_clock,
+    recv_frame_and_check,
+)
+
+REG_CONTROL = 0x00
+REG_MAX_OUTS_SEG = 0x0C
+REG_MAX_SEG_SIZE = 0x10
+REG_STATUS = 0x40
+REG_VALID_CNT = 0x44
+REG_RESEND_CNT = 0x4C
+
+
+def _run_extended_case(case_name: str) -> bool:
+    return (
+        env_flag("RUN_RSSI_EXTENDED_TESTS", default=False)
+        or os.environ.get("COCOTB_TESTCASE") == case_name
+    )
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.clk = dut.axisClk
+        self.axil = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "S_AXI"), dut.axisClk, dut.axisRst)
+        self.clt_source = FlatSsiEndpoint(dut, prefix="cltSApp")
+        self.clt_sink = FlatSsiEndpoint(dut, prefix="cltMApp")
+        self.srv_source = FlatSsiEndpoint(dut, prefix="srvSApp")
+        self.srv_sink = FlatSsiEndpoint(dut, prefix="srvMApp")
+        self.clt_tsp_input = FlatSsiEndpoint(dut, prefix="cltSTsp")
+        self.clt_tsp_output = FlatSsiEndpoint(dut, prefix="cltMTsp")
+        self.srv_tsp_input = FlatSsiEndpoint(dut, prefix="srvSTsp")
+        self.srv_tsp_output = FlatSsiEndpoint(dut, prefix="srvMTsp")
+        self.clt_tsp_sink = self.clt_tsp_output
+        self.srv_tsp_sink = self.srv_tsp_output
+        self.drop_next_client_data = False
+        self.drop_next_server_data = False
+        self.drop_client_data_count = 0
+        self.drop_server_data_count = 0
+        self.drop_next_client_syn = False
+        self.drop_next_server_syn = False
+        self.drop_next_client_ack = False
+        self.drop_next_server_ack = False
+        self.drop_next_client_null = False
+        self.drop_next_server_null = False
+        self.dropped_client_ack_count = 0
+        self.dropped_server_ack_count = 0
+        self.dropped_client_null_count = 0
+        self.dropped_server_null_count = 0
+        self.drop_all_client = False
+        self.drop_all_server = False
+        self.pause_next_client_header_cycles = 0
+        self.pause_next_server_header_cycles = 0
+        self.pause_next_client_payload_cycles = 0
+        self.pause_next_server_payload_cycles = 0
+        self.loopback_tasks = []
+
+    @classmethod
+    async def create(
+        cls,
+        dut,
+        *,
+        start_loopbacks: bool = True,
+        direct_client_open: int = 1,
+        direct_server_open: int = 1,
+    ):
+        start_clock(dut.axisClk, period_ns=5.0)
+        dut.axisRst.setimmediatevalue(1)
+
+        tb = cls(dut)
+        tb.clt_source.set_idle()
+        tb.srv_source.set_idle()
+        tb.clt_tsp_input.set_idle()
+        tb.srv_tsp_input.set_idle()
+
+        for signal_name, value in {
+            "cltOpen_i": direct_client_open,
+            "cltClose_i": 0,
+            "cltInject_i": 0,
+            "srvOpen_i": direct_server_open,
+            "srvClose_i": 0,
+            "srvInject_i": 0,
+            "cltMAppTReady": 0,
+            "cltMTspTReady": 0,
+            "srvMAppTReady": 0,
+            "srvMTspTReady": 0,
+        }.items():
+            getattr(dut, signal_name).setimmediatevalue(value)
+
+        await reset_dut(dut, clk_name="axisClk", rst_name="axisRst")
+        if start_loopbacks:
+            tb.start_transport_loopbacks()
+        return tb
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    async def pulse(self, signal_name: str) -> None:
+        getattr(self.dut, signal_name).value = 1
+        await self.cycle()
+        getattr(self.dut, signal_name).value = 0
+
+    async def axil_write(self, address: int, value: int) -> None:
+        await axil_write_u32(self.axil, address, value)
+        await self.cycle(2)
+
+    async def axil_read(self, address: int) -> int:
+        return await axil_read_u32(self.axil, address)
+
+    async def wait_connected(self, *, timeout_cycles: int = 256) -> None:
+        for _ in range(timeout_cycles):
+            await Timer(1, unit="ns")
+            if int(self.dut.cltConnected_o.value) and int(self.dut.srvConnected_o.value):
+                return
+            await RisingEdge(self.clk)
+        raise AssertionError("Timed out waiting for both RSSI cores to connect")
+
+    async def wait_disconnected(self, *, timeout_cycles: int = 256) -> None:
+        for _ in range(timeout_cycles):
+            await Timer(1, unit="ns")
+            if not int(self.dut.cltConnected_o.value) and not int(self.dut.srvConnected_o.value):
+                return
+            await RisingEdge(self.clk)
+        raise AssertionError("Timed out waiting for both RSSI cores to disconnect")
+
+    async def drain_app_output(self, endpoint: FlatSsiEndpoint, ready_signal, *, quiet_cycles: int = 8) -> None:
+        # `RssiCore` resets its application output FIFOs until the connection
+        # opens.  Accept and discard any reset-release beat before starting the
+        # user-payload check so the assertion is about RSSI DATA delivery.
+        ready_signal.value = 1
+        quiet_count = 0
+        for _ in range(128):
+            await Timer(1, unit="ns")
+            if int(endpoint._sig("TValid").value) == 1:
+                quiet_count = 0
+            else:
+                quiet_count += 1
+                if quiet_count >= quiet_cycles:
+                    ready_signal.value = 0
+                    return
+            await RisingEdge(self.clk)
+        ready_signal.value = 0
+        raise AssertionError(f"Timed out draining {endpoint.prefix} output")
+
+    async def assert_no_app_output(self, endpoint: FlatSsiEndpoint, *, cycles: int) -> None:
+        for _ in range(cycles):
+            await Timer(1, unit="ns")
+            assert int(endpoint._sig("TValid").value) == 0, f"Unexpected {endpoint.prefix} application output"
+            await RisingEdge(self.clk)
+
+    async def collect_app_frames(
+        self,
+        endpoint: FlatSsiEndpoint,
+        ready_signal,
+        *,
+        cycles: int,
+    ) -> list[list[SsiBeat]]:
+        ready_signal.value = 1
+        frames = []
+        frame = []
+        for _ in range(cycles):
+            await FallingEdge(self.clk)
+            await Timer(1, unit="ns")
+            if int(endpoint._sig("TValid").value) == 1:
+                beat = endpoint.snapshot()
+                frame.append(beat)
+                if beat.last == 1:
+                    frames.append(frame)
+                    frame = []
+        ready_signal.value = 0
+        assert not frame, f"Partial {endpoint.prefix} application frame was left unterminated"
+        return frames
+
+    async def drain_app_outputs(self) -> None:
+        await self.drain_app_output(self.clt_sink, self.dut.cltMAppTReady)
+        await self.drain_app_output(self.srv_sink, self.dut.srvMAppTReady)
+
+    async def send_app_frame(self, endpoint: FlatSsiEndpoint, beats: list[SsiBeat]) -> None:
+        for beat in beats:
+            endpoint.drive(beat)
+            await endpoint.wait_ready(clk=self.clk)
+        endpoint.set_idle()
+
+    def start_transport_loopbacks(self) -> None:
+        self.loopback_tasks = [
+            cocotb.start_soon(
+                self.loopback_transport(
+                    self.clt_tsp_output,
+                    self.srv_tsp_input,
+                    self.dut.cltMTspTReady,
+                    side="client",
+                )
+            ),
+            cocotb.start_soon(
+                self.loopback_transport(
+                    self.srv_tsp_output,
+                    self.clt_tsp_input,
+                    self.dut.srvMTspTReady,
+                    side="server",
+                )
+            ),
+        ]
+
+    def should_drop_transport_frame(self, *, side: str, beat: SsiBeat) -> bool:
+        if getattr(self, f"drop_all_{side}"):
+            return True
+        if beat.sof != 1:
+            return False
+
+        header_word = protocol_bytes_from_stream_word(beat.data)
+        flags = header_word[0]
+        is_syn = bool(flags & RSSI_FLAG_SYN)
+        is_ack = bool(flags & RSSI_FLAG_ACK)
+        is_null = bool(flags & RSSI_FLAG_NULL)
+        is_rst = bool(flags & RSSI_FLAG_RST)
+
+        if is_syn and getattr(self, f"drop_next_{side}_syn"):
+            setattr(self, f"drop_next_{side}_syn", False)
+            return True
+
+        is_data = not is_syn and not is_null and not is_rst and beat.last == 0
+        if is_data and getattr(self, f"drop_next_{side}_data"):
+            setattr(self, f"drop_next_{side}_data", False)
+            return True
+        if is_data and getattr(self, f"drop_{side}_data_count") > 0:
+            setattr(self, f"drop_{side}_data_count", getattr(self, f"drop_{side}_data_count") - 1)
+            return True
+
+        is_ack_only = is_ack and not is_syn and not is_null and not is_rst and beat.last == 1
+        if is_ack_only and getattr(self, f"drop_next_{side}_ack"):
+            setattr(self, f"drop_next_{side}_ack", False)
+            setattr(self, f"dropped_{side}_ack_count", getattr(self, f"dropped_{side}_ack_count") + 1)
+            return True
+
+        if is_null and getattr(self, f"drop_next_{side}_null"):
+            setattr(self, f"drop_next_{side}_null", False)
+            setattr(self, f"dropped_{side}_null_count", getattr(self, f"dropped_{side}_null_count") + 1)
+            return True
+
+        return False
+
+    async def loopback_transport(
+        self,
+        source: FlatSsiEndpoint,
+        destination: FlatSsiEndpoint,
+        source_ready,
+        *,
+        side: str,
+    ) -> None:
+        dropping = False
+        destination.set_idle()
+        source_ready.value = 0
+
+        while True:
+            await FallingEdge(self.clk)
+            await Timer(1, unit="ns")
+
+            valid = int(source._sig("TValid").value) == 1
+            beat = source.snapshot() if valid else None
+
+            if valid and beat.sof == 1 and getattr(self, f"pause_next_{side}_header_cycles") > 0:
+                pause_cycles = getattr(self, f"pause_next_{side}_header_cycles")
+                setattr(self, f"pause_next_{side}_header_cycles", 0)
+                destination.set_idle()
+                source_ready.value = 0
+                await self.cycle(pause_cycles)
+                continue
+
+            if valid and beat.sof == 0 and getattr(self, f"pause_next_{side}_payload_cycles") > 0:
+                pause_cycles = getattr(self, f"pause_next_{side}_payload_cycles")
+                setattr(self, f"pause_next_{side}_payload_cycles", 0)
+                destination.set_idle()
+                source_ready.value = 0
+                await self.cycle(pause_cycles)
+                continue
+
+            drop_frame = valid and (dropping or self.should_drop_transport_frame(side=side, beat=beat))
+
+            if drop_frame:
+                destination.set_idle()
+                source_ready.value = 1
+                dropping = beat.last == 0
+                continue
+
+            if valid:
+                destination.drive(beat)
+            else:
+                destination.set_idle()
+
+            await Timer(1, unit="ns")
+            source_ready.value = destination._sig("TReady").value
+
+    async def recv_transport_data_frame(
+        self,
+        endpoint: FlatSsiEndpoint,
+        *,
+        timeout_cycles: int = 512,
+    ) -> list[SsiBeat]:
+        return await recv_transport_data_frame(
+            endpoint,
+            clk=self.clk,
+            timeout_cycles=timeout_cycles,
+        )
+
+    async def recv_transport_frame(
+        self,
+        endpoint: FlatSsiEndpoint,
+        *,
+        match,
+        timeout_cycles: int = 512,
+    ) -> list[SsiBeat]:
+        return await recv_matching_transport_frame(
+            endpoint,
+            clk=self.clk,
+            match=match,
+            timeout_cycles=timeout_cycles,
+        )
+
+
+@cocotb.test()
+async def active_open_negotiates_parameters_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+    assert int(dut.cltMaxSegSize_o.value) == 32
+    assert int(dut.srvMaxSegSize_o.value) == 32
+
+
+@cocotb.test()
+async def dropped_client_syn_retries_and_connects_test(dut):
+    tb = await TB.create(dut, start_loopbacks=False)
+    tb.drop_next_client_syn = True
+    tb.start_transport_loopbacks()
+
+    await tb.wait_connected(timeout_cycles=1024)
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+
+@cocotb.test()
+async def dropped_server_syn_ack_retries_and_connects_test(dut):
+    tb = await TB.create(dut, start_loopbacks=False)
+    tb.drop_next_server_syn = True
+    tb.start_transport_loopbacks()
+
+    await tb.wait_connected(timeout_cycles=1024)
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+
+@cocotb.test()
+async def dropped_client_final_ack_retries_and_connects_test(dut):
+    tb = await TB.create(dut, start_loopbacks=False)
+    tb.drop_next_client_ack = True
+    tb.start_transport_loopbacks()
+
+    await tb.wait_connected(timeout_cycles=1024)
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+
+@cocotb.test()
+async def bidirectional_payload_delivery_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    client_payload = 0x1122_3344_5566_7788
+    server_payload = 0x8877_6655_4433_2211
+
+    clt_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    srv_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(client_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=256,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=client_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    clt_transport_beats = await clt_transport
+    assert (
+        clt_transport_beats[1].data == client_payload
+    ), f"Client transport DATA payload was corrupted before server RX: {format_transport_frame(clt_transport_beats)}"
+    await srv_recv
+
+    srv_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.srv_tsp_sink))
+    clt_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.clt_sink,
+            clk=tb.clk,
+            ready_signal=dut.cltMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(server_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=256,
+        )
+    )
+    await tb.send_app_frame(
+        tb.srv_source,
+        [SsiBeat(data=server_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    srv_transport_beats = await srv_transport
+    assert (
+        srv_transport_beats[1].data == server_payload
+    ), f"Server transport DATA payload was corrupted before client RX: {format_transport_frame(srv_transport_beats)}"
+    await clt_recv
+
+
+@cocotb.test()
+async def multi_beat_partial_keep_and_eofe_round_trip_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    beats = [
+        SsiBeat(data=0x0102_0304_0506_0708, keep=0xFF, last=0, sof=1, eofe=0),
+        SsiBeat(data=0x1112_1314_0000_0000, keep=0x0F, last=1, sof=0, eofe=1),
+    ]
+
+    srv_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (beats[0].data, beats[0].keep, beats[0].last, beats[0].sof, 0),
+                (beats[1].data, beats[1].keep, beats[1].last, beats[1].sof, 0),
+            ],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(tb.clt_source, beats)
+    await srv_recv
+
+
+@cocotb.test()
+async def server_data_loss_retransmits_and_recovers_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    payload = 0xABCD_0000_1234_EF01
+
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.srv_tsp_sink))
+    tb.drop_next_server_data = True
+    await tb.send_app_frame(
+        tb.srv_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+    assert first_beats[1].data == payload
+
+    await tb.assert_no_app_output(tb.clt_sink, cycles=6)
+
+    second_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.srv_tsp_sink))
+    second_beats = await second_transport
+    second_header = parse_header(protocol_bytes_from_stream_word(second_beats[0].data))
+    assert second_header.sequence == first_header.sequence
+    assert second_beats[1].data == payload
+
+    frames = await tb.collect_app_frames(tb.clt_sink, dut.cltMAppTReady, cycles=128)
+    assert len(frames) == 1, f"Unexpected client output frames after retransmission: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+
+
+@cocotb.test()
+async def dropped_client_data_retransmits_and_recovers_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    payload = 0xCAFE_BABE_1234_5678
+
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    tb.drop_next_client_data = True
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+    assert (
+        first_beats[1].data == payload
+    ), f"Initial client DATA payload was corrupted before the loss gate: {format_transport_frame(first_beats)}"
+
+    # The one-shot wrapper gate consumes the first DATA frame before server RX.
+    # Before the retransmit timeout has room to fire, no application payload
+    # should be visible at the server.
+    await tb.assert_no_app_output(tb.srv_sink, cycles=6)
+
+    second_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    second_beats = await second_transport
+    second_header = parse_header(protocol_bytes_from_stream_word(second_beats[0].data))
+    assert second_header.sequence == first_header.sequence
+    assert (
+        second_beats[1].data == payload
+    ), f"Retransmitted client DATA payload was corrupted: {format_transport_frame(second_beats)}"
+
+    frames = await tb.collect_app_frames(tb.srv_sink, dut.srvMAppTReady, cycles=512)
+    assert len(frames) == 1, f"Unexpected server output frames after retransmission: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+
+
+@cocotb.test()
+async def bidirectional_data_losses_recover_without_duplicate_delivery_test(dut):
+    if not env_flag("RSSI_REPEATED_LOSS_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    client_payload = 0xA5A5_5A5A_0000_0000
+    tb.drop_next_client_data = True
+
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=client_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+    assert first_beats[1].data == client_payload
+
+    second_beats = await tb.recv_transport_data_frame(tb.clt_tsp_sink, timeout_cycles=2048)
+    second_header = parse_header(protocol_bytes_from_stream_word(second_beats[0].data))
+    assert second_header.sequence == first_header.sequence
+    assert second_beats[1].data == client_payload
+
+    frames = await tb.collect_app_frames(tb.srv_sink, dut.srvMAppTReady, cycles=512)
+    assert len(frames) == 1, f"Unexpected server output frames after client loss: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(client_payload, 0xFF, 1, 1, 0)],
+    )
+
+    await tb.cycle(128)
+
+    server_payload = 0x5A5A_A5A5_0000_0001
+    tb.drop_next_server_data = True
+
+    third_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.srv_tsp_sink))
+    await tb.send_app_frame(
+        tb.srv_source,
+        [SsiBeat(data=server_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    third_beats = await third_transport
+    third_header = parse_header(protocol_bytes_from_stream_word(third_beats[0].data))
+    assert third_beats[1].data == server_payload
+
+    fourth_beats = await tb.recv_transport_data_frame(tb.srv_tsp_sink, timeout_cycles=2048)
+    fourth_header = parse_header(protocol_bytes_from_stream_word(fourth_beats[0].data))
+    assert fourth_header.sequence == third_header.sequence
+    assert fourth_beats[1].data == server_payload
+
+    frames = await tb.collect_app_frames(tb.clt_sink, dut.cltMAppTReady, cycles=512)
+    assert len(frames) == 1, f"Unexpected client output frames after server loss: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(server_payload, 0xFF, 1, 1, 0)],
+    )
+
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+
+
+@cocotb.test()
+async def lost_first_data_drops_later_data_until_retransmit_test(dut):
+    if not env_flag("RSSI_OUT_OF_ORDER_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    first_payload = 0x0F00_0000_0000_0001
+    second_payload = 0x0F00_0000_0000_0002
+    tb.drop_next_client_data = True
+
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=first_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+
+    second_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=second_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    second_beats = await second_transport
+    second_header = parse_header(protocol_bytes_from_stream_word(second_beats[0].data))
+
+    assert second_header.sequence == ((first_header.sequence + 1) & 0xFF)
+    await tb.assert_no_app_output(tb.srv_sink, cycles=32)
+
+    frames = await tb.collect_app_frames(tb.srv_sink, dut.srvMAppTReady, cycles=2048)
+    summaries = [
+        [(beat.data, beat.keep, beat.last, beat.sof, beat.eofe) for beat in frame]
+        for frame in frames
+    ]
+    assert summaries == [
+        [(first_payload, 0xFF, 1, 1, 0)],
+        [(second_payload, 0xFF, 1, 1, 0)],
+    ]
+
+
+@cocotb.test()
+async def lost_server_ack_control_does_not_duplicate_delivery_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    payload = 0x1111_AAAA_2222_BBBB
+    tb.drop_next_server_ack = True
+    tb.drop_next_server_null = True
+
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    first_beats = await first_transport
+    assert first_beats[1].data == payload
+
+    frames = await tb.collect_app_frames(tb.srv_sink, dut.srvMAppTReady, cycles=160)
+    assert len(frames) == 1, f"ACK loss caused duplicate server delivery: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+    assert tb.dropped_server_ack_count + tb.dropped_server_null_count >= 1
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+
+
+@cocotb.test()
+async def corrupted_client_data_retransmits_and_recovers_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    payload = 0x0BAD_F00D_4455_6677
+
+    control_transport = cocotb.start_soon(
+        tb.recv_transport_frame(
+            tb.clt_tsp_sink,
+            match=lambda header, beats: len(beats) == 1 and not header.syn,
+        )
+    )
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await control_transport
+    await tb.pulse("cltInject_i")
+
+    first_beats = await first_transport
+    first_header_bytes = protocol_bytes_from_stream_word(first_beats[0].data)
+    first_header = parse_header(first_header_bytes)
+    assert not checksum_is_valid(first_header_bytes)
+    assert (
+        first_beats[1].data == payload
+    ), f"Injected client DATA payload was corrupted before server RX: {format_transport_frame(first_beats)}"
+
+    await tb.assert_no_app_output(tb.srv_sink, cycles=6)
+
+    second_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    second_beats = await second_transport
+    second_header_bytes = protocol_bytes_from_stream_word(second_beats[0].data)
+    second_header = parse_header(second_header_bytes)
+    assert second_header.sequence == first_header.sequence
+    assert checksum_is_valid(second_header_bytes)
+    assert (
+        second_beats[1].data == payload
+    ), f"Retransmitted client DATA payload was corrupted: {format_transport_frame(second_beats)}"
+
+    frames = await tb.collect_app_frames(tb.srv_sink, dut.srvMAppTReady, cycles=128)
+    assert len(frames) == 1, f"Unexpected server output frames after checksum recovery: {frames}"
+    assert_beat_views(
+        frames[0],
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+
+
+@cocotb.test()
+async def server_backpressure_advertises_busy_to_client_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    busy_transport = cocotb.start_soon(
+        tb.recv_transport_frame(
+            tb.srv_tsp_sink,
+            match=lambda header, beats: header.busy and header.ack,
+            timeout_cycles=4096,
+        )
+    )
+
+    for index in range(40):
+        await tb.send_app_frame(
+            tb.clt_source,
+            [SsiBeat(data=0xB000_0000_0000_0000 | index, keep=0xFF, last=1, sof=1, eofe=0)],
+        )
+        if busy_transport.done():
+            break
+
+    busy_beats = await busy_transport
+    busy_header = parse_header(protocol_bytes_from_stream_word(busy_beats[0].data))
+    assert busy_header.busy
+    assert busy_header.ack
+    assert int(dut.cltStatusReg_o.value) & (1 << 8)
+
+
+@cocotb.test()
+async def server_backpressure_recovers_without_lost_or_duplicate_frames_test(dut):
+    if not _run_extended_case("server_backpressure_recovers_without_lost_or_duplicate_frames_test"):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    sent_payloads = []
+    for index in range(40):
+        payload = 0xBC00_0000_0000_0000 | index
+        await tb.send_app_frame(
+            tb.clt_source,
+            [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+        )
+        sent_payloads.append(payload)
+        await tb.cycle(4)
+        if int(dut.cltStatusReg_o.value) & (1 << 8):
+            break
+
+    assert int(dut.cltStatusReg_o.value) & (1 << 8)
+
+    for payload in sent_payloads:
+        await recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    await tb.assert_no_app_output(tb.srv_sink, cycles=16)
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+
+
+@cocotb.test()
+async def max_retransmissions_close_client_and_emit_rst_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    rst_transport = cocotb.start_soon(
+        tb.recv_transport_frame(
+            tb.clt_tsp_sink,
+            match=lambda header, beats: header.rst,
+            timeout_cycles=4096,
+        )
+    )
+
+    tb.drop_all_client = True
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=0xDDDD_EEEE_AAAA_5555, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+
+    rst_beats = await rst_transport
+    rst_header = parse_header(protocol_bytes_from_stream_word(rst_beats[0].data))
+    assert rst_header.rst
+    assert not rst_header.ack
+
+    await tb.wait_disconnected(timeout_cycles=512)
+
+
+@cocotb.test()
+async def dropped_client_null_keepalive_does_not_close_server_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    tb.drop_next_client_null = True
+    await tb.cycle(96)
+
+    assert tb.dropped_client_null_count >= 1
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+    assert (int(dut.srvStatusReg_o.value) >> 2) & 0x1 == 0
+
+
+@cocotb.test()
+async def idle_client_null_keepalive_keeps_server_connected_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+
+    # With the wrapper's timeout generics, the client should emit NULL
+    # keepalives every NULL_TOUT/3 count.  Waiting longer than one full server
+    # NULL timeout verifies the integrated keepalive path without relying on
+    # internal monitor signals.
+    await tb.cycle(80)
+
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+    assert (int(dut.srvStatusReg_o.value) >> 2) & 0x1 == 0
+
+
+@cocotb.test()
+async def client_null_keepalive_is_acknowledged_by_server_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    null_beats = await tb.recv_transport_frame(
+        tb.clt_tsp_sink,
+        match=lambda header, beats: header.nul and len(beats) == 1,
+        timeout_cycles=512,
+    )
+    null_header = parse_header(protocol_bytes_from_stream_word(null_beats[0].data))
+
+    ack_beats = await tb.recv_transport_frame(
+        tb.srv_tsp_sink,
+        match=lambda header, beats: header.ack and not header.syn and not header.nul and not header.rst,
+        timeout_cycles=128,
+    )
+    ack_header = parse_header(protocol_bytes_from_stream_word(ack_beats[0].data))
+
+    assert ack_header.acknowledge == null_header.sequence
+    assert int(dut.srvConnected_o.value) == 1
+
+
+@cocotb.test()
+async def missing_client_keepalives_close_server_connection_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    tb.drop_all_client = True
+    await tb.cycle(96)
+
+    assert int(dut.srvConnected_o.value) == 0
+    assert (int(dut.srvStatusReg_o.value) >> 2) & 0x1 == 1
+
+
+@cocotb.test()
+async def explicit_client_close_tears_down_integrated_connection_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+
+    dut.cltClose_i.value = 1
+    await tb.cycle()
+    dut.cltClose_i.value = 0
+
+    await tb.wait_disconnected()
+
+
+@cocotb.test()
+async def close_then_reopen_clears_state_and_delivers_new_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    first_payload = 0xC105_E000_0000_0001
+    first_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(first_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=first_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await first_recv
+
+    dut.cltOpen_i.value = 0
+    dut.srvOpen_i.value = 0
+    await tb.pulse("cltClose_i")
+    await tb.wait_disconnected(timeout_cycles=512)
+    await tb.cycle(8)
+
+    dut.srvOpen_i.value = 1
+    await tb.cycle(2)
+    dut.cltOpen_i.value = 1
+    await tb.wait_connected(timeout_cycles=2048)
+    await tb.drain_app_outputs()
+
+    second_payload = 0xC105_E000_0000_0002
+    second_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(second_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=second_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await second_recv
+
+
+@cocotb.test()
+async def client_axil_control_path_opens_injects_reads_and_closes_test(dut):
+    if not env_flag("RSSI_AXIL_CONTROL_CASE", default=False):
+        return
+
+    tb = await TB.create(dut, direct_client_open=0)
+
+    await tb.axil_write(REG_CONTROL, 0x0C)
+    await tb.axil_write(REG_MAX_OUTS_SEG, 2)
+    await tb.axil_write(REG_MAX_SEG_SIZE, 16)
+    await tb.axil_write(REG_CONTROL, 0x0D)
+
+    await tb.wait_connected(timeout_cycles=1024)
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltMaxSegSize_o.value) == 16
+    assert (await tb.axil_read(REG_MAX_SEG_SIZE)) & 0xFFFF == 16
+    assert (await tb.axil_read(REG_STATUS)) & 0x1 == 1
+
+    payload = 0xA711_0000_0000_0001
+    recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await recv
+
+    faulted_transport = cocotb.start_soon(
+        tb.recv_transport_frame(
+            tb.clt_tsp_sink,
+            match=lambda header, beats: (
+                not header.syn
+                and not checksum_is_valid(protocol_bytes_from_stream_word(beats[0].data))
+            ),
+            timeout_cycles=2048,
+        )
+    )
+    await tb.axil_write(REG_CONTROL, 0x1D)
+    faulted_beats = await faulted_transport
+    faulted_header_bytes = protocol_bytes_from_stream_word(faulted_beats[0].data)
+    assert not checksum_is_valid(faulted_header_bytes)
+    await tb.axil_write(REG_CONTROL, 0x0D)
+
+    assert await tb.axil_read(REG_VALID_CNT) >= 1
+    assert await tb.axil_read(REG_RESEND_CNT) >= 0
+
+    await tb.axil_write(REG_CONTROL, 0x0E)
+    await tb.wait_disconnected(timeout_cycles=512)
+    assert (await tb.axil_read(REG_STATUS)) & 0x1 == 0
+
+
+@cocotb.test()
+async def checksum_disabled_connection_and_payload_test(dut):
+    if not env_flag("RSSI_CHECKSUM_DISABLED_CORE_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    payload = 0xC0DE_0000_0000_0000
+    transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    beats = await transport
+    header = parse_header(protocol_bytes_from_stream_word(beats[0].data))
+    assert header.checksum == 0
+    await recv
+
+
+@cocotb.test()
+async def transport_ready_stalls_preserve_header_and_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    header_stall_payload = 0x5700_0000_0000_0001
+    tb.pause_next_client_header_cycles = 5
+    header_stall_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(header_stall_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=header_stall_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await header_stall_recv
+
+    payload_stall_beats = [
+        SsiBeat(data=0x5700_0000_0000_0010, keep=0xFF, last=0, sof=1, eofe=0),
+        SsiBeat(data=0x5700_0000_0000_0011, keep=0xFF, last=1, sof=0, eofe=0),
+    ]
+    tb.pause_next_client_payload_cycles = 5
+    payload_stall_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(beat.data, beat.keep, beat.last, beat.sof, beat.eofe) for beat in payload_stall_beats],
+            timeout_cycles=1024,
+        )
+    )
+    await tb.send_app_frame(tb.clt_source, payload_stall_beats)
+    await payload_stall_recv
+
+
+@cocotb.test()
+async def bidirectional_multi_frame_stress_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    for index in range(6):
+        client_payload = 0xC100_0000_0000_0000 | index
+        server_payload = 0x5E00_0000_0000_0000 | index
+
+        srv_recv = cocotb.start_soon(
+            recv_frame_and_check(
+                tb.srv_sink,
+                clk=tb.clk,
+                ready_signal=dut.srvMAppTReady,
+                fields=("data", "keep", "last", "sof", "eofe"),
+                expected=[(client_payload, 0xFF, 1, 1, 0)],
+                timeout_cycles=512,
+            )
+        )
+        await tb.send_app_frame(
+            tb.clt_source,
+            [SsiBeat(data=client_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+        )
+        await srv_recv
+
+        clt_recv = cocotb.start_soon(
+            recv_frame_and_check(
+                tb.clt_sink,
+                clk=tb.clk,
+                ready_signal=dut.cltMAppTReady,
+                fields=("data", "keep", "last", "sof", "eofe"),
+                expected=[(server_payload, 0xFF, 1, 1, 0)],
+                timeout_cycles=512,
+            )
+        )
+        await tb.send_app_frame(
+            tb.srv_source,
+            [SsiBeat(data=server_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+        )
+        await clt_recv
+
+    assert int(dut.cltConnected_o.value) == 1
+    assert int(dut.srvConnected_o.value) == 1
+
+
+@cocotb.test()
+async def client_sequence_wraparound_delivers_frame_test(dut):
+    if not env_flag("RSSI_SEQUENCE_WRAP_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    first_payload = 0x00FF_0000_0000_0001
+    first_transport = cocotb.start_soon(tb.recv_transport_data_frame(tb.clt_tsp_sink))
+    first_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(first_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=first_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+    await first_recv
+
+    assert first_header.sequence <= 1
+
+
+PARAMETER_SWEEP = [
+    pytest.param(
+        {
+            "WINDOW_ADDR_SIZE_G": 2,
+            "SEGMENT_ADDR_SIZE_G": 5,
+            "MAX_NUM_OUTS_SEG_G": 4,
+            "MAX_SEG_SIZE_G": 32,
+            "ACK_TOUT_G": 4,
+            "RETRANS_TOUT_G": 16,
+            "NULL_TOUT_G": 48,
+            "MAX_RETRANS_CNT_G": 2,
+            "MAX_CUM_ACK_CNT_G": 2,
+        },
+        id="direct_transport_small_timeouts",
+    )
+]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiCore(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCore_sequence_wraparound():
+    parameters = {
+        "WINDOW_ADDR_SIZE_G": 2,
+        "SEGMENT_ADDR_SIZE_G": 5,
+        "MAX_NUM_OUTS_SEG_G": 4,
+        "MAX_SEG_SIZE_G": 32,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 16,
+        "NULL_TOUT_G": 48,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+        "CLIENT_INIT_SEQ_N_G": 254,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "client_sequence_wraparound_delivers_frame_test",
+            "RSSI_SEQUENCE_WRAP_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCore_repeated_data_loss():
+    parameters = {
+        "WINDOW_ADDR_SIZE_G": 2,
+        "SEGMENT_ADDR_SIZE_G": 5,
+        "MAX_NUM_OUTS_SEG_G": 4,
+        "MAX_SEG_SIZE_G": 32,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 16,
+        "NULL_TOUT_G": 48,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "bidirectional_data_losses_recover_without_duplicate_delivery_test",
+            "RSSI_REPEATED_LOSS_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCore_out_of_order_recovery():
+    parameters = {
+        "WINDOW_ADDR_SIZE_G": 2,
+        "SEGMENT_ADDR_SIZE_G": 5,
+        "MAX_NUM_OUTS_SEG_G": 4,
+        "MAX_SEG_SIZE_G": 32,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 96,
+        "NULL_TOUT_G": 192,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "lost_first_data_drops_later_data_until_retransmit_test",
+            "RSSI_OUT_OF_ORDER_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCore_axil_control_path():
+    parameters = {
+        "WINDOW_ADDR_SIZE_G": 2,
+        "SEGMENT_ADDR_SIZE_G": 5,
+        "MAX_NUM_OUTS_SEG_G": 4,
+        "MAX_SEG_SIZE_G": 32,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 16,
+        "NULL_TOUT_G": 48,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "client_axil_control_path_opens_injects_reads_and_closes_test",
+            "RSSI_AXIL_CONTROL_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCore_checksum_disabled():
+    parameters = {
+        "WINDOW_ADDR_SIZE_G": 2,
+        "SEGMENT_ADDR_SIZE_G": 5,
+        "MAX_NUM_OUTS_SEG_G": 4,
+        "MAX_SEG_SIZE_G": 32,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 16,
+        "NULL_TOUT_G": 48,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+        "HEADER_CHKSUM_EN_G": False,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicoreintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "checksum_disabled_connection_and_payload_test",
+            "RSSI_CHECKSUM_DISABLED_CORE_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiCoreWrapper.py
+++ b/tests/protocols/rssi/test_RssiCoreWrapper.py
@@ -1,0 +1,324 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file, may be
+## copied, modified, propagated, or distributed except according to the terms
+## contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify that the user-facing `RssiCoreWrapper` preserves the
+#   already-tested `RssiCore` behavior while adding the wrapper's application
+#   mux/demux, chunker bypass, legacy packetizer/depacketizer, and derived
+#   buffer sizing.  This file is intentionally a wrapper smoke/regression layer,
+#   not a replay of the full RSSI protocol matrix in `test_RssiCore.py`.
+# - DUT shape: `RssiCoreWrapperIntegrationWrapper` instantiates one client
+#   wrapper and one server wrapper with one flattened application stream on each
+#   side.  RSSI transport is connected directly between wrappers, while cocotb
+#   drives only the application streams and observes wrapper status registers.
+# - Stimulus: Hold both endpoints open, wait for active-open connection, drain
+#   reset-release application output, and send SSI-style payload frames through
+#   each wrapper's application boundary.  The backpressure case holds server
+#   application output stalled long enough to exercise the wrapper/core BUSY
+#   reporting path.
+# - Checks: Both wrappers must report connected status.  Bidirectional payload
+#   delivery must preserve valid DATA bytes, TKEEP, TLAST, and SOF.  Focused
+#   partial-keep coverage pins the current RSSI v1 behavior that application
+#   EOFE is cleared on receive.  The focused backpressure run verifies that
+#   stalled server output is advertised through the client-visible BUSY status
+#   bit.
+# - Parameter strategy: Sweep bypass-chunker and packetizer modes across
+#   multiple `WINDOW_ADDR_SIZE_G` and `MAX_SEG_SIZE_G` values.  This catches
+#   wrapper elaboration and derived RSSI FIFO/pause-threshold issues without
+#   requiring an exhaustive Cartesian product.
+# - Timing: Small timeout generics keep the wrapper checks bounded.  If a
+#   protocol-level failure appears here, reproduce it in `test_RssiCore.py`
+#   unless the failure is clearly caused by wrapper-only packetizer, chunker, or
+#   route logic.
+
+import cocotb
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import RSSI_CORE_WRAPPER_VHDL_SOURCES
+from tests.protocols.ssi.ssi_test_utils import (
+    FlatSsiEndpoint,
+    SsiBeat,
+    cycle as ssi_cycle,
+    data_mask_from_keep,
+    recv_frame,
+    reset_dut,
+    start_clock,
+    recv_frame_and_check,
+)
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.clk = dut.axisClk
+        self.clt_source = FlatSsiEndpoint(dut, prefix="cltSApp")
+        self.clt_sink = FlatSsiEndpoint(dut, prefix="cltMApp")
+        self.srv_source = FlatSsiEndpoint(dut, prefix="srvSApp")
+        self.srv_sink = FlatSsiEndpoint(dut, prefix="srvMApp")
+
+    @classmethod
+    async def create(cls, dut):
+        start_clock(dut.axisClk, period_ns=5.0)
+        dut.axisRst.setimmediatevalue(1)
+
+        tb = cls(dut)
+        tb.clt_source.set_idle()
+        tb.srv_source.set_idle()
+
+        for signal_name, value in {
+            "cltOpen_i": 1,
+            "cltClose_i": 0,
+            "srvOpen_i": 1,
+            "srvClose_i": 0,
+            "cltMAppTReady": 0,
+            "srvMAppTReady": 0,
+        }.items():
+            getattr(dut, signal_name).setimmediatevalue(value)
+
+        await reset_dut(dut, clk_name="axisClk", rst_name="axisRst")
+        return tb
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    async def wait_connected(self, *, timeout_cycles: int = 512) -> None:
+        for _ in range(timeout_cycles):
+            await Timer(1, unit="ns")
+            if int(self.dut.cltConnected_o.value) and int(self.dut.srvConnected_o.value):
+                return
+            await RisingEdge(self.clk)
+        raise AssertionError("Timed out waiting for both RSSI core wrappers to connect")
+
+    async def drain_app_output(self, endpoint: FlatSsiEndpoint, ready_signal, *, quiet_cycles: int = 8) -> None:
+        ready_signal.value = 1
+        quiet_count = 0
+        for _ in range(128):
+            await Timer(1, unit="ns")
+            if int(endpoint._sig("TValid").value) == 1:
+                quiet_count = 0
+            else:
+                quiet_count += 1
+                if quiet_count >= quiet_cycles:
+                    ready_signal.value = 0
+                    return
+            await RisingEdge(self.clk)
+        ready_signal.value = 0
+        raise AssertionError(f"Timed out draining {endpoint.prefix} output")
+
+    async def drain_app_outputs(self) -> None:
+        await self.drain_app_output(self.clt_sink, self.dut.cltMAppTReady)
+        await self.drain_app_output(self.srv_sink, self.dut.srvMAppTReady)
+
+    async def send_app_frame(self, endpoint: FlatSsiEndpoint, beats: list[SsiBeat]) -> None:
+        for beat in beats:
+            endpoint.drive(beat)
+            await endpoint.wait_ready(clk=self.clk)
+        endpoint.set_idle()
+
+
+def assert_frame_preserves_valid_bytes(actual: list[SsiBeat], expected: list[SsiBeat]) -> None:
+    assert len(actual) == len(expected)
+    for actual_beat, expected_beat in zip(actual, expected):
+        mask = data_mask_from_keep(expected_beat.keep)
+        assert actual_beat.data & mask == expected_beat.data & mask
+        assert actual_beat.keep == expected_beat.keep
+        assert actual_beat.last == expected_beat.last
+        assert actual_beat.sof == expected_beat.sof
+        assert actual_beat.eofe == 0
+
+
+@cocotb.test()
+async def wrapper_active_open_and_bidirectional_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+    client_payload = 0x1020_3040_5060_7080
+    server_payload = 0x8070_6050_4030_2010
+
+    srv_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(client_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_source,
+        [SsiBeat(data=client_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await srv_recv
+
+    clt_recv = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.clt_sink,
+            clk=tb.clk,
+            ready_signal=dut.cltMAppTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(server_payload, 0xFF, 1, 1, 0)],
+            timeout_cycles=512,
+        )
+    )
+    await tb.send_app_frame(
+        tb.srv_source,
+        [SsiBeat(data=server_payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await clt_recv
+
+
+@cocotb.test()
+async def wrapper_partial_keep_and_eofe_payload_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    beats = [
+        SsiBeat(data=0x3300_0000_0000_0001, keep=0xFF, last=0, sof=1, eofe=0),
+        SsiBeat(data=0x3300_0000_0000_0002, keep=0x03, last=1, sof=0, eofe=1),
+    ]
+
+    srv_recv = cocotb.start_soon(
+        recv_frame(
+            tb.srv_sink,
+            clk=tb.clk,
+            ready_signal=dut.srvMAppTReady,
+            timeout_cycles=1024,
+        )
+    )
+    await tb.send_app_frame(tb.clt_source, beats)
+    assert_frame_preserves_valid_bytes(await srv_recv, beats)
+
+
+@cocotb.test()
+async def wrapper_server_backpressure_advertises_busy_test(dut):
+    if not env_flag("RSSI_WRAPPER_BACKPRESSURE_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    for index in range(40):
+        await tb.send_app_frame(
+            tb.clt_source,
+            [SsiBeat(data=0xBEEF_0000_0000_0000 | index, keep=0xFF, last=1, sof=1, eofe=0)],
+        )
+        await tb.cycle(4)
+        if int(dut.cltStatusReg_o.value) & (1 << 8):
+            break
+
+    assert int(dut.cltStatusReg_o.value) & (1 << 8)
+
+
+BASE_PARAMETERS = {
+    "ACK_TOUT_G": 4,
+    "RETRANS_TOUT_G": 16,
+    "NULL_TOUT_G": 48,
+    "MAX_RETRANS_CNT_G": 2,
+    "MAX_CUM_ACK_CNT_G": 2,
+}
+
+
+PARAMETER_SWEEP = [
+    pytest.param(
+        {
+            **BASE_PARAMETERS,
+            "BYPASS_CHUNKER_G": True,
+            "WINDOW_ADDR_SIZE_G": 1,
+            "MAX_SEG_SIZE_G": 64,
+        },
+        id="bypass_chunker_window1_seg64",
+    ),
+    pytest.param(
+        {
+            **BASE_PARAMETERS,
+            "BYPASS_CHUNKER_G": True,
+            "WINDOW_ADDR_SIZE_G": 3,
+            "MAX_SEG_SIZE_G": 256,
+        },
+        id="bypass_chunker_window3_seg256",
+    ),
+    pytest.param(
+        {
+            **BASE_PARAMETERS,
+            "BYPASS_CHUNKER_G": False,
+            "WINDOW_ADDR_SIZE_G": 2,
+            "MAX_SEG_SIZE_G": 128,
+        },
+        id="packetizer_window2_seg128",
+    ),
+    pytest.param(
+        {
+            **BASE_PARAMETERS,
+            "BYPASS_CHUNKER_G": False,
+            "WINDOW_ADDR_SIZE_G": 3,
+            "MAX_SEG_SIZE_G": 64,
+        },
+        id="packetizer_window3_seg64",
+    ),
+]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiCoreWrapper(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicorewrapperintegrationwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_WRAPPER_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreWrapperIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCoreWrapper_backpressure():
+    parameters = {
+        **BASE_PARAMETERS,
+        "BYPASS_CHUNKER_G": True,
+        "WINDOW_ADDR_SIZE_G": 2,
+        "MAX_SEG_SIZE_G": 128,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicorewrapperintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "wrapper_server_backpressure_advertises_busy_test",
+            "RSSI_WRAPPER_BACKPRESSURE_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_WRAPPER_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreWrapperIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiCoreWrapperMultiStream.py
+++ b/tests/protocols/rssi/test_RssiCoreWrapperMultiStream.py
@@ -1,0 +1,610 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file, may be
+## copied, modified, propagated, or distributed except according to the terms
+## contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Exercise the `RssiCoreWrapper` path that is most visible to users
+#   with multiple application streams.  `test_RssiCoreWrapper.py` covers the
+#   one-stream wrapper and segment-size sweeps; this file proves that the
+#   packetizer2/depacketizer2 routing layer preserves RSSI reliability and
+#   stream identity when `APP_STREAMS_G > 1`.
+# - DUT shape: `RssiCoreWrapperMultiStreamIntegrationWrapper` instantiates a
+#   client wrapper and a server wrapper, each with two flattened application
+#   streams.  RSSI transport streams are exposed to cocotb and looped back in
+#   Python so the tests can observe DATA frames and inject one transport loss
+#   without adding behavior to the VHDL wrapper.
+# - Stimulus: Hold both endpoints open, wait for the active-open handshake, and
+#   then wait an additional initialization interval before sending payloads.
+#   The extra wait lets `AxiStreamDepacketizer2` clear its per-`TDEST` route
+#   state after RSSI link-up, avoiding a test race that is unrelated to RSSI
+#   protocol behavior.
+# - Checks: Default CI coverage runs one small packetizer2 parameter set and
+#   one client-to-server routed payload cocotb test.  That test proves the
+#   two-stream wrapper elaborates, connects, emits transport DATA, and delivers
+#   independent client streams 0 and 1 to the expected server routes.  Extended
+#   coverage adds partial-keep/EOFE preservation, bidirectional routing, and
+#   one dropped client DATA transport frame that must retransmit with the same
+#   RSSI sequence number and recover the stream-1 payload exactly once.
+# - Parameter strategy: Use `APP_STREAMS_G=2`, explicit `APP_STREAM_ROUTES_G`,
+#   `APP_ILEAVE_EN_G=true`, and the legacy packetizer/depacketizer path.  The
+#   default pytest entry pins `COCOTB_TESTCASE` to the routed payload smoke
+#   unless `RUN_RSSI_EXTENDED_TESTS=1` is set.  A focused pytest entry can still
+#   run only the bidirectional route case for the small window/segment-size
+#   parameter set when that nodeid is selected directly.
+# - Timing: Event-driven receives wait for expected transport or application
+#   frames with bounded timeouts.  Transport loopback drops only multi-beat DATA
+#   frames after a test arms the hook, leaving ACK/NULL control traffic free to
+#   maintain the connection.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.triggers import FallingEdge, RisingEdge, Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RSSI_CORE_WRAPPER_VHDL_SOURCES,
+    format_transport_frame,
+    parse_header,
+    protocol_bytes_from_stream_word,
+    recv_transport_data_frame,
+)
+from tests.protocols.ssi.ssi_test_utils import (
+    FlatSsiEndpoint,
+    SsiBeat,
+    cycle as ssi_cycle,
+    data_mask_from_keep,
+    recv_frame,
+    recv_frame_and_check,
+    reset_dut,
+    start_clock,
+)
+
+
+# RssiCoreWrapper uses TDEST_BITS_G=8 for AxiStreamDepacketizer2, which clears
+# per-route state after link-up before it can safely accept routed DATA.
+DEPACKETIZER2_INIT_WAIT_CYCLES = 1024
+
+
+def _run_extended_case(case_name: str) -> bool:
+    return (
+        env_flag("RUN_RSSI_EXTENDED_TESTS", default=False)
+        or os.environ.get("COCOTB_TESTCASE") == case_name
+    )
+
+
+def _default_extra_env(parameters: dict[str, object]) -> dict[str, object]:
+    if env_flag("RUN_RSSI_EXTENDED_TESTS", default=False):
+        return parameters
+    return {
+        **parameters,
+        "COCOTB_TESTCASE": "multi_stream_client_to_server_payload_routes_test",
+    }
+
+
+def _explicit_pytest_selection(request, test_name: str) -> bool:
+    return any("::" in arg and test_name in arg for arg in request.config.args)
+
+
+def assert_frame_preserves_valid_bytes(actual: list[SsiBeat], expected: list[SsiBeat]) -> None:
+    assert len(actual) == len(expected)
+    for actual_beat, expected_beat in zip(actual, expected):
+        mask = data_mask_from_keep(expected_beat.keep)
+        assert actual_beat.data & mask == expected_beat.data & mask
+        assert actual_beat.keep == expected_beat.keep
+        assert actual_beat.last == expected_beat.last
+        assert actual_beat.sof == expected_beat.sof
+        assert actual_beat.eofe == expected_beat.eofe
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        self.clk = dut.axisClk
+        self.clt_sources = [
+            FlatSsiEndpoint(dut, prefix="cltSApp0"),
+            FlatSsiEndpoint(dut, prefix="cltSApp1"),
+        ]
+        self.clt_sinks = [
+            FlatSsiEndpoint(dut, prefix="cltMApp0"),
+            FlatSsiEndpoint(dut, prefix="cltMApp1"),
+        ]
+        self.srv_sources = [
+            FlatSsiEndpoint(dut, prefix="srvSApp0"),
+            FlatSsiEndpoint(dut, prefix="srvSApp1"),
+        ]
+        self.srv_sinks = [
+            FlatSsiEndpoint(dut, prefix="srvMApp0"),
+            FlatSsiEndpoint(dut, prefix="srvMApp1"),
+        ]
+        self.clt_tsp_input = FlatSsiEndpoint(dut, prefix="cltSTsp")
+        self.clt_tsp_output = FlatSsiEndpoint(dut, prefix="cltMTsp")
+        self.srv_tsp_input = FlatSsiEndpoint(dut, prefix="srvSTsp")
+        self.srv_tsp_output = FlatSsiEndpoint(dut, prefix="srvMTsp")
+        self.clt_tsp_monitor = self.clt_tsp_output
+        self.srv_tsp_monitor = self.srv_tsp_output
+        self.drop_next_client_data = False
+        self.drop_next_server_data = False
+        self.loopback_tasks = []
+
+    @classmethod
+    async def create(cls, dut):
+        start_clock(dut.axisClk, period_ns=5.0)
+        dut.axisRst.setimmediatevalue(1)
+
+        tb = cls(dut)
+        for endpoint in tb.clt_sources + tb.srv_sources + [tb.clt_tsp_input, tb.srv_tsp_input]:
+            endpoint.set_idle()
+
+        for signal_name, value in {
+            "cltOpen_i": 1,
+            "cltClose_i": 0,
+            "srvOpen_i": 1,
+            "srvClose_i": 0,
+            "cltMApp0TReady": 0,
+            "cltMApp1TReady": 0,
+            "cltMTspTReady": 0,
+            "srvMApp0TReady": 0,
+            "srvMApp1TReady": 0,
+            "srvMTspTReady": 0,
+        }.items():
+            getattr(dut, signal_name).setimmediatevalue(value)
+
+        await reset_dut(dut, clk_name="axisClk", rst_name="axisRst")
+        tb.start_transport_loopbacks()
+        return tb
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    async def wait_connected(self, *, timeout_cycles: int = 1024) -> None:
+        for _ in range(timeout_cycles):
+            await Timer(1, unit="ns")
+            if int(self.dut.cltConnected_o.value) and int(self.dut.srvConnected_o.value):
+                return
+            await RisingEdge(self.clk)
+        raise AssertionError("Timed out waiting for both RSSI core wrappers to connect")
+
+    async def drain_app_output(self, endpoint: FlatSsiEndpoint, ready_signal, *, quiet_cycles: int = 8) -> None:
+        ready_signal.value = 1
+        quiet_count = 0
+        for _ in range(128):
+            await Timer(1, unit="ns")
+            if int(endpoint._sig("TValid").value) == 1:
+                quiet_count = 0
+            else:
+                quiet_count += 1
+                if quiet_count >= quiet_cycles:
+                    ready_signal.value = 0
+                    return
+            await RisingEdge(self.clk)
+        ready_signal.value = 0
+        raise AssertionError(f"Timed out draining {endpoint.prefix} output")
+
+    async def drain_app_outputs(self) -> None:
+        for index, endpoint in enumerate(self.clt_sinks):
+            await self.drain_app_output(endpoint, getattr(self.dut, f"cltMApp{index}TReady"))
+        for index, endpoint in enumerate(self.srv_sinks):
+            await self.drain_app_output(endpoint, getattr(self.dut, f"srvMApp{index}TReady"))
+
+    async def send_app_frame(self, endpoint: FlatSsiEndpoint, beats: list[SsiBeat]) -> None:
+        for beat in beats:
+            await endpoint.send(beat, clk=self.clk)
+        endpoint.set_idle()
+
+    def start_transport_loopbacks(self) -> None:
+        self.loopback_tasks = [
+            cocotb.start_soon(
+                self.loopback_transport(
+                    self.clt_tsp_output,
+                    self.srv_tsp_input,
+                    self.dut.cltMTspTReady,
+                    drop_attr="drop_next_client_data",
+                )
+            ),
+            cocotb.start_soon(
+                self.loopback_transport(
+                    self.srv_tsp_output,
+                    self.clt_tsp_input,
+                    self.dut.srvMTspTReady,
+                    drop_attr="drop_next_server_data",
+                )
+            ),
+        ]
+
+    async def loopback_transport(
+        self,
+        source: FlatSsiEndpoint,
+        destination: FlatSsiEndpoint,
+        source_ready,
+        *,
+        drop_attr: str,
+    ) -> None:
+        dropping = False
+        destination.set_idle()
+        source_ready.value = 0
+
+        while True:
+            await FallingEdge(self.clk)
+            await Timer(1, unit="ns")
+
+            valid = int(source._sig("TValid").value) == 1
+            beat = source.snapshot() if valid else None
+
+            if (
+                valid
+                and (dropping or (getattr(self, drop_attr) and beat.last == 0))
+            ):
+                destination.set_idle()
+                source_ready.value = 1
+                dropping = beat.last == 0
+                setattr(self, drop_attr, False)
+                continue
+
+            if valid:
+                destination.drive(beat)
+            else:
+                destination.set_idle()
+
+            await Timer(1, unit="ns")
+            source_ready.value = destination._sig("TReady").value
+
+    async def recv_transport_data_frame(
+        self,
+        endpoint: FlatSsiEndpoint,
+        *,
+        timeout_cycles: int = 1024,
+    ) -> list[SsiBeat]:
+        return await recv_transport_data_frame(
+            endpoint,
+            clk=self.clk,
+            timeout_cycles=timeout_cycles,
+        )
+
+
+@cocotb.test()
+async def multi_stream_active_open_smoke_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+
+@cocotb.test()
+async def multi_stream_client_to_server_payload_routes_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+    await tb.cycle(DEPACKETIZER2_INIT_WAIT_CYCLES)
+
+    assert int(dut.cltStatusReg_o.value) & 0x1
+    assert int(dut.srvStatusReg_o.value) & 0x1
+
+    payload0 = 0x1111_2222_3333_4444
+    payload1 = 0xAAAA_BBBB_CCCC_DDDD
+
+    clt_tsp_data = cocotb.start_soon(
+        tb.recv_transport_data_frame(tb.clt_tsp_monitor, timeout_cycles=1024)
+    )
+    srv_out0 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sinks[0],
+            clk=tb.clk,
+            ready_signal=dut.srvMApp0TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(payload0, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    srv_out1 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sinks[1],
+            clk=tb.clk,
+            ready_signal=dut.srvMApp1TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(payload1, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+
+    await tb.send_app_frame(
+        tb.clt_sources[0],
+        [SsiBeat(data=payload0, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await tb.send_app_frame(
+        tb.clt_sources[1],
+        [SsiBeat(data=payload1, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+
+    await clt_tsp_data
+    await srv_out0
+    await srv_out1
+
+
+@cocotb.test()
+async def multi_stream_bidirectional_payload_routes_test(dut):
+    if not _run_extended_case("multi_stream_bidirectional_payload_routes_test"):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+    await tb.cycle(DEPACKETIZER2_INIT_WAIT_CYCLES)
+
+    client_payload0 = 0x1111_0000_0000_0000
+    client_payload1 = 0x1111_0000_0000_0001
+    server_payload0 = 0x2222_0000_0000_0000
+    server_payload1 = 0x2222_0000_0000_0001
+
+    srv_out0 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sinks[0],
+            clk=tb.clk,
+            ready_signal=dut.srvMApp0TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(client_payload0, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    srv_out1 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.srv_sinks[1],
+            clk=tb.clk,
+            ready_signal=dut.srvMApp1TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(client_payload1, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    await tb.send_app_frame(
+        tb.clt_sources[0],
+        [SsiBeat(data=client_payload0, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await tb.send_app_frame(
+        tb.clt_sources[1],
+        [SsiBeat(data=client_payload1, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await srv_out0
+    await srv_out1
+
+    clt_out0 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.clt_sinks[0],
+            clk=tb.clk,
+            ready_signal=dut.cltMApp0TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(server_payload0, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    clt_out1 = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.clt_sinks[1],
+            clk=tb.clk,
+            ready_signal=dut.cltMApp1TReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(server_payload1, 0xFF, 1, 1, 0)],
+            timeout_cycles=1024,
+        )
+    )
+    await tb.send_app_frame(
+        tb.srv_sources[0],
+        [SsiBeat(data=server_payload0, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await tb.send_app_frame(
+        tb.srv_sources[1],
+        [SsiBeat(data=server_payload1, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+    await clt_out0
+    await clt_out1
+
+
+@cocotb.test()
+async def multi_stream_partial_keep_and_eofe_routes_test(dut):
+    if not _run_extended_case("multi_stream_partial_keep_and_eofe_routes_test"):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+    await tb.cycle(DEPACKETIZER2_INIT_WAIT_CYCLES)
+
+    beats = [
+        SsiBeat(data=0x4400_0000_0000_0001, keep=0xFF, last=0, sof=1, eofe=0),
+        SsiBeat(data=0x4400_0000_0000_0002, keep=0x1F, last=1, sof=0, eofe=1),
+    ]
+
+    srv_recv = cocotb.start_soon(
+        recv_frame(
+            tb.srv_sinks[1],
+            clk=tb.clk,
+            ready_signal=dut.srvMApp1TReady,
+            timeout_cycles=2048,
+        )
+    )
+    await tb.send_app_frame(tb.clt_sources[1], beats)
+    assert_frame_preserves_valid_bytes(await srv_recv, beats)
+
+
+@cocotb.test()
+async def multi_stream_dropped_client_data_retransmits_to_route_test(dut):
+    if not _run_extended_case("multi_stream_dropped_client_data_retransmits_to_route_test"):
+        return
+
+    tb = await TB.create(dut)
+
+    await tb.wait_connected()
+    await tb.drain_app_outputs()
+    await tb.cycle(DEPACKETIZER2_INIT_WAIT_CYCLES)
+
+    payload = 0xDEAD_BEEF_0102_0304
+
+    first_transport = cocotb.start_soon(
+        tb.recv_transport_data_frame(tb.clt_tsp_monitor, timeout_cycles=2048)
+    )
+    tb.drop_next_client_data = True
+    await tb.send_app_frame(
+        tb.clt_sources[1],
+        [SsiBeat(data=payload, keep=0xFF, last=1, sof=1, eofe=0)],
+    )
+
+    first_beats = await first_transport
+    first_header = parse_header(protocol_bytes_from_stream_word(first_beats[0].data))
+
+    second_transport = cocotb.start_soon(
+        tb.recv_transport_data_frame(tb.clt_tsp_monitor, timeout_cycles=2048)
+    )
+    second_beats = await second_transport
+    second_header = parse_header(protocol_bytes_from_stream_word(second_beats[0].data))
+
+    assert second_header.sequence == first_header.sequence, (
+        "Retransmitted wrapper DATA did not reuse the dropped sequence; "
+        f"first={format_transport_frame(first_beats)} "
+        f"second={format_transport_frame(second_beats)}"
+    )
+
+    await recv_frame_and_check(
+        tb.srv_sinks[1],
+        clk=tb.clk,
+        ready_signal=dut.srvMApp1TReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+        timeout_cycles=1024,
+    )
+
+
+PARAMETER_SWEEP = [
+    pytest.param(
+        {
+            "BYPASS_CHUNKER_G": False,
+            "APP_ILEAVE_EN_G": True,
+            "WINDOW_ADDR_SIZE_G": 2,
+            "MAX_SEG_SIZE_G": 64,
+            "ACK_TOUT_G": 4,
+            "RETRANS_TOUT_G": 16,
+            "NULL_TOUT_G": 48,
+            "MAX_RETRANS_CNT_G": 2,
+            "MAX_CUM_ACK_CNT_G": 2,
+        },
+        id="packetizer2_two_streams_window2_seg64",
+    ),
+]
+
+
+EXTENDED_PARAMETER_SWEEP = [
+    pytest.param(
+        {
+            "BYPASS_CHUNKER_G": False,
+            "APP_ILEAVE_EN_G": True,
+            "WINDOW_ADDR_SIZE_G": 3,
+            "MAX_SEG_SIZE_G": 128,
+            "ACK_TOUT_G": 4,
+            "RETRANS_TOUT_G": 16,
+            "NULL_TOUT_G": 48,
+            "MAX_RETRANS_CNT_G": 2,
+            "MAX_CUM_ACK_CNT_G": 2,
+        },
+        id="packetizer2_two_streams_window3_seg128",
+    ),
+]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiCoreWrapperMultiStream(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicorewrappermultistreamintegrationwrapper",
+        parameters=parameters,
+        extra_env=_default_extra_env(parameters),
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_WRAPPER_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreWrapperMultiStreamIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.skipif(
+    not env_flag("RUN_RSSI_EXTENDED_TESTS", default=False),
+    reason="set RUN_RSSI_EXTENDED_TESTS=1 to run extended RSSI multi-stream wrapper coverage",
+)
+@pytest.mark.parametrize("parameters", EXTENDED_PARAMETER_SWEEP)
+def test_RssiCoreWrapperMultiStream_extended(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicorewrappermultistreamintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "RUN_RSSI_EXTENDED_TESTS": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_WRAPPER_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreWrapperMultiStreamIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiCoreWrapperMultiStream_bidirectional_packetizer2(request):
+    if (
+        not env_flag("RUN_RSSI_EXTENDED_TESTS", default=False)
+        and not _explicit_pytest_selection(
+            request,
+            "test_RssiCoreWrapperMultiStream_bidirectional_packetizer2",
+        )
+    ):
+        pytest.skip(
+            "set RUN_RSSI_EXTENDED_TESTS=1 or run this nodeid explicitly for "
+            "focused bidirectional packetizer2 route coverage"
+        )
+
+    parameters = {
+        "BYPASS_CHUNKER_G": False,
+        "APP_ILEAVE_EN_G": True,
+        "WINDOW_ADDR_SIZE_G": 2,
+        "MAX_SEG_SIZE_G": 64,
+        "ACK_TOUT_G": 4,
+        "RETRANS_TOUT_G": 16,
+        "NULL_TOUT_G": 48,
+        "MAX_RETRANS_CNT_G": 2,
+        "MAX_CUM_ACK_CNT_G": 2,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssicorewrappermultistreamintegrationwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "multi_stream_bidirectional_payload_routes_test",
+        },
+        extra_vhdl_sources={
+            "surf": [
+                *RSSI_CORE_WRAPPER_VHDL_SOURCES,
+                "protocols/rssi/v1/wrappers/RssiCoreWrapperMultiStreamIntegrationWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiHeaderReg.py
+++ b/tests/protocols/rssi/test_RssiHeaderReg.py
@@ -1,0 +1,271 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Pin the RSSI header encoder independently of checksum generation
+#   and transmit-state sequencing.  This file is the byte-layout oracle for
+#   ACK, DATA, NULL, RST, and SYN headers emitted by the RTL.
+# - DUT shape: Run `RssiHeaderReg` directly with the default SURF RSSI
+#   header-size generics.  The test drives scalar request strobes and flattened
+#   parameter fields, then samples the 64-bit header word returned for each
+#   requested address.
+# - Stimulus: Register one coherent set of TX sequence, RX acknowledgment,
+#   busy, ACK-valid, and SYN negotiation parameters.  Request ACK, DATA, NULL,
+#   RST, and SYN header words by address.  DATA is checked both with and without
+#   a valid ACK so the ACK-bit capture rule is explicit.
+# - Checks: Emitted words must match the shared Python protocol helper for flag
+#   bits, busy propagation, ACK bit capture, sequence/ack fields, header
+#   lengths, reserved bytes, checksum placeholders, and all SYN parameter
+#   fields.  The test intentionally compares protocol-order bytes so endian
+#   mistakes in the packed 64-bit word are visible.
+# - Timing: Inputs are captured while no header strobe is active.  Each header
+#   request is sampled after the module's registered one-cycle response, which
+#   matches the timing assumed by `RssiTxFsm` when it asks for a header word
+#   before checksum insertion.
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+
+from tests.common.regression_utils import run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RssiParams,
+    build_ack_header,
+    build_data_header,
+    build_null_header,
+    build_rst_header,
+    build_syn_header,
+    header_words,
+    parse_header,
+)
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        # `RssiHeaderReg` has one synchronous state register and no ready/valid
+        # handshake, so the testbench only needs a clock and deterministic
+        # post-edge sampling.
+        cocotb.start_soon(Clock(dut.clk_i, 5.0, unit="ns").start())
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.clk_i)
+            # Wait past the default `TPD_G` so registered outputs are settled
+            # before Python reads them.
+            await Timer(2, unit="ns")
+
+    async def reset(self) -> None:
+        # Reset all header request strobes and data fields before deasserting
+        # reset; otherwise the combinational address decode can briefly see
+        # unknowns at time zero.
+        self.dut.rst_i.setimmediatevalue(1)
+        self.clear_header_selects()
+        self.dut.ack_i.setimmediatevalue(0)
+        self.dut.txSeqN_i.setimmediatevalue(0)
+        self.dut.rxAckN_i.setimmediatevalue(0)
+        self.dut.busyHeadSt_i.setimmediatevalue(0)
+        self.dut.addr_i.setimmediatevalue(0)
+        await self.set_params(RssiParams())
+        await self.cycle(4)
+        self.dut.rst_i.value = 0
+        await self.cycle(2)
+
+    def clear_header_selects(self) -> None:
+        # Do not clear `busyHeadSt_i` here.  In the RTL this input is both the
+        # captured local BUSY status and the value inserted into requested
+        # headers; clearing it during a request would test a topology that
+        # `RssiCore` does not use.
+        self.dut.synHeadSt_i.value = 0
+        self.dut.rstHeadSt_i.value = 0
+        self.dut.dataHeadSt_i.value = 0
+        self.dut.nullHeadSt_i.value = 0
+        self.dut.ackHeadSt_i.value = 0
+
+    async def set_params(self, params: RssiParams) -> None:
+        # The wrapper flattens `RssiParamType` because GHDL/cocotb does not
+        # expose record fields on the DUT port as Python child handles.
+        self.dut.paramVersion_i.value = params.version
+        self.dut.paramChksumEn_i.value = params.chksum_en
+        self.dut.paramTimeoutUnit_i.value = params.timeout_unit
+        self.dut.paramMaxOutsSeg_i.value = params.max_outs_seg
+        self.dut.paramMaxSegSize_i.value = params.max_seg_size
+        self.dut.paramRetransTout_i.value = params.retrans_tout
+        self.dut.paramCumulAckTout_i.value = params.cumul_ack_tout
+        self.dut.paramNullSegTout_i.value = params.null_seg_tout
+        self.dut.paramMaxRetrans_i.value = params.max_retrans
+        self.dut.paramMaxCumAck_i.value = params.max_cum_ack
+        self.dut.paramMaxOutofseq_i.value = params.max_outofseq
+        self.dut.paramConnectionId_i.value = params.connection_id
+
+    async def capture_inputs(
+        self,
+        *,
+        ack: int,
+        busy: int,
+        tx_seq: int,
+        rx_ack: int,
+        params: RssiParams | None = None,
+    ) -> None:
+        # HeaderReg samples these fields only while no header strobe is active.
+        # Hold that idle condition for two cycles so the registered copy is
+        # unambiguous before a header word is requested.
+        self.clear_header_selects()
+        if params is not None:
+            await self.set_params(params)
+        self.dut.ack_i.value = ack
+        self.dut.busyHeadSt_i.value = busy
+        self.dut.txSeqN_i.value = tx_seq
+        self.dut.rxAckN_i.value = rx_ack
+        await self.cycle(2)
+
+    async def read_header_word(self, select_name: str, address: int) -> tuple[int, int, int]:
+        # Address is a 64-bit word index into the generated header.  The output
+        # response is registered, so one clock after asserting the selected
+        # header request is the first valid sample point.
+        self.clear_header_selects()
+        getattr(self.dut, select_name).value = 1
+        self.dut.addr_i.value = address
+        await self.cycle()
+        word = int(self.dut.headerData_o.value)
+        ready = int(self.dut.ready_o.value)
+        length = int(self.dut.headerLength_o.value)
+        getattr(self.dut, select_name).value = 0
+        await self.cycle()
+        return word, ready, length
+
+
+@cocotb.test()
+async def non_syn_header_fields_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    # Capture one common set of control fields, then ask for each non-SYN
+    # segment type so differences in flag packing are easy to see.
+    await tb.capture_inputs(ack=1, busy=1, tx_seq=0x22, rx_ack=0x33)
+
+    cases = [
+        ("ackHeadSt_i", build_ack_header(sequence=0x22, acknowledge=0x33, busy=True, enable_checksum=False)),
+        ("dataHeadSt_i", build_data_header(sequence=0x22, acknowledge=0x33, ack=True, busy=True, enable_checksum=False)),
+        ("nullHeadSt_i", build_null_header(sequence=0x22, acknowledge=0x33, ack=True, busy=True, enable_checksum=False)),
+        ("rstHeadSt_i", build_rst_header(sequence=0x22, acknowledge=0x33, busy=True, enable_checksum=False)),
+    ]
+
+    for select_name, expected_header in cases:
+        # The helper builds protocol-order bytes with a zero checksum field;
+        # HeaderReg emits the same pre-checksum 64-bit word.
+        word, ready, length = await tb.read_header_word(select_name, 0)
+        assert ready == 1
+        assert length == 1
+        assert word == header_words(expected_header)[0]
+        parsed = parse_header(expected_header)
+        assert parsed.header_length == 8
+        assert parsed.sequence == 0x22
+        assert parsed.acknowledge == 0x33
+        assert parsed.checksum == 0
+
+
+@cocotb.test()
+async def ack_bit_is_registered_before_header_request_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Change `ack_i` after the idle capture cycle.  The DATA header should use
+    # the previously registered ACK state, not the just-changed pin value.
+    await tb.capture_inputs(ack=0, busy=0, tx_seq=0x44, rx_ack=0x55)
+    tb.dut.ack_i.value = 1
+    word, ready, _ = await tb.read_header_word("dataHeadSt_i", 0)
+    assert ready == 1
+    assert word == header_words(
+        build_data_header(sequence=0x44, acknowledge=0x55, ack=False, enable_checksum=False)
+    )[0]
+
+    # Repeat the check in the opposite direction so both ACK clear and ACK set
+    # behavior are pinned.
+    await tb.capture_inputs(ack=1, busy=0, tx_seq=0x44, rx_ack=0x55)
+    tb.dut.ack_i.value = 0
+    word, ready, _ = await tb.read_header_word("dataHeadSt_i", 0)
+    assert ready == 1
+    assert word == header_words(
+        build_data_header(sequence=0x44, acknowledge=0x55, ack=True, enable_checksum=False)
+    )[0]
+
+
+@cocotb.test()
+async def syn_header_parameter_words_test(dut):
+    tb = TB(dut)
+    params = RssiParams(
+        version=2,
+        chksum_en=1,
+        max_outs_seg=0x0A,
+        max_seg_size=0x05DC,
+        retrans_tout=0x0102,
+        cumul_ack_tout=0x0304,
+        null_seg_tout=0x0506,
+        max_retrans=0x07,
+        max_cum_ack=0x08,
+        max_outofseq=0x09,
+        timeout_unit=0x0A,
+        connection_id=0x1122_3344,
+    )
+    await tb.reset()
+    # Use non-default values in every SYN parameter field so word boundaries and
+    # byte ordering mistakes are visible in a single comparison.
+    await tb.capture_inputs(ack=1, busy=0, tx_seq=0x66, rx_ack=0x77, params=params)
+
+    expected = build_syn_header(
+        sequence=0x66,
+        acknowledge=0x77,
+        ack=True,
+        params=params,
+        enable_checksum=False,
+    )
+    for address, expected_word in enumerate(header_words(expected)):
+        # SYN spans three 64-bit words.  `headerLength_o` reports that word
+        # count, not byte count.
+        word, ready, length = await tb.read_header_word("synHeadSt_i", address)
+        assert ready == 1
+        assert length == 3
+        assert word == expected_word
+
+    parsed = parse_header(expected)
+    assert parsed.params == params
+
+
+@cocotb.test()
+async def unmapped_header_address_returns_not_ready_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    await tb.capture_inputs(ack=1, busy=0, tx_seq=0x01, rx_ack=0x02)
+
+    # Most header types deassert ready for out-of-range addresses.  NULL has a
+    # preserved legacy behavior that reports ready with zero data.
+    for select_name in ("ackHeadSt_i", "dataHeadSt_i", "rstHeadSt_i", "synHeadSt_i"):
+        word, ready, _ = await tb.read_header_word(select_name, 3)
+        assert ready == 0
+        assert word == 0
+
+    word, ready, _ = await tb.read_header_word("nullHeadSt_i", 3)
+    assert ready == 1
+    assert word == 0
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="default_header_sizes")]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiHeaderReg(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssiheaderregwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={"surf": ["protocols/rssi/v1/wrappers/RssiHeaderRegWrapper.vhd"]},
+    )

--- a/tests/protocols/rssi/test_RssiMonitor.py
+++ b/tests/protocols/rssi/test_RssiMonitor.py
@@ -1,0 +1,243 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify the RSSI monitor/timer side effects that drive ACK, NULL,
+#   retransmission, BUSY, and close requests.  These behaviors are timing-heavy
+#   and easier to isolate here than through a full `RssiCore` integration test.
+# - DUT shape: Run `RssiMonitor` through a thin wrapper that flattens RSSI
+#   parameter and received-flag records.  Timeout scale is one count per clock
+#   so tests can reason in cycles and avoid long protocol-time waits.
+# - Stimulus: Start from an active connection and drive received header flags,
+#   transmitted-header strobes, local BUSY state, and transmit-buffer
+#   occupancy directly.  This bypasses the RX/TX FSMs while still exercising
+#   the monitor's policy decisions.
+# - Checks: Remote BUSY must suppress retransmission timeout progress.  Server
+#   liveness must refresh only on DATA or NULL receipt, not ACK/BUSY-only
+#   traffic.  Local BUSY must request an immediate ACK on assertion and then
+#   periodic BUSY ACKs at the RSSI page's recommended Retransmission
+#   Timeout/2 cadence.
+# - Timing: Samples are taken after the default `TPD_G` output delay.  Timeout
+#   thresholds are small deterministic cycle counts, and each test uses direct
+#   cycle waits rather than real-time delays so failures map cleanly to counter
+#   behavior.
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+        cocotb.start_soon(Clock(dut.axisClk, 5.0, unit="ns").start())
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.axisClk)
+            await Timer(2, unit="ns")
+
+    def _set_flag_defaults(self) -> None:
+        self.dut.rxFlagsSyn_i.value = 0
+        self.dut.rxFlagsAck_i.value = 0
+        self.dut.rxFlagsEack_i.value = 0
+        self.dut.rxFlagsRst_i.value = 0
+        self.dut.rxFlagsNul_i.value = 0
+        self.dut.rxFlagsData_i.value = 0
+        self.dut.rxFlagsBusy_i.value = 0
+        self.dut.rxFlagsEofe_i.value = 0
+
+    def _set_param_defaults(self) -> None:
+        self.dut.paramVersion_i.value = 0
+        self.dut.paramChksumEn_i.value = 1
+        self.dut.paramTimeoutUnit_i.value = 1
+        self.dut.paramMaxOutsSeg_i.value = 4
+        self.dut.paramMaxSegSize_i.value = 8
+        self.dut.paramRetransTout_i.value = 4
+        self.dut.paramCumulAckTout_i.value = 4
+        self.dut.paramNullSegTout_i.value = 4
+        self.dut.paramMaxRetrans_i.value = 10
+        self.dut.paramMaxCumAck_i.value = 4
+        self.dut.paramMaxOutofseq_i.value = 0
+        self.dut.paramConnectionId_i.value = 0
+
+    async def reset(self, *, connected: bool = True) -> None:
+        self.dut.axisRst.setimmediatevalue(1)
+        self.dut.connActive_i.setimmediatevalue(0)
+        self.dut.localBusy_i.setimmediatevalue(0)
+        self._set_param_defaults()
+        self._set_flag_defaults()
+        self.dut.rxLastSeqN_i.setimmediatevalue(0)
+        self.dut.rxWindowSize_i.setimmediatevalue(4)
+        self.dut.txBufferEmpty_i.setimmediatevalue(1)
+        self.dut.rxValid_i.setimmediatevalue(0)
+        self.dut.rxDrop_i.setimmediatevalue(0)
+        self.dut.ackHeadSt_i.setimmediatevalue(0)
+        self.dut.rstHeadSt_i.setimmediatevalue(0)
+        self.dut.dataHeadSt_i.setimmediatevalue(0)
+        self.dut.nullHeadSt_i.setimmediatevalue(0)
+        self.dut.lenErr_i.setimmediatevalue(0)
+        self.dut.ackErr_i.setimmediatevalue(0)
+        self.dut.peerConnTout_i.setimmediatevalue(0)
+        self.dut.paramReject_i.setimmediatevalue(0)
+        await self.cycle(4)
+        self.dut.axisRst.value = 0
+        await self.cycle(2)
+        self.dut.connActive_i.value = int(connected)
+        await self.cycle(2)
+
+    async def expect_no_resend(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle()
+            assert int(self.dut.sndResend_o.value) == 0
+
+    async def wait_for_resend(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle()
+            if int(self.dut.sndResend_o.value) == 1:
+                return
+        raise AssertionError("Timed out waiting for sndResend_o")
+
+    async def wait_for_close(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle()
+            if int(self.dut.closeRq_o.value) == 1:
+                return
+        raise AssertionError("Timed out waiting for closeRq_o")
+
+    async def wait_for_ack(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle()
+            if int(self.dut.sndAck_o.value) == 1:
+                return
+        raise AssertionError("Timed out waiting for sndAck_o")
+
+    async def expect_no_ack(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await self.cycle()
+            assert int(self.dut.sndAck_o.value) == 0
+
+    async def pulse_ack_sent(self) -> None:
+        self.dut.ackHeadSt_i.value = 1
+        await self.cycle()
+        self.dut.ackHeadSt_i.value = 0
+        await self.cycle()
+
+    async def pulse_rx_flag(self, flag_name: str) -> None:
+        self._set_flag_defaults()
+        getattr(self.dut, flag_name).value = 1
+        self.dut.rxValid_i.value = 1
+        await self.cycle()
+        self.dut.rxValid_i.value = 0
+        getattr(self.dut, flag_name).value = 0
+
+
+@cocotb.test()
+async def remote_busy_suppresses_retransmission_timeout_progress_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # An occupied TX buffer lets the retransmission timer run.  While the peer
+    # advertises BUSY, the timer must be held reset and no resend request should
+    # be generated even after more than one retransmission timeout interval.
+    dut.txBufferEmpty_i.value = 0
+    dut.rxFlagsBusy_i.value = 1
+    await tb.expect_no_resend(cycles=10)
+    assert int(dut.statusReg_o.value) & (1 << 8)
+
+    # Releasing BUSY allows the same outstanding segment to time out normally.
+    dut.rxFlagsBusy_i.value = 0
+    await tb.wait_for_resend(cycles=8)
+    assert int(dut.sndResend_o.value) == 1
+    await tb.cycle()
+    assert int(dut.resendCnt_o.value) == 1
+
+
+@cocotb.test()
+async def server_ack_and_busy_only_traffic_does_not_reset_null_timeout_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Server-side liveness is defined by DATA or NULL receipt.  Standalone ACK
+    # and BUSY traffic may affect other timers, but it must not prevent the
+    # server null-timeout close when no DATA/NULL arrives.
+    await tb.pulse_rx_flag("rxFlagsNul_i")
+
+    for index in range(10):
+        tb._set_flag_defaults()
+        flag_name = "rxFlagsAck_i" if index % 2 == 0 else "rxFlagsBusy_i"
+        getattr(dut, flag_name).value = 1
+        dut.rxValid_i.value = 1
+        await tb.cycle()
+        if int(dut.closeRq_o.value) == 1:
+            break
+    else:
+        raise AssertionError("ACK/BUSY-only traffic incorrectly prevented server null timeout")
+
+
+@cocotb.test()
+async def local_busy_rising_edge_requests_ack_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Local busy is advertised through the next outgoing header.  The monitor
+    # must request an ACK immediately so the header generator can carry BUSY
+    # even when no cumulative ACK threshold has been reached.
+    dut.localBusy_i.value = 1
+    await tb.wait_for_ack(cycles=2)
+    assert int(dut.sndAck_o.value) == 1
+    assert int(dut.statusReg_o.value) & (1 << 7)
+
+    await tb.pulse_ack_sent()
+    assert int(dut.sndAck_o.value) == 0
+
+
+@cocotb.test()
+async def local_busy_generates_periodic_ack_after_cumulative_timeout_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+
+    # Local BUSY periodic ACKs follow the RSSI page recommendation of
+    # Retransmission Timeout/2, not the shorter cumulative ACK timeout.
+    dut.paramCumulAckTout_i.value = 2
+    dut.paramRetransTout_i.value = 20
+    dut.localBusy_i.value = 1
+
+    await tb.wait_for_ack(cycles=2)
+    await tb.pulse_ack_sent()
+    await tb.expect_no_ack(cycles=6)
+    await tb.wait_for_ack(cycles=6)
+    assert int(dut.sndAck_o.value) == 1
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="server_monitor")]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiMonitor(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssimonitorwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiMonitor.vhd",
+                "protocols/rssi/v1/wrappers/RssiMonitorWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiRxFsm.py
+++ b/tests/protocols/rssi/test_RssiRxFsm.py
@@ -1,0 +1,612 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify receive-side RSSI header screening, payload buffering, and
+#   application delivery at the `RssiRxFsm` boundary.  This is the directed
+#   decode/drop/accept layer below `RssiCore`; connection negotiation and TX
+#   retransmission policy are tested elsewhere.
+# - DUT shape: Run `RssiRxFsm` through a thin wrapper with small receive and
+#   transmit windows, optional header checksum validation, and an internal
+#   behavioral segment RAM.  The wrapper flattens SSI records, RX/TX sequence
+#   inputs, decoded flag outputs, and SYN parameter outputs so tests can assert
+#   leaf-FSM behavior directly.
+# - Stimulus: Drive flattened transport-side SSI frames containing encoded RSSI
+#   ACK, DATA, NULL, RST, and SYN headers plus payload words where applicable.
+#   Tests vary checksum validity, unsupported flag combinations, SYN length,
+#   payload continuation, sequence numbers, and duplicate/out-of-order DATA.
+# - Checks: Valid in-order DATA must pulse `rxValidSeg_o`, update visible
+#   sequence/ack/flag fields, and deliver exactly the expected application
+#   frame.  Invalid checksum, unsupported EACK, illegal DATA/BUSY/ACK flag
+#   combinations, malformed SYN, out-of-order DATA, and duplicate DATA must
+#   pulse/drop as appropriate and stay silent on the application side.  With
+#   `HEADER_CHKSUM_EN_G=false`, `chksumOk_i` is ignored while the checksum
+#   valid pulse still supplies timing.
+# - Timing: Transport input waits for sampled ready before changing beats.
+#   Status checks wait past the default `TPD_G` output delay, and app-output
+#   checks account for the registered segment RAM read latency used by the real
+#   `RssiCore` path.
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RssiParams,
+    RSSI_FLAG_BUSY,
+    RSSI_FLAG_EACK,
+    RSSI_FLAG_NULL,
+    RSSI_FLAG_RST,
+    build_ack_header,
+    build_null_header,
+    build_data_header,
+    build_syn_header,
+    header_words,
+    stream_words_from_header,
+    stream_word_from_header_word,
+)
+from tests.protocols.ssi.ssi_test_utils import (
+    cycle as ssi_cycle,
+    expect_no_output,
+    recv_frame_and_check,
+    setup_flat_ssi_testbench,
+    SsiBeat,
+)
+
+
+class TB:
+    def __init__(self, dut, bench):
+        self.dut = dut
+        self.clk = bench.clk
+        self.source = bench.source
+        self.sink = bench.sink
+        assert self.source is not None
+        assert self.sink is not None
+
+    @classmethod
+    async def create(cls, dut, *, connected: bool = True):
+        # Reuse the SSI test infrastructure now that the RSSI wrapper exposes
+        # the same flattened `sAxis`/`mAxis` names as the SSI wrappers.  The
+        # RSSI-specific class only needs to add connection state and checksum
+        # timing around those generic frame helpers.
+        bench = await setup_flat_ssi_testbench(
+            dut,
+            source_prefix="sAxis",
+            sink_prefix="mAxis",
+            initial_values={
+                "connActive_i": int(connected),
+                "rxWindowSize_i": 4,
+                "rxBufferSize_i": 4,
+                "txWindowSize_i": 4,
+                "lastAckN_i": 0,
+                "mAxisTReady": 0,
+                "chksumValid_i": 0,
+                "chksumOk_i": 1,
+            },
+        )
+        return cls(dut, bench)
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    async def send_transport_word(
+        self,
+        *,
+        data: int,
+        sof: int,
+        last: int,
+        keep: int = 0xFF,
+        eofe: int = 0,
+    ) -> None:
+        # `FlatSsiEndpoint.send()` owns the ready/valid handshake and returns
+        # the source to idle.  RSSI still controls the protocol-level SOF/LAST
+        # placement, so the header is the only beat with `sof=1`.
+        await self.source.send(
+            SsiBeat(data=data, keep=keep, last=last, sof=sof, eofe=eofe),
+            clk=self.clk,
+        )
+        await self.cycle()
+
+    async def send_data_segment(
+        self,
+        *,
+        sequence: int,
+        acknowledge: int,
+        payload_words: list[int],
+        ack: bool = True,
+        busy: bool = False,
+        extra_flags: int = 0,
+        checksum_ok: bool = True,
+        send_payload_after_bad_checksum: bool = False,
+    ) -> None:
+        header = bytearray(
+            build_data_header(
+                sequence=sequence,
+                acknowledge=acknowledge,
+                ack=ack,
+                busy=busy,
+                enable_checksum=False,
+            )
+        )
+        header[0] |= extra_flags
+        header_word = stream_word_from_header_word(header_words(header)[0])
+
+        # `RssiRxFsm` receives checksum status from the core-level checksum
+        # block after the header word has been strobed.  Keep valid low while
+        # the header is accepted so CHECK sees registered header fields before
+        # making the pass/drop decision.
+        self.dut.chksumValid_i.value = 0
+        self.dut.chksumOk_i.value = int(checksum_ok)
+
+        await self.send_transport_word(data=header_word, sof=1, last=0)
+        self.dut.chksumValid_i.value = 1
+        await self.cycle()
+        self.dut.chksumValid_i.value = 0
+
+        if not checksum_ok and not send_payload_after_bad_checksum:
+            return
+
+        for index, payload_word in enumerate(payload_words):
+            await self.send_transport_word(
+                data=payload_word,
+                sof=0,
+                last=int(index == len(payload_words) - 1),
+            )
+
+    async def send_single_word_header(
+        self,
+        header: bytes,
+        *,
+        checksum_ok: bool = True,
+        eofe: int = 0,
+    ) -> None:
+        # Non-DATA control segments are one RSSI header word.  The receive FSM
+        # still waits for the core checksum result before accepting or dropping
+        # the segment.
+        header_word = stream_word_from_header_word(header_words(header)[0])
+        self.dut.chksumValid_i.value = 0
+        self.dut.chksumOk_i.value = int(checksum_ok)
+
+        await self.send_transport_word(data=header_word, sof=1, last=1, eofe=eofe)
+        self.dut.chksumValid_i.value = 1
+        await self.cycle()
+        self.dut.chksumValid_i.value = 0
+
+    async def send_syn_segment(
+        self,
+        *,
+        sequence: int,
+        acknowledge: int,
+        ack: bool = False,
+        extra_flags: int = 0,
+        extra_payload_words: list[int] | None = None,
+        checksum_ok: bool = True,
+    ) -> None:
+        params = RssiParams(connection_id=0xA5A5_1234)
+        header = bytearray(
+            build_syn_header(
+                sequence=sequence,
+                acknowledge=acknowledge,
+                ack=ack,
+                params=params,
+                enable_checksum=False,
+            )
+        )
+        header[0] |= extra_flags
+        words = stream_words_from_header(bytes(header))
+        payload_words = extra_payload_words or []
+
+        self.dut.chksumValid_i.value = 0
+        self.dut.chksumOk_i.value = int(checksum_ok)
+
+        for index, word in enumerate(words):
+            is_last = index == len(words) - 1 and not payload_words
+            await self.send_transport_word(
+                data=word,
+                sof=int(index == 0),
+                last=int(is_last),
+            )
+
+        self.dut.chksumValid_i.value = 1
+        await self.cycle()
+        self.dut.chksumValid_i.value = 0
+
+        for index, payload_word in enumerate(payload_words):
+            await self.send_transport_word(
+                data=payload_word,
+                sof=0,
+                last=int(index == len(payload_words) - 1),
+            )
+
+    async def wait_status_pulse(self, signal_name: str, *, cycles: int = 32) -> None:
+        signal = getattr(self.dut, signal_name)
+        await Timer(1, unit="ns")
+        if int(signal.value) == 1:
+            return
+        for _ in range(cycles):
+            await self.cycle()
+            if int(signal.value) == 1:
+                return
+        raise AssertionError(f"Timed out waiting for {signal_name}")
+
+    async def expect_no_app_output(self, *, cycles: int = 16) -> None:
+        # Dropped segments may take a few cycles to unwind back to WAIT_SOF, so
+        # check a bounded quiet window rather than only the immediate cycle.
+        self.dut.mAxisTReady.value = 1
+        await expect_no_output(self.sink, clk=self.clk, cycles=cycles)
+        self.dut.mAxisTReady.value = 0
+
+
+@cocotb.test()
+async def valid_in_order_data_segment_is_accepted_test(dut):
+    tb = await TB.create(dut)
+
+    payload = 0x8877_6655_4433_2211
+    tail_payload = 0x0123_4567_89AB_CDEF
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[payload, tail_payload],
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+
+    # The RX FSM records the accepted RSSI header fields when the header screen
+    # and sequence-window checks pass.
+    assert int(dut.rxSeqN_o.value) == 1
+    assert int(dut.rxAckN_o.value) == 0
+    assert int(dut.rxFlagAck_o.value) == 1
+    assert int(dut.rxFlagData_o.value) == 1
+
+    await recv_frame_and_check(
+        tb.sink,
+        clk=tb.clk,
+        ready_signal=dut.mAxisTReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[
+            (payload, 0xFF, 0, 1, 0),
+            (tail_payload, 0xFF, 1, 0, 0),
+        ],
+    )
+
+
+@cocotb.test()
+async def checksum_failure_drops_without_application_output_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[0xDEAD_BEEF_CAFE_1234],
+        checksum_ok=False,
+    )
+    await tb.wait_status_pulse("rxDropSeg_o")
+    await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def checksum_failed_data_payload_is_flushed_before_retransmit_test(dut):
+    tb = await TB.create(dut)
+
+    bad_payload = 0xDEAD_BEEF_CAFE_1234
+    retransmit_payload = 0x1234_5678_9ABC_DEF0
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[bad_payload],
+        checksum_ok=False,
+        send_payload_after_bad_checksum=True,
+    )
+    await drop_wait
+    await tb.expect_no_app_output()
+
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[retransmit_payload],
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+    await recv_frame_and_check(
+        tb.sink,
+        clk=tb.clk,
+        ready_signal=dut.mAxisTReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(retransmit_payload, 0xFF, 1, 1, 0)],
+    )
+
+
+@cocotb.test()
+async def checksum_disabled_accepts_data_when_checksum_status_is_bad_test(dut):
+    if not env_flag("RSSI_CHECKSUM_DISABLED_CASE", default=False):
+        return
+
+    tb = await TB.create(dut)
+
+    payload = 0xCAFE_0000_0000_BEEF
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[payload],
+        checksum_ok=False,
+        send_payload_after_bad_checksum=True,
+    )
+    await tb.wait_status_pulse("rxValidSeg_o", cycles=128)
+
+    await recv_frame_and_check(
+        tb.sink,
+        clk=tb.clk,
+        ready_signal=dut.mAxisTReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+
+
+@cocotb.test()
+async def null_segment_is_accepted_without_application_output_test(dut):
+    tb = await TB.create(dut)
+
+    await tb.send_single_word_header(
+        build_null_header(sequence=1, acknowledge=0, enable_checksum=False)
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+
+    assert int(dut.rxSeqN_o.value) == 1
+    assert int(dut.rxAckN_o.value) == 0
+    assert int(dut.rxFlagAck_o.value) == 1
+    assert int(dut.rxFlagNull_o.value) == 1
+    assert int(dut.rxFlagData_o.value) == 0
+    await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def valid_data_payload_delivery_test(dut):
+    tb = await TB.create(dut)
+
+    payload = 0x8877_6655_4433_2211
+    tail_payload = 0x0123_4567_89AB_CDEF
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[payload, tail_payload],
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+
+    await recv_frame_and_check(
+        tb.sink,
+        clk=tb.clk,
+        ready_signal=dut.mAxisTReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[
+            (payload, 0xFF, 0, 1, 0),
+            (tail_payload, 0xFF, 1, 0, 0),
+        ],
+    )
+
+
+@cocotb.test()
+async def illegal_data_flag_combinations_drop_test(dut):
+    tb = await TB.create(dut)
+
+    # DATA must carry ACK and must not be combined with BUSY or unsupported EACK.
+    for ack, busy, extra_flags in (
+        (False, False, 0),
+        (True, True, 0),
+        (True, False, RSSI_FLAG_EACK),
+    ):
+        drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+        await tb.send_data_segment(
+            sequence=1,
+            acknowledge=0,
+            payload_words=[0x0102_0304_0506_0708],
+            ack=ack,
+            busy=busy,
+            extra_flags=extra_flags,
+        )
+        await drop_wait
+        await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def standalone_eack_segment_drops_test(dut):
+    tb = await TB.create(dut)
+
+    # EACK is reserved by the SURF RSSI v1 profile.  Even when combined with
+    # ACK as in the RUDP lineage, hardware should reject it rather than treat
+    # it as a supported extended acknowledgment.
+    header = bytearray(
+        build_ack_header(sequence=1, acknowledge=0, enable_checksum=False)
+    )
+    header[0] |= RSSI_FLAG_EACK
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_single_word_header(bytes(header))
+    await drop_wait
+    await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def malformed_header_and_ack_window_violations_drop_test(dut):
+    tb = await TB.create(dut)
+
+    malformed_header = bytearray(
+        build_null_header(sequence=1, acknowledge=0, enable_checksum=False)
+    )
+    malformed_header[1] = 9
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_single_word_header(bytes(malformed_header))
+    await drop_wait
+    await tb.expect_no_app_output()
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=5,
+        payload_words=[0x0102_0304_0506_0708],
+    )
+    await drop_wait
+    await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def valid_syn_segment_is_accepted_and_captures_parameters_test(dut):
+    tb = await TB.create(dut, connected=False)
+
+    await tb.send_syn_segment(sequence=0x22, acknowledge=0x00)
+    await tb.wait_status_pulse("rxValidSeg_o")
+
+    assert int(dut.rxSeqN_o.value) == 0x22
+    assert int(dut.rxFlagSyn_o.value) == 1
+    assert int(dut.rxFlagNull_o.value) == 0
+    assert int(dut.rxFlagBusy_o.value) == 0
+    assert int(dut.paramVersion_o.value) == 1
+    assert int(dut.paramChksumEn_o.value) == 1
+    assert int(dut.paramConnId_o.value) == 0xA5A5_1234
+
+
+@cocotb.test()
+async def illegal_syn_flag_combinations_drop_test(dut):
+    tb = await TB.create(dut, connected=False)
+
+    # The RSSI profile keeps SYN separate from extended ACK, RST, BUSY, and NUL
+    # semantics.
+    for extra_flags in (
+        RSSI_FLAG_EACK,
+        RSSI_FLAG_BUSY,
+        RSSI_FLAG_RST,
+        RSSI_FLAG_NULL,
+    ):
+        drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+        await tb.send_syn_segment(
+            sequence=0x31,
+            acknowledge=0x00,
+            extra_flags=extra_flags,
+        )
+        await drop_wait
+        assert int(dut.rxValidSeg_o.value) == 0
+        assert int(dut.paramConnId_o.value) == 0
+
+
+@cocotb.test()
+async def syn_with_extra_payload_drops_test(dut):
+    tb = await TB.create(dut, connected=False)
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_syn_segment(
+        sequence=0x42,
+        acknowledge=0x00,
+        extra_payload_words=[0x1122_3344_5566_7788],
+    )
+    await drop_wait
+    assert int(dut.rxValidSeg_o.value) == 0
+    assert int(dut.paramConnId_o.value) == 0
+    await tb.expect_no_app_output()
+
+
+@cocotb.test()
+async def out_of_order_data_drops_then_in_order_retransmit_accepts_test(dut):
+    tb = await TB.create(dut)
+
+    out_of_order_payload = 0x2222_2222_2222_2222
+    in_order_payload = 0x1111_1111_1111_1111
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_data_segment(
+        sequence=2,
+        acknowledge=0,
+        payload_words=[out_of_order_payload],
+    )
+    await drop_wait
+    assert int(dut.rxValidSeg_o.value) == 0
+    assert int(dut.rxSeqN_o.value) == 2
+    await tb.expect_no_app_output()
+
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[in_order_payload],
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+    assert int(dut.rxSeqN_o.value) == 1
+
+
+@cocotb.test()
+async def duplicate_data_after_delivery_drops_without_second_output_test(dut):
+    tb = await TB.create(dut)
+
+    payload = 0x1357_9BDF_2468_ACE0
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[payload],
+    )
+    await tb.wait_status_pulse("rxValidSeg_o")
+    await recv_frame_and_check(
+        tb.sink,
+        clk=tb.clk,
+        ready_signal=dut.mAxisTReady,
+        fields=("data", "keep", "last", "sof", "eofe"),
+        expected=[(payload, 0xFF, 1, 1, 0)],
+    )
+
+    drop_wait = cocotb.start_soon(tb.wait_status_pulse("rxDropSeg_o"))
+    await tb.send_data_segment(
+        sequence=1,
+        acknowledge=0,
+        payload_words=[payload],
+    )
+    await drop_wait
+    await tb.expect_no_app_output()
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="small_window")]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiRxFsm(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssirxfsmwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiRxFsm.vhd",
+                "protocols/rssi/v1/wrappers/RssiRxFsmWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+def test_RssiRxFsm_checksum_disabled():
+    parameters = {"HEADER_CHKSUM_EN_G": "false"}
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssirxfsmwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TESTCASE": "checksum_disabled_accepts_data_when_checksum_status_is_bad_test",
+            "RSSI_CHECKSUM_DISABLED_CASE": 1,
+        },
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiRxFsm.vhd",
+                "protocols/rssi/v1/wrappers/RssiRxFsmWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/rssi/test_RssiTxFsm.py
+++ b/tests/protocols/rssi/test_RssiTxFsm.py
@@ -1,0 +1,836 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Purpose: Verify transmit-side RSSI segment generation, sequence
+#   consumption, ACK processing, window release, retransmission, and checksum
+#   insertion at the `RssiTxFsm` boundary.  This file proves the TX leaf logic
+#   before it is paired with the RX FSM and monitor in `RssiCore`.
+# - DUT shape: Run `RssiTxFsm` through a thin wrapper with a small transmit
+#   window, deterministic checksum provider, a real `RssiHeaderReg`, and a
+#   behavioral segment RAM whose read timing matches the registered RAM path
+#   used by `RssiCore`.  The wrapper exposes flattened SSI application and
+#   transport streams plus control/status signals for directed checks.
+# - Stimulus: Start from an active connection, issue ACK, DATA, NULL, RST, SYN,
+#   resend, and close requests, drive application payload beats, and return
+#   checksum-valid strobes only after the DUT asks for a header checksum.
+#   Separate cases drive peer ACK numbers to release one or multiple
+#   outstanding segments.
+# - Checks: Standalone ACK emits exactly one RSSI ACK segment, preserves the
+#   current TX sequence, and carries the expected checksum.  DATA, NULL, RST,
+#   and SYN emit the expected headers and consume sequence numbers where the
+#   RSSI profile requires it.  Multi-word DATA preserves payload/TKEEP/TLAST
+#   across the segment RAM and resend path.  Cumulative ACK frees multiple
+#   buffered segments.  Checksum injection corrupts ACK, NULL, and DATA header
+#   checksums without corrupting payload.
+# - Timing: Output checks start with `TREADY` asserted, then present checksum
+#   valid after the DUT's checksum request so the header RAM path is sampled
+#   after its registered update.  Tests observe complete accepted transport
+#   frames rather than peeking at internal state-machine cycles.
+
+import cocotb
+import pytest
+from cocotb.triggers import FallingEdge, RisingEdge, Timer
+
+from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.protocols.rssi.rssi_test_utils import (
+    RssiParams,
+    build_ack_header,
+    build_data_header,
+    build_null_header,
+    build_rst_header,
+    build_syn_header,
+    checksum_is_valid,
+    parse_header,
+    protocol_bytes_from_stream_word,
+    stream_word_from_protocol_bytes,
+    stream_words_from_header,
+)
+from tests.protocols.ssi.ssi_test_utils import (
+    SsiBeat,
+    cycle as ssi_cycle,
+    expect_no_output,
+    recv_frame_and_check,
+    send_contiguous_frame,
+    setup_flat_ssi_testbench,
+    wait_signal_pulse,
+)
+
+
+def _header_with_test_checksum(header: bytes) -> bytes:
+    return header[:-2] + bytes.fromhex("beef")
+
+
+def _header_with_corrupted_test_checksum(header: bytes) -> bytes:
+    checksum = int.from_bytes(header[-2:], "big") ^ 0xFFFF
+    return header[:-2] + checksum.to_bytes(2, "big")
+
+
+async def _send_contiguous_frame_after_tpd(endpoint, beats: list[SsiBeat], *, clk) -> None:
+    # `RssiTxFsm` drives its application buffer controls with the default
+    # 1 ns `TPD_G`.  Hold each accepted beat beyond that delay before advancing
+    # to the next beat so the wrapper RAM samples the same stable value a real
+    # registered SSI source would present after the clock edge.
+    for beat in beats:
+        endpoint.drive(beat)
+        for _ in range(1024):
+            await RisingEdge(clk)
+            await Timer(2, unit="ns")
+            if int(endpoint._sig("TReady").value) == 1:
+                break
+        else:
+            raise AssertionError(f"Timed out waiting for sampled handshake on {endpoint.prefix}TReady")
+    endpoint.set_idle()
+
+
+class TB:
+    def __init__(self, dut, bench):
+        self.dut = dut
+        self.clk = bench.clk
+        self.source = bench.source
+        self.sink = bench.sink
+        assert self.source is not None
+        assert self.sink is not None
+
+    @classmethod
+    async def create(
+        cls,
+        dut,
+        *,
+        connected: bool = True,
+        tx_ack_flag: int = 1,
+        buffer_size: int = 4,
+    ):
+        bench = await setup_flat_ssi_testbench(
+            dut,
+            source_prefix="sAxis",
+            sink_prefix="mAxis",
+            initial_values={
+                "connActive_i": int(connected),
+                "closed_i": 0,
+                "injectFault_i": 0,
+                "sndSyn_i": 0,
+                "sndAck_i": 0,
+                "sndRst_i": 0,
+                "sndResend_i": 0,
+                "sndNull_i": 0,
+                "windowSize_i": 4,
+                "bufferSize_i": buffer_size,
+                "initSeqN_i": 0x12,
+                "txAckFlag_i": tx_ack_flag,
+                "rxAckN_i": 0x34,
+                "localBusy_i": 0,
+                "ack_i": 0,
+                "ackN_i": 0,
+                "mAxisTReady": 0,
+                "chksumValid_i": 0,
+                "chksum_i": 0xBEEF,
+            },
+        )
+        tb = cls(dut, bench)
+        # Let INIT -> DISS_CONN -> CONN settle after reset so the first request
+        # is accepted from the connected-state request decoder.
+        await tb.cycle(4)
+        return tb
+
+    async def cycle(self, count: int = 1) -> None:
+        await ssi_cycle(self.clk, count=count)
+
+    async def pulse(self, signal_name: str) -> None:
+        signal = getattr(self.dut, signal_name)
+        signal.value = 1
+        await self.cycle()
+        signal.value = 0
+
+    async def provide_checksum_after_strobe(self) -> None:
+        await wait_signal_pulse(self.dut.chksumStrobe_o, clk=self.clk)
+        self.dut.chksumValid_i.value = 1
+
+    async def finish_checksum(self) -> None:
+        self.dut.chksumValid_i.value = 0
+        await self.cycle()
+
+    async def recv_frame_selected_fields(
+        self,
+        *,
+        fields: tuple[str, ...],
+        timeout_cycles: int = 128,
+    ) -> list[dict[str, int]]:
+        self.dut.mAxisTReady.value = 1
+        beats = []
+        try:
+            for _ in range(timeout_cycles):
+                await FallingEdge(self.clk)
+                await Timer(1, unit="ns")
+                if int(self.dut.mAxisTValid.value) == 1:
+                    beat = {}
+                    for field in fields:
+                        beat[field] = int(getattr(self.dut, field).value)
+                    beats.append(beat)
+                    await RisingEdge(self.clk)
+                    await Timer(1, unit="ns")
+                    if beat.get("mAxisTLast", 0) == 1:
+                        return beats
+                else:
+                    await RisingEdge(self.clk)
+                    await Timer(1, unit="ns")
+        finally:
+            self.dut.mAxisTReady.value = 0
+        raise AssertionError("Timed out waiting for selected mAxis frame fields")
+
+
+def _assert_non_syn_header(
+    beat,
+    *,
+    sequence: int,
+    acknowledge: int,
+    ack: bool,
+    rst: bool = False,
+    nul: bool = False,
+) -> None:
+    parsed = parse_header(protocol_bytes_from_stream_word(beat.data))
+    assert parsed.ack is ack
+    assert not parsed.syn
+    assert parsed.rst is rst
+    assert parsed.nul is nul
+    assert parsed.sequence == sequence
+    assert parsed.acknowledge == acknowledge
+    assert parsed.checksum == 0xBEEF
+
+
+@cocotb.test()
+async def standalone_ack_emits_one_header_without_sequence_consumption_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_ack_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (expected_stream_word, 0xFF, 1, 1, 0),
+            ],
+        )
+    )
+
+    await tb.pulse("sndAck_i")
+    await tb.provide_checksum_after_strobe()
+
+    [beat] = await recv_task
+    assert beat.data == expected_stream_word
+    await tb.finish_checksum()
+
+    _assert_non_syn_header(beat, sequence=initial_seq, acknowledge=0x34, ack=True)
+
+    # ACK-only segments acknowledge peer traffic but do not allocate a local
+    # sequence number in the RSSI profile.
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == initial_seq
+
+
+@cocotb.test()
+async def syn_emits_three_word_header_and_consumes_sequence_test(dut):
+    tb = await TB.create(dut, connected=False, tx_ack_flag=0)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_syn_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            ack=False,
+            params=RssiParams(
+                version=0,
+                chksum_en=0,
+                max_outs_seg=0,
+                max_seg_size=0,
+                retrans_tout=0,
+                cumul_ack_tout=0,
+                null_seg_tout=0,
+                max_retrans=0,
+                max_cum_ack=0,
+                max_outofseq=0,
+                timeout_unit=0,
+                connection_id=0,
+            ),
+            enable_checksum=False,
+        )
+    )
+    expected_words = stream_words_from_header(expected_header)
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (expected_words[0], 0xFF, 0, 1, 0),
+                (expected_words[1], 0xFF, 0, 0, 0),
+                (expected_words[2], 0xFF, 1, 0, 0),
+            ],
+        )
+    )
+
+    await tb.pulse("sndSyn_i")
+    await tb.provide_checksum_after_strobe()
+
+    beats = await recv_task
+    await tb.finish_checksum()
+
+    parsed = parse_header(b"".join(protocol_bytes_from_stream_word(beat.data) for beat in beats))
+    assert parsed.syn
+    assert not parsed.ack
+    assert parsed.sequence == initial_seq
+    assert parsed.acknowledge == 0x34
+    assert parsed.checksum == 0xBEEF
+    assert parsed.params == RssiParams(
+        version=0,
+        chksum_en=0,
+        max_outs_seg=0,
+        max_seg_size=0,
+        retrans_tout=0,
+        cumul_ack_tout=0,
+        null_seg_tout=0,
+        max_retrans=0,
+        max_cum_ack=0,
+        max_outofseq=0,
+        timeout_unit=0,
+        connection_id=0,
+    )
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+
+
+@cocotb.test()
+async def one_word_data_ack_and_resend_sequence_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_data_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+    payload_word = 0x1122_3344_5566_7788
+
+    recv_task = cocotb.start_soon(
+        tb.recv_frame_selected_fields(
+            fields=("mAxisTData", "mAxisTLast", "mAxisSof", "mAxisEofe"),
+        )
+    )
+
+    await send_contiguous_frame(
+        tb.source,
+        [SsiBeat(data=payload_word, keep=0xFF, last=1, sof=1, eofe=0)],
+        clk=tb.clk,
+    )
+    await tb.provide_checksum_after_strobe()
+
+    header_beat, payload_beat = await recv_task
+    await tb.finish_checksum()
+
+    assert header_beat == {
+        "mAxisTData": expected_stream_word,
+        "mAxisTLast": 0,
+        "mAxisSof": 1,
+        "mAxisEofe": 0,
+    }
+    assert payload_beat == {
+        "mAxisTData": payload_word,
+        "mAxisTLast": 1,
+        "mAxisSof": 0,
+        "mAxisEofe": 0,
+    }
+
+    parsed = parse_header(protocol_bytes_from_stream_word(header_beat["mAxisTData"]))
+    assert parsed.ack
+    assert not parsed.syn
+    assert not parsed.rst
+    assert not parsed.nul
+    assert parsed.sequence == initial_seq
+    assert parsed.acknowledge == 0x34
+    assert parsed.checksum == 0xBEEF
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 0
+
+    resend_task = cocotb.start_soon(
+        tb.recv_frame_selected_fields(
+            fields=("mAxisTData", "mAxisTLast", "mAxisSof", "mAxisEofe"),
+        )
+    )
+
+    await tb.pulse("sndResend_i")
+    await tb.provide_checksum_after_strobe()
+
+    resend_header_beat, resend_payload_beat = await resend_task
+    await tb.finish_checksum()
+
+    assert resend_header_beat == {
+        "mAxisTData": expected_stream_word,
+        "mAxisTLast": 0,
+        "mAxisSof": 1,
+        "mAxisEofe": 0,
+    }
+    assert resend_payload_beat == {
+        "mAxisTData": payload_word,
+        "mAxisTLast": 1,
+        "mAxisSof": 0,
+        "mAxisEofe": 0,
+    }
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 0
+
+    dut.ackN_i.value = initial_seq
+    await tb.pulse("ack_i")
+    await tb.cycle(4)
+    assert int(dut.lastAckN_o.value) == initial_seq
+    assert int(dut.bufferEmpty_o.value) == 1
+
+
+@cocotb.test()
+async def null_request_is_ignored_while_data_is_unacknowledged_test(dut):
+    tb = await TB.create(dut)
+
+    payload_word = 0x1122_3344_5566_7788
+    data_task = cocotb.start_soon(
+        tb.recv_frame_selected_fields(
+            fields=("mAxisTData", "mAxisTLast", "mAxisSof", "mAxisEofe"),
+        )
+    )
+
+    await send_contiguous_frame(
+        tb.source,
+        [SsiBeat(data=payload_word, keep=0xFF, last=1, sof=1, eofe=0)],
+        clk=tb.clk,
+    )
+    await tb.provide_checksum_after_strobe()
+    await data_task
+    await tb.finish_checksum()
+
+    await tb.cycle(2)
+    assert int(dut.bufferEmpty_o.value) == 0
+
+    await tb.pulse("sndNull_i")
+    dut.mAxisTReady.value = 1
+    for _ in range(16):
+        await Timer(1, unit="ns")
+        assert int(dut.chksumStrobe_o.value) == 0
+        assert int(dut.mAxisTValid.value) == 0
+        await tb.cycle()
+    dut.mAxisTReady.value = 0
+
+
+@cocotb.test()
+async def cumulative_ack_releases_multiple_outstanding_segments_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    payloads = [
+        0x0101_0101_0101_0101,
+        0x0202_0202_0202_0202,
+        0x0303_0303_0303_0303,
+    ]
+
+    for index, payload_word in enumerate(payloads):
+        seq = (initial_seq + index) & 0xFF
+        expected_header = _header_with_test_checksum(
+            build_data_header(
+                sequence=seq,
+                acknowledge=0x34,
+                enable_checksum=False,
+            )
+        )
+        recv_task = cocotb.start_soon(
+            recv_frame_and_check(
+                tb.sink,
+                clk=tb.clk,
+                ready_signal=dut.mAxisTReady,
+                fields=("data", "keep", "last", "sof", "eofe"),
+                expected=[
+                    (stream_word_from_protocol_bytes(expected_header), 0xFF, 0, 1, 0),
+                    (payload_word, 0xFF, 1, 0, 0),
+                ],
+            )
+        )
+        await send_contiguous_frame(
+            tb.source,
+            [SsiBeat(data=payload_word, keep=0xFF, last=1, sof=1, eofe=0)],
+            clk=tb.clk,
+        )
+        await tb.provide_checksum_after_strobe()
+        await recv_task
+        await tb.finish_checksum()
+        await tb.cycle(2)
+        assert int(dut.bufferEmpty_o.value) == 0
+
+    assert int(dut.txSeqN_o.value) == (initial_seq + len(payloads)) & 0xFF
+
+    dut.ackN_i.value = (initial_seq + len(payloads) - 1) & 0xFF
+    await tb.pulse("ack_i")
+    await tb.cycle(8)
+    assert int(dut.lastAckN_o.value) == (initial_seq + len(payloads) - 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 1
+
+
+@cocotb.test()
+async def one_word_data_tkeep_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_data_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+    payload_word = 0x1122_3344_5566_7788
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (expected_stream_word, 0xFF, 0, 1, 0),
+                (payload_word, 0xFF, 1, 0, 0),
+            ],
+        )
+    )
+
+    await send_contiguous_frame(
+        tb.source,
+        [SsiBeat(data=payload_word, keep=0xFF, last=1, sof=1, eofe=0)],
+        clk=tb.clk,
+    )
+    await tb.provide_checksum_after_strobe()
+
+    await recv_task
+
+
+@cocotb.test()
+async def multi_word_data_preserves_payload_keep_and_resend_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_data_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+    payload = [
+        SsiBeat(data=0x0102_0304_0506_0708, keep=0xFF, last=0, sof=1, eofe=0),
+        SsiBeat(data=0x1112_1314_1516_1718, keep=0xFF, last=0, sof=0, eofe=0),
+        SsiBeat(data=0x2122_2324_0000_0000, keep=0x0F, last=1, sof=0, eofe=0),
+    ]
+    expected = [
+        (expected_stream_word, 0xFF, 0, 1, 0),
+        (payload[0].data, 0xFF, 0, 0, 0),
+        (payload[1].data, 0xFF, 0, 0, 0),
+        (payload[2].data, 0x0F, 1, 0, 0),
+    ]
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=expected,
+        )
+    )
+
+    await _send_contiguous_frame_after_tpd(tb.source, payload, clk=tb.clk)
+    await tb.provide_checksum_after_strobe()
+    await recv_task
+    await tb.finish_checksum()
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 0
+
+    resend_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=expected,
+        )
+    )
+
+    await tb.pulse("sndResend_i")
+    await tb.provide_checksum_after_strobe()
+    await resend_task
+    await tb.finish_checksum()
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+
+
+@cocotb.test()
+async def oversized_application_frame_reports_len_error_without_transport_output_test(dut):
+    tb = await TB.create(dut, buffer_size=1)
+
+    await send_contiguous_frame(
+        tb.source,
+        [
+            SsiBeat(data=0x0000_0000_0000_0001, keep=0xFF, last=0, sof=1, eofe=0),
+            SsiBeat(data=0x0000_0000_0000_0002, keep=0xFF, last=0, sof=0, eofe=0),
+            SsiBeat(data=0x0000_0000_0000_0003, keep=0xFF, last=0, sof=0, eofe=0),
+            SsiBeat(data=0x0000_0000_0000_0004, keep=0xFF, last=0, sof=0, eofe=0),
+        ],
+        clk=tb.clk,
+    )
+
+    await wait_signal_pulse(dut.lenErr_o, clk=tb.clk)
+    await expect_no_output(tb.sink, clk=tb.clk, cycles=16)
+    assert int(dut.bufferEmpty_o.value) == 1
+
+
+@cocotb.test()
+async def checksum_fault_injection_corrupts_ack_null_and_data_headers_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+
+    ack_header = _header_with_corrupted_test_checksum(
+        _header_with_test_checksum(
+            build_ack_header(
+                sequence=initial_seq,
+                acknowledge=0x34,
+                enable_checksum=False,
+            )
+        )
+    )
+    ack_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(stream_word_from_protocol_bytes(ack_header), 0xFF, 1, 1, 0)],
+        )
+    )
+
+    await tb.pulse("injectFault_i")
+    await tb.pulse("sndAck_i")
+    await tb.provide_checksum_after_strobe()
+    [ack_beat] = await ack_task
+    await tb.finish_checksum()
+
+    parsed_ack = parse_header(protocol_bytes_from_stream_word(ack_beat.data))
+    assert parsed_ack.ack
+    assert parsed_ack.sequence == initial_seq
+    assert parsed_ack.acknowledge == 0x34
+    assert parsed_ack.checksum == 0x4110
+    assert not checksum_is_valid(protocol_bytes_from_stream_word(ack_beat.data))
+
+    await tb.cycle(2)
+    null_seq = int(dut.txSeqN_o.value)
+    null_header = _header_with_corrupted_test_checksum(
+        _header_with_test_checksum(
+            build_null_header(
+                sequence=null_seq,
+                acknowledge=0x34,
+                enable_checksum=False,
+            )
+        )
+    )
+    null_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[(stream_word_from_protocol_bytes(null_header), 0xFF, 1, 1, 0)],
+        )
+    )
+
+    await tb.pulse("injectFault_i")
+    await tb.pulse("sndNull_i")
+    await tb.provide_checksum_after_strobe()
+    [null_beat] = await null_task
+    await tb.finish_checksum()
+
+    parsed_null = parse_header(protocol_bytes_from_stream_word(null_beat.data))
+    assert parsed_null.ack
+    assert parsed_null.nul
+    assert parsed_null.sequence == null_seq
+    assert parsed_null.acknowledge == 0x34
+    assert parsed_null.checksum == 0x4110
+    assert not checksum_is_valid(protocol_bytes_from_stream_word(null_beat.data))
+
+    await tb.cycle(2)
+    data_seq = int(dut.txSeqN_o.value)
+    data_header = _header_with_corrupted_test_checksum(
+        _header_with_test_checksum(
+            build_data_header(
+                sequence=data_seq,
+                acknowledge=0x34,
+                enable_checksum=False,
+            )
+        )
+    )
+    payload_word = 0xA1A2_A3A4_A5A6_A7A8
+    data_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (stream_word_from_protocol_bytes(data_header), 0xFF, 0, 1, 0),
+                (payload_word, 0xFF, 1, 0, 0),
+            ],
+        )
+    )
+
+    await tb.pulse("injectFault_i")
+    await send_contiguous_frame(
+        tb.source,
+        [SsiBeat(data=payload_word, keep=0xFF, last=1, sof=1, eofe=0)],
+        clk=tb.clk,
+    )
+    await tb.provide_checksum_after_strobe()
+    beats = await data_task
+    await tb.finish_checksum()
+
+    parsed_data = parse_header(protocol_bytes_from_stream_word(beats[0].data))
+    assert parsed_data.ack
+    assert parsed_data.sequence == data_seq
+    assert parsed_data.acknowledge == 0x34
+    assert parsed_data.checksum == 0x4110
+    assert not checksum_is_valid(protocol_bytes_from_stream_word(beats[0].data))
+
+
+@cocotb.test()
+async def null_segment_emits_ack_header_and_consumes_sequence_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_null_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (expected_stream_word, 0xFF, 1, 1, 0),
+            ],
+        )
+    )
+
+    await tb.pulse("sndNull_i")
+    await tb.provide_checksum_after_strobe()
+
+    [beat] = await recv_task
+    await tb.finish_checksum()
+
+    _assert_non_syn_header(beat, sequence=initial_seq, acknowledge=0x34, ack=True, nul=True)
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 0
+
+
+@cocotb.test()
+async def rst_segment_emits_header_and_consumes_sequence_without_buffering_test(dut):
+    tb = await TB.create(dut)
+
+    initial_seq = int(dut.txSeqN_o.value)
+    expected_header = _header_with_test_checksum(
+        build_rst_header(
+            sequence=initial_seq,
+            acknowledge=0x34,
+            enable_checksum=False,
+        )
+    )
+    expected_stream_word = stream_word_from_protocol_bytes(expected_header)
+
+    recv_task = cocotb.start_soon(
+        recv_frame_and_check(
+            tb.sink,
+            clk=tb.clk,
+            ready_signal=dut.mAxisTReady,
+            fields=("data", "keep", "last", "sof", "eofe"),
+            expected=[
+                (expected_stream_word, 0xFF, 1, 1, 0),
+            ],
+        )
+    )
+
+    await tb.pulse("sndRst_i")
+    await tb.provide_checksum_after_strobe()
+
+    [beat] = await recv_task
+    await tb.finish_checksum()
+
+    _assert_non_syn_header(beat, sequence=initial_seq, acknowledge=0x34, ack=False, rst=True)
+
+    await tb.cycle(2)
+    assert int(dut.txSeqN_o.value) == (initial_seq + 1) & 0xFF
+    assert int(dut.bufferEmpty_o.value) == 1
+
+
+PARAMETER_SWEEP = [pytest.param({}, id="small_window")]
+
+KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
+
+
+@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_RssiTxFsm(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.rssitxfsmwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/rssi/v1/rtl/RssiTxFsm.vhd",
+                "protocols/rssi/v1/wrappers/RssiTxFsmWrapper.vhd",
+            ],
+        },
+        force_compile=True,
+    )

--- a/tests/protocols/ssi/ssi_test_utils.py
+++ b/tests/protocols/ssi/ssi_test_utils.py
@@ -152,6 +152,14 @@ def keep_mask(data_bytes: int) -> int:
     return (1 << data_bytes) - 1
 
 
+def data_mask_from_keep(keep: int, *, max_bytes: int = 8) -> int:
+    mask = 0
+    for byte_index in range(max_bytes):
+        if keep & (1 << byte_index):
+            mask |= 0xFF << (8 * byte_index)
+    return mask
+
+
 def start_clock(signal, *, period_ns: float = 5.0) -> None:
     # cocotb clocks run in the background once started.
     cocotb.start_soon(Clock(signal, period_ns, unit="ns").start())


### PR DESCRIPTION
### Description
Add the RSSI regression foundation: cocotb protocol helpers, RSSI-focused simulation wrappers, wrapper loading in the RSSI ruckus manifest, and initial RSSI protocol documentation.

The default CI-safe coverage verifies the standalone RSSI checksum block and header encoder. The broader RSSI characterization tests are included but gated behind `RUN_RSSI_KNOWN_ISSUE_TESTS=1` so this foundation PR can merge before the follow-up RTL fix PRs.

### Details
This PR is intentionally limited to regression infrastructure and default-safe tests. It does not include production RSSI RTL fixes.

Included default coverage:
- `tests/protocols/rssi/test_RssiChksum.py`
- `tests/protocols/rssi/test_RssiHeaderReg.py`

Included opt-in follow-up coverage:
- AXI-Lite register interface
- connection FSM
- monitor liveness and BUSY ACK behavior
- RX/TX FSM behavior
- direct `RssiCore` integration
- `RssiCoreWrapper` and multi-stream wrapper integration

Validation:

```text
./.venv/bin/python -B -m pytest -q -p no:cacheprovider tests/protocols/rssi
2 passed, 21 skipped
```

Also checked:

```text
./.venv/bin/python -B -m py_compile tests/protocols/rssi/*.py
```

`make MODULES=/Users/bareese/surf import` could not be rerun in this checkout because `/Users/bareese/surf/ruckus/system_ghdl.mk` is not present.
