### PR TITLE
Fix AxiStreamBatcher tail corruption on clock-gap timeout

### DIFF
--- a/protocols/batcher/rtl/AxiStreamBatcher.vhd
+++ b/protocols/batcher/rtl/AxiStreamBatcher.vhd
@@ -176,7 +176,14 @@ begin
       -- Reset the strobes
       v.rxSlave.tReady := r.forceTerm;
       if (txSlave.tReady = '1') then
-         v.txMaster := axiStreamMasterInit(AXIS_CONFIG_G);
+         -- Preserve the pending tail while waiting for a clock-gap timeout
+         if (r.state = GAP_S) then
+            v.txMaster.tValid := '0';
+            v.txMaster.tLast  := '0';
+            v.txMaster.tUser  := (others => '0');
+         else
+            v.txMaster := axiStreamMasterInit(AXIS_CONFIG_G);
+         end if;
       end if;
 
       -- Check for max. super frame

--- a/tests/protocols/batcher/README.md
+++ b/tests/protocols/batcher/README.md
@@ -8,7 +8,8 @@ drivers, byte compaction, and V2 superframe reference helpers live in
 The suite is layered deliberately:
 
 - `test_AxiStreamBatcher.py` proves the leaf V2 byte-stream contract, subframe
-  metadata, termination controls, and output stability under backpressure.
+  metadata, termination controls, and output stability under backpressure. It
+  also covers the V1 padded-tail hold and release across a clock-gap timeout.
 - `test_AxiStreamBatcherAxil.py` proves reset values, register readback, CDC
   behavior, and the stream-side effects of threshold, gap, soft-reset, and
   blowoff controls. It reuses the leaf oracle instead of repeating the full

--- a/tests/protocols/batcher/README.md
+++ b/tests/protocols/batcher/README.md
@@ -18,6 +18,10 @@ The suite is layered deliberately:
   selection, TDEST remapping, transition frames, alignment checks, timeout and
   bypass/drop policy, counters, and multi-input progress.
 
+`AxiStreamBatcher` holds a completed subframe tail with `TVALID=0` while waiting
+in `GAP_S`. The tail data and byte enables must remain intact until a new
+subframe arrives or the clock-gap timeout emits the tail.
+
 Keep future additions at the narrowest layer that owns the behavior. Packet
 grammar belongs in the leaf test; register behavior belongs in the AXI-Lite
 test; arbitration, routing, and cross-source policy belong in the event-builder

--- a/tests/protocols/batcher/batcher_test_utils.py
+++ b/tests/protocols/batcher/batcher_test_utils.py
@@ -162,11 +162,38 @@ def batcher_v2_header(*, seq: int = 0, data_bytes: int = 8) -> bytes:
     return bytes([0x2 | ((width & 0xF) << 4), seq & 0xFF])
 
 
+def batcher_v1_header(*, seq: int = 0, data_bytes: int = 8) -> bytes:
+    width = (data_bytes // 2).bit_length() - 1
+    return bytes([0x1 | ((width & 0xF) << 4), seq & 0xFF]).ljust(data_bytes, b"\x00")
+
+
 def batcher_subframe_tail(*, byte_count: int, dest: int, first_user: int, last_user: int) -> bytes:
     return (
         byte_count.to_bytes(4, "little")
         + bytes([dest & 0xFF, first_user & 0xFF, last_user & 0xFF])
     )
+
+
+def expected_batched_v1_bytes(
+    frames: list[tuple[bytes, int, int, int]],
+    *,
+    seq: int = 0,
+    data_bytes: int = 8,
+) -> bytes:
+    width = (data_bytes // 2).bit_length() - 1
+    stream = bytearray(batcher_v1_header(seq=seq, data_bytes=data_bytes))
+    for payload, dest, first_user, last_user in frames:
+        stream.extend(payload)
+        stream.extend(b"\x00" * (-len(payload) % data_bytes))
+        tail = batcher_subframe_tail(
+            byte_count=len(payload),
+            dest=dest,
+            first_user=first_user,
+            last_user=last_user,
+        ) + bytes([width & 0xF])
+        stream.extend(tail)
+        stream.extend(b"\x00" * (-len(tail) % data_bytes))
+    return bytes(stream)
 
 
 def expected_batched_bytes(frames: list[tuple[bytes, int, int, int]], *, seq: int = 0) -> bytes:

--- a/tests/protocols/batcher/test_AxiStreamBatcher.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcher.py
@@ -128,7 +128,7 @@ async def two_subframes_share_one_superframe_test(dut):
 
 
 @cocotb.test()
-async def idle_gap_terminates_pending_tail_test(dut):
+async def v2_idle_gap_terminates_pending_tail_test(dut):
     tb = TB(dut)
     await tb.reset()
     dut.maxSubFrames.value = 8

--- a/tests/protocols/batcher/test_AxiStreamBatcher.py
+++ b/tests/protocols/batcher/test_AxiStreamBatcher.py
@@ -9,9 +9,9 @@
 ##############################################################################
 
 # Test methodology:
-# - Sweep: Use a standalone `AxiStreamBatcher` wrapper in V2 mode with an
-#   8-byte AXI Stream width so the regression checks the compacted output path
-#   implemented through `AxiStreamGearbox`.
+# - Sweep: Use a standalone `AxiStreamBatcher` wrapper at an 8-byte AXI Stream
+#   width. Exercise the V2 compacted output path through `AxiStreamGearbox` and
+#   the V1 padded-output path for the idle-gap tail regression.
 # - Stimulus: Drive one or more input subframes with varied payload lengths,
 #   `TKEEP`, `TDEST`, first-byte `TUSER`, and last-byte `TUSER`, then terminate
 #   superframes by subframe count, idle gap, byte threshold, and sink
@@ -26,13 +26,19 @@ import cocotb
 import pytest
 from cocotb.triggers import with_timeout
 
-from tests.common.regression_utils import run_surf_vhdl_test
+from tests.common.regression_utils import (
+    cocotb_filtered_env,
+    cocotb_test_filter,
+    cocotb_test_filter_excluding,
+    run_surf_vhdl_test,
+)
 from tests.protocols.batcher.batcher_test_utils import (
     AxisBeat,
     FlatAxisEndpoint,
     beats_to_bytes,
     cycle,
     expected_batched_bytes,
+    expected_batched_v1_bytes,
     keep_count,
     payload_to_beats,
     recv_beats,
@@ -126,7 +132,7 @@ async def idle_gap_terminates_pending_tail_test(dut):
     tb = TB(dut)
     await tb.reset()
     dut.maxSubFrames.value = 8
-    dut.maxClkGap.value = 3
+    dut.maxClkGap.value = 32
 
     # With no second subframe arriving, the small max-clock-gap setting must
     # close the superframe after the tail has been accepted into the batcher.
@@ -146,6 +152,35 @@ async def idle_gap_terminates_pending_tail_test(dut):
     rx_beats = await with_timeout(rx_task, 4, "us")
 
     assert beats_to_bytes(rx_beats) == expected_batched_bytes([frame])
+    assert rx_beats[-1].last == 1
+
+
+@cocotb.test()
+async def v1_idle_gap_preserves_pending_tail_test(dut):
+    tb = TB(dut)
+    await tb.reset()
+    dut.maxSubFrames.value = 8
+    dut.maxClkGap.value = 8
+
+    # Version 1 holds the padded tail word with TVALID deasserted while GAP_S
+    # waits for this timeout.  The held data must survive until the timeout
+    # reasserts TVALID and marks that same word as the terminal superframe beat.
+    payload = bytes(range(0x60, 0x6B))
+    frame = (payload, 0x2, 0x44, 0xB1)
+    rx_task = cocotb.start_soon(recv_until_last(tb.sink, clk=dut.axisClk))
+    await send_frame(
+        tb.source,
+        payload_to_beats(
+            payload,
+            dest=frame[1],
+            first_user=frame[2],
+            last_user=frame[3],
+        ),
+        clk=dut.axisClk,
+    )
+    rx_beats = await with_timeout(rx_task, 4, "us")
+
+    assert beats_to_bytes(rx_beats) == expected_batched_v1_bytes([frame])
     assert rx_beats[-1].last == 1
 
 
@@ -309,7 +344,35 @@ def test_AxiStreamBatcher(parameters):
         test_file=__file__,
         toplevel="surf.axistreambatcherwrapper",
         parameters=parameters,
-        extra_env=parameters,
+        extra_env=cocotb_filtered_env(
+            parameters,
+            cocotb_test_filter_excluding("v1_idle_gap_preserves_pending_tail_test"),
+        ),
+        extra_vhdl_sources={
+            "surf": [
+                "protocols/batcher/wrappers/AxiStreamBatcherWrapper.vhd",
+            ],
+        },
+    )
+
+
+def test_AxiStreamBatcher_v1_idle_gap():
+    parameters = {
+        "VERSION_G": 1,
+        "DATA_BYTES_G": 8,
+        "INPUT_PIPE_STAGES_G": 0,
+        "OUTPUT_PIPE_STAGES_G": 1,
+    }
+    run_surf_vhdl_test(
+        test_file=__file__,
+        toplevel="surf.axistreambatcherwrapper",
+        parameters=parameters,
+        extra_env={
+            **parameters,
+            "COCOTB_TEST_FILTER": cocotb_test_filter(
+                "v1_idle_gap_preserves_pending_tail_test"
+            ),
+        },
         extra_vhdl_sources={
             "surf": [
                 "protocols/batcher/wrappers/AxiStreamBatcherWrapper.vhd",


### PR DESCRIPTION
### Description
Fix AxiStreamBatcher Version 1 superframe-tail corruption when a bursty input stream is terminated by the clock-gap timeout.

### Details
Commit 566ea051c changed the shared output-register clear to axiStreamMasterInit. In Version 1, the output pipeline can assert ready while the pending tail has valid deasserted in GAP_S, causing the held tail data to be cleared before the timeout emits it. The resulting zero tail reports a zero subframe size to downstream software.

The fix preserves the pending output word while in GAP_S and continues using axiStreamMasterInit in all other states. This retains the Version 2 behavior that restores full-width keep and strobe values between compacted words.

The regression suite now includes an independent Version 1 padded-frame oracle and a directed idle-gap test. The test was confirmed to fail on the original RTL with an eight-byte zero terminal tail and pass with this fix. The existing Version 2 idle-gap test now waits 32 cycles to exercise a sustained gap.

Verification:
- Full batcher regression: 7 passed
- VSG: 0 violations
- Flake8 and compileall: pass
- Cocotb compliance audit: pass
- Git diff whitespace check: pass

### Related
- Regression introduced by https://github.com/slaclab/surf/pull/1383