### PR TITLE
Correct RSSI TX NULL ordering and checksum injection

### DIFF
--- a/protocols/rssi/v1/rtl/RssiTxFsm.vhd
+++ b/protocols/rssi/v1/rtl/RssiTxFsm.vhd
@@ -64,7 +64,7 @@ entity RssiTxFsm is
       DATA_HEADER_SIZE_G : natural := 8;
 
       HEADER_CHKSUM_EN_G : boolean := true
-      );
+   );
    port (
       clk_i : in sl;
       rst_i : in sl;
@@ -153,7 +153,7 @@ entity RssiTxFsm is
 
       -- Segment buffer indicator
       bufferEmpty_o : out sl
-      );
+   );
 end entity RssiTxFsm;
 
 architecture rtl of RssiTxFsm is
@@ -185,7 +185,7 @@ architecture rtl of RssiTxFsm is
       RESEND_H_S,
       RESEND_DATA_S,
       RESEND_PP_S
-      );
+   );
 
    type AppStateType is (
       IDLE_S,
@@ -193,17 +193,16 @@ architecture rtl of RssiTxFsm is
       SEG_RCV_S,
       SEG_RDY_S,
       SEG_LEN_ERR
-      );
+   );
 
    type AckStateType is (
       IDLE_S,
       ERR_S,
       ACK_S
     --EACK_S,
-      );
+   );
 
    type RegType is record
-
       -- Buffer window handling and acknowledgment control
       -----------------------------------------
       windowArray    : WindowTypeArray(0 to 2 ** WINDOW_ADDR_SIZE_G-1);
@@ -275,7 +274,7 @@ architecture rtl of RssiTxFsm is
       tspSsiSlave  : SsiSlaveType;
 
       -- State Machine
-      tspState   : tspStateType;
+      tspState   : TspStateType;
       txTspState : slv(7 downto 0);
    end record RegType;
 
@@ -358,6 +357,7 @@ architecture rtl of RssiTxFsm is
    signal rin               : RegType;
    signal s_chksum          : slv(chksum_i'range);
    signal s_headerAndChksum : slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
+   signal s_corruptHeader   : slv(RSSI_WORD_WIDTH_C*8-1 downto 0);
 
    -- attribute dont_touch                      : string;
    -- attribute dont_touch of r                 : signal is "TRUE";
@@ -369,13 +369,15 @@ begin
    -- Send all 0 if checksum disabled
    s_chksum          <= ite(HEADER_CHKSUM_EN_G, chksum_i, (chksum_i'range => '0'));
    s_headerAndChksum <= rdHeaderData_i(63 downto 16) & s_chksum(15 downto 0);
+   s_corruptHeader   <= s_headerAndChksum xor x"000000000000FFFF";
 
    -----------------------------------------------------------------------------------------------
    comb : process (ackN_i, ack_i, appSsiMaster_i, bufferSize_i, chksumValid_i,
                    closed_i, connActive_i, headerLength_i, headerRdy_i,
                    initSeqN_i, injectFault_i, r, rdBuffData_i, rdHeaderData_i,
-                   rst_i, s_headerAndChksum, sndAck_i, sndNull_i, sndResend_i,
-                   sndRst_i, sndSyn_i, tspSsiSlave_i, windowSize_i) is
+                   rst_i, s_corruptHeader, s_headerAndChksum, sndAck_i,
+                   sndNull_i, sndResend_i, sndRst_i, sndSyn_i, tspSsiSlave_i,
+                   windowSize_i) is
 
       variable v : RegType;
 
@@ -892,7 +894,7 @@ begin
                v.tspState := RESEND_INIT_S;
             elsif (sndAck_i = '1') then
                v.tspState := ACK_H_S;
-            elsif (sndNull_i = '1' and r.bufferFull = '0' and r.appBusy = '0') then
+            elsif (sndNull_i = '1' and r.bufferEmpty = '1' and r.appBusy = '0') then
                v.tspState := NULL_WE_S;
             elsif (connActive_i = '0') then
                v.tspState := INIT_S;
@@ -943,6 +945,7 @@ begin
                   -- Add checksum
                   v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
                   v.tspSsiMaster.valid                                := '1';
+                  v.tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0)   := (others => '1');
                   v.tspSsiMaster.eof                                  := '1';
                   v.tspSsiMaster.eofe                                 := '0';
 
@@ -1007,8 +1010,13 @@ begin
                v.tspSsiMaster.eof   := '1';
                v.tspSsiMaster.eofe  := '0';
 
-               -- Add checksum to last two bytes
-               v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
+               if (r.injectFaultReg = '1') then
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_corruptHeader);
+               else
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
+               end if;
+
+               v.injectFaultReg := '0';
 
                --
                if connActive_i = '0' then
@@ -1178,8 +1186,13 @@ begin
                v.tspSsiMaster.eof   := '1';
                v.tspSsiMaster.eofe  := '0';
 
-               -- Add checksum to last two bytes
-               v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
+               if (r.injectFaultReg = '1') then
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_corruptHeader);
+               else
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);
+               end if;
+
+               v.injectFaultReg := '0';
 
                -- Increment seqN
                v.nextSeqN := r.nextSeqN+1;  -- Increment SEQ number at the end of segment transmission
@@ -1261,13 +1274,14 @@ begin
                v.tspSsiMaster.valid := '1';
                v.tspSsiMaster.sof   := '1';
                v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0) := (others => '1');
                v.tspSsiMaster.dest  := (others => '0');
                v.tspSsiMaster.eof   := '0';
                v.tspSsiMaster.eofe  := '0';
 
                -- Inject fault into checksum
                if (r.injectFaultReg = '1') then
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1');  -- Flip bits in checksum! Point of fault injection!
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_corruptHeader);
                else
                   v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);  -- Add checksum to last two bytes
                end if;
@@ -1307,6 +1321,7 @@ begin
             -- Other SSI parameters
             v.tspSsiMaster.sof                                  := '0';
             v.tspSsiMaster.strb                                 := (others => '1');
+            v.tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0)   := (others => '1');
             v.tspSsiMaster.dest                                 := (others => '0');
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := rdBuffData_i;
 
@@ -1440,11 +1455,12 @@ begin
                v.tspSsiMaster.sof   := '1';
                v.tspSsiMaster.valid := '1';
                v.tspSsiMaster.strb  := (others => '1');
+               v.tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0) := (others => '1');
                v.tspSsiMaster.dest  := (others => '0');
 
                -- Inject fault into checksum
                if (r.injectFaultReg = '1') then
-                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum) xor (s_headerAndChksum'range => '1');  -- Flip bits in checksum! Point of fault injection!
+                  v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_corruptHeader);
                else
                   v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := endianSwap64(s_headerAndChksum);  -- Add checksum to last two bytes
                end if;
@@ -1501,6 +1517,7 @@ begin
             -- Other SSI parameters
             v.tspSsiMaster.sof                                  := '0';
             v.tspSsiMaster.strb                                 := (others => '1');
+            v.tspSsiMaster.keep(RSSI_WORD_WIDTH_C-1 downto 0)   := (others => '1');
             v.tspSsiMaster.dest                                 := (others => '0');
             v.tspSsiMaster.data(RSSI_WORD_WIDTH_C*8-1 downto 0) := rdBuffData_i;
 
@@ -1639,4 +1656,5 @@ begin
    end process seq;
 
 ---------------------------------------------------------------------
+
 end architecture rtl;

--- a/tests/protocols/rssi/test_RssiTxFsm.py
+++ b/tests/protocols/rssi/test_RssiTxFsm.py
@@ -39,7 +39,7 @@ import cocotb
 import pytest
 from cocotb.triggers import FallingEdge, RisingEdge, Timer
 
-from tests.common.regression_utils import env_flag, run_surf_vhdl_test
+from tests.common.regression_utils import run_surf_vhdl_test
 from tests.protocols.rssi.rssi_test_utils import (
     RssiParams,
     build_ack_header,
@@ -815,10 +815,7 @@ async def rst_segment_emits_header_and_consumes_sequence_without_buffering_test(
 
 PARAMETER_SWEEP = [pytest.param({}, id="small_window")]
 
-KNOWN_ISSUE_REASON = "set RUN_RSSI_KNOWN_ISSUE_TESTS=1 to run RSSI cases that require follow-up RTL fixes"
 
-
-@pytest.mark.skipif(not env_flag("RUN_RSSI_KNOWN_ISSUE_TESTS", default=False), reason=KNOWN_ISSUE_REASON)
 @pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
 def test_RssiTxFsm(parameters):
     run_surf_vhdl_test(


### PR DESCRIPTION
### Description
Fix RSSI transmit-side NULL ordering and checksum fault injection behavior.

`RssiTxFsm` previously allowed a NULL segment whenever the transmit window was not full. That meant a keepalive NULL could be inserted while earlier DATA was still unacknowledged. Since NULL is a sequenced RSSI segment and is saved in the transmit window for retransmission, inserting it ahead of outstanding DATA can let the peer advance receive sequencing around a lost DATA segment instead of forcing the DATA retransmission path to recover in order.

The debug checksum fault-injection path also only applied to DATA/resend headers and flipped the entire 64-bit header word. That did create a bad checksum, but it also corrupted protocol fields such as flags, sequence, and acknowledge. This made the diagnostic less representative of a real checksum-only header error, and it did not cover ACK-only or NULL headers.

This changes `RssiTxFsm` so NULL requests are accepted only when the transmit window is empty and the application side is idle. It also changes fault injection to flip only the 16-bit checksum field and applies that behavior consistently to ACK, NULL, DATA, and resend headers. The TX FSM regression is ungated now that these cases pass.

### Details
This fix is necessary because RSSI treats NULL as a real sequenced transport segment, not as an unsequenced idle symbol. The TX FSM file documents that sequence number is incremented for SYN, DATA, NULL, and RST, and that DATA, NULL, and RST are saved into the transmit buffer. A NULL keepalive therefore must not be allowed to consume a later sequence number while earlier DATA is still awaiting acknowledgement.

This has usually worked until now because NULL requests are generated by idle-time monitoring, so normal traffic often either has no outstanding DATA when NULL fires or receives ACKs quickly enough that the transmit window is empty again. The ordering bug shows up in directed tests that hold a DATA segment unacknowledged and then request NULL. The checksum-injection bug was also mostly invisible in normal operation because `injectFault_i` is a diagnostic path; without injection, the normal checksum generator still produced valid headers.

The relevant protocol intent is:
- DATA, NULL, SYN, and RST consume RSSI sequence numbers; ACK-only traffic does not.
- DATA, NULL, and RST are retransmittable transmit-window entries.
- NULL is the idle/keepalive segment driven by the negotiated null timeout, so it should not bypass older sequenced data.
- The RSSI header checksum is the final 16-bit checksum field of the header; a checksum-fault diagnostic should corrupt that field without also changing flags, sequence, acknowledge, or payload data.

The Rogue RSSI controller already follows the same model:
- application DATA waits while the transmit list is full before calling `transportTx(..., seqUpdate=true)` in [`Controller.cpp`](https://github.com/slaclab/rogue/blob/e30812114e7e6c338d8ab204d2ec2f61aa1527e8/src/rogue/protocols/rssi/Controller.cpp#L397-L410);
- `transportTx()` stores only sequenced frames in `txList_`, increments `locSequence_` for those frames, and updates `txTime_` on every transmitted frame in [`Controller.cpp`](https://github.com/slaclab/rogue/blob/e30812114e7e6c338d8ab204d2ec2f61aa1527e8/src/rogue/protocols/rssi/Controller.cpp#L591-L619);
- `stateOpen()` sends NULL only after the transmit-idle/null-timeout condition, marks it as ACK+NULL, and passes `seqUpdate=doNull` so NULL is sequenced like DATA in [`Controller.cpp`](https://github.com/slaclab/rogue/blob/e30812114e7e6c338d8ab204d2ec2f61aa1527e8/src/rogue/protocols/rssi/Controller.cpp#L922-L934);
- retransmission walks the outstanding sequence range from the last acknowledged transmit sequence to the current local sequence in [`Controller.cpp`](https://github.com/slaclab/rogue/blob/e30812114e7e6c338d8ab204d2ec2f61aa1527e8/src/rogue/protocols/rssi/Controller.cpp#L937-L944);
- `Header::update()` rebuilds the RSSI header fields and writes the computed checksum into the checksum field in [`Header.cpp`](https://github.com/slaclab/rogue/blob/e30812114e7e6c338d8ab204d2ec2f61aa1527e8/src/rogue/protocols/rssi/Header.cpp#L172-L202). Rogue does not have SURF's hardware `injectFault_i` diagnostic, but its normal header path keeps flags/sequence/acknowledge distinct from the checksum field, which is the behavior this diagnostic is meant to perturb.

So this PR changes the RTL TX FSM to match the Rogue implementation and RSSI protocol intent: keepalive NULLs remain sequenced traffic and wait for the outstanding transmit window to drain, and checksum fault injection corrupts the checksum field only.

Validation:

```text
make MODULES="$PWD" import
pytest -q -p no:cacheprovider tests/protocols/rssi/test_RssiTxFsm.py
1 passed
pytest -q -p no:cacheprovider tests/protocols/rssi
6 passed, 17 skipped
flake8 --count tests/protocols/rssi
0
vsg -c vsg-linter.yml -f protocols/rssi/v1/rtl/RssiTxFsm.vhd protocols/rssi/v1/wrappers/RssiTxFsmWrapper.vhd
0 violations
```

### Related
Follows #1453, which is now merged into `pre-release`. This PR targets `pre-release` directly and
carries a single commit containing only the TX FSM fix.
