### PR TITLE
Correct RSSI monitor busy and liveness timing

### DIFF
--- a/protocols/rssi/v1/rtl/RssiMonitor.vhd
+++ b/protocols/rssi/v1/rtl/RssiMonitor.vhd
@@ -52,8 +52,8 @@ entity RssiMonitor is
       STATUS_WIDTH_G      : positive := 8;
       CNT_WIDTH_G         : positive := 32;
       RETRANSMIT_ENABLE_G : boolean  := true
-    --
-      );
+   --
+   );
    port (
       clk_i : in sl;
       rst_i : in sl;
@@ -185,7 +185,9 @@ architecture rtl of RssiMonitor is
    signal rin      : RegType;
    signal s_status : slv(STATUS_WIDTH_G - 1 downto 0);
 --
+
 begin
+
    -- Status assignment
    s_status(0) <= r.retransMax and r.sndResend and not r.sndResendD1;
    s_status(1) <= r.nullTout;
@@ -312,8 +314,6 @@ begin
          if (connActive_i = '0' or
              (rxValid_i = '1' and rxFlags_i.data = '1') or
              (rxValid_i = '1' and rxFlags_i.nul = '1') or
-             (rxValid_i = '1' and rxFlags_i.ack = '1') or
-             (rxValid_i = '1' and rxFlags_i.busy = '1') or
              RETRANSMIT_ENABLE_G = false  -- Disable null timeout
              ) then
             v.nullToutCnt := (others => '0');
@@ -356,7 +356,7 @@ begin
           dataHeadSt_i = '1' or
           rstHeadSt_i = '1' or
           nullHeadSt_i = '1' or
-          (rxLastSeqN_i - r.lastAckSeqN) = 0
+          ((rxLastSeqN_i - r.lastAckSeqN) = 0 and localBusy_i = '0')
           ) then
          v.ackToutCnt := (others => '0');
       elsif ((rxLastSeqN_i - r.lastAckSeqN) > 0 and (rxLastSeqN_i - r.lastAckSeqN) <= rxWindowSize_i) or (localBusy_i = '1') then
@@ -374,8 +374,16 @@ begin
           ) then
          v.sndAck := '0';
 
+      -- Periodic BUSY acknowledgment request.  The RSSI page recommends
+      -- Retransmission Timeout/2 so the peer keeps its retransmission timer
+      -- reset while this receiver remains busy.
+      elsif (localBusy_i = '1' and (rxLastSeqN_i - r.lastAckSeqN) = 0 and
+             r.ackToutCnt >= ((conv_integer(rssiParam_i.retransTout)*SAMPLES_PER_TIME_C)/2)) then
+         v.sndAck := '1';
+
       -- Timeout acknowledgment request
-      elsif (r.ackToutCnt >= (conv_integer(rssiParam_i.cumulAckTout)* SAMPLES_PER_TIME_C)) then
+      elsif ((rxLastSeqN_i - r.lastAckSeqN) > 0 and
+             r.ackToutCnt >= (conv_integer(rssiParam_i.cumulAckTout)* SAMPLES_PER_TIME_C)) then
          v.sndAck := '1';
 
       -- Cumulative acknowledgment request
@@ -460,4 +468,5 @@ begin
    resendCnt_o <= r.resendCnt;
    reconCnt_o  <= r.reconCnt;
 ---------------------------------------------------------------------
+
 end architecture rtl;

--- a/tests/protocols/rssi/test_RssiMonitor.py
+++ b/tests/protocols/rssi/test_RssiMonitor.py
@@ -34,7 +34,7 @@ import pytest
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 
-from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.common.regression_utils import run_surf_vhdl_test
 
 
 class TB:
@@ -222,10 +222,7 @@ async def local_busy_generates_periodic_ack_after_cumulative_timeout_test(dut):
 
 PARAMETER_SWEEP = [pytest.param({}, id="server_monitor")]
 
-KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
 
-
-@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
 @pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
 def test_RssiMonitor(parameters):
     run_surf_vhdl_test(


### PR DESCRIPTION
### Description
Fix RSSI monitor liveness and local-BUSY ACK timing.

`RssiMonitor` previously treated received ACK-only and BUSY-only traffic as server liveness, which allowed control traffic to reset the server null-timeout counter even when the peer was no longer sending DATA or NULL keepalive segments. It also stopped the ACK timeout counter when no new receive sequence number was pending, which prevented a receiver that remained locally busy from periodically advertising BUSY after the first busy ACK was sent.

This changes the server null-timeout refresh condition to DATA or NULL receipt only, and lets local BUSY drive periodic ACK requests at `Retransmission Timeout/2` when there is no newly pending receive sequence number to acknowledge.

### Details
This fix is necessary because RSSI liveness is meant to prove that the peer is still sending sequenced DATA/NULL traffic. ACK-only or BUSY-only control traffic can show that something is still responding, but it should not keep the server-side null-timeout detector alive indefinitely. Likewise, BUSY flow control relies on repeated BUSY advertisement so the peer transmitter does not advance into retransmit/close behavior while the receiver remains busy.

This behavior is called out in the SLAC RSSI protocol page:
- In the Null Timeout section, the server closes the connection if no DATA or NULL segments arrive within the negotiated Null Timeout.
- In the BUSY flow-control section, a busy receiver should either put BUSY on outgoing data or periodically send ACK segments with BUSY set, with Retransmission Timeout/2 as the recommended period.

This has usually worked until now because common deployments do not sit for long periods in ACK/BUSY-only traffic with no DATA or NULL keepalive, and local BUSY is often transient. A rising local-BUSY edge already generated an immediate ACK, so short backpressure events were covered. The missing behavior shows up in directed tests that keep the receiver busy after that first ACK or continue sending control-only traffic while DATA/NULL liveness is absent.

The Rogue RSSI controller already follows this split in `~/rogue/src/rogue/protocols/rssi/Controller.cpp`:
- received ACKs release transmit-buffer entries, and received BUSY only updates the remote-busy state;
- DATA or NULL in the expected sequence is what advances the receive sequence and is queued toward the application path, with NULL later dropped at the application boundary;
- in open state, Rogue sends an ACK frame when an ACK is pending or local busy persists past the cumulative-ACK timeout, and `transportTx()` marks that outgoing ACK busy while preserving the last acknowledged receive sequence when the local endpoint is busy.

So this PR changes the RTL monitor to match the Rogue implementation and the SLAC RSSI protocol intent: ACK/BUSY-only control traffic does not count as DATA/NULL liveness, and persistent local BUSY is periodically re-advertised.

Validation:

```text
./.venv/bin/vsg -c vsg-linter.yml -f protocols/rssi/v1/rtl/RssiMonitor.vhd protocols/rssi/v1/wrappers/RssiMonitorWrapper.vhd
./.venv/bin/python -B -m pytest -q -p no:cacheprovider tests/protocols/rssi/test_RssiMonitor.py
1 passed
./.venv/bin/python -B -m pytest -q -p no:cacheprovider tests/protocols/rssi
3 passed, 20 skipped
```

### Related
The RSSI regression foundation (#1453) is already merged into pre-release, so
this now targets pre-release directly.

