### PR TITLE
Fix DHCP BOOTP broadcast flag and XID continuity in UdpEngineDhcp (RFC 2131)

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Parallel Regression Tests
         run: |
           make MODULES=$PWD import
-          python -m pytest --cov -v -n auto --dist=worksteal tests/axi tests/base tests/dsp tests/protocols tests/ethernet/RoCEv2
+          python -m pytest --cov -v -n auto --dist=worksteal tests/axi tests/base tests/dsp tests/protocols tests/ethernet/RoCEv2 tests/ethernet/UdpEngine
 
       - name: Code Coverage
         run: |

--- a/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
@@ -294,7 +294,10 @@ begin
                      v.txMaster.tData(7 downto 0)   := r.xid(31 downto 24);
                   -- SECS/FLAGS
                   when 2 =>
-                     v.txMaster.tData(31 downto 0) := x"00080000";
+                     -- FLAGS = 0x8000: BOOTP broadcast flag (RFC 2131 4.1) so the
+                     -- server broadcasts the Offer/ACK rather than unicasting to the
+                     -- not-yet-leased yiaddr.
+                     v.txMaster.tData(31 downto 0) := x"00800000";
                   -- SIADDR
                   when 5 =>
                      -- Check for DHCP request

--- a/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
+++ b/ethernet/UdpEngine/rtl/UdpEngineDhcp.vhd
@@ -262,8 +262,12 @@ begin
                   if r.commCnt = 0 then
                      -- Reset the counter
                      v.cnt   := 0;
-                     -- Increment the counter
-                     v.xid   := r.xid + 1;
+                     -- Start a new transaction ID only for a new DHCP Discover or a
+                     -- lease renewal; the SELECTING-state DHCP Request must reuse the
+                     -- XID from the Discover/Offer exchange (RFC 2131 4.4.1, Table 5)
+                     if (r.dhcpReq = '0') or (r.leaseCnt /= 0) then
+                        v.xid := r.xid + 1;
+                     end if;
                      -- Next state
                      v.state := REQ_S;
                   end if;

--- a/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
+++ b/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
@@ -33,6 +33,7 @@ from tests.ethernet.EthMacCore.ethmac_test_utils import (
 )
 from tests.ethernet.UdpEngine.udp_test_utils import (
     DHCP_ACK,
+    DHCP_BOOTP_FLAG_BROADCAST,
     DHCP_DISCOVER,
     DHCP_OFFER,
     DHCP_REQUEST,
@@ -40,6 +41,7 @@ from tests.ethernet.UdpEngine.udp_test_utils import (
     LEGACY_MAC_WIRES,
     UDP_RTL_SOURCES,
     build_dhcp_reply_payload,
+    extract_dhcp_bootp_flags,
     extract_dhcp_message_type,
     extract_dhcp_requested_ip,
     extract_dhcp_server_identifier,
@@ -69,6 +71,16 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
     discover_xid = extract_dhcp_xid(discover_payload)
     assert extract_dhcp_message_type(discover_payload) == DHCP_DISCOVER
 
+    # RFC 2131 4.1: a client that cannot receive unicast datagrams before its IP
+    # is configured must set the BOOTP broadcast flag (bit 15, 0x8000). With the
+    # flag clear, a spec-compliant server unicasts its Offer to the not-yet-leased
+    # yiaddr, which may never be delivered to the client (observed in the field as
+    # an endless Discover/Offer loop), so the client never sends a Request.
+    discover_flags = extract_dhcp_bootp_flags(discover_payload)
+    assert discover_flags & DHCP_BOOTP_FLAG_BROADCAST, (
+        f"BOOTP broadcast flag missing from Discover: flags=0x{discover_flags:04x}"
+    )
+
     # A matching offer should move the state machine into the request phase
     # while preserving the same DHCP transaction identifier.
     offer_payload = build_dhcp_reply_payload(
@@ -93,6 +105,11 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
     assert extract_dhcp_message_type(request_payload) == DHCP_REQUEST
     assert extract_dhcp_requested_ip(request_payload) == "192.168.2.44"
     assert extract_dhcp_server_identifier(request_payload) == LEGACY_IPS[1]
+
+    request_flags = extract_dhcp_bootp_flags(request_payload)
+    assert request_flags & DHCP_BOOTP_FLAG_BROADCAST, (
+        f"BOOTP broadcast flag missing from Request: flags=0x{request_flags:04x}"
+    )
 
     # The ack is the step that should finally publish the leased IP address on
     # the wrapper-visible `dhcpIp` output.

--- a/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
+++ b/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
@@ -76,9 +76,12 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
     # flag clear, a spec-compliant server unicasts its Offer to the not-yet-leased
     # yiaddr, which may never be delivered to the client (observed in the field as
     # an endless Discover/Offer loop), so the client never sends a Request.
+    # RFC 2131 also requires the remaining 15 flag bits to be zero, so check
+    # for exact equality rather than just the broadcast bit.
     discover_flags = extract_dhcp_bootp_flags(discover_payload)
-    assert discover_flags & DHCP_BOOTP_FLAG_BROADCAST, (
-        f"BOOTP broadcast flag missing from Discover: flags=0x{discover_flags:04x}"
+    assert discover_flags == DHCP_BOOTP_FLAG_BROADCAST, (
+        f"Unexpected BOOTP flags in Discover: flags=0x{discover_flags:04x} "
+        f"(expected 0x{DHCP_BOOTP_FLAG_BROADCAST:04x})"
     )
 
     # A matching offer should move the state machine into the request phase
@@ -107,8 +110,9 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
     assert extract_dhcp_server_identifier(request_payload) == LEGACY_IPS[1]
 
     request_flags = extract_dhcp_bootp_flags(request_payload)
-    assert request_flags & DHCP_BOOTP_FLAG_BROADCAST, (
-        f"BOOTP broadcast flag missing from Request: flags=0x{request_flags:04x}"
+    assert request_flags == DHCP_BOOTP_FLAG_BROADCAST, (
+        f"Unexpected BOOTP flags in Request: flags=0x{request_flags:04x} "
+        f"(expected 0x{DHCP_BOOTP_FLAG_BROADCAST:04x})"
     )
 
     # The ack is the step that should finally publish the leased IP address on

--- a/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
+++ b/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
@@ -121,6 +121,12 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
     request_payload = payload_from_beats(request_observed)
     request_xid = extract_dhcp_xid(request_payload)
     assert extract_dhcp_message_type(request_payload) == DHCP_REQUEST
+    # RFC 2131 4.4.1 / Table 5: the SELECTING-state request reuses the XID from
+    # the discover/offer exchange.
+    assert request_xid == discover_xid, (
+        f"Request XID 0x{request_xid:08x} does not match Discover XID "
+        f"0x{discover_xid:08x}"
+    )
     assert extract_dhcp_requested_ip(request_payload) == "192.168.2.44"
     assert extract_dhcp_server_identifier(request_payload) == LEGACY_IPS[1]
 

--- a/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
+++ b/tests/ethernet/UdpEngine/test_UdpEngineDhcp.py
@@ -15,6 +15,13 @@
 #   DHCP offer, capture the resulting request, then inject the matching ack.
 # - Checks: The outbound discover and request must advertise the correct DHCP
 #   message type and XID continuity, and the final ack must update `dhcpIp`.
+# - Negative paths: Offers whose XID or CHADDR do not match the outstanding
+#   transaction must be discarded (RFC 2131 4.4.1) so the engine re-discovers
+#   instead of advancing to the request phase or leasing an address.
+# - Robustness: The option parser must complete the exchange when options are
+#   reordered, padded, and interleaved with unknown/odd-length options, and the
+#   engine must retransmit its discover after the communication timeout when no
+#   server replies.
 # - Timing: The test relies on the wrapper's shortened timers so the protocol
 #   steps occur through the real timeout logic rather than direct state forcing.
 
@@ -36,6 +43,13 @@ from tests.ethernet.UdpEngine.udp_test_utils import (
     DHCP_BOOTP_FLAG_BROADCAST,
     DHCP_DISCOVER,
     DHCP_OFFER,
+    DHCP_OPT_DOMAIN_NAME,
+    DHCP_OPT_END,
+    DHCP_OPT_LEASE_TIME,
+    DHCP_OPT_MESSAGE_TYPE,
+    DHCP_OPT_PAD,
+    DHCP_OPT_SERVER_IDENTIFIER,
+    DHCP_OPT_SUBNET_MASK,
     DHCP_REQUEST,
     LEGACY_IPS,
     LEGACY_MAC_WIRES,
@@ -47,6 +61,7 @@ from tests.ethernet.UdpEngine.udp_test_utils import (
     extract_dhcp_server_identifier,
     extract_dhcp_xid,
     ipv4_config_word,
+    ipv4_to_bytes,
     setup_udp_dhcp_bench,
 )
 
@@ -135,6 +150,194 @@ async def udp_engine_dhcp_offer_ack_sequence_test(dut):
         if int(dut.dhcpIp.value) == ipv4_config_word("192.168.2.44"):
             break
     assert int(dut.dhcpIp.value) == ipv4_config_word("192.168.2.44")
+
+
+@cocotb.test()
+async def udp_engine_dhcp_rejects_mismatched_xid_test(dut):
+    # RFC 2131 4.4.1: the client discards replies whose XID does not match its
+    # outstanding transaction. A corrupted offer must not advance the state
+    # machine to the request phase; the next outbound frame is a re-discover.
+    bench = await setup_udp_dhcp_bench(dut)
+
+    discover_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=256,
+    )
+    discover_payload = payload_from_beats(discover_observed)
+    assert extract_dhcp_message_type(discover_payload) == DHCP_DISCOVER
+    discover_xid = extract_dhcp_xid(discover_payload)
+
+    bad_offer = build_dhcp_reply_payload(
+        message_type=DHCP_OFFER,
+        xid=(discover_xid ^ 0xDEADBEEF) & 0xFFFFFFFF,
+        client_mac=LEGACY_MAC_WIRES[0],
+        yiaddr="192.168.2.44",
+        siaddr=LEGACY_IPS[1],
+    )
+    offer_send = cocotb.start_soon(
+        send_contiguous_frame(bench.source, frame_beats_from_bytes(bad_offer), clk=bench.clk)
+    )
+    next_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=512,
+    )
+    await offer_send
+    next_payload = payload_from_beats(next_observed)
+    assert extract_dhcp_message_type(next_payload) == DHCP_DISCOVER, (
+        "Engine advanced past a mismatched-XID offer instead of discarding it"
+    )
+    assert int(dut.dhcpIp.value) == 0
+
+
+@cocotb.test()
+async def udp_engine_dhcp_rejects_mismatched_chaddr_test(dut):
+    # A reply whose CHADDR does not match the local MAC belongs to another
+    # client and must be discarded even when the XID happens to match.
+    bench = await setup_udp_dhcp_bench(dut)
+
+    discover_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=256,
+    )
+    discover_payload = payload_from_beats(discover_observed)
+    assert extract_dhcp_message_type(discover_payload) == DHCP_DISCOVER
+    discover_xid = extract_dhcp_xid(discover_payload)
+
+    bad_offer = build_dhcp_reply_payload(
+        message_type=DHCP_OFFER,
+        xid=discover_xid,
+        client_mac=LEGACY_MAC_WIRES[1],  # bench client is LEGACY_MAC_WIRES[0]
+        yiaddr="192.168.2.44",
+        siaddr=LEGACY_IPS[1],
+    )
+    offer_send = cocotb.start_soon(
+        send_contiguous_frame(bench.source, frame_beats_from_bytes(bad_offer), clk=bench.clk)
+    )
+    next_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=512,
+    )
+    await offer_send
+    next_payload = payload_from_beats(next_observed)
+    assert extract_dhcp_message_type(next_payload) == DHCP_DISCOVER, (
+        "Engine advanced past a mismatched-CHADDR offer instead of discarding it"
+    )
+    assert int(dut.dhcpIp.value) == 0
+
+
+@cocotb.test()
+async def udp_engine_dhcp_option_order_robustness_test(dut):
+    # DHCP options are a TLV stream with no mandated ordering. Real servers
+    # interleave pads and unknown options (a production capture at SLAC carried
+    # subnet mask, a 17-byte domain name, server identifier, and lease time
+    # ahead of nothing in particular). The parser must complete the full DORA
+    # exchange when the message-type option arrives last, pads are interleaved,
+    # and unknown odd-length options must be skipped byte-wise.
+    bench = await setup_udp_dhcp_bench(dut)
+
+    def scrambled_options(message_type: int) -> bytes:
+        return bytes(
+            [DHCP_OPT_PAD]
+            + [DHCP_OPT_SUBNET_MASK, 4] + list(ipv4_to_bytes("255.255.255.0"))
+            + [DHCP_OPT_DOMAIN_NAME, 17] + list(b"slac.stanford.edu")
+            + [DHCP_OPT_LEASE_TIME, 4] + list((120).to_bytes(4, byteorder="big"))
+            + [DHCP_OPT_SERVER_IDENTIFIER, 4] + list(ipv4_to_bytes(LEGACY_IPS[1]))
+            + [DHCP_OPT_PAD, DHCP_OPT_PAD]
+            + [DHCP_OPT_MESSAGE_TYPE, 1, message_type]
+            + [DHCP_OPT_END]
+        )
+
+    discover_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=256,
+    )
+    discover_payload = payload_from_beats(discover_observed)
+    assert extract_dhcp_message_type(discover_payload) == DHCP_DISCOVER
+    discover_xid = extract_dhcp_xid(discover_payload)
+
+    offer_payload = build_dhcp_reply_payload(
+        message_type=DHCP_OFFER,
+        xid=discover_xid,
+        client_mac=LEGACY_MAC_WIRES[0],
+        yiaddr="192.168.2.44",
+        siaddr=LEGACY_IPS[1],
+        raw_options=scrambled_options(DHCP_OFFER),
+    )
+    offer_send = cocotb.start_soon(
+        send_contiguous_frame(bench.source, frame_beats_from_bytes(offer_payload), clk=bench.clk)
+    )
+    request_observed = await recv_frame(
+        bench.sink,
+        clk=bench.clk,
+        ready_signal=dut.mDhcpTReady,
+        timeout_cycles=256,
+    )
+    await offer_send
+    request_payload = payload_from_beats(request_observed)
+    request_xid = extract_dhcp_xid(request_payload)
+    assert extract_dhcp_message_type(request_payload) == DHCP_REQUEST
+    assert extract_dhcp_requested_ip(request_payload) == "192.168.2.44"
+    assert extract_dhcp_server_identifier(request_payload) == LEGACY_IPS[1]
+
+    ack_payload = build_dhcp_reply_payload(
+        message_type=DHCP_ACK,
+        xid=request_xid,
+        client_mac=LEGACY_MAC_WIRES[0],
+        yiaddr="192.168.2.44",
+        siaddr=LEGACY_IPS[1],
+        raw_options=scrambled_options(DHCP_ACK),
+    )
+    ack_send = cocotb.start_soon(
+        send_contiguous_frame(bench.source, frame_beats_from_bytes(ack_payload), clk=bench.clk)
+    )
+    await ack_send
+    for _ in range(DHCP_ACK_PUBLISH_TIMEOUT_CYCLES):
+        await cycle(bench.clk, 1)
+        if int(dut.dhcpIp.value) == ipv4_config_word("192.168.2.44"):
+            break
+    assert int(dut.dhcpIp.value) == ipv4_config_word("192.168.2.44")
+
+
+@cocotb.test()
+async def udp_engine_dhcp_discover_retransmit_test(dut):
+    # With no server reply, the engine must retransmit the discover after its
+    # communication timeout rather than stalling. XID handling across
+    # retransmissions is deliberately unconstrained (RFC 2131 allows either
+    # reusing or regenerating it).
+    bench = await setup_udp_dhcp_bench(dut)
+
+    first_payload = payload_from_beats(
+        await recv_frame(
+            bench.sink,
+            clk=bench.clk,
+            ready_signal=dut.mDhcpTReady,
+            timeout_cycles=256,
+        )
+    )
+    assert extract_dhcp_message_type(first_payload) == DHCP_DISCOVER
+
+    second_payload = payload_from_beats(
+        await recv_frame(
+            bench.sink,
+            clk=bench.clk,
+            ready_signal=dut.mDhcpTReady,
+            timeout_cycles=512,
+        )
+    )
+    assert extract_dhcp_message_type(second_payload) == DHCP_DISCOVER, (
+        "Engine failed to retransmit the discover after the communication timeout"
+    )
+    assert int(dut.dhcpIp.value) == 0
 
 
 @pytest.mark.parametrize("parameters", [pytest.param({}, id="udp_engine_dhcp_flat_wrapper")])

--- a/tests/ethernet/UdpEngine/udp_test_utils.py
+++ b/tests/ethernet/UdpEngine/udp_test_utils.py
@@ -72,6 +72,8 @@ DHCP_OPT_REQUESTED_IP = 50
 DHCP_OPT_LEASE_TIME = 51
 DHCP_OPT_SERVER_IDENTIFIER = 54
 DHCP_OPT_END = 255
+DHCP_BOOTP_FLAGS_OFFSET = 10
+DHCP_BOOTP_FLAG_BROADCAST = 0x8000
 
 
 @dataclass
@@ -238,6 +240,14 @@ def build_dhcp_reply_payload(
 
 def extract_dhcp_xid(payload: bytes) -> int:
     return int.from_bytes(payload[4:8], byteorder="big")
+
+
+def extract_dhcp_bootp_flags(payload: bytes) -> int:
+    """Return the 16-bit big-endian BOOTP flags field (header bytes 10-11)."""
+    return int.from_bytes(
+        payload[DHCP_BOOTP_FLAGS_OFFSET : DHCP_BOOTP_FLAGS_OFFSET + 2],
+        byteorder="big",
+    )
 
 
 def extract_dhcp_message_type(payload: bytes) -> int | None:

--- a/tests/ethernet/UdpEngine/udp_test_utils.py
+++ b/tests/ethernet/UdpEngine/udp_test_utils.py
@@ -67,6 +67,9 @@ DHCP_HTYPE_ETHERNET = 0x01
 DHCP_HLEN_ETHERNET = 0x06
 DHCP_FIXED_HEADER_BYTES = 240
 DHCP_MAGIC_COOKIE = bytes.fromhex("63825363")
+DHCP_OPT_PAD = 0
+DHCP_OPT_SUBNET_MASK = 1
+DHCP_OPT_DOMAIN_NAME = 15
 DHCP_OPT_MESSAGE_TYPE = 53
 DHCP_OPT_REQUESTED_IP = 50
 DHCP_OPT_LEASE_TIME = 51
@@ -210,6 +213,7 @@ def build_dhcp_reply_payload(
     yiaddr: str,
     siaddr: str,
     lease_time: int = 120,
+    raw_options: bytes | None = None,
 ) -> bytes:
     # DHCP options start after the 240-byte BOOTP fixed header.
     payload = bytearray(DHCP_FIXED_HEADER_BYTES)
@@ -222,6 +226,12 @@ def build_dhcp_reply_payload(
     payload[20:24] = ipv4_to_bytes(siaddr)
     payload[28:34] = client_mac.to_bytes(6, byteorder="big")
     payload[236:240] = DHCP_MAGIC_COOKIE
+    if raw_options is not None:
+        # Caller supplies the full TLV option block (including the end option) so
+        # tests can exercise arbitrary option ordering, padding, and unknown
+        # options without duplicating the fixed-header construction.
+        payload.extend(raw_options)
+        return bytes(payload)
     payload.extend(
         bytes(
             [


### PR DESCRIPTION
## Summary

This PR started as a one-nibble RTL fix for the BOOTP broadcast flag and has grown to close the RFC 2131 coverage gaps that same audit surfaced. It now contains, in order:

1. **BOOTP broadcast-flag fix** (`0x0800` → `0x8000`) + a flags assertion — the original fix.
2. **DHCP corner-case tests** — four new cocotb tests that pass on the flag-fixed RTL (no RTL change).
3. **XID-continuity fix** — a real RFC 2131 §4.4.1 violation in the Discover→Request transaction ID.

Each is a separate commit so it can be reviewed (or dropped) independently.

---

## 1. BOOTP broadcast flag (`0x0800` → `0x8000`)

`UdpEngineDhcp.vhd` builds the outbound DHCP Discover/Request SECS/FLAGS word as `x"00080000"`. Because AXI-stream lane 0 is the first byte on the wire (big-endian; the same convention used for the XID word just above and `CLIENT_HDR_C`), `x"00080000"` transmits as wire bytes `00 00 08 00` → `secs=0x0000`, **`flags=0x0800`**. The RFC 2131 §4.1 broadcast flag is bit 15 = `0x8000`, so the flags-high byte must be `0x80`, not `0x08`. This is a one-nibble typo present in every release since v1.0.0.

Fix: `x"00080000"` → `x"00800000"`.

### Field symptom

Gen1 PRL SIM modules failed to acquire an address via DHCP after a reflash (fresh lease). `tcpdump` showed an endless **Discover → Offer → Discover** loop with no Request. With the broadcast flag clear, the DHCP server unicasts its Offer to the not-yet-leased `yiaddr`; on the affected network segment that unicast is never delivered to the client (it does not yet own the IP), so the Offer never reaches the DHCP engine and the client re-Discovers forever. Modules that already held a lease were unaffected because lease renewal uses unicast Request→ACK and never needs the server to unicast an Offer to an unowned address — so the bug only bites on fresh acquisition (e.g. after any power-cycle/reflash). Setting the broadcast flag makes the server broadcast the Offer/ACK, which the client reliably receives.

The existing `udp_engine_dhcp_offer_ack_sequence_test` exercised the full DORA exchange but never inspected the BOOTP flags field — the coverage gap that let this ship. Added `extract_dhcp_bootp_flags()` (+ `DHCP_BOOTP_FLAGS_OFFSET`, `DHCP_BOOTP_FLAG_BROADCAST`) and exact-equality assertions (RFC 2131 also requires the other 15 flag bits to be zero) on both the Discover and the Request. The Discover assertion **fails on the unpatched RTL** (`flags=0x0800`) and passes with the fix.

---

## 2. DHCP corner-case coverage (test-only)

The DHCP test only covered the happy-path DORA sequence. Four new cocotb tests, all passing on the flag-fixed RTL with **no RTL change**, lock in RFC 2131 client-side behavior:

- **Mismatched XID** — an Offer whose XID differs from the outstanding transaction is discarded; the engine re-discovers instead of advancing to Request (RFC 2131 §4.4.1).
- **Mismatched CHADDR** — an Offer addressed to another client's MAC is discarded even when the XID matches.
- **Option-order robustness** — the full offer/request/ack completes with a scrambled TLV option block (leading pad, subnet mask, 17-byte domain name, lease time, server identifier, interleaved pads, message-type last), exercising the byte-serial option parser's ordering and unknown-option handling.
- **Discover retransmit** — with no server reply, the Discover is retransmitted after the communication timeout rather than stalling.

`build_dhcp_reply_payload` gains a keyword-only `raw_options` escape hatch (default behavior unchanged) so tests can supply an arbitrary option block. The new tests make no assertion about XID relationships across retransmissions (RFC 2131 permits either reuse or regeneration), so they stay valid regardless of the change in §3.

---

## 3. Preserve XID across Discover→Request (RFC 2131 §4.4.1)

`IDLE_S` incremented the transaction ID on **every** transmission, including the SELECTING-state DHCP Request that `VERIFY_S` triggers immediately after accepting an Offer (it forces `commCnt := 0`, re-entering the `IDLE_S` transmit path). RFC 2131 §4.4.1 / Table 5 requires that Request to carry the **same** XID as the Discover/Offer exchange, but the engine sent `discover_xid + 1`.

Fix: guard the increment so it only fires for a new Discover (`dhcpReq = '0'`) or a lease renewal (`leaseCnt /= 0`). The SELECTING Request (`dhcpReq = '1'`, `leaseCnt = 0`) now reuses the existing XID; renewal transactions still take a fresh one.

Fail-first evidence: adding `assert request_xid == discover_xid` to `udp_engine_dhcp_offer_ack_sequence_test` fails on the pre-fix RTL with `Request XID 0x00000002 does not match Discover XID 0x00000001`; with the guard applied the full module passes.

---
