### PR TITLE
Document SURF cocotb regression methodology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,18 @@ Start with [README.md](README.md) for user-facing links and the source tree inde
 - [protocols/README.md](protocols/README.md) for PGP, SSI, SRP, RSSI, CoaXPress, JESD204B, I2C/SPI/UART, and related protocol cores.
 - [xilinx/README.md](xilinx/README.md) for Xilinx-family primitives, wrappers, and XVC UDP support.
 - [python/README.md](python/README.md) for the PyRogue package under `python/surf`.
-- [tests/README.md](tests/README.md) for cocotb regression layout, methodology comments, helper reuse, and simulator conventions.
+- [tests/README.md](tests/README.md) for the authoritative cocotb regression
+  methodology, coding style, coverage expectations, layout, and simulator
+  conventions.
+- [tests/common/README.md](tests/common/README.md) for the shared pytest/GHDL
+  runner, parameter and environment handling, build isolation, and reusable
+  regression helpers.
+- [tests/protocols/README.md](tests/protocols/README.md) for protocol-oracle,
+  layering, malformed-traffic, ready/valid, and integration-test guidance; then
+  read the nearest subsystem README, such as
+  [tests/protocols/batcher/README.md](tests/protocols/batcher/README.md) or
+  [tests/protocols/rssi/README.md](tests/protocols/rssi/README.md), when working
+  in that area.
 - [docs/plans/README.md](docs/plans/README.md) for substantial task planning, progress notes, and handoff conventions.
 
 Top-level `ruckus.tcl` loads `axi`, `base`, `dsp`, `devices`, `ethernet`, `protocols`, and `xilinx`. Module-level `ruckus.tcl` files should continue to be the source of truth for which HDL files and submodules are part of a build.
@@ -169,7 +180,9 @@ C, C++, and C header files should use the same license text with `//` comment de
 
 Tcl, shell, YAML, and other hash-comment files should use the Python-style `#-----------------------------------------------------------------------------` license block when they are maintained SURF source. For executable scripts with a shebang, keep the shebang first and place the license block immediately after it.
 
-Checked-in cocotb regression files must also include the `Test methodology` block described in [tests/README.md](tests/README.md), immediately after the license header.
+New or substantially edited cocotb regression files must also include the
+module-specific `Test methodology` block described in
+[tests/README.md](tests/README.md), immediately after the license header.
 
 ## Python Conventions
 
@@ -200,7 +213,11 @@ Checked-in cocotb regression files must also include the `Test methodology` bloc
 
 ## Tests And Verification
 
-- For RTL regressions, use the guidance in [tests/README.md](tests/README.md). The expected stack is `pytest + cocotb + GHDL + ruckus`.
+- For RTL regressions, start with [tests/README.md](tests/README.md). Use
+  [tests/common/README.md](tests/common/README.md) for runner/build mechanics,
+  [tests/protocols/README.md](tests/protocols/README.md) for protocol tests, and
+  the nearest test-subsystem README for local commands or exceptions. The
+  expected default stack is `pytest + cocotb + GHDL + ruckus`.
 - For docs-only changes, no RTL or Python tests are required, but check links and headings if the edit adds navigation.
 - For ruckus or source-list changes, run `make MODULES="$PWD" import` when practical.
 - For edited VHDL, run `./.venv/bin/vsg -c vsg-linter.yml path/to/file.vhd` and the most focused relevant cocotb/pytest target when practical.
@@ -225,7 +242,14 @@ Before considering an RTL change done, check:
 
 ## Documentation Updates
 
-When adding a new subsystem, add or update the closest `README.md` if the layout or usage is not obvious. Keep README files short and navigational: describe what belongs in the folder, important subdirectories, and any local build/test conventions, then link upward through the parent README chain.
+When adding a new subsystem, add or update the closest `README.md` if the layout
+or usage is not obvious. Keep README files short and navigational: describe what
+belongs in the folder, important subdirectories, and any local build/test
+conventions, then link upward through the parent README chain. Test-subsystem
+READMEs should link to [tests/README.md](tests/README.md), and protocol-test
+READMEs should also link to
+[tests/protocols/README.md](tests/protocols/README.md), so local instructions
+extend rather than duplicate the shared methodology.
 
 Add deeper README files as substantial areas are touched, especially in high-traffic module families such as `axi/axi-stream`, `axi/axi-lite`, `protocols/pgp`, `protocols/coaxpress`, `protocols/ssi`, `protocols/srp`, `ethernet/IpV4Engine`, `ethernet/UdpEngine`, and `ethernet/EthMacCore`. Prefer adding the README in the same change that introduces new layout or conventions for that area.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,9 @@ module-specific `Test methodology` block described in
 - For edited VHDL, run `./.venv/bin/vsg -c vsg-linter.yml path/to/file.vhd` and the most focused relevant cocotb/pytest target when practical.
 - For Python/PyRogue changes, run a focused import or pytest that exercises the changed module. Avoid packaging commands unless the task specifically requires packaging validation.
 - For cocotb tests, prefer `./.venv/bin/python -m pytest -q tests/<subsystem-or-file>`. Use `-n 0` when serial simulator logs are needed.
+- Select or explicitly skip cocotb scenarios that do not apply to a parameter case; do not return early and record an unexercised scenario as a pass.
+- Use `extra_vhdl_sources` only for design units absent from the ruckus import, and keep finite cocotb tasks awaited or lifetime agents explicitly owned by the bench.
+- For bug regressions, demonstrate failure on the known-bad RTL when practical, or document the defect-catching assertion and why the comparison could not be run.
 - For protocol or bus behavior changes, include tests or a clear verification note covering sidebands, backpressure, reset behavior, and boundary/error cases relevant to the change.
 - Avoid hand-editing generated or cache directories such as `build/`, `tests/sim_build/`, `.pytest_cache/`, `docs/_build/`, and `docs/_generated/`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -105,9 +105,9 @@ falls back to running the complete `tests/` tree.
 
 ## Python Test Files
 
-Every checked-in cocotb test file should start with the standard SLAC/SURF
-license header followed immediately by a module-specific `Test methodology`
-block:
+Every new or substantially edited cocotb test file should start with the
+standard SLAC/SURF license header followed immediately by a module-specific
+`Test methodology` block. The concise form is:
 
 ```python
 ##############################################################################
@@ -124,7 +124,12 @@ block:
 ```
 
 Do not use generic methodology text. The block should tell a reader what this
-specific bench proves and what it intentionally does not prove.
+specific bench proves and what it intentionally does not prove. Complex
+protocol or integration tests may expand the headings (`Purpose`, `DUT shape`,
+`Protocol checks`, `Parameter strategy`, and similar), but must still make the
+scope/configuration, DUT boundary, stimulus, checks, and timing assumptions
+easy to find. A prose methodology with the same information is acceptable in a
+legacy file; use the labeled form for new work.
 
 Use in-body comments at the major coroutine steps: clock startup, reset,
 stimulus phases, backpressure, trigger waits, and result checks. Keep comments
@@ -182,6 +187,9 @@ A focused regression normally covers the relevant subset of:
 Use deterministic directed cases for protocol rules and boundary conditions.
 Randomized cases are valuable after a trustworthy reference model exists, but
 they do not replace readable directed regressions for known contracts and bugs.
+Seed every randomized case explicitly. Keep the seed fixed or pass it through a
+named environment value, and include the effective seed in a failure message or
+log so the exact stimulus can be reproduced.
 
 ## Parameter Sweeps
 
@@ -198,6 +206,13 @@ fragile or overly long build paths.
 Pass only HDL generics as `parameters`. Put Python-only case metadata in
 `extra_env`, or use `hdl_parameters_from(parameters)` when a case dictionary
 contains both.
+
+Normally let cocotb run all entrypoints in the module for each pytest build.
+When separate pytest nodes intentionally select one cocotb scenario, pass a
+selector through `extra_env` (for example `COCOTB_TESTCASE` or a documented
+subsystem-specific variable), give the selector a deterministic default, and
+make sure it participates in the simulation-build identity. A focused pytest
+node should not silently rerun unrelated cocotb scenarios.
 
 ## Reuse And Helpers
 
@@ -231,6 +246,13 @@ Assert externally visible behavior, not implementation accidents. Good checks
 usually include payload bytes, `TKEEP`, `TLAST`, `TUSER`/SOF/EOFE bits, address
 or ID sidebands, response codes, counters, or accepted-handshake timing.
 
+Initialize reset and every testbench-driven control/data input before the first
+active clock edge, preferably with `setimmediatevalue()` during bench setup.
+Hold reset for an explicit number of clock edges, release it on the intended
+edge, and allow any documented pipeline settling time before sampling outputs.
+This prevents unresolved startup values from turning into simulator-dependent
+stimulus.
+
 Use bounded waits and explicit timeouts for protocol progress. Avoid
 open-ended `while True` loops unless they are wrapped by `with_timeout()` or a
 helper that has a cycle limit.
@@ -243,9 +265,19 @@ Account for `TPD_G`, registered outputs, and GHDL scheduling. Sampling exactly
 on a clock edge can create false failures; most helpers settle with a short
 `Timer` after `RisingEdge()`.
 
-Known RTL issues or intentionally open coverage should be explicit. If a bench
-is checked in skipped or opt-in, document the condition and gate it with a clear
-environment variable such as `RUN_KNOWN_ISSUE_TESTS`.
+Keep skip reasons and opt-in coverage explicit, and distinguish why a case is
+not in the default run:
+
+- Gate a regression for an unresolved RTL defect with a clear variable such as
+  `RUN_KNOWN_ISSUE_TESTS`, keep the issue visible in the methodology or local
+  README, and promote the case to default coverage with the fix.
+- Gate an unusually long soak or stress matrix with a separately named
+  `RUN_*_EXTENDED_TESTS` variable; do not label stable-but-slow coverage as a
+  known issue.
+- Use `pytest.skip()` or `pytest.mark.skipif()` for genuinely optional external
+  tools, licenses, platforms, or production libraries, and state the exact
+  missing prerequisite. A required CI job should provision that prerequisite
+  and treat an unexpected skip as a failure.
 
 ## Running Tests
 
@@ -258,6 +290,12 @@ make MODULES="$PWD" import
 
 Run `make ... import` when the imported HDL source cache is missing or stale.
 Use `-n 0` for focused debug runs when serial simulator logs matter.
+
+Assume the suite will run under pytest-xdist. Each case must have an isolated
+simulation build directory and must not compete for a fixed port, ready file,
+result file, or other process-global resource. Tests that launch peer processes
+must use bounded startup/shutdown waits and clean them up in a `finally` block
+or shared teardown helper, including after an assertion fails.
 
 After any command that launches pytest, cocotb, GHDL, or another simulator
 runner, check for stale simulator child processes before starting another run.
@@ -317,8 +355,14 @@ Before considering a new regression ready:
 - Reset, backpressure, sidebands, and error/boundary cases relevant to the DUT
   are covered or explicitly documented as out of scope.
 - Shared helpers were reused or extended instead of duplicated.
-- Any retained VHDL wrapper is thin, locally documented, present in the right
-  ruckus manifest, and clean under `vsg-linter.yml`.
+- Random stimulus is seeded and failures report enough information to replay
+  the case.
+- The case is safe under pytest-xdist: build artifacts and external resources
+  are isolated, and child processes are cleaned up on failure.
+- Any retained VHDL wrapper is thin, locally documented, clean under
+  `vsg-linter.yml`, and reachable through its intended source path: the nearest
+  ruckus manifest for build-facing HDL or `extra_vhdl_sources` for a
+  cocotb-only wrapper.
 - The focused test and the nearest practical subsystem suite pass.
 - `git diff --check` is clean and no stale simulator process remains.
 - The nearest README is updated if the test introduces a new layout, helper,

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,17 @@ an uncovered module to improve.
 
 ## Quick Start
 
+If the local Python/GHDL/ruckus environment has not been prepared, run the
+repository setup helper first:
+
+```bash
+./scripts/setup_regression_env.sh
+```
+
+The script checks the required host tools, creates `.venv`, installs the Python
+requirements, and locates or clones ruckus. Review its output, activate the
+environment if desired, and then follow the workflow below.
+
 1. Read this README and the nearest subsystem README, if one exists.
 2. Search the surrounding tests and helper modules before writing new drivers
    or protocol models.
@@ -26,8 +37,8 @@ an uncovered module to improve.
    ./.venv/bin/python -m pytest -n 0 -q tests/<subsystem>/test_<Target>.py
    ```
 
-6. Lint every edited VHDL file, run the relevant subsystem regression, and
-   check for stale simulator processes before handing the change off.
+6. Lint every edited VHDL file and run the relevant subsystem regression before
+   handing the change off.
 
 Additional references:
 
@@ -173,6 +184,12 @@ the behavior:
 - Treat package declarations as transitively covered unless an important
   function or procedure needs a small wrapper and a direct behavioral test.
 
+For a bug regression, verify when practical that the new test fails against the
+known-bad RTL and passes with the fix. If that comparison cannot be run,
+document why and identify the assertion that would catch the original defect.
+Reaching the formerly failing code path without checking its externally visible
+effect is not sufficient regression coverage.
+
 A focused regression normally covers the relevant subset of:
 
 - reset assertion, release, and recovery;
@@ -207,12 +224,18 @@ Pass only HDL generics as `parameters`. Put Python-only case metadata in
 `extra_env`, or use `hdl_parameters_from(parameters)` when a case dictionary
 contains both.
 
-Normally let cocotb run all entrypoints in the module for each pytest build.
-When separate pytest nodes intentionally select one cocotb scenario, pass a
-selector through `extra_env` (for example `COCOTB_TESTCASE` or a documented
+Prefer a pytest node that names one cocotb scenario or one coherent scenario
+group. Normally let cocotb run all applicable entrypoints in that group. When
+separate pytest nodes intentionally select one cocotb scenario, pass a selector
+through `extra_env` (for example `COCOTB_TESTCASE` or a documented
 subsystem-specific variable), give the selector a deterministic default, and
 make sure it participates in the simulation-build identity. A focused pytest
 node should not silently rerun unrelated cocotb scenarios.
+
+An entrypoint that is inapplicable to the current parameter set must be
+explicitly skipped or excluded by pytest/cocotb selection. Do not return
+successfully before exercising the behavior and assertions named by the test;
+that records a no-op as a pass and obscures what the regression actually ran.
 
 ## Reuse And Helpers
 
@@ -240,11 +263,34 @@ Use `start_lockstep_clocks()` for `COMMON_CLK_G` or similar wrappers that expect
 truly shared clock edges. Do not start two independent same-period clock
 coroutines when the DUT contract is common-clock behavior.
 
+## Isolation And Coroutine Lifecycle
+
+Each cocotb entrypoint must establish its own defined starting state. Initialize
+every testbench-driven input, reset the DUT when it has a meaningful reset, and
+clear Python-side queues, scoreboards, and monitor state. Do not depend on the
+execution order of cocotb entrypoints or on state left by an earlier test.
+
+Every finite transaction task started with `cocotb.start_soon()` must be awaited
+before the test completes. A monitor, protocol peer, or other task intended to
+run for the lifetime of the test should be retained by the bench, named for its
+purpose, and documented as a lifetime agent. Give benches that own several such
+agents an explicit cleanup method when they need orderly cancellation or can
+hold an external resource. External processes, sockets, ports, and files always
+require bounded setup/teardown and cleanup on assertion failure.
+
+Use operation-specific cycle limits or `with_timeout()` for protocol progress.
+Add `timeout_time`/`timeout_unit` to complex concurrent or integration
+entrypoints as a final deadlock watchdog. Small finite leaf tests do not need a
+decorator timeout when every possible wait is already bounded.
+
 ## Assertions And Timing
 
 Assert externally visible behavior, not implementation accidents. Good checks
 usually include payload bytes, `TKEEP`, `TLAST`, `TUSER`/SOF/EOFE bits, address
 or ID sidebands, response codes, counters, or accepted-handshake timing.
+For a complex or parameterized check, include enough context in the failure to
+identify the case, transaction or beat index, expected value, observed value,
+and random seed when applicable.
 
 Initialize reset and every testbench-driven control/data input before the first
 active clock edge, preferably with `setimmediatevalue()` during bench setup.
@@ -261,16 +307,19 @@ When a contract includes backpressure, burst length, sideband propagation, or
 arbitration order, monitor accepted handshakes directly. Final memory contents
 alone are not enough for timing-visible behavior.
 
-Account for `TPD_G`, registered outputs, and GHDL scheduling. Sampling exactly
-on a clock edge can create false failures; most helpers settle with a short
-`Timer` after `RisingEdge()`.
+Account for `TPD_G`, registered outputs, and GHDL scheduling. After an edge, use
+`ReadOnly()` when only delta-cycle settling is required. When the RTL schedules
+a real nonzero `after TPD_G`, wait for that configured propagation delay and
+then sample the stable value. Keep this distinction visible in a shared helper;
+do not add an unexplained fixed delay merely to make a race disappear.
 
 Keep skip reasons and opt-in coverage explicit, and distinguish why a case is
 not in the default run:
 
 - Gate a regression for an unresolved RTL defect with a clear variable such as
-  `RUN_KNOWN_ISSUE_TESTS`, keep the issue visible in the methodology or local
-  README, and promote the case to default coverage with the fix.
+  `RUN_KNOWN_ISSUE_TESTS`. Name the tracked defect, expected failure, and
+  condition for restoring the case to default coverage in the methodology or
+  local README, and promote the case with the fix.
 - Gate an unusually long soak or stress matrix with a separately named
   `RUN_*_EXTENDED_TESTS` variable; do not label stable-but-slow coverage as a
   known issue.
@@ -297,8 +346,10 @@ result file, or other process-global resource. Tests that launch peer processes
 must use bounded startup/shutdown waits and clean them up in a `finally` block
 or shared teardown helper, including after an assertion fails.
 
-After any command that launches pytest, cocotb, GHDL, or another simulator
-runner, check for stale simulator child processes before starting another run.
+The runner or test fixture should clean up simulator children and external
+peers during normal execution. After an interrupted or hung run, check for stale
+processes before retrying so they cannot retain a build directory, port, or
+license.
 
 ## VHDL Wrappers
 
@@ -351,10 +402,16 @@ Before considering a new regression ready:
 - The Python file has the standard license header, a specific methodology
   block, and comments around non-obvious cocotb sequencing.
 - The test asserts behavior rather than merely reaching the end of simulation.
+- A bug regression was shown to fail on known-bad RTL when practical, or the
+  limitation and defect-catching assertion are documented.
+- Inapplicable scenarios are selected out or reported as skipped; no entrypoint
+  silently returns before exercising its named behavior.
 - Every wait is bounded directly or by a helper with a cycle/time limit.
 - Reset, backpressure, sidebands, and error/boundary cases relevant to the DUT
   are covered or explicitly documented as out of scope.
 - Shared helpers were reused or extended instead of duplicated.
+- Finite background tasks are awaited, lifetime agents have explicit ownership,
+  and external resources are cleaned up on failure.
 - Random stimulus is seeded and failures report enough information to replay
   the case.
 - The case is safe under pytest-xdist: build artifacts and external resources
@@ -363,7 +420,10 @@ Before considering a new regression ready:
   `vsg-linter.yml`, and reachable through its intended source path: the nearest
   ruckus manifest for build-facing HDL or `extra_vhdl_sources` for a
   cocotb-only wrapper.
+- `extra_vhdl_sources` does not repeat production HDL already supplied by the
+  ruckus import.
 - The focused test and the nearest practical subsystem suite pass.
-- `git diff --check` is clean and no stale simulator process remains.
+- `git diff --check` is clean; after an interrupted run, no stale simulator or
+  peer process remains.
 - The nearest README is updated if the test introduces a new layout, helper,
   simulator requirement, deferred dependency, or non-obvious invocation.

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,40 @@ This directory holds Python-authored regressions for synthesizable SURF RTL.
 The default stack is `pytest + cocotb + GHDL + ruckus`; VHDL should only be
 used for thin wrappers, shims, or required simulation models.
 
+This README is the authoritative guide for new SURF regression work. Historical
+task plans and module queues are not prerequisites and do not define the next
+module that must be tested. Add or deepen coverage when a subsystem is being
+changed, when a bug needs a permanent reproducer, or when a contributor chooses
+an uncovered module to improve.
+
+## Quick Start
+
+1. Read this README and the nearest subsystem README, if one exists.
+2. Search the surrounding tests and helper modules before writing new drivers
+   or protocol models.
+3. Identify the externally visible contract and the smallest useful DUT or
+   wrapper boundary.
+4. Write the module-specific `Test methodology` block before implementing the
+   test. It should make the intended sweep, stimulus, checks, and timing clear.
+5. Import the HDL sources and run the narrowest useful pytest target:
+
+   ```bash
+   make MODULES="$PWD" import
+   ./.venv/bin/python -m pytest -n 0 -q tests/<subsystem>/test_<Target>.py
+   ```
+
+6. Lint every edited VHDL file, run the relevant subsystem regression, and
+   check for stale simulator processes before handing the change off.
+
+Additional references:
+
+- [`tests/common/README.md`](common/README.md) documents the shared runner,
+  parameter cases, environment parsing, and clock helpers.
+- [`tests/protocols/README.md`](protocols/README.md) documents protocol-oracle,
+  layering, malformed-frame, and integration-test practices.
+- Subsystem READMEs may define protocol- or simulator-specific commands, but
+  they should extend rather than replace this guide.
+
 ## Layout
 
 - Keep executable tests under subsystem packages, such as `tests/base/fifo/`,
@@ -109,6 +143,45 @@ Common structure:
   or `parameter_case()`.
 - A final pytest wrapper named for the RTL target, calling
   `run_surf_vhdl_test(test_file=__file__, ...)`.
+
+Keep the cocotb entrypoints and the pytest wrapper in the same file unless a
+subsystem has a documented reason to separate them. Pytest owns build
+parameters and simulator launches; cocotb owns cycle-level stimulus and checks.
+
+## Designing The Test
+
+Start from the public contract, not the current implementation. Read the entity
+ports and generics, the nearest package and README, and any applicable protocol
+or register-map specification. Then choose the smallest boundary that can prove
+the behavior:
+
+- Test reusable leaves directly when their behavior is observable without a
+  large integration topology.
+- Use an integration test when arbitration, CDC, configuration propagation, or
+  interaction between already-tested leaves is the actual contract.
+- Do not replay a leaf's complete packet grammar or parameter matrix through
+  every higher-level wrapper. Higher-level tests should focus on what that layer
+  adds.
+- Treat compile/elaboration-only smoke coverage as useful but distinct from a
+  functional regression. A functional test needs meaningful stimulus and
+  assertions.
+- Treat package declarations as transitively covered unless an important
+  function or procedure needs a small wrapper and a direct behavioral test.
+
+A focused regression normally covers the relevant subset of:
+
+- reset assertion, release, and recovery;
+- nominal data or control flow;
+- backpressure and accepted-handshake timing;
+- frame, burst, or transaction boundaries;
+- payload ordering and byte enables such as `TKEEP`/`TSTRB`;
+- sidebands such as `TLAST`, `TDEST`, `TID`, SOF, and EOFE;
+- invalid inputs, error responses, overflow, timeout, or recovery behavior;
+- representative generic or clock-domain configurations.
+
+Use deterministic directed cases for protocol rules and boundary conditions.
+Randomized cases are valuable after a trustworthy reference model exists, but
+they do not replace readable directed regressions for known contracts and bugs.
 
 ## Parameter Sweeps
 
@@ -224,3 +297,29 @@ command to confirm the file is clean.
 VHDL packages are usually covered transitively through modules that use them.
 Add a dedicated package wrapper only when a behavioral function or procedure is
 important and not reached naturally through existing DUT coverage.
+
+There is no active repository-wide queue of modules that must be completed in a
+fixed order. When selecting new work, prefer high-reuse modules, code being
+modified, untested bug fixes, and simulator-friendly leaves that establish
+helpers useful to later integration tests. Vendor-heavy or mixed-language
+blocks may be deferred when the standard GHDL flow cannot exercise their real
+dependencies; document that limitation near the subsystem rather than adding a
+test double that changes the DUT boundary.
+
+## Completion Checklist
+
+Before considering a new regression ready:
+
+- The Python file has the standard license header, a specific methodology
+  block, and comments around non-obvious cocotb sequencing.
+- The test asserts behavior rather than merely reaching the end of simulation.
+- Every wait is bounded directly or by a helper with a cycle/time limit.
+- Reset, backpressure, sidebands, and error/boundary cases relevant to the DUT
+  are covered or explicitly documented as out of scope.
+- Shared helpers were reused or extended instead of duplicated.
+- Any retained VHDL wrapper is thin, locally documented, present in the right
+  ruckus manifest, and clean under `vsg-linter.yml`.
+- The focused test and the nearest practical subsystem suite pass.
+- `git diff --check` is clean and no stale simulator process remains.
+- The nearest README is updated if the test introduces a new layout, helper,
+  simulator requirement, deferred dependency, or non-obvious invocation.

--- a/tests/common/README.md
+++ b/tests/common/README.md
@@ -24,7 +24,7 @@ PARAMETER_SWEEP = [
 def test_my_target(parameters):
     run_surf_vhdl_test(
         test_file=__file__,
-        toplevel="MyTargetWrapper",
+        toplevel="surf.MyTargetWrapper",
         parameters=hdl_parameters_from(parameters),
         extra_env=parameters,
     )
@@ -34,17 +34,20 @@ Use `parameters` only for VHDL generics. Use `extra_env` for Python-side case
 metadata. When one dictionary contains both, pass it through
 `hdl_parameters_from()` before giving it to the simulator.
 
-Use `extra_vhdl_sources` for a wrapper or simulation model that is intentionally
-outside the imported SURF source list. Production RTL belongs in the nearest
-`ruckus.tcl`; do not use this argument to hide a missing build-manifest entry or
-repeat a unit already supplied by the import, which can produce a library
-redefinition error.
+Use `extra_vhdl_sources` only for a cocotb-only wrapper or simulation model whose
+design unit is absent from the ruckus import. Check the imported source tree
+under `build/SRC_VHDL/` before adding a path. Production and reusable wrapper RTL
+belongs in the nearest `ruckus.tcl`; do not use this argument to hide a missing
+build-manifest entry or repeat an imported design unit. Compiling the same unit
+from both paths can redefine it, make compile order significant, or leave a
+cached build using a different source than the reviewer expects.
 
-Use `sim_build_key` only when normal parameter-derived names would be too long
-or when a subsystem requires a deliberately stable build location. The default
-path already includes `parameters` and `extra_env`, which isolates parallel
-cases. A custom key must preserve that isolation; never point concurrently
-runnable variants at the same build directory.
+The default build path includes `parameters` and `extra_env`, and the shared
+runner hashes path components that would be unsafe or excessively long. Use
+`sim_build_key` only when a subsystem requires a deliberately stable or more
+meaningful build identity. A custom key must still distinguish every
+concurrently runnable compile configuration and selected cocotb scenario; never
+point incompatible variants at the same build directory.
 
 Leave `force_compile=False` for normal regressions. Set it only when a
 documented source-topology or simulator-cache limitation makes reuse unsafe;
@@ -105,4 +108,14 @@ so a broken handshake becomes a useful failure instead of a hung worker.
 
 When a pytest wrapper selects one of several cocotb entrypoints, pass the
 selector in `extra_env`. Because the shared runner includes `extra_env` in the
-default build path, selected scenarios remain isolated under pytest-xdist.
+default build path, selected scenarios remain isolated under pytest-xdist. Give
+the selector a deterministic default and make each pytest node run only the
+scenario or coherent scenario group named by that node; do not use a bare return
+inside an otherwise selected cocotb test to turn an inapplicable case into a
+pass.
+
+Retain every task returned by `cocotb.start_soon()`. Await finite producers,
+consumers, and transactions before the entrypoint completes. Store monitors or
+protocol peers intended to run for the whole test on the bench, document them as
+lifetime agents, and provide cleanup when cancellation order matters or an
+agent owns a socket, process, file, or other external resource.

--- a/tests/common/README.md
+++ b/tests/common/README.md
@@ -36,10 +36,27 @@ metadata. When one dictionary contains both, pass it through
 
 Use `extra_vhdl_sources` for a wrapper or simulation model that is intentionally
 outside the imported SURF source list. Production RTL belongs in the nearest
-`ruckus.tcl`; do not use this argument to hide a missing build-manifest entry.
+`ruckus.tcl`; do not use this argument to hide a missing build-manifest entry or
+repeat a unit already supplied by the import, which can produce a library
+redefinition error.
 
 Use `sim_build_key` only when normal parameter-derived names would be too long
-or when a subsystem requires a deliberately shared/stable build location.
+or when a subsystem requires a deliberately stable build location. The default
+path already includes `parameters` and `extra_env`, which isolates parallel
+cases. A custom key must preserve that isolation; never point concurrently
+runnable variants at the same build directory.
+
+Leave `force_compile=False` for normal regressions. Set it only when a
+documented source-topology or simulator-cache limitation makes reuse unsafe;
+it is not a substitute for a unique build identity.
+
+The shared runner is the default for VHDL/GHDL regressions. A direct
+`cocotb-test` or simulator-specific runner is justified only when the flow
+needs capabilities the shared path cannot express, such as a mixed-language
+top, a vendor simulator, precompiled libraries, or explicit external-process
+lifecycle control. Document the exception beside the custom runner or in the
+subsystem README, and retain the common source, compile-option, result-file,
+and build-isolation conventions where they apply.
 
 ## Shared Helpers
 
@@ -85,3 +102,7 @@ Use parallel execution for a stable subsystem suite:
 Do not call the runner directly from a cocotb coroutine. Pytest launches the
 simulator; cocotb code runs inside it. Keep every protocol-progress wait bounded
 so a broken handshake becomes a useful failure instead of a hung worker.
+
+When a pytest wrapper selects one of several cocotb entrypoints, pass the
+selector in `extra_env`. Because the shared runner includes `extra_env` in the
+default build path, selected scenarios remain isolated under pytest-xdist.

--- a/tests/common/README.md
+++ b/tests/common/README.md
@@ -1,0 +1,87 @@
+# Common Regression Infrastructure
+
+The helpers in this directory provide the shared pytest/cocotb launch path for
+SURF regressions. Start with the repository-wide [regression style
+guide](../README.md) and use this page when wiring a new Python test into GHDL.
+
+## Standard Runner
+
+`run_surf_vhdl_test()` in `regression_utils.py` launches GHDL through
+`cocotb-test`, loads the ruckus-imported SURF libraries, selects the cocotb
+module from `test_file`, and gives each parameter case its own simulation build
+directory.
+
+A normal pytest wrapper looks like this:
+
+```python
+PARAMETER_SWEEP = [
+    parameter_case("default", DATA_WIDTH_G=16, RST_ASYNC_G=False),
+    parameter_case("async_reset", DATA_WIDTH_G=16, RST_ASYNC_G=True),
+]
+
+
+@pytest.mark.parametrize("parameters", PARAMETER_SWEEP)
+def test_my_target(parameters):
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="MyTargetWrapper",
+        parameters=hdl_parameters_from(parameters),
+        extra_env=parameters,
+    )
+```
+
+Use `parameters` only for VHDL generics. Use `extra_env` for Python-side case
+metadata. When one dictionary contains both, pass it through
+`hdl_parameters_from()` before giving it to the simulator.
+
+Use `extra_vhdl_sources` for a wrapper or simulation model that is intentionally
+outside the imported SURF source list. Production RTL belongs in the nearest
+`ruckus.tcl`; do not use this argument to hide a missing build-manifest entry.
+
+Use `sim_build_key` only when normal parameter-derived names would be too long
+or when a subsystem requires a deliberately shared/stable build location.
+
+## Shared Helpers
+
+- `parameter_case()` creates readable pytest IDs for curated cases.
+- `hdl_parameters_from()` filters mixed case dictionaries to keys ending in
+  `_G`.
+- `env_flag()`, `env_sl()`, `env_int()`, `env_hex()`, and `env_float()` parse
+  simulator environment values consistently inside cocotb coroutines.
+- `start_lockstep_clocks()` drives multiple logically common clocks from one
+  coroutine so their edges cannot drift.
+- `build_vhdl_sources()` and `merge_vhdl_sources()` are runner plumbing; tests
+  should normally reach them only through `run_surf_vhdl_test()`.
+
+Bus and protocol transaction helpers live closer to their users:
+
+- `tests/axi/utils.py` contains shared AXI-family handshake utilities.
+- `tests/protocols/<protocol>/*_test_utils.py` contains protocol frames,
+  reference models, sources, sinks, and scoreboards.
+- Subsystem helpers should implement mechanics, while policy assertions remain
+  visible in the module test.
+
+## Build And Debug Workflow
+
+Run the ruckus import after source-list changes or when `build/SRC_VHDL` is
+missing or stale:
+
+```bash
+make MODULES="$PWD" import
+```
+
+Use a serial focused run for readable simulator logs:
+
+```bash
+./.venv/bin/python -m pytest -n 0 -q tests/<area>/test_<Target>.py
+```
+
+Use parallel execution for a stable subsystem suite:
+
+```bash
+./.venv/bin/python -m pytest -n auto --dist=worksteal -q tests/<area>
+```
+
+Do not call the runner directly from a cocotb coroutine. Pytest launches the
+simulator; cocotb code runs inside it. Keep every protocol-progress wait bounded
+so a broken handshake becomes a useful failure instead of a hung worker.

--- a/tests/protocols/README.md
+++ b/tests/protocols/README.md
@@ -1,0 +1,84 @@
+# Protocol Regression Guidance
+
+Protocol tests follow the repository-wide [cocotb regression style
+guide](../README.md). This page captures the additional practices that apply to
+framed, reliable, layered, or specification-defined protocols.
+
+## Build One Shared Protocol Oracle
+
+Put packet constants, field encoders/decoders, checksum or CRC reference code,
+and mechanical source/sink helpers in the subsystem's `*_test_utils.py` module.
+Derive them from the normative protocol specification or the established SURF
+package definitions, not from copied literals in individual tests.
+
+Keep policy assertions in the test that names the behavior. A helper may build
+a DATA frame or calculate its checksum; the test should still say that an
+out-of-order frame must be dropped, an EOFE marker must propagate, or a timeout
+must increment a particular counter. This keeps helpers from becoming an
+unreviewed second implementation of the DUT.
+
+When the specification and current RTL disagree, make the distinction explicit:
+
+- A clear specification requirement should become a directed regression and,
+  when necessary, an RTL fix.
+- An ambiguous behavior should first be a characterization test with its scope
+  documented.
+- A deliberately narrower SURF profile should be described in the subsystem
+  README and test methodology rather than presented as full protocol
+  compliance.
+
+## Test By Layer
+
+Prefer a progression that establishes trustworthy lower-level behavior before
+large integration scenarios:
+
+1. Field packing, checksums/CRCs, encoders, and decoders.
+2. Leaf transmit and receive state machines.
+3. Flow control, retries, timeouts, register interfaces, and CDC boundaries.
+4. Core or wrapper integration, routing, and multi-stream interaction.
+
+An integration test should focus on what the integrated layer adds. Reuse the
+same protocol oracle, but do not duplicate every leaf permutation at the top
+level.
+
+## Required Protocol Cases
+
+Choose the cases relevant to the DUT, including:
+
+- minimum, typical, maximum, and non-word-aligned payload sizes;
+- exact and partial final beats with correct `TKEEP`/`TSTRB`;
+- SOF, EOF, EOFE, `TLAST`, `TDEST`, `TID`, and per-byte `TUSER` propagation;
+- output backpressure and input idle gaps;
+- malformed headers, lengths, flags, checksums/CRCs, and trailers;
+- truncated frames, early/late termination, and recovery on the next frame;
+- retry, acknowledgment, busy, timeout, overflow, and drop behavior;
+- reset while idle and, where meaningful, reset with a partial transaction;
+- sequence/tag wraparound and representative parameter boundaries;
+- multi-lane or multi-stream ordering and arbitration when supported.
+
+Assert both positive and negative behavior. For invalid traffic, verify not only
+that an error is reported but also that forbidden payload or control output is
+not emitted and that subsequent valid traffic recovers.
+
+## Ready/Valid Discipline
+
+A source must hold data and all sidebands stable until an accepting clock edge.
+A sink applying backpressure should verify that the DUT does the same. Use the
+shared sampled-ready helper or a suitable `cocotbext.axi` endpoint instead of
+open-coding subtly different handshake loops.
+
+Monitor accepted handshakes when timing, arbitration, or frame boundaries are
+part of the contract. Comparing only final payload bytes can miss duplicated
+beats, dropped sidebands, premature `TLAST`, or incorrect ordering.
+
+## Wrappers And Integration Models
+
+Keep wrapper HDL limited to record flattening, deterministic tie-offs,
+simulator-friendly generics, or the smallest required topology. Packet
+generation, retry peers, scoreboards, and assertions belong in Python.
+
+Use real protocol dependencies at the chosen DUT boundary. Do not replace a
+generated core or lower protocol layer with a permissive test double and then
+claim coverage of the full assembly. If the standard GHDL flow cannot compile
+the real mixed-language or vendor dependency, document the deferral in the
+subsystem README and test the accessible leaves directly.

--- a/tests/protocols/README.md
+++ b/tests/protocols/README.md
@@ -11,6 +11,12 @@ and mechanical source/sink helpers in the subsystem's `*_test_utils.py` module.
 Derive them from the normative protocol specification or the established SURF
 package definitions, not from copied literals in individual tests.
 
+Anchor the oracle with small published or hand-worked known-answer vectors
+before trusting it for randomized or integration traffic. Keep at least one
+vector independent of the DUT implementation and, where practical, independent
+of the helper's encoder path as well. A Python model that transliterates the RTL
+line by line can reproduce the same defect and is not an independent oracle.
+
 Keep policy assertions in the test that names the behavior. A helper may build
 a DATA frame or calculate its checksum; the test should still say that an
 out-of-order frame must be dropped, an EOFE marker must propagate, or a timeout
@@ -40,6 +46,12 @@ large integration scenarios:
 An integration test should focus on what the integrated layer adds. Reuse the
 same protocol oracle, but do not duplicate every leaf permutation at the top
 level.
+
+As a suite grows, split it by coherent behavior rather than by an arbitrary
+line limit: encoding, transmit, receive, flow control/recovery, register
+control, and integration are useful boundaries. Keep shared frames and
+mechanics in the oracle module, while each test module owns the assertions and
+methodology for the behavior named by that file.
 
 ## Required Protocol Cases
 

--- a/tests/protocols/batcher/README.md
+++ b/tests/protocols/batcher/README.md
@@ -1,0 +1,31 @@
+# Batcher Regressions
+
+These tests follow the repository-wide [regression style guide](../../README.md)
+and [protocol guidance](../README.md). Shared AXI Stream beats, source/sink
+drivers, byte compaction, and V2 superframe reference helpers live in
+`batcher_test_utils.py`.
+
+The suite is layered deliberately:
+
+- `test_AxiStreamBatcher.py` proves the leaf V2 byte-stream contract, subframe
+  metadata, termination controls, and output stability under backpressure.
+- `test_AxiStreamBatcherAxil.py` proves reset values, register readback, CDC
+  behavior, and the stream-side effects of threshold, gap, soft-reset, and
+  blowoff controls. It reuses the leaf oracle instead of repeating the full
+  packet matrix.
+- `test_AxiStreamBatcherEventBuilder.py` focuses on indexed/routed source
+  selection, TDEST remapping, transition frames, alignment checks, timeout and
+  bypass/drop policy, counters, and multi-input progress.
+
+Keep future additions at the narrowest layer that owns the behavior. Packet
+grammar belongs in the leaf test; register behavior belongs in the AXI-Lite
+test; arbitration, routing, and cross-source policy belong in the event-builder
+test. Extend `batcher_test_utils.py` for reusable mechanics, but leave the
+policy being asserted visible in the individual test.
+
+Run the suite with:
+
+```bash
+make MODULES="$PWD" import
+./.venv/bin/python -m pytest -n auto --dist=worksteal -q tests/protocols/batcher
+```

--- a/tests/protocols/batcher/README.md
+++ b/tests/protocols/batcher/README.md
@@ -23,6 +23,12 @@ test; arbitration, routing, and cross-source policy belong in the event-builder
 test. Extend `batcher_test_utils.py` for reusable mechanics, but leave the
 policy being asserted visible in the individual test.
 
+Routed and unrouted configurations do not make every scenario applicable. Make
+that relationship explicit in the pytest parameter/selector matrix, or report
+the scenario as skipped with the configuration in the reason. Do not enter a
+cocotb test and return successfully before its named routing, remapping, or
+transition behavior has been exercised.
+
 Run the suite with:
 
 ```bash

--- a/tests/protocols/rssi/README.md
+++ b/tests/protocols/rssi/README.md
@@ -1,0 +1,62 @@
+# RSSI Regressions
+
+These tests follow the repository-wide [regression style guide](../../README.md)
+and [protocol guidance](../README.md). The implementation and sizing guidance
+is documented in [`protocols/rssi/README.md`](../../../protocols/rssi/README.md).
+
+## Protocol Oracle And Layers
+
+`rssi_test_utils.py` is the shared oracle for RSSI flags, header encoding,
+checksum calculation, frame construction/parsing, SSI transport mechanics, and
+common client/server setup. Keep protocol constants and mechanical helpers
+there; keep assertions about RSSI policy in the test that names the behavior.
+
+The suite progresses from leaves to integration:
+
+- `test_RssiChksum.py` and `test_RssiHeaderReg.py` cover checksum and wire-header
+  formatting.
+- `test_RssiRxFsm.py`, `test_RssiTxFsm.py`, `test_RssiMonitor.py`, and
+  `test_RssiConnFsm.py` cover receive/transmit legality, ACK/NULL/BUSY timing,
+  retransmission, connection negotiation, close, and recovery.
+- `test_RssiAxiLiteRegItf.py` covers the register map, range clamping,
+  negotiated/current readback, counters, and visible controls/status.
+- `test_RssiCore.py` covers direct client/server negotiation, payload transfer,
+  backpressure, loss/retransmission, checksums, keepalive, close/reopen, BUSY,
+  and AXI-Lite-controlled behavior.
+- `test_RssiCoreWrapper.py` and `test_RssiCoreWrapperMultiStream.py` cover the
+  packetizer/chunker boundary, segment/window configurations, routing,
+  multi-stream loss recovery, and application-side sidebands.
+
+Default CI runs the currently stable RSSI cases. Focused cases that still expose
+unresolved RTL behavior are opt-in behind `RUN_RSSI_KNOWN_ISSUE_TESTS=1`, and a
+smaller group of long-running integration cases additionally uses
+`RUN_RSSI_EXTENDED_TESTS=1`. Keep the skip reason beside each gated pytest entry
+and promote the case to default coverage when its blocking RTL issue is fixed.
+
+## RSSI-Specific Expectations
+
+The SURF RSSI profile uses 8-byte non-SYN headers, 24-byte SYN headers, 8-bit
+sequence numbers, cumulative ACKs, ordered delivery, retransmission, NULL
+keepalives, and BUSY flow control. Current hardware does not implement EACK
+out-of-sequence delivery. Tests should use the SURF/Rogue profile as the
+concrete contract and consult the RUDP lineage only where the profile leaves a
+behavior unspecified.
+
+Directed negative cases should verify that illegal flag combinations, malformed
+headers, bad checksums, and out-of-order frames do not leak application payload.
+Recovery cases should then send valid traffic and prove that the endpoint makes
+forward progress without duplicate delivery.
+
+Run the default suite with:
+
+```bash
+make MODULES="$PWD" import
+./.venv/bin/python -m pytest -n auto --dist=worksteal -q tests/protocols/rssi
+```
+
+Run known-issue and extended cases explicitly with:
+
+```bash
+RUN_RSSI_KNOWN_ISSUE_TESTS=1 RUN_RSSI_EXTENDED_TESTS=1 \
+    ./.venv/bin/python -m pytest -n 0 -q tests/protocols/rssi
+```

--- a/tests/protocols/rssi/README.md
+++ b/tests/protocols/rssi/README.md
@@ -30,8 +30,17 @@ The suite progresses from leaves to integration:
 Default CI runs the currently stable RSSI cases. Focused cases that still expose
 unresolved RTL behavior are opt-in behind `RUN_RSSI_KNOWN_ISSUE_TESTS=1`, and a
 smaller group of long-running integration cases additionally uses
-`RUN_RSSI_EXTENDED_TESTS=1`. Keep the skip reason beside each gated pytest entry
-and promote the case to default coverage when its blocking RTL issue is fixed.
+`RUN_RSSI_EXTENDED_TESTS=1`. A `COCOTB_TESTCASE` selector chooses a named
+cocotb scenario; the `RUN_*` gates decide whether the corresponding pytest node
+is eligible to launch it. Keep these roles separate so an enabled node cannot
+silently run unrelated scenarios.
+
+Keep the skip reason beside each gated pytest entry. A known-issue case must
+identify a durable defect reference or documented local issue, state the
+expected failure, and say what change allows the gate to be removed. Promote the
+case to default coverage in the same change that fixes the blocking RTL. Keep
+stable-but-long coverage under the extended gate rather than calling it a known
+issue.
 
 ## RSSI-Specific Expectations
 
@@ -46,6 +55,13 @@ Directed negative cases should verify that illegal flag combinations, malformed
 headers, bad checksums, and out-of-order frames do not leak application payload.
 Recovery cases should then send valid traffic and prove that the endpoint makes
 forward progress without duplicate delivery.
+
+When one methodology block can no longer describe a coherent set of scenarios,
+split the integration suite by behavior while continuing to share the RSSI
+oracle. Useful boundaries are negotiation and close, data and retransmission,
+flow control and keepalive, connection lifecycle, AXI-Lite control, and
+multi-stream integration. Preserve the existing pytest case names and gate
+semantics during such a split so coverage does not disappear unnoticed.
 
 Run the default suite with:
 


### PR DESCRIPTION
### Description

Document the standard SURF RTL regression methodology so contributors can use the guidance under `tests/` as the authoritative reference for adding cocotb coverage.

### Details

- Adds a quick-start workflow, test-design guidance, coverage expectations, wrapper conventions, and a completion checklist to `tests/README.md`.
- Documents the shared pytest/cocotb/GHDL runner and helper APIs under `tests/common/`.
- Adds reusable protocol-regression guidance for protocol oracles, layered testing, malformed traffic, ready/valid behavior, and real dependency boundaries.
- Adds focused Batcher and RSSI regression READMEs based on the durable methodology from the retired planning work.
- Explicitly sets aside the old repository-wide module queue in favor of contributor-selected coverage as modules are changed or revisited.

This branch is based directly on `pre-release` and contains documentation only; it does not add, modify, or delete executable regression tests or RTL.

Validation: `git diff --check origin/pre-release..verification-2`.
