### PR TITLE
fix(i2c): saturate I2cMaster timeout counter

### DIFF
--- a/protocols/i2c/rtl/I2cMaster.vhd
+++ b/protocols/i2c/rtl/I2cMaster.vhd
@@ -260,7 +260,10 @@ begin
 
 
          when WAIT_ADDR_ACK_S =>
-            v.timer := r.timer + 1;
+            -- Saturate the timer to prevent an out of range value
+            if (r.timer /= TIMEOUT_C) then
+               v.timer := r.timer + 1;
+            end if;
 
             if (byteCtrlOut.cmdAck = '1') then     -- Master sent the command
                if (byteCtrlOut.ackOut = '0') then  -- Slave ack'd the transfer
@@ -302,7 +305,10 @@ begin
 
 
          when WAIT_READ_DATA_S =>
-            v.timer := r.timer + 1;
+            -- Saturate the timer to prevent an out of range value
+            if (r.timer /= TIMEOUT_C) then
+               v.timer := r.timer + 1;
+            end if;
 
             v.byteCtrlIn.stop  := r.byteCtrlIn.stop;  -- Hold stop or it wont get seen
             v.byteCtrlIn.ackIn := r.byteCtrlIn.ackIn;  -- This too
@@ -331,7 +337,10 @@ begin
             end if;
 
          when WAIT_WRITE_ACK_S =>
-            v.timer := r.timer + 1;
+            -- Saturate the timer to prevent an out of range value
+            if (r.timer /= TIMEOUT_C) then
+               v.timer := r.timer + 1;
+            end if;
 
             v.byteCtrlIn.stop := r.byteCtrlIn.stop;
             if (byteCtrlOut.cmdAck = '1') then     -- Master sent the command


### PR DESCRIPTION
### Description
`I2cMaster.vhd` declares the FSM timeout counter as `integer range 0 to TIMEOUT_C`, but the three waiting states (`WAIT_ADDR_ACK_S`, `WAIT_READ_DATA_S`, `WAIT_WRITE_ACK_S`) incremented it unconditionally. The timeout detection compares `r.timer` against `TIMEOUT_C`, so on the cycle the register reaches its maximum the case statement first evaluates `TIMEOUT_C + 1`, which is outside the declared range. This aborts VCS simulations of any design that lets an I2C transaction reach its timeout:

```
Error-[SIMERR_CONSTERR_INDEXEDRANGE] Range Violation Error
protocols/i2c/rtl/I2cMaster.vhd, 263
              v.timer := r.timer + 1;
  Value 782501 is out of range 0 to 782500
```

Each increment is now guarded so the counter saturates at `TIMEOUT_C`.
