### PR TITLE
fix(simlink): stop backend switches from colliding in library surf

### DIFF
--- a/simlink/docs/architecture.md
+++ b/simlink/docs/architecture.md
@@ -187,7 +187,7 @@ Rate shaping applies only to `RogueTcpStream`.
 
 `simlink/ruckus.tcl` loads the public simulation interfaces and exactly one
 backend. It first
-honors `RUCKUS_SIM_BACKEND`, then detects GHDL or VCS environments, and
+honors `RUCKUS_SIM_BACKEND`, then detects a GHDL analysis run, and
 otherwise selects xsim. In a persistent Vivado project it removes stale
 sibling-backend sources to avoid duplicate entity definitions.
 

--- a/simlink/docs/getting-started.md
+++ b/simlink/docs/getting-started.md
@@ -29,9 +29,10 @@ your shell contains more than one simulator environment:
 export RUCKUS_SIM_BACKEND=ghdl  # or vcs or xsim
 ```
 
-If it is not set, `simlink/ruckus.tcl` selects GHDL when `GHDLFLAGS` exists,
-then VCS when `VCS_VERSION` exists, and otherwise xsim. It loads exactly one
-backend so the three implementations of each leaf entity do not collide.
+If it is not set, `simlink/ruckus.tcl` selects GHDL when `GHDLFLAGS` exists, and
+otherwise xsim. It loads exactly one backend so the three implementations of
+each leaf entity do not collide, and in a persistent Vivado project it removes a
+sibling backend left behind by an earlier make target.
 
 ## 2. Check the common prerequisites
 
@@ -246,7 +247,7 @@ for the checked mixed-language examples and loader troubleshooting.
 | --- | --- | --- |
 | `RUCKUS_SIM_BACKEND` | ruckus source selection | Explicitly selects `ghdl`, `vcs`, or `xsim` |
 | `SURF_SIMLINK_TRANSPORT_TIMEOUT_MS` | All SimLink instances in the simulator process | Positive decimal timeout for stalled/missing-peer transport; default is 30000 ms |
-| `VCS_HOME`, `VCS_VERSION` | VCS build and selection | Locate the VCS headers/tools and identify the compatibility version |
+| `VCS_HOME`, `VCS_VERSION` | VCS build only | Locate the VCS headers/tools and identify the compatibility version; neither selects a backend |
 | `SIMLINK_ROGUE_PYTHON` | Tests only | Select a Python interpreter that imports Rogue and PyRogue |
 | `SIMLINK_RUN_VCS` | Tests only | Explicitly permits the licensed VCS regression to run |
 

--- a/simlink/docs/migration-from-vcs.md
+++ b/simlink/docs/migration-from-vcs.md
@@ -40,9 +40,14 @@ That behavior is ambiguous in shells containing both Vivado and VCS settings.
 The current order is:
 
 1. explicit `RUCKUS_SIM_BACKEND`;
-2. GHDL when `GHDLFLAGS` exists;
-3. VCS when `VCS_VERSION` exists; or
-4. xsim otherwise.
+2. GHDL when `GHDLFLAGS` exists; or
+3. xsim otherwise.
+
+`VCS_VERSION` is deliberately not used to select a backend. Setup scripts
+commonly source Vivado and VCS in the same shell, so it is set even for a pure
+Vivado user, which made `make bit` persist the vcs backend while `make gui`
+persisted xsim into the same project. `make vcs` asks for vcs through
+`RUCKUS_SIM_BACKEND` instead.
 
 Set the value explicitly in shared setup scripts:
 

--- a/simlink/ruckus.tcl
+++ b/simlink/ruckus.tcl
@@ -6,33 +6,88 @@ source $::env(RUCKUS_PROC_TCL)
 # of a normal SURF import.
 loadSource -lib surf -sim_only -dir "$::DIR_PATH/sim"
 
-# Select the simulator backend. Prefer the backend explicitly requested by the
-# ruckus make target (make xsim/gui -> xsim, make vcs -> vcs). Fall back to
-# environment sniffing for older ruckus. Note: sniffing VCS_VERSION alone is
-# unreliable because users commonly source both Vivado and VCS in one setup
-# script, so VCS_VERSION is set even during a Vivado xsim run.
-if {[info exists ::env(RUCKUS_SIM_BACKEND)]} {
+# The interchangeable backend directories. Each one declares the same VHDL
+# entity and architecture names (RogueTcpStream, RogueTcpMemory, RogueSideBand)
+# in library surf, so exactly one may be in the project at a time. Single source
+# of truth for both the validity check and the sibling purge below.
+set simBackendList {ghdl vcs xsim}
+
+# Select the simulator backend. ruckus exports RUCKUS_SIM_BACKEND for every
+# target that actually runs a simulator: "make xsim" and "make gui" request
+# xsim, "make vcs" requests vcs, and system_ghdl.mk requests ghdl. Every other
+# Vivado target (bit, syn, dcp, prom, mcs, pdi, msim, batch, interactive,
+# sources) leaves it unset and falls back to xsim, the only simulator a
+# persisted Vivado project can launch on its own. That keeps bit/syn/dcp/gui/
+# xsim in agreement, so the common target switch costs no add/remove churn.
+#
+# GHDLFLAGS is still honored ahead of that default because it is the one signal
+# that is guaranteed present in a GHDL analysis run: SURF's own Makefile exports
+# it unconditionally, so "make analysis" stays on the ghdl backend even against
+# a ruckus predating the RUCKUS_SIM_BACKEND export. Handing GHDL the xsim
+# backend would be fatal rather than merely wrong, because that backend pulls in
+# SystemVerilog DPI leaves that GHDL cannot parse.
+#
+# VCS_VERSION is deliberately NOT sniffed. Site setup scripts commonly source
+# Vivado and VCS in one shell, so VCS_VERSION is set even for a pure Vivado
+# user, which made "make bit" persist the vcs backend while "make gui"
+# persisted xsim into the same project, colliding in library surf.
+if { [info exists ::env(RUCKUS_SIM_BACKEND)] } {
    set simBackend $::env(RUCKUS_SIM_BACKEND)
-} elseif {[info exists ::env(GHDLFLAGS)]} {
+} elseif { [info exists ::env(GHDLFLAGS)] } {
    set simBackend "ghdl"
-} elseif {[info exists ::env(VCS_VERSION)]} {
-   set simBackend "vcs"
 } else {
    set simBackend "xsim"
 }
 
-# When re-generating an existing Vivado project, purge sibling-backend sources
-# so switching backends doesn't leave duplicate RogueTcp* entities in sim_1.
-# Only remove when present, to avoid needless add/remove churn in the project.
-# Guard on VIVADO_VERSION because get_files/remove_files are Vivado-only; GHDL
-# re-analyzes from scratch and has no persistent project to clean.
-if {$::env(VIVADO_VERSION) > 0.0} {
-   foreach other {ghdl vcs xsim} {
-      if {${other} ne ${simBackend}} {
-         set staleFiles [get_files -quiet [file normalize "$::DIR_PATH/${other}/*"]]
-         if {[llength ${staleFiles}] > 0} {
-            remove_files -quiet ${staleFiles}
+# Validate before touching the project. An unsupported value would otherwise
+# purge every real backend first and only then fail inside loadSource, leaving a
+# persisted project with no backend at all.
+if { [lsearch -exact ${simBackendList} ${simBackend}] < 0 } {
+   puts "\n\n\n\n\n********************************************************"
+   puts "simlink/ruckus.tcl: RUCKUS_SIM_BACKEND=${simBackend} is not a SimLink backend"
+   puts "Supported backends: ${simBackendList}"
+   puts "********************************************************\n\n\n\n\n"
+   exit -1
+}
+
+# Purge the sibling backends from sim_1 before loading the selected one. The
+# Vivado project persists across make targets (vivado/project.tcl re-opens an
+# existing .xpr and vivado/sources.tcl re-runs for every target), so switching
+# backends would otherwise leave two copies of RogueTcpStream(RogueTcpStream) in
+# library surf and fail with "[filemgmt 20-1318] Duplicate Design Unit". Guarded
+# on VIVADO_VERSION because get_files/remove_files are Vivado-only; the GHDL,
+# Design Compiler, and Genus flows set it to -1.0 and re-analyze from scratch
+# with no project to clean. The [info exists] test matters because the
+# standalone system_vcs.mk flow never defines VIVADO_VERSION at all.
+if { [info exists ::env(VIVADO_VERSION)] && $::env(VIVADO_VERSION) > 0.0 } {
+   # Match on the file's directory, anchored on the last two path components
+   # (for example "simlink/vcs"). An absolute pattern cannot be used here: the
+   # .xpr stores paths relative to $PPRDIR and can reach this repository through
+   # a different symlink prefix than [file normalize] resolves to, so an
+   # absolute pattern silently matches nothing even when the stale files are
+   # present. Anchoring two components also keeps a project that merely lives
+   # under some directory named "vcs" from matching everything in sim_1.
+   set simlinkTail [file tail $::DIR_PATH]
+   # Enumerate sim_1 membership rather than the Rogue*.vhd base names, so the
+   # backend-specific SystemVerilog DPI leaves under xsim/ are purged too.
+   set simFiles [get_files -quiet -of_objects [get_filesets sim_1]]
+   foreach other ${simBackendList} {
+      if { ${other} eq ${simBackend} } {
+         continue
+      }
+      set staleFiles ""
+      foreach simFile ${simFiles} {
+         if { [string match "*/${simlinkTail}/${other}" [file dirname ${simFile}]] } {
+            lappend staleFiles ${simFile}
          }
+      }
+      # -fileset is explicit because remove_files defaults to the current source
+      # fileset (sources_1), where these simulation-only files do not live. No
+      # -quiet, so a genuine removal failure is reported instead of silently
+      # leaving a duplicate design unit behind.
+      if { [llength ${staleFiles}] > 0 } {
+         puts "simlink/ruckus.tcl: removing stale ${other} backend sources from sim_1"
+         remove_files -fileset sim_1 ${staleFiles}
       }
    }
 }


### PR DESCRIPTION
Fixes `[filemgmt 20-1318] Duplicate Design Unit 'RogueTcpStream(RogueTcpStream)'
found in library 'surf'` when a persistent Vivado project is switched between
`make bit`, `make gui`, `make xsim`, and `make vcs` without an intervening
`make clean`.

`simlink/{ghdl,vcs,xsim}/` each declare the same entity and architecture names
in library `surf`, so exactly one may be in a project at a time.
`simlink/ruckus.tcl` already tried to enforce that. It did not work.

## Root cause

Two defects combined, both verified rather than inferred.

**1. `make bit` and `make gui` disagreed on the backend.** ruckus exports
`RUCKUS_SIM_BACKEND` only for `xsim`/`gui`/`vcs`. `make bit` leaves it unset, so
selection fell through to a `VCS_VERSION` sniff. Site setup scripts commonly
source Vivado and VCS in one shell (ours does), so `VCS_VERSION` is set even for
a pure Vivado user. `make bit` persisted the **vcs** backend; `make gui`
persisted **xsim** into the same project. Confirmed by inspecting a live `.xpr`:
`sim_1` held `simlink/sim/*` plus `simlink/vcs/{RogueSideBand,RogueTcpMemory,RogueTcpStream}.vhd`.

**2. The sibling-backend purge never ran.** It did:

```tcl
set staleFiles [get_files -quiet [file normalize "$::DIR_PATH/${other}/*"]]
```

Vivado stores `sim_1` paths relative to `$PPRDIR` and reports them without
resolving symlinks, so `get_files` returns e.g.
`/sdf/home/<user>/.../simlink/vcs/RogueTcpStream.vhd` while `file normalize`
yields `/sdf/group/.../simlink/vcs`. The two never `string match`, `llength` was
0, and `remove_files` was **never reached**. Measured in Vivado 2024.1 against a
populated project: the old pattern matched **0 of 3** stale files.

A second, latent defect sat behind it: `remove_files` had no `-fileset`, so it
would have targeted the current source fileset (`sources_1`, made current by
`vivado/sources.tcl:86`) rather than `sim_1` where these `-sim_only` files live,
with `-quiet` hiding the failure. Fixing only the path matching would have left
the purge broken, so both change together.

## Changes

- Match the file's **directory** against the trailing `simlink/<backend>` pair.
  Immune to the path spelling, and anchoring two components avoids emptying
  `sim_1` for a project that merely lives under some directory named `vcs`.
- Enumerate `sim_1` membership instead of the `Rogue*.vhd` base names, so the
  three `simlink/xsim/*Dpi.sv` DPI leaves are purged too. A basename filter
  (as in `RogueSimSources`) would leave them behind permanently.
- `remove_files -fileset sim_1`, no `-quiet`, with one log line per backend
  actually purged.
- Default to `xsim` when `RUCKUS_SIM_BACKEND` is unset, so `bit`, `syn`, `dcp`,
  `gui`, and `xsim` all agree and the common switch costs zero churn. `xsim` is
  the only simulator a persisted Vivado project can launch on its own.
- **`GHDLFLAGS` is still honored ahead of that default.** SURF's own `Makefile`
  exports it unconditionally, so `make analysis` stays on the ghdl backend even
  against a ruckus predating the `RUCKUS_SIM_BACKEND` export. Handing GHDL the
  xsim backend is fatal, not merely wrong: it pulls in SystemVerilog that GHDL
  cannot parse.
- Validate the backend name **before** purging, so a typo in
  `RUCKUS_SIM_BACKEND` no longer empties the project and then dies inside
  `loadSource`.
- Guard the `VIVADO_VERSION` test with `[info exists]`; the standalone
  `system_vcs.mk` flow never defines it, so the old unguarded dereference would
  have thrown there.
