### PR TITLE
Fix RSSI segment FIFO pause threshold for small buffers

### DIFF
--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -88,8 +88,7 @@ entity RssiCore is
 
       -- Counters
       MAX_RETRANS_CNT_G : positive := 2;
-      MAX_CUM_ACK_CNT_G : positive := 3
-   );
+      MAX_CUM_ACK_CNT_G : positive := 3);
    port (
       clk_i : in sl;
       rst_i : in sl;
@@ -699,8 +698,7 @@ begin
       generic map (
          TPD_G        => TPD_G,
          DATA_WIDTH_G => 64,
-         CSUM_WIDTH_G => 16
-      )
+         CSUM_WIDTH_G => 16)
       port map (
          clk_i    => clk_i,
          rst_i    => rst_i,
@@ -787,8 +785,7 @@ begin
       generic map (
          TPD_G        => TPD_G,
          DATA_WIDTH_G => 64,
-         CSUM_WIDTH_G => 16
-      )
+         CSUM_WIDTH_G => 16)
       port map (
          clk_i    => clk_i,
          rst_i    => rst_i,

--- a/protocols/rssi/v1/rtl/RssiCore.vhd
+++ b/protocols/rssi/v1/rtl/RssiCore.vhd
@@ -89,7 +89,7 @@ entity RssiCore is
       -- Counters
       MAX_RETRANS_CNT_G : positive := 2;
       MAX_CUM_ACK_CNT_G : positive := 3
-      );
+   );
    port (
       clk_i : in sl;
       rst_i : in sl;
@@ -128,6 +128,10 @@ end entity RssiCore;
 architecture rtl of RssiCore is
 
    constant BUFFER_ADDR_WIDTH_C : positive := (SEGMENT_ADDR_SIZE_G+WINDOW_ADDR_SIZE_G);
+   -- Pause one segment early, padded by 16 words.  The padding is capped at half
+   -- a segment so that segment buffers smaller than 32 words keep a valid,
+   -- proportional threshold instead of going non-positive.
+   constant FIFO_PAUSE_THRESH_C : positive := (2**SEGMENT_ADDR_SIZE_G) - minimum(16, 2**(SEGMENT_ADDR_SIZE_G-1));
 
    -- Busy Flags
    signal s_localBusy : sl;
@@ -291,8 +295,8 @@ architecture rtl of RssiCore is
    -- attribute dont_touch of s_mAppAxisCtrl : signal is "TRUE";
    -- attribute dont_touch of s_mTspAxisCtrl : signal is "TRUE";
 
-----------------------------------------------------------------------
 begin
+
    -- Assertions to check generics
    assert (1 <= MAX_NUM_OUTS_SEG_G and MAX_NUM_OUTS_SEG_G <= (2**WINDOW_ADDR_SIZE_G)) report "MAX_NUM_OUTS_SEG_G should be less or equal to 2**WINDOW_ADDR_SIZE_G" severity failure;
    assert (8 <= MAX_SEG_SIZE_G and MAX_SEG_SIZE_G <= (2**SEGMENT_ADDR_SIZE_G)*8) report "MAX_SEG_SIZE_G should be less or equal to (2**SEGMENT_ADDR_SIZE_G)*8" severity failure;
@@ -696,7 +700,7 @@ begin
          TPD_G        => TPD_G,
          DATA_WIDTH_G => 64,
          CSUM_WIDTH_G => 16
-         )
+      )
       port map (
          clk_i    => clk_i,
          rst_i    => rst_i,
@@ -784,7 +788,7 @@ begin
          TPD_G        => TPD_G,
          DATA_WIDTH_G => 64,
          CSUM_WIDTH_G => 16
-         )
+      )
       port map (
          clk_i    => clk_i,
          rst_i    => rst_i,
@@ -828,7 +832,7 @@ begin
          MEMORY_TYPE_G       => "block",
          FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1,  -- Enough to store 2 segments
          FIFO_FIXED_THRESH_G => true,
-         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16,  -- Threshold at 1 segment minus padding
+         FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_C,  -- Threshold at 1 segment minus padding
          INT_WIDTH_SELECT_G  => "CUSTOM",
          INT_DATA_WIDTH_G    => RSSI_WORD_WIDTH_C,
          SLAVE_AXI_CONFIG_G  => RSSI_AXIS_CONFIG_C,
@@ -860,7 +864,7 @@ begin
          MEMORY_TYPE_G       => "block",
          FIFO_ADDR_WIDTH_G   => SEGMENT_ADDR_SIZE_G+1,  -- Enough to store 2 segments
          FIFO_FIXED_THRESH_G => true,
-         FIFO_PAUSE_THRESH_G => (2**SEGMENT_ADDR_SIZE_G) - 16,  -- Threshold at 1 segment minus padding
+         FIFO_PAUSE_THRESH_G => FIFO_PAUSE_THRESH_C,  -- Threshold at 1 segment minus padding
          INT_WIDTH_SELECT_G  => "CUSTOM",
          INT_DATA_WIDTH_G    => RSSI_WORD_WIDTH_C,
          SLAVE_AXI_CONFIG_G  => RSSI_AXIS_CONFIG_C,


### PR DESCRIPTION
### Description
Fix the RSSI segment buffer FIFO pause threshold so that small segment buffers produce a valid, proportional threshold instead of an out of range one.

`RssiCore` passed `(2**SEGMENT_ADDR_SIZE_G) - 16` straight into the `FIFO_PAUSE_THRESH_G` generic of both the application and transport `AxiStreamFifoV2` instances. That generic is declared as `integer range 1 to (2**24)` in `axi/axi-stream/rtl/AxiStreamFifoV2.vhd:46`, so the expression has to stay positive. It does not once the segment buffer is 16 words or smaller.

Line references below are against this PR's `RssiCore.vhd` unless stated otherwise. All other files are unmodified by this PR.

### Fix
Cap the 16 word padding at half a segment instead of flooring the result (`RssiCore.vhd:134`):

```vhdl
constant FIFO_PAUSE_THRESH_C : positive := (2**SEGMENT_ADDR_SIZE_G) - minimum(16, 2**(SEGMENT_ADDR_SIZE_G-1));
```

| `SEGMENT_ADDR_SIZE_G` | FIFO depth | Threshold | vs. old formula |
| --- | --- | --- | --- |
| 3 | 16 | 4 | was -8 (illegal) |
| 4 | 32 | 8 | was 0 (illegal) |
| 5 | 64 | 16 | unchanged |
| 6 | 128 | 48 | unchanged |
| 7 (default) | 256 | 112 | unchanged |

Every configuration that elaborates today is bit-for-bit unchanged, since the padding cap only engages below `SEGMENT_ADDR_SIZE_G` of 5. Below that the threshold works out to exactly half a segment.

A simple `maximum(1, ...)` floor was considered and rejected. `FifoWrFsm.vhd:169` asserts pause on `count > FULL_THRES_G`, and both FSMs gate on pause (`RssiTxFsm.vhd:1342`, `RssiRxFsm.vhd:662`), so a threshold of 1 would stall the TX and RX FSMs after only two buffered words. Capping the padding keeps the original "one segment early, minus padding" intent proportional at small sizes.

The formula was checked to satisfy both applicable bounds, the generic's `1 to (2**24)` range and `FifoWrFsm.vhd:93`'s `FULL_THRES_G <= ((2**ADDR_WIDTH_G)-1)`, for every `SEGMENT_ADDR_SIZE_G` in 1..24.
