### PR TITLE
fix: remove non-ASCII characters from VHDL comments

### DIFF
--- a/.github/workflows/surf_ci.yml
+++ b/.github/workflows/surf_ci.yml
@@ -60,6 +60,13 @@ jobs:
             exit 1
           fi
 
+      - name: Check for non-ASCII characters in VHDL
+        run: |
+          if LC_ALL=C grep -rnP '[^\x00-\x7F]' --include=\*.vhd .; then
+            echo "Error: Non-ASCII characters found in VHDL source! Some tools (e.g. Cadence Genus) read VHDL with an ASCII codec and will fail. Please use plain ASCII (e.g. '-' instead of en/em dashes)."
+            exit 1
+          fi
+
       - name: Python Linter Checking
         run: |
           python -m compileall -f python/ scripts/ tests/

--- a/axi/axi-stream/rtl/AxiStreamCompact.vhd
+++ b/axi/axi-stream/rtl/AxiStreamCompact.vhd
@@ -125,7 +125,7 @@ begin
          v.obMaster.tValid := '0';
       end if;
 
-      -- Output slot is free – we can do work
+      -- Output slot is free - we can do work
       if v.obMaster.tValid = '0' then
 
          -- Case A: a previous tLast beat overflowed; flush the remainder first
@@ -147,7 +147,7 @@ begin
             -- Do NOT accept new input this cycle
             v.ibSlave.tReady  := '0';
 
-         -- Case B: normal operation – accept input
+         -- Case B: normal operation - accept input
          else
             v.ibSlave.tReady := '1';
 
@@ -208,7 +208,7 @@ begin
                      end if;
                   end if;
 
-               -- Not enough bytes yet, but this is the last beat – flush partial
+               -- Not enough bytes yet, but this is the last beat - flush partial
                elsif sAxisMaster.tLast = '1' then
 
                   v.obMaster.tData := (others => '0');

--- a/ethernet/RoCEv2/rtl/RoCEv2AxiStreamRdmaCore.vhd
+++ b/ethernet/RoCEv2/rtl/RoCEv2AxiStreamRdmaCore.vhd
@@ -361,7 +361,7 @@ begin  -- architecture rtl
    sAxisSlave <= AXI_STREAM_SLAVE_FORCE_C when (r.dispatchEnable = '0') else fifoSAxisSlave;
 
    ----------------------------------------------------------------------------
-   -- AxiStreamMon: monitor the FIFO drain stream (fifoMaster/fifoSlave) — frame
+   -- AxiStreamMon: monitor the FIFO drain stream (fifoMaster/fifoSlave) - frame
    -- count/size/rate/bandwidth of the PRBS packets drained into the replay ring.
    -- Single clock (statusClk = axisClk = roceClk => COMMON_CLK_G=true); the status
    -- outputs are exposed read-only on the merged AXI-Lite map (regComb, 0x200+).

--- a/protocols/jesd204b/rtl/JesdIlasGen.vhd
+++ b/protocols/jesd204b/rtl/JesdIlasGen.vhd
@@ -6,7 +6,7 @@
 --              Second ILAS multiframe (mfCnt=1) carries /Q/ (0x9C) at octet 1
 --              followed by 14 link-configuration octets (incl. FCHK).
 --
--- Spec: JESD204B §8.2 Figure 50 rules 3/4; §8.3 Table 20/21
+-- Spec: JESD204B 8.2 Figure 50 rules 3/4; 8.3 Table 20/21
 -- Observed: JesdIlasGen previously emitted only /R/ and /A/; second multiframe
 --           lacked /Q/ and link-config octets entirely.
 -- Root cause: No mfCnt tracking; config-octet emission logic absent.
@@ -15,8 +15,8 @@
 --      (DID_G..CF_G) and runtime ports (lid_i, scrEnable_i, subClass_i) are
 --      all defaulted so existing instantiations compile unchanged.
 -- JESDV=001 (JESD204B, Table 20). ADJCNT/ADJDIR/PHADJ left 0 (Subclass-2 only).
--- RES1/RES2 set to 0x00 (Table 21 "set to all X" — transmit as 0).
--- FCHK = Sigma(config[0..12]) mod 256 per §8.3 Table 20 CHKSUM.
+-- RES1/RES2 set to 0x00 (Table 21 "set to all X" - transmit as 0).
+-- FCHK = Sigma(config[0..12]) mod 256 per 8.3 Table 20 CHKSUM.
 -- Interop: SURF RX ILA state counts multiframes, does not parse config octets
 --          (JesdSyncFsmRx ILA_S state); config-octet content cannot break
 --          SURF<->SURF loopback.
@@ -131,7 +131,7 @@ begin
          v.wordCnt := (others => '0');
       end if;
 
-      -- Build 14 config octets per JESD204B §8.3 Table 21
+      -- Build 14 config octets per JESD204B 8.3 Table 21
       -- octet 0: DID[7:0]
       cfg(0)  := DID_G;
       -- octet 1: ADJCNT[7:4]=0 (Subclass-2 only), BID[3:0]

--- a/protocols/jesd204b/wrappers/JesdScramblerWrapper.vhd
+++ b/protocols/jesd204b/wrappers/JesdScramblerWrapper.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: Cocotb-facing wrapper — instantiates JesdAlignChGen (TX) and
+-- Description: Cocotb-facing wrapper - instantiates JesdAlignChGen (TX) and
 --              JesdAlignFrRepCh (RX) back-to-back to exercise the inline
 --              1+x^14+x^15 scrambler/descrambler round-trip.
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Cadence Genus reads VHDL files with an ASCII codec (`AnalyzeSrcFileLists`) and aborts on any byte `>= 0x80`:

```
RuntimeError: failed to read VHDL file at .../AxiStreamCompact.vhd:
'ascii' codec can't decode byte 0xe2 in position 4898: ordinal not in range(128)
```

Four `.vhd` files contained non-ASCII characters in comments — en/em dashes (`–`/`—`), section signs (`§`), and smart quotes — which broke Genus source analysis.

## Changes

- **AxiStreamCompact.vhd** — 3x en dash `–` -> `-`
- **JesdIlasGen.vhd** — em dash `—` -> `-`, section signs `§` removed
- **JesdScramblerWrapper.vhd** — em dash `—` -> `-`
- **RoCEv2AxiStreamRdmaCore.vhd** — em dash `—` -> `-`

All edits are in comments; no functional RTL changed.

## CI

Added a **"Check for non-ASCII characters in VHDL"** step in the `lint` job, placed immediately after the trailing-whitespace/tab check. Uses `LC_ALL=C grep` for byte-wise matching that mirrors Genus's ASCII-codec failure mode, and prints `file:line` for any offender.

## Audit

Scanned all 1186 tracked `.vhd` files with an ASCII-decode check (the exact operation Genus performs): all now decode as pure ASCII.