### PR TITLE
Fix GtRxAlignCheck reset clock domain crossings and add cocotb regression coverage

### DIFF
--- a/python/surf/xilinx/_GtRxAlignCheck.py
+++ b/python/surf/xilinx/_GtRxAlignCheck.py
@@ -28,7 +28,7 @@ class GtRxAlignCheck(pr.Device):
 
         self.add(pr.RemoteVariable(
             name        = "PhaseTarget",
-            description = "Timing frame phase lock target",
+            description = "Timing frame phase lock target. Side effect: any write to offset 0x100 clears all PhaseHist bins",
             offset      =  0x100,
             bitSize     =  7,
             bitOffset   =  0,
@@ -37,7 +37,7 @@ class GtRxAlignCheck(pr.Device):
 
         self.add(pr.RemoteVariable(
             name        = "Mask",
-            description = "Register Mask Value",
+            description = "Register Mask Value. Side effect: any write to offset 0x100 clears all PhaseHist bins",
             offset      =  0x100,
             bitSize     =  7,
             bitOffset   =  8,
@@ -46,7 +46,7 @@ class GtRxAlignCheck(pr.Device):
 
         self.add(pr.RemoteVariable(
             name        = "ResetLen",
-            description = "Reset length",
+            description = "Reset length. Side effect: any write to offset 0x100 clears all PhaseHist bins",
             offset      =  0x100,
             bitSize     =  4,
             bitOffset   =  16,
@@ -166,7 +166,7 @@ class GtRxAlignCheck(pr.Device):
 
         self.add(pr.RemoteVariable(
             name        = "PhaseHistRaw",
-            description = "Timing frame phase",
+            description = "Timing frame phase histogram. Cleared by a write to PhaseTarget, Mask or ResetLen (all share offset 0x100)",
             offset      =  0x00,
             valueBits   = 8,
             valueStride = 8,
@@ -178,7 +178,7 @@ class GtRxAlignCheck(pr.Device):
         for i in range(40):
             self.add(pr.LinkVariable(
                 name         = f'PhaseHist[{i}]',
-                description  = f'Timing frame phase histogram bin {i}',
+                description  = f'Timing frame phase histogram bin {i}. Cleared by a write to PhaseTarget, Mask or ResetLen',
                 guiGroup='Hist',
                 disp         = '{:d}',
                 mode         = 'RO',

--- a/tests/xilinx/__init__.py
+++ b/tests/xilinx/__init__.py
@@ -1,0 +1,11 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+

--- a/tests/xilinx/general/__init__.py
+++ b/tests/xilinx/general/__init__.py
@@ -1,0 +1,11 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+

--- a/tests/xilinx/general/gt_rx_align_check_test_utils.py
+++ b/tests/xilinx/general/gt_rx_align_check_test_utils.py
@@ -1,0 +1,330 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+"""Helpers for the GtRxAlignCheck bench.
+
+Two models stand in for the GT wizard, mirroring how TimingGtCoreWrapper wires
+the checker to a GTHE3 core:
+
+- `DrpAxiLiteSlave` answers the master-side AXI-Lite read that fetches
+  COMMA_ALIGN_LATENCY through AxiLiteToDrp.
+- `GtBuffBypassModel` reproduces gtwiz_buffbypass_rx_done_out and
+  gtwiz_buffbypass_rx_error_out in the RX clock domain, reacting to the
+  checker's reset output the way the buffer bypass helper block does.
+"""
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+from cocotbext.axi import AxiResp
+
+
+# Register map offsets, mirroring surf.GtRxAlignCheck and the PyRogue model in
+# python/surf/xilinx/_GtRxAlignCheck.py.
+PHASE_HIST_BASE = 0x000
+CONFIG_ADDR = 0x100          # PhaseTarget[6:0], Mask[14:8], ResetLen[19:16]
+LAST_PHASE_ADDR = 0x104
+TX_CLK_FREQ_ADDR = 0x108
+RX_CLK_FREQ_ADDR = 0x10C
+LOCKED_ADDR = 0x110
+OVERRIDE_ADDR = 0x114
+RST_RETRY_CNT_ADDR = 0x118
+RETRY_CNT_ADDR = 0x11C
+REF_CLK_FREQ_ADDR = 0x120
+
+PHASE_HIST_BINS = 40
+
+# DRP offset of COMMA_ALIGN_LATENCY. GTHE3 uses DRP address 0x150 and the other
+# supported families use 0x250, both shifted left by two for the byte-addressed
+# AXI-Lite view.
+COMMA_ALIGN_LATENCY_OFFSET = {
+    "GTHE3": 0x0000_0540,
+    "GTYE3": 0x0000_0940,
+    "GTHE4": 0x0000_0940,
+    "GTYE4": 0x0000_0940,
+}
+
+
+def comma_align_latency_addr(gt_type: str, drp_base: int) -> int:
+    """Return the AXI-Lite address the checker reads for the phase."""
+
+    return (drp_base + COMMA_ALIGN_LATENCY_OFFSET[gt_type]) & 0xFFFF_FFFF
+
+
+def config_word(*, target: int, mask: int, rst_len: int) -> int:
+    """Pack the 0x100 configuration register."""
+
+    return (target & 0x7F) | ((mask & 0x7F) << 8) | ((rst_len & 0xF) << 16)
+
+
+def phase_hist_bin(index: int) -> tuple[int, int]:
+    """Return the (offset, bit shift) of one phase histogram bin.
+
+    The RTL maps bin `i` with `axiSlaveRegisterR(axilEp, toSlv(4*(i/4), 12),
+    8*(i mod 4), ...)`, so four 8-bit bins are packed per 32-bit word.
+    """
+
+    if not 0 <= index < PHASE_HIST_BINS:
+        raise ValueError(f"Phase histogram bin out of range: {index}")
+    return PHASE_HIST_BASE + 4 * (index // 4), 8 * (index % 4)
+
+
+class DrpAxiLiteSlave:
+    """Master-side AXI-Lite slave that returns scripted phase values.
+
+    The ready/valid stepping follows the `SimpleAxiLiteSlave` model already used
+    by tests/axi/axi_lite/test_AxiLiteMaster.py. Reads pop the next entry from
+    `phases`; once the list is exhausted the final value repeats, so a test can
+    script a retry sequence and then let the DUT settle.
+    """
+
+    def __init__(self, dut, *, phases):
+        self.dut = dut
+        self.phases = list(phases)
+        if not self.phases:
+            raise ValueError("DrpAxiLiteSlave needs at least one phase value")
+        self.read_addresses = []
+        self.read_count = 0
+        self.read_resp = AxiResp.OKAY
+
+        dut.M_AXI_AWREADY.setimmediatevalue(0)
+        dut.M_AXI_WREADY.setimmediatevalue(0)
+        dut.M_AXI_BVALID.setimmediatevalue(0)
+        dut.M_AXI_BRESP.setimmediatevalue(0)
+        dut.M_AXI_ARREADY.setimmediatevalue(0)
+        dut.M_AXI_RVALID.setimmediatevalue(0)
+        dut.M_AXI_RRESP.setimmediatevalue(0)
+        dut.M_AXI_RDATA.setimmediatevalue(0)
+
+        cocotb.start_soon(self._run_read())
+
+    def set_phases(self, phases) -> None:
+        """Replace the scripted phase sequence and restart from its head."""
+
+        phases = list(phases)
+        if not phases:
+            raise ValueError("DrpAxiLiteSlave needs at least one phase value")
+        self.phases = phases
+        self.read_count = 0
+
+    def _next_phase(self) -> int:
+        # Hold the last scripted value so a settled DUT keeps reading the same
+        # phase instead of running off the end of the list.
+        index = min(self.read_count, len(self.phases) - 1)
+        return self.phases[index]
+
+    def in_reset(self) -> bool:
+        try:
+            return int(self.dut.axilRst.value) == 1
+        except ValueError:
+            return True
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.axilClk)
+            await Timer(1, unit="ns")
+
+    async def _wait_while_reset(self) -> None:
+        while self.in_reset():
+            self.dut.M_AXI_ARREADY.value = 0
+            self.dut.M_AXI_RVALID.value = 0
+            await self.cycle(1)
+
+    async def _run_read(self) -> None:
+        while True:
+            await self._wait_while_reset()
+
+            # Wait for the address phase of the checker's DRP read.
+            while not int(self.dut.M_AXI_ARVALID.value):
+                await self._wait_while_reset()
+                if not self.in_reset():
+                    await self.cycle(1)
+
+            araddr = int(self.dut.M_AXI_ARADDR.value)
+            self.read_addresses.append(araddr)
+            self.dut.M_AXI_ARREADY.value = 1
+            await self.cycle(1)
+            self.dut.M_AXI_ARREADY.value = 0
+
+            # Return the next scripted COMMA_ALIGN_LATENCY value. The checker
+            # only consumes rdData[15:0], and rdData[6:0] is the phase.
+            phase = self._next_phase()
+            self.read_count += 1
+            self.dut.M_AXI_RDATA.value = phase & 0xFFFF
+            self.dut.M_AXI_RRESP.value = int(self.read_resp)
+            self.dut.M_AXI_RVALID.value = 1
+            while not int(self.dut.M_AXI_RREADY.value):
+                await self._wait_while_reset()
+                if not self.in_reset():
+                    await self.cycle(1)
+            await self.cycle(1)
+            self.dut.M_AXI_RVALID.value = 0
+
+
+class GtBuffBypassModel:
+    """RX-clock-domain model of the GT RX buffer bypass helper block.
+
+    TimingGtCoreWrapper drives `gtwiz_buffbypass_rx_reset_in` from the checker's
+    `resetOut` through an `RstSync` in the RX clock domain, and both
+    `gtwiz_buffbypass_rx_done_out` and `gtwiz_buffbypass_rx_error_out` are
+    RX-domain status levels that stay asserted until that reset is pulsed.
+
+    This model reproduces that contract:
+
+    - `resetOut` asserted clears `resetDone` and `resetErr` after
+      `reset_latency` RX clocks, standing in for the wrapper's RstSync.
+    - After `resetOut` deasserts, the alignment procedure takes
+      `align_latency` RX clocks and then asserts `resetDone`.
+    - `error_mode` controls whether `resetErr` also asserts, and
+      `err_lead_cycles` lets a test assert the error ahead of done so the
+      done/error ordering across the clock domain crossing is controllable.
+    """
+
+    def __init__(
+        self,
+        dut,
+        *,
+        rx_clk,
+        reset_latency: int = 2,
+        align_latency: int = 6,
+    ):
+        self.dut = dut
+        self.rx_clk = rx_clk
+        self.reset_latency = reset_latency
+        self.align_latency = align_latency
+
+        # None means "never assert error". Set to an int to assert the error
+        # that many RX clocks before resetDone rises; 0 means simultaneously.
+        self.err_lead_cycles = None
+        # When True the model asserts resetErr but never resetDone, which the
+        # checker cannot act on because the error is gated by done.
+        self.err_without_done = False
+
+        self.done_assert_count = 0
+        self.err_assert_count = 0
+
+        dut.resetDone.setimmediatevalue(0)
+        dut.resetErr.setimmediatevalue(0)
+
+        cocotb.start_soon(self._run())
+
+    def arm_error(self, *, lead_cycles: int = 0) -> None:
+        """Make the next alignment attempt report an error."""
+
+        self.err_lead_cycles = lead_cycles
+        self.err_without_done = False
+
+    def arm_error_without_done(self) -> None:
+        """Assert resetErr but never resetDone on the next attempt."""
+
+        self.err_lead_cycles = 0
+        self.err_without_done = True
+
+    def clear_error(self) -> None:
+        """Let subsequent alignment attempts succeed."""
+
+        self.err_lead_cycles = None
+        self.err_without_done = False
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.rx_clk)
+
+    async def _clear_status(self) -> None:
+        await self.cycle(self.reset_latency)
+        self.dut.resetDone.value = 0
+        self.dut.resetErr.value = 0
+
+    def _reset_requested(self) -> bool:
+        try:
+            return int(self.dut.resetOut.value) == 1
+        except ValueError:
+            # resetOut is still uninitialized this early in elaboration.
+            return False
+
+    async def _run(self) -> None:
+        while True:
+            # Track the checker's reset request. resetOut is registered in the
+            # axilClk domain, so sample it from the RX clock like real hardware.
+            await self.cycle(1)
+            if not self._reset_requested():
+                continue
+
+            # Reset asserted: drop both status levels.
+            await self._clear_status()
+
+            # Wait for the reset to be released before restarting the
+            # alignment procedure.
+            while self._reset_requested():
+                await self.cycle(1)
+
+            lead = self.err_lead_cycles
+            if lead is None:
+                # Nominal alignment: done rises, no error.
+                await self.cycle(self.align_latency)
+                self.dut.resetDone.value = 1
+                self.done_assert_count += 1
+                continue
+
+            # Failing alignment. Assert the error `lead` RX clocks ahead of
+            # done so the bench can exercise both orderings of the two
+            # RX-domain levels as they cross into axilClk.
+            await self.cycle(max(self.align_latency - lead, 1))
+            self.dut.resetErr.value = 1
+            self.err_assert_count += 1
+
+            if self.err_without_done:
+                # Leave done low. The checker gates the error with done, so
+                # this attempt must not produce a reset.
+                continue
+
+            if lead > 0:
+                await self.cycle(lead)
+            self.dut.resetDone.value = 1
+            self.done_assert_count += 1
+
+            # One error per arming, so the retry that follows can succeed.
+            self.clear_error()
+
+
+class ResetOutMonitor:
+    """Count and measure `resetOut` assertions in the axilClk domain."""
+
+    def __init__(self, dut):
+        self.dut = dut
+        self.pulses = 0
+        self.max_width = 0
+        self._width = 0
+        cocotb.start_soon(self._run())
+
+    def reset_counts(self) -> None:
+        self.pulses = 0
+        self.max_width = 0
+        self._width = 0
+
+    async def _run(self) -> None:
+        previous = 0
+        while True:
+            await RisingEdge(self.dut.axilClk)
+            await Timer(1, unit="ns")
+            try:
+                current = int(self.dut.resetOut.value)
+            except ValueError:
+                continue
+
+            if current == 1:
+                if previous == 0:
+                    self.pulses += 1
+                    self._width = 1
+                else:
+                    self._width += 1
+                self.max_width = max(self.max_width, self._width)
+            previous = current

--- a/tests/xilinx/general/test_GtRxAlignCheck.py
+++ b/tests/xilinx/general/test_GtRxAlignCheck.py
@@ -1,0 +1,585 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+# Test methodology:
+# - Sweep: Three elaborations. A GTHE3 case with a zero DRP base proves the
+#   0x540 COMMA_ALIGN_LATENCY offset, a GTHE4 case with a non-zero base proves
+#   the 0x940 offset and the base-address addition, and a SIMULATION_G case
+#   proves the override generic defaults set so the checker locks on its first
+#   read. GT_TYPE_G and SIMULATION_G change elaboration, so they cannot be
+#   varied inside one build.
+# - Stimulus: A scripted AXI-Lite slave answers the master-side DRP read with
+#   chosen COMMA_ALIGN_LATENCY phase values, and an RX-clock-domain model
+#   reproduces gtwiz_buffbypass_rx_done_out and gtwiz_buffbypass_rx_error_out
+#   reacting to resetOut, the way TimingGtCoreWrapper wires a GTHE3 core. The
+#   register map is driven over the flattened slave port with cocotbext.axi.
+# - Checks: Lock on a masked phase match, retry-and-count on mismatch, phase
+#   histogram accumulation and its clear-on-config-write side effect, target
+#   and mask reprogramming, the override register and generic, retry counter
+#   clearing, programmable reset length, asynchronous resetIn restart, and
+#   axilRst returning the map to its reset values. Two checks are explicit
+#   regression tests: an out-of-range 7-bit phase must not disturb the 40-bin
+#   histogram, and an error asserted well before resetDone must still produce
+#   exactly one reset.
+# - Timing: axilClk, rxClk, txClk and refClk all run at distinct periods so the
+#   GT status crossings are genuinely asynchronous, and resetIn is driven off
+#   the clock edge to exercise its synchronizer. resetOut assertions are counted
+#   and width-measured by a sampling monitor rather than inferred from register
+#   state, because the pulse count is the contract for the error path.
+# - Does not prove: The TxClkFreq, RxClkFreq and RefClkFreq registers read zero
+#   throughout. The RTL fixes SyncClockFreq at REFRESH_RATE_G => 1.0, so a
+#   measurement window is AXI_CLK_FREQ_G axilClk cycles, one second of sim time
+#   at the real 156.25 MHz. That measurement is covered by
+#   tests/base/sync/test_SyncClockFreq.py. The retryCnt saturation at 0xFFFF is
+#   also out of reach, since it needs 65535 reset-and-reread cycles.
+
+import os
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiResp
+
+from tests.axi.utils import axil_read_u32, axil_write_u32
+from tests.common.regression_utils import (
+    env_flag,
+    env_int,
+    parameter_case,
+    run_surf_vhdl_test,
+)
+from tests.xilinx.general.gt_rx_align_check_test_utils import (
+    CONFIG_ADDR,
+    LAST_PHASE_ADDR,
+    LOCKED_ADDR,
+    OVERRIDE_ADDR,
+    PHASE_HIST_BINS,
+    REF_CLK_FREQ_ADDR,
+    RETRY_CNT_ADDR,
+    RST_RETRY_CNT_ADDR,
+    RX_CLK_FREQ_ADDR,
+    TX_CLK_FREQ_ADDR,
+    DrpAxiLiteSlave,
+    GtBuffBypassModel,
+    ResetOutMonitor,
+    comma_align_latency_addr,
+    config_word,
+    phase_hist_bin,
+)
+
+
+# SIMULATION_G forces the override flag set at reset, which defeats every
+# retry-based check, so those tests are skipped in that elaboration.
+SIM_OVERRIDE = env_flag("SIMULATION_G", default=False)
+
+AXIL_PERIOD_NS = 6.4
+RX_PERIOD_NS = 8.4
+TX_PERIOD_NS = 7.1
+REF_PERIOD_NS = 5.3
+
+# Mid-period offset used to move resetIn away from an axilClk edge. Keep this a
+# value the simulator can represent exactly; a computed fraction of the period
+# such as AXIL_PERIOD_NS/3 is not representable at 1 fs precision.
+RESET_IN_SKEW_NS = 2.1
+
+# Matches the entity defaults that the wrapper leaves alone.
+DEFAULT_TARGET = 16
+DEFAULT_MASK = 126
+DEFAULT_RST_LEN = 3
+
+# 126 masks off bit 0, so 16 and 17 both satisfy the lock comparison.
+MATCHING_PHASE = DEFAULT_TARGET
+MISMATCH_PHASES = (20, 21)
+
+
+class TB:
+    def __init__(self, dut, *, phases=(MATCHING_PHASE,)):
+        self.dut = dut
+        self.gt_type = os.environ.get("GT_TYPE_G", "GTHE3")
+        self.drp_base = env_int("DRP_ADDR_INT_G", default=0)
+        self.expected_drp_addr = comma_align_latency_addr(self.gt_type, self.drp_base)
+
+        # Distinct periods on every clock so the GT status crossings and the
+        # frequency monitors all see truly asynchronous relationships.
+        cocotb.start_soon(Clock(dut.axilClk, AXIL_PERIOD_NS, unit="ns").start())
+        cocotb.start_soon(Clock(dut.rxClk, RX_PERIOD_NS, unit="ns").start())
+        cocotb.start_soon(Clock(dut.txClk, TX_PERIOD_NS, unit="ns").start())
+        cocotb.start_soon(Clock(dut.refClk, REF_PERIOD_NS, unit="ns").start())
+
+        dut.axilRst.setimmediatevalue(1)
+        dut.resetIn.setimmediatevalue(0)
+
+        self.axil = AxiLiteMaster(
+            bus=AxiLiteBus.from_prefix(dut, "S_AXI"),
+            clock=dut.axilClk,
+            reset=dut.axilRst,
+            reset_active_level=True,
+        )
+        self.drp = DrpAxiLiteSlave(dut, phases=phases)
+        self.gt = GtBuffBypassModel(dut, rx_clk=dut.rxClk)
+        self.monitor = ResetOutMonitor(dut)
+
+    async def cycle(self, count: int = 1) -> None:
+        for _ in range(count):
+            await RisingEdge(self.dut.axilClk)
+            await Timer(1, unit="ns")
+
+    async def reset(self) -> None:
+        # Hold axilRst so the checker restarts from REG_INIT_C, then let the GT
+        # model run its first alignment pass before any register access.
+        self.dut.axilRst.setimmediatevalue(1)
+        self.dut.resetIn.value = 0
+        await self.cycle(5)
+        self.dut.axilRst.value = 0
+        await self.cycle(5)
+        self.monitor.reset_counts()
+
+    async def wait_for_lock(self, *, timeout_cycles: int = 4000) -> None:
+        for _ in range(timeout_cycles):
+            await self.cycle(1)
+            if int(self.dut.locked.value) == 1:
+                return
+        raise AssertionError("Timed out waiting for GtRxAlignCheck to lock")
+
+    async def wait_for_unlock(self, *, timeout_cycles: int = 2000) -> None:
+        for _ in range(timeout_cycles):
+            await self.cycle(1)
+            if int(self.dut.locked.value) == 0:
+                return
+        raise AssertionError("Timed out waiting for GtRxAlignCheck to unlock")
+
+    async def wait_for_drp_reads(self, count: int, *, timeout_cycles: int = 4000) -> None:
+        for _ in range(timeout_cycles):
+            await self.cycle(1)
+            if self.drp.read_count >= count:
+                return
+        raise AssertionError(
+            f"Timed out waiting for {count} DRP reads, saw {self.drp.read_count}"
+        )
+
+    async def wait_for_gt_error(self, *, timeout_cycles: int = 2000) -> None:
+        # The GT model reports the error on its own clock, so wait for it rather
+        # than assuming a fixed number of axilClk cycles have gone by.
+        for _ in range(timeout_cycles):
+            await self.cycle(1)
+            if self.gt.err_assert_count >= 1:
+                return
+        raise AssertionError("Timed out waiting for the GT model to assert resetErr")
+
+    async def wait_for_reset_pulses(self, count: int, *, timeout_cycles: int = 2000) -> None:
+        for _ in range(timeout_cycles):
+            await self.cycle(1)
+            if self.monitor.pulses >= count:
+                return
+        raise AssertionError(
+            f"Timed out waiting for {count} resetOut pulses, saw {self.monitor.pulses}"
+        )
+
+    async def read_hist_bin(self, index: int) -> int:
+        offset, shift = phase_hist_bin(index)
+        word = await axil_read_u32(self.axil, offset)
+        return (word >> shift) & 0xFF
+
+    async def read_all_hist_bins(self) -> list[int]:
+        return [await self.read_hist_bin(index) for index in range(PHASE_HIST_BINS)]
+
+    async def write_config(self, *, target: int, mask: int, rst_len: int) -> None:
+        await axil_write_u32(
+            self.axil, CONFIG_ADDR, config_word(target=target, mask=mask, rst_len=rst_len)
+        )
+
+    async def pulse_reset_in(self, *, hold_cycles: int = 4) -> None:
+        # resetIn is documented ASYNC to axilClk, so move it mid-period rather
+        # than on an edge to exercise the synchronizer instead of a clean setup.
+        await RisingEdge(self.dut.axilClk)
+        await Timer(RESET_IN_SKEW_NS, unit="ns")
+        self.dut.resetIn.value = 1
+        await self.cycle(hold_cycles)
+        await Timer(RESET_IN_SKEW_NS, unit="ns")
+        self.dut.resetIn.value = 0
+
+
+@cocotb.test()
+async def lock_on_matching_phase_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+    await tb.reset()
+
+    # A phase that satisfies (phase xor target) and mask == 0 should lock on the
+    # first DRP read without any reset retry.
+    await tb.wait_for_lock()
+
+    assert int(dut.locked.value) == 1
+    assert await axil_read_u32(tb.axil, LOCKED_ADDR) & 0x1 == 1
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MATCHING_PHASE
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 0
+    assert await tb.read_hist_bin(MATCHING_PHASE) == 1
+
+    # resetOut must be released once locked, so the GT datapath is not held.
+    assert int(dut.resetOut.value) == 0
+
+    # The DRP read has to target DRP_ADDR_G plus the family-specific
+    # COMMA_ALIGN_LATENCY offset.
+    assert tb.drp.read_addresses
+    assert tb.drp.read_addresses[0] == tb.expected_drp_addr
+
+    # Frequency monitors need a full one-second measurement window, so they are
+    # expected to still read zero here. See the methodology block.
+    assert await axil_read_u32(tb.axil, TX_CLK_FREQ_ADDR) == 0
+    assert await axil_read_u32(tb.axil, RX_CLK_FREQ_ADDR) == 0
+    assert await axil_read_u32(tb.axil, REF_CLK_FREQ_ADDR) == 0
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def retry_until_match_test(dut):
+    phases = (MISMATCH_PHASES[0], MISMATCH_PHASES[1], MATCHING_PHASE)
+    tb = TB(dut, phases=phases)
+    await tb.reset()
+
+    # Two mismatching phases must each trigger a reset retry before the third
+    # read lands on the target.
+    await tb.wait_for_lock()
+
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 2
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MATCHING_PHASE
+
+    # Every read, matching or not, bumps its own histogram bin.
+    for phase in phases:
+        assert await tb.read_hist_bin(phase) == 1
+
+    # Each mismatch drives one resetOut assertion.
+    assert tb.monitor.pulses == 2
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def mask_and_target_programming_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[0],))
+    await tb.reset()
+
+    # Retarget the comparison at the phase the DRP is returning, so what was a
+    # permanent mismatch becomes an immediate match.
+    await tb.write_config(target=MISMATCH_PHASES[0], mask=0x7F, rst_len=DEFAULT_RST_LEN)
+
+    readback = await axil_read_u32(tb.axil, CONFIG_ADDR)
+    assert readback & 0x7F == MISMATCH_PHASES[0]
+    assert (readback >> 8) & 0x7F == 0x7F
+    assert (readback >> 16) & 0xF == DEFAULT_RST_LEN
+
+    await tb.wait_for_lock()
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MISMATCH_PHASES[0]
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def zero_mask_matches_any_phase_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[1],))
+    await tb.reset()
+
+    # With the mask cleared, the masked comparison is always zero, so any phase
+    # satisfies the lock condition regardless of the target.
+    await tb.write_config(target=0, mask=0x00, rst_len=DEFAULT_RST_LEN)
+
+    await tb.wait_for_lock()
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MISMATCH_PHASES[1]
+
+
+@cocotb.test()
+async def config_write_clears_histogram_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+    await tb.reset()
+    await tb.wait_for_lock()
+
+    # Confirm there is histogram content to lose before exercising the clear.
+    assert await tb.read_hist_bin(MATCHING_PHASE) >= 1
+
+    # Any write to 0x100 clears the sampler. Use a distinct config value so the
+    # test also proves the configuration fields keep their newly written values
+    # and are not themselves reset by the side effect.
+    await tb.write_config(target=33, mask=0x55, rst_len=9)
+
+    assert await tb.read_all_hist_bins() == [0] * PHASE_HIST_BINS
+
+    readback = await axil_read_u32(tb.axil, CONFIG_ADDR)
+    assert readback & 0x7F == 33
+    assert (readback >> 8) & 0x7F == 0x55
+    assert (readback >> 16) & 0xF == 9
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def override_register_forces_lock_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[0],))
+    await tb.reset()
+
+    # A permanently mismatching phase should keep retrying, never locking.
+    await tb.wait_for_drp_reads(2)
+    assert int(dut.locked.value) == 0
+
+    # Setting the override register makes the checker accept whatever phase it
+    # reads and stop resetting the transceiver.
+    await axil_write_u32(tb.axil, OVERRIDE_ADDR, 1)
+    await tb.wait_for_lock()
+
+    assert await axil_read_u32(tb.axil, OVERRIDE_ADDR) & 0x1 == 1
+    assert await axil_read_u32(tb.axil, LOCKED_ADDR) & 0x1 == 1
+
+
+@cocotb.test(skip=not SIM_OVERRIDE)
+async def simulation_generic_locks_immediately_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[0],))
+    await tb.reset()
+
+    # SIMULATION_G seeds the override flag, so a mismatching phase still locks
+    # on the first read and the register reads back already set.
+    assert await axil_read_u32(tb.axil, OVERRIDE_ADDR) & 0x1 == 1
+
+    await tb.wait_for_lock()
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 0
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MISMATCH_PHASES[0]
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def retry_counter_clear_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[0],))
+    await tb.reset()
+
+    # Let a few retries accumulate on a phase that never matches.
+    await tb.wait_for_drp_reads(3)
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) > 0
+
+    # The 0x118 strobe clears the counter. It is a one-shot in the RTL, so read
+    # back promptly while the DUT is still retrying.
+    await axil_write_u32(tb.axil, RST_RETRY_CNT_ADDR, 1)
+    await tb.cycle(2)
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 0
+
+
+@cocotb.test()
+async def reset_in_restarts_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+    await tb.reset()
+    await tb.wait_for_lock()
+
+    retry_before = await axil_read_u32(tb.axil, RETRY_CNT_ADDR)
+    tb.monitor.reset_counts()
+
+    # resetIn is asynchronous to axilClk, so assert it off the clock edge.
+    await tb.pulse_reset_in()
+
+    await tb.wait_for_unlock()
+    assert tb.monitor.pulses >= 1
+
+    # The checker must recover on its own once resetIn is released.
+    await tb.wait_for_lock()
+
+    # Resets requested through resetIn are excluded from the retry counter,
+    # which only counts internally triggered alignment retries.
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == retry_before
+
+
+@cocotb.test()
+async def reset_err_after_done_restarts_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+
+    # Arm the failure before releasing axilRst so the very first alignment
+    # attempt reports an error. Driving the error from the initial attempt keeps
+    # the error path the only thing that can assert resetOut, so the pulse count
+    # below is unambiguous.
+    tb.gt.arm_error(lead_cycles=0)
+    await tb.reset()
+    assert tb.monitor.pulses == 0
+
+    # Nominal helper-block ordering: done and error rise together.
+    await tb.wait_for_gt_error()
+    await tb.wait_for_reset_pulses(1)
+
+    # The error is a sticky RX-domain level, so the checker must issue exactly
+    # one reset for it rather than re-triggering while it stays asserted.
+    await tb.wait_for_lock()
+    assert tb.gt.err_assert_count == 1
+    assert tb.monitor.pulses == 1
+
+    # Error-triggered resets are excluded from the retry counter, which only
+    # counts phase-mismatch retries.
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 0
+
+
+@cocotb.test()
+async def reset_err_before_done_restarts_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+
+    # Regression test for the pre-CDC gate. resetErr rises 12 rxClk ahead of
+    # resetDone here. Synchronizing the two levels separately and combining them
+    # in axilClk makes the result depend on relative synchronizer latency, and a
+    # one-shot on the error is silently dropped at this skew. Gating the two in
+    # the RX clock domain makes the reset happen regardless of the ordering.
+    tb.gt.arm_error(lead_cycles=12)
+    await tb.reset()
+    assert tb.monitor.pulses == 0
+
+    await tb.wait_for_gt_error()
+    await tb.wait_for_reset_pulses(1)
+
+    assert tb.gt.err_assert_count == 1
+    assert tb.monitor.pulses == 1
+
+    # And the checker still recovers afterwards.
+    await tb.wait_for_lock()
+
+
+@cocotb.test()
+async def reset_err_without_done_no_restart_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+
+    # The RTL gates resetErr with resetDone, so an error raised while done stays
+    # low cannot reach the reset logic. That is deliberate: the checker only acts
+    # on errors reported by a completed alignment procedure.
+    tb.gt.arm_error_without_done()
+    await tb.reset()
+
+    await tb.wait_for_gt_error()
+    tb.monitor.reset_counts()
+
+    # With done held low the checker parks waiting: no reset, no DRP read, and
+    # no lock.
+    await tb.cycle(400)
+    assert int(dut.resetDone.value) == 0
+    assert int(dut.resetErr.value) == 1
+    assert int(dut.locked.value) == 0
+    assert tb.monitor.pulses == 0
+    assert tb.drp.read_count == 0
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def out_of_range_phase_test(dut):
+    # 0x7F and 40 are both outside the 40-entry sample array. The RTL reads a
+    # 7-bit COMMA_ALIGN_LATENCY field, so values up to 127 are possible from a
+    # garbage or in-reset DRP read.
+    out_of_range = (0x7F, PHASE_HIST_BINS)
+    tb = TB(dut, phases=(out_of_range[0], out_of_range[1], MATCHING_PHASE))
+    await tb.reset()
+
+    # Regression test for the sample index bound check. Without it these reads
+    # index past the end of the array, which is a GHDL bound-check failure and
+    # a lost increment in hardware.
+    await tb.wait_for_lock()
+
+    # LastPhase still reports the out-of-range value, and the mismatch still
+    # drives a retry, so only the histogram increment is suppressed.
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 2
+    assert await axil_read_u32(tb.axil, LAST_PHASE_ADDR) & 0x7F == MATCHING_PHASE
+
+    bins = await tb.read_all_hist_bins()
+    assert bins[MATCHING_PHASE] == 1
+    # No in-range bin may have absorbed an out-of-range read, so the matching
+    # phase is the only bin that moved.
+    assert sum(bins) == 1
+
+
+@cocotb.test(skip=SIM_OVERRIDE)
+async def rstlen_programmable_test(dut):
+    tb = TB(dut, phases=(MISMATCH_PHASES[0],))
+    await tb.reset()
+
+    # RESET_S holds resetOut while rstcnt counts up to rstlen, so a longer
+    # rstlen must widen the measured assertion.
+    long_rst_len = 12
+    await tb.write_config(target=DEFAULT_TARGET, mask=DEFAULT_MASK, rst_len=long_rst_len)
+
+    tb.monitor.reset_counts()
+    await tb.wait_for_drp_reads(tb.drp.read_count + 2)
+
+    assert tb.monitor.pulses >= 1
+    assert tb.monitor.max_width >= long_rst_len + 1
+
+
+@cocotb.test()
+async def axil_reset_returns_to_init_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+    await tb.reset()
+    await tb.wait_for_lock()
+
+    # Dirty the writable state so the reset has something to undo.
+    await tb.write_config(target=33, mask=0x55, rst_len=9)
+    await axil_write_u32(tb.axil, OVERRIDE_ADDR, 1)
+    await tb.cycle(4)
+
+    # REG_INIT_C holds rst asserted and locked cleared, so axilRst must show up
+    # immediately on both outputs.
+    dut.axilRst.value = 1
+    await tb.cycle(3)
+    assert int(dut.locked.value) == 0
+    assert int(dut.resetOut.value) == 1
+
+    dut.axilRst.value = 0
+    await tb.cycle(3)
+
+    # The configuration fields must be back at their generic-derived defaults
+    # and the counters and histogram cleared.
+    readback = await axil_read_u32(tb.axil, CONFIG_ADDR)
+    assert readback & 0x7F == DEFAULT_TARGET
+    assert (readback >> 8) & 0x7F == DEFAULT_MASK
+    assert (readback >> 16) & 0xF == DEFAULT_RST_LEN
+    assert await axil_read_u32(tb.axil, RETRY_CNT_ADDR) == 0
+    assert await axil_read_u32(tb.axil, OVERRIDE_ADDR) & 0x1 == int(SIM_OVERRIDE)
+
+
+@cocotb.test()
+async def unmapped_access_returns_ok_test(dut):
+    tb = TB(dut, phases=(MATCHING_PHASE,))
+    await tb.reset()
+    await tb.wait_for_lock()
+
+    # The RTL closes the endpoint with axiSlaveDefault(..., AXI_RESP_OK_C), so
+    # unmapped offsets answer OKAY rather than DECERR. Pin that, because the
+    # response code is part of the register-map contract that software sees.
+    txn = await tb.axil.read(0x200, 4)
+    assert txn.resp == AxiResp.OKAY
+
+    txn = await tb.axil.write(0x204, (0).to_bytes(4, "little"))
+    assert txn.resp == AxiResp.OKAY
+
+
+PARAMETER_SWEEP = [
+    parameter_case(
+        "gthe3_base0",
+        GT_TYPE_G="GTHE3",
+        SIMULATION_G="false",
+        LOCK_VALUE_G="16",
+        MASK_VALUE_G="126",
+        DRP_ADDR_INT_G="0",
+    ),
+    parameter_case(
+        "gthe4_offset",
+        GT_TYPE_G="GTHE4",
+        SIMULATION_G="false",
+        LOCK_VALUE_G="16",
+        MASK_VALUE_G="126",
+        DRP_ADDR_INT_G="4194304",
+    ),
+    parameter_case(
+        "simulation_override",
+        GT_TYPE_G="GTHE3",
+        SIMULATION_G="true",
+        LOCK_VALUE_G="16",
+        MASK_VALUE_G="126",
+        DRP_ADDR_INT_G="0",
+    ),
+]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_GtRxAlignCheck(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.gtrxaligncheckwrapper",
+        parameters=parameters,
+        extra_env=parameters,
+        extra_vhdl_sources={
+            "surf": ["xilinx/general/wrappers/GtRxAlignCheckWrapper.vhd"],
+        },
+    )

--- a/xilinx/general/rtl/GtRxAlignCheck.vhd
+++ b/xilinx/general/rtl/GtRxAlignCheck.vhd
@@ -298,6 +298,9 @@ begin
       end case;
 
       -- Check for software controlled sampler reset
+      -- Note: tgt/mask/rstlen share offset 0x100, so a write that only updates
+      --       those fields also clears the samples. The fields themselves keep
+      --       their newly written values; only r.sample is cleared here.
       if (axilEp.axiStatus.writeEnable = '1') and (sAxilWriteMaster.awaddr(8 downto 0) = toSlv(256, 9)) then
          v.sample := (others => (others => '0'));
       end if;

--- a/xilinx/general/rtl/GtRxAlignCheck.vhd
+++ b/xilinx/general/rtl/GtRxAlignCheck.vhd
@@ -317,8 +317,8 @@ begin
       if (r.rstRetryCnt = '1') then
          -- Reset clause first
          v.retryCnt := (others => '0');
-      elsif (v.rst = '1' and r.rst = '0' and resetInSync = '0' and resetErrValidSync = '0') then
-         -- Edge-triggered
+      elsif (v.rst = '1' and r.rst = '0' and resetInSync = '0' and resetErrValidSync = '0' and r.retryCnt /= x"FFFF") then
+         -- Edge-triggered and saturates instead of rolling over
          v.retryCnt := r.retryCnt + 1;
       end if;
 

--- a/xilinx/general/rtl/GtRxAlignCheck.vhd
+++ b/xilinx/general/rtl/GtRxAlignCheck.vhd
@@ -36,11 +36,11 @@ entity GtRxAlignCheck is
       rxClk            : in  sl;
       refClk           : in  sl;
       -- GTH Status/Control Interface
-      resetIn          : in  sl;
-      resetOut         : out sl;
-      resetDone        : in  sl;
-      resetErr         : in  sl;
-      locked           : out sl;
+      resetIn          : in  sl;            -- ASYNC to axilClk
+      resetOut         : out sl;            -- SYNC to axilClk
+      resetDone        : in  sl;            -- ASYNC to axilClk
+      resetErr         : in  sl;            -- ASYNC to axilClk
+      locked           : out sl;            -- SYNC to axilClk
       -- Clock and Reset
       axilClk          : in  sl;
       axilRst          : in  sl;
@@ -112,6 +112,10 @@ architecture rtl of GtRxAlignCheck is
 
    signal ack : AxiLiteAckType;
 
+   signal resetInSync       : sl;
+   signal resetDoneSync     : sl;
+   signal resetErrValid     : sl;
+   signal resetErrValidSync : sl;
 
    signal txClkFreq  : slv(31 downto 0);
    signal rxClkFreq  : slv(31 downto 0);
@@ -161,8 +165,36 @@ begin
          locClk  => axilClk,
          refClk  => axilClk);
 
-   comb : process (ack, axilRst, r, refClkFreq, resetDone, resetErr, resetIn,
-                   rxClkFreq, sAxilReadMaster, sAxilWriteMaster, txClkFreq) is
+   U_resetInSync : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => axilClk,
+         dataIn  => resetIn,
+         dataOut => resetInSync);
+
+   U_resetDoneSync : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => axilClk,
+         dataIn  => resetDone,
+         dataOut => resetDoneSync);
+
+   -- Qualify the error with done in the GT's RX clock domain, before the CDC.
+   resetErrValid <= resetDone and resetErr;
+
+   U_resetErrValidSync : entity surf.SynchronizerOneShot
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => axilClk,
+         dataIn  => resetErrValid,
+         dataOut => resetErrValidSync);
+
+   comb : process (ack, axilRst, r, refClkFreq, resetDoneSync,
+                   resetErrValidSync, resetInSync, rxClkFreq, sAxilReadMaster,
+                   sAxilWriteMaster, txClkFreq) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndpointType;
       variable i      : natural;
@@ -211,7 +243,7 @@ begin
             -- Check the counter
             if (r.rstcnt = r.rstlen) then
                -- Wait for the reset transition
-               if (resetDone = '0') then
+               if (resetDoneSync = '0') then
                   -- Reset the counter
                   v.rstcnt := (others => '0');
                   -- Next state
@@ -224,7 +256,7 @@ begin
          ----------------------------------------------------------------------
          when READ_S =>
             -- Wait for the reset transition and check state of master AXI-Lite
-            if (resetDone = '1') and (ack.done = '0') then
+            if (resetDoneSync = '1') and (ack.done = '0') then
                -- Start the master AXI-Lite transaction
                v.req.request := '1';
                v.req.rnw     := '1';    -- read operation
@@ -269,7 +301,7 @@ begin
       end if;
 
       -- Check for user reset
-      if (resetIn = '1') or (resetErr = '1' and resetDone = '1') then
+      if (resetInSync = '1') or (resetErrValidSync = '1') then
          -- Setup flags for reset state
          v.rst         := '1';
          v.req.request := '0';
@@ -283,7 +315,7 @@ begin
       if (r.rstRetryCnt = '1') then
          -- Reset clause first
          v.retryCnt := (others => '0');
-      elsif (v.rst = '1' and r.rst = '0' and resetIn = '0' and resetErr = '0') then
+      elsif (v.rst = '1' and r.rst = '0' and resetInSync = '0' and resetErrValidSync = '0') then
          -- Edge-triggered
          v.retryCnt := r.retryCnt + 1;
       end if;

--- a/xilinx/general/rtl/GtRxAlignCheck.vhd
+++ b/xilinx/general/rtl/GtRxAlignCheck.vhd
@@ -272,10 +272,12 @@ begin
                v.req.request := '0';
                -- Get the index pointer
                i             := conv_integer(ack.rdData(6 downto 0));
-               -- Increment the counter
-               v.sample(i)   := r.sample(i) + 1;
+               -- Increment the counter (7-bit DRP field can exceed the sample array)
+               if (i < r.sample'length) then
+                  v.sample(i) := r.sample(i) + 1;
+               end if;
                -- Save the last byte alignment check
-               v.last        := ack.rdData(15 downto 0);
+               v.last := ack.rdData(15 downto 0);
                -- Check the byte alignment
                if ((((ack.rdData(6 downto 0) xor r.tgt) and r.mask) = toSlv(0, 7))
                    or v.override = '1') then

--- a/xilinx/general/wrappers/GtRxAlignCheckWrapper.vhd
+++ b/xilinx/general/wrappers/GtRxAlignCheckWrapper.vhd
@@ -1,0 +1,226 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Cocotb-facing wrapper for surf.GtRxAlignCheck that flattens the
+--              slave register-map and master DRP AXI-Lite records, and exposes
+--              the DRP base address as an integer generic for stable test
+--              parameterization under GHDL.
+-------------------------------------------------------------------------------
+-- This file is part of 'SLAC Firmware Standard Library'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'SLAC Firmware Standard Library', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity GtRxAlignCheckWrapper is
+   generic (
+      TPD_G          : time    := 1 ns;
+      SIMULATION_G   : boolean := false;
+      LOCK_VALUE_G   : integer := 16;
+      MASK_VALUE_G   : integer := 126;
+      GT_TYPE_G      : string  := "GTHE3";  -- or GTYE3, GTHE4, GTYE4
+      DRP_ADDR_INT_G : natural := 0);
+   port (
+      -- Clock and Reset
+      axilClk       : in  sl;
+      axilRst       : in  sl;
+      -- Clock Monitoring
+      txClk         : in  sl;
+      rxClk         : in  sl;
+      refClk        : in  sl;
+      -- GTH Status/Control Interface
+      resetIn       : in  sl;
+      resetOut      : out sl;
+      resetDone     : in  sl;
+      resetErr      : in  sl;
+      locked        : out sl;
+      -- Slave AXI-Lite Interface (register map)
+      S_AXI_AWADDR  : in  slv(11 downto 0);
+      S_AXI_AWPROT  : in  slv(2 downto 0);
+      S_AXI_AWVALID : in  sl;
+      S_AXI_AWREADY : out sl;
+      S_AXI_WDATA   : in  slv(31 downto 0);
+      S_AXI_WSTRB   : in  slv(3 downto 0);
+      S_AXI_WVALID  : in  sl;
+      S_AXI_WREADY  : out sl;
+      S_AXI_BRESP   : out slv(1 downto 0);
+      S_AXI_BVALID  : out sl;
+      S_AXI_BREADY  : in  sl;
+      S_AXI_ARADDR  : in  slv(11 downto 0);
+      S_AXI_ARPROT  : in  slv(2 downto 0);
+      S_AXI_ARVALID : in  sl;
+      S_AXI_ARREADY : out sl;
+      S_AXI_RDATA   : out slv(31 downto 0);
+      S_AXI_RRESP   : out slv(1 downto 0);
+      S_AXI_RVALID  : out sl;
+      S_AXI_RREADY  : in  sl;
+      -- Master AXI-Lite Interface (DRP read path)
+      M_AXI_AWADDR  : out slv(31 downto 0);
+      M_AXI_AWPROT  : out slv(2 downto 0);
+      M_AXI_AWVALID : out sl;
+      M_AXI_AWREADY : in  sl;
+      M_AXI_WDATA   : out slv(31 downto 0);
+      M_AXI_WSTRB   : out slv(3 downto 0);
+      M_AXI_WVALID  : out sl;
+      M_AXI_WREADY  : in  sl;
+      M_AXI_BRESP   : in  slv(1 downto 0);
+      M_AXI_BVALID  : in  sl;
+      M_AXI_BREADY  : out sl;
+      M_AXI_ARADDR  : out slv(31 downto 0);
+      M_AXI_ARPROT  : out slv(2 downto 0);
+      M_AXI_ARVALID : out sl;
+      M_AXI_ARREADY : in  sl;
+      M_AXI_RDATA   : in  slv(31 downto 0);
+      M_AXI_RRESP   : in  slv(1 downto 0);
+      M_AXI_RVALID  : in  sl;
+      M_AXI_RREADY  : out sl);
+end entity GtRxAlignCheckWrapper;
+
+architecture rtl of GtRxAlignCheckWrapper is
+
+   -- Translate the cocotb-friendly integer generic into the DRP base address
+   -- slv used by the underlying checker.
+   constant DRP_ADDR_C : slv(31 downto 0) := toSlv(DRP_ADDR_INT_G, 32);
+
+   signal axilAResetN : sl := '1';
+
+   signal sAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal sAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal sAxilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal sAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+
+   signal mAxilReadMaster  : AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+   signal mAxilReadSlave   : AxiLiteReadSlaveType   := AXI_LITE_READ_SLAVE_INIT_C;
+   signal mAxilWriteMaster : AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+   signal mAxilWriteSlave  : AxiLiteWriteSlaveType  := AXI_LITE_WRITE_SLAVE_INIT_C;
+
+begin
+
+   ---------------------
+   -- Input flattening
+   ---------------------
+   axilAResetN <= not axilRst;
+
+   -----------------------------------------------------
+   -- Shim layer: register map slave and DRP read master
+   -----------------------------------------------------
+   U_SlaveShim : entity surf.SlaveAxiLiteIpIntegrator
+      generic map (
+         INTERFACENAME => "S_AXI",
+         EN_ERROR_RESP => true,
+         HAS_PROT      => 1,
+         HAS_WSTRB     => 1,
+         ADDR_WIDTH    => 12)
+      port map (
+         S_AXI_ACLK      => axilClk,
+         S_AXI_ARESETN   => axilAResetN,
+         S_AXI_AWADDR    => S_AXI_AWADDR,
+         S_AXI_AWPROT    => S_AXI_AWPROT,
+         S_AXI_AWVALID   => S_AXI_AWVALID,
+         S_AXI_AWREADY   => S_AXI_AWREADY,
+         S_AXI_WDATA     => S_AXI_WDATA,
+         S_AXI_WSTRB     => S_AXI_WSTRB,
+         S_AXI_WVALID    => S_AXI_WVALID,
+         S_AXI_WREADY    => S_AXI_WREADY,
+         S_AXI_BRESP     => S_AXI_BRESP,
+         S_AXI_BVALID    => S_AXI_BVALID,
+         S_AXI_BREADY    => S_AXI_BREADY,
+         S_AXI_ARADDR    => S_AXI_ARADDR,
+         S_AXI_ARPROT    => S_AXI_ARPROT,
+         S_AXI_ARVALID   => S_AXI_ARVALID,
+         S_AXI_ARREADY   => S_AXI_ARREADY,
+         S_AXI_RDATA     => S_AXI_RDATA,
+         S_AXI_RRESP     => S_AXI_RRESP,
+         S_AXI_RVALID    => S_AXI_RVALID,
+         S_AXI_RREADY    => S_AXI_RREADY,
+         axilClk         => open,
+         axilRst         => open,
+         axilReadMaster  => sAxilReadMaster,
+         axilReadSlave   => sAxilReadSlave,
+         axilWriteMaster => sAxilWriteMaster,
+         axilWriteSlave  => sAxilWriteSlave);
+
+   U_MasterShim : entity surf.MasterAxiLiteIpIntegrator
+      generic map (
+         INTERFACENAME => "M_AXI",
+         EN_ERROR_RESP => true,
+         HAS_PROT      => 1,
+         HAS_WSTRB     => 1,
+         ADDR_WIDTH    => 32)
+      port map (
+         M_AXI_ACLK      => axilClk,
+         M_AXI_ARESETN   => axilAResetN,
+         M_AXI_AWADDR    => M_AXI_AWADDR,
+         M_AXI_AWPROT    => M_AXI_AWPROT,
+         M_AXI_AWVALID   => M_AXI_AWVALID,
+         M_AXI_AWREADY   => M_AXI_AWREADY,
+         M_AXI_WDATA     => M_AXI_WDATA,
+         M_AXI_WSTRB     => M_AXI_WSTRB,
+         M_AXI_WVALID    => M_AXI_WVALID,
+         M_AXI_WREADY    => M_AXI_WREADY,
+         M_AXI_BRESP     => M_AXI_BRESP,
+         M_AXI_BVALID    => M_AXI_BVALID,
+         M_AXI_BREADY    => M_AXI_BREADY,
+         M_AXI_ARADDR    => M_AXI_ARADDR,
+         M_AXI_ARPROT    => M_AXI_ARPROT,
+         M_AXI_ARVALID   => M_AXI_ARVALID,
+         M_AXI_ARREADY   => M_AXI_ARREADY,
+         M_AXI_RDATA     => M_AXI_RDATA,
+         M_AXI_RRESP     => M_AXI_RRESP,
+         M_AXI_RVALID    => M_AXI_RVALID,
+         M_AXI_RREADY    => M_AXI_RREADY,
+         axilClk         => open,
+         axilRst         => open,
+         axilReadMaster  => mAxilReadMaster,
+         axilReadSlave   => mAxilReadSlave,
+         axilWriteMaster => mAxilWriteMaster,
+         axilWriteSlave  => mAxilWriteSlave);
+
+   ------------------------
+   -- DUT instantiation
+   ------------------------
+   U_DUT : entity surf.GtRxAlignCheck
+      generic map (
+         TPD_G          => TPD_G,
+         SIMULATION_G   => SIMULATION_G,
+         LOCK_VALUE_G   => LOCK_VALUE_G,
+         MASK_VALUE_G   => MASK_VALUE_G,
+         GT_TYPE_G      => GT_TYPE_G,
+         AXI_CLK_FREQ_G => 156.25E+6,
+         DRP_ADDR_G     => DRP_ADDR_C)
+      port map (
+         -- Clock Monitoring
+         txClk            => txClk,
+         rxClk            => rxClk,
+         refClk           => refClk,
+         -- GTH Status/Control Interface
+         resetIn          => resetIn,
+         resetOut         => resetOut,
+         resetDone        => resetDone,
+         resetErr         => resetErr,
+         locked           => locked,
+         -- Clock and Reset
+         axilClk          => axilClk,
+         axilRst          => axilRst,
+         -- Master AXI-Lite Interface
+         mAxilReadMaster  => mAxilReadMaster,
+         mAxilReadSlave   => mAxilReadSlave,
+         mAxilWriteMaster => mAxilWriteMaster,
+         mAxilWriteSlave  => mAxilWriteSlave,
+         -- Slave AXI-Lite Interface
+         sAxilReadMaster  => sAxilReadMaster,
+         sAxilReadSlave   => sAxilReadSlave,
+         sAxilWriteMaster => sAxilWriteMaster,
+         sAxilWriteSlave  => sAxilWriteSlave);
+
+end architecture rtl;

--- a/xilinx/ruckus.tcl
+++ b/xilinx/ruckus.tcl
@@ -8,6 +8,7 @@ if {  $::env(VIVADO_VERSION) > 0.0} {
    loadRuckusTcl "$::DIR_PATH/xvc-udp"
 } else {
    loadSource -lib surf -path "$::DIR_PATH/general/rtl/SelectIoRxGearboxAligner.vhd"
+   loadSource -lib surf -path "$::DIR_PATH/general/rtl/GtRxAlignCheck.vhd"
    loadSource -lib surf -dir  "$::DIR_PATH/dummy"
 }
 


### PR DESCRIPTION
### Description

Fixes three defects in `GtRxAlignCheck`, documents a register side effect, and adds the module's first automated regression.

**Reset clock domain crossings.** `resetIn`, `resetDone` and `resetErr` are asynchronous to `axilClk` but were read directly by the combinational process; the latter two come from the GT wizard buffer bypass helper block in the `rxusrclk2` domain. Each now crosses through a synchronizer, and the error is qualified with `resetDone` in the GT's RX clock domain ahead of the crossing so the condition does not depend on relative synchronizer latency.

**Sample index bound.** `COMMA_ALIGN_LATENCY` is a 7-bit field, so the phase histogram index could reach 127 while the array holds 40 counters, and any read above 39 indexed past the end. `LastPhase` and the alignment comparison are unchanged, so an out-of-range read is still reported and still triggers a retry.

**Retry counter saturation.** `RetryCnt` wrapped, so 65536 retries read back as 0. It now holds at 0xFFFF, matching the "Does not roll-over" contract already documented in the PyRogue model.

**Register map documentation.** `PhaseTarget`, `Mask` and `ResetLen` share offset 0x100 with the sampler clear, so writing those fields also clears all 40 histogram bins while leaving the fields at their new values. This was undocumented in both the RTL and PyRogue.

**Build and test coverage.** The non-Vivado branch of `xilinx/ruckus.tcl` omitted `GtRxAlignCheck`, so it was absent from the GHDL build and never reached by CI's `make analysis`. It is now loaded, and `tests/xilinx/general/test_GtRxAlignCheck.py` adds 16 cocotb cases across three elaborations covering the state machine, the register map and the reset paths, including both `GT_TYPE_G` branches of the DRP address.

### Details

The error gate is the substantive design decision. `resetDone` and `resetErr` are sticky levels from the same helper block, so they are combined in the RX domain and one composite event crosses into `axilClk`. Combining them after separate synchronizers makes the result latency dependent: a one-shot on the error is dropped when done rises more than about one `axilClk` cycle later.

Two cases are regression tests, both confirmed to fail when the corresponding fix is reverted:

- An error 12 `rxClk` ahead of done must still produce exactly one reset. Reverting to separately synchronized levels fails only this test while the zero-skew case still passes, so it is specific to the skew.
- A phase of 0x7F must not disturb the histogram. Removing the bound check makes GHDL abort with `index (127) out of bounds (39 downto 0)`.

The clock frequency registers are left uncovered: the RTL fixes `SyncClockFreq` at `REFRESH_RATE_G => 1.0`, so one measurement window is a second of simulated time, and `tests/base/sync/test_SyncClockFreq.py` already proves that measurement.

Verified locally: repo-wide `scripts/vsg_linter.sh`, `make MODULES=$PWD analysis` now including `GtRxAlignCheck`, `flake8 python/ scripts/ tests/`, and `pytest tests/xilinx` serially and in parallel.

Follow-up, out of scope here: in the PGP2fc path `buffBypassRxError` feeds only `GtRxAlignCheck.resetErr` and reaches no status port, so software there cannot see a buffer bypass error. The timing core exposes it as `rxStatus.bufferByErr`.
